### PR TITLE
chore: expand workflow metadata

### DIFF
--- a/.github/github-repo-workflow.json
+++ b/.github/github-repo-workflow.json
@@ -1,13 +1,101 @@
 {
   "defaultBranch": "main",
-  "importantWorkflows": ["CI"],
+  "projectType": "media-workstation-app",
+  "docs": {
+    "index": "docs/README.md",
+    "acceptanceGate": "docs/policies/acceptance-gate.md",
+    "codingStandards": "docs/policies/coding-standards.md",
+    "architecture": "docs/architecture/module-boundaries.md",
+    "databaseTooling": "docs/development/database-tooling.md",
+    "workstationUi": "docs/style/workstation-ui.md",
+    "style": [
+      "docs/style/index.md",
+      "docs/style/python.md",
+      "docs/style/frontend.md",
+      "docs/style/testing.md",
+      "docs/style/workstation-ui.md"
+    ],
+    "design": [
+      "docs/design/workstation-home-screen-brief.md",
+      "docs/design/workstation-home-screen-inventory.md",
+      "docs/design/operator-workstation-shell-brief.md"
+    ]
+  },
+  "qualityGate": {
+    "test": {
+      "backendCi": "uv run --with pytest pytest -q -k \"not test_bootstrap_remote_macos_returns_noop_when_no_bootstrap_issues and not test_bootstrap_remote_macos_routes_xcode_issue_to_request_helper and not test_remote_host_status_targets_current_machine_without_ssh_probe and not test_ffmpeg_hwaccel_included_when_videotoolbox_available\"",
+      "backendFull": "uv run --with pytest pytest",
+      "frontend": "npm --prefix frontend test"
+    },
+    "lint": {
+      "frontend": "npm --prefix frontend run lint"
+    },
+    "typecheck": {
+      "frontend": "npm --prefix frontend run check"
+    },
+    "build": {
+      "frontend": "npm --prefix frontend run build",
+      "package": "uv build"
+    },
+    "smoke": {
+      "cli": "uv run mediaforce --help"
+    },
+    "acceptance": {
+      "default": "bash scripts/pre-commit-check.sh"
+    },
+    "inspection": {
+      "tool": "jetbrains",
+      "ide": "PyCharm",
+      "scopePreference": ["changed_files", "directory", "whole_project"]
+    },
+    "docsRequiredWhen": [
+      "behavior changes",
+      "api changes",
+      "config changes",
+      "operations changes",
+      "ownership boundaries change",
+      "user-visible UI changes",
+      "operator workflow changes",
+      "media processing behavior changes"
+    ]
+  },
+  "importantWorkflows": ["CI", "CodeQL", "Dependency Graph"],
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],
   "relatedRepos": [],
   "validatedThrough": [],
+  "githubSignals": {
+    "postMerge": {
+      "waitForActions": true,
+      "checkSecurityAndQuality": true
+    },
+    "capabilities": {
+      "codeScanning": "available",
+      "secretScanning": "available",
+      "dependabotAlerts": "available",
+      "securityAdvisories": "available"
+    },
+    "refreshWhen": [
+      "repo visibility changes",
+      "GitHub plan changes",
+      "security settings change",
+      "token permissions change"
+    ]
+  },
   "cleanup": {
     "deleteMergedLocalBranches": true,
     "removeMergedCleanWorktrees": true
+  },
+  "metadataFreshness": {
+    "updateWhen": [
+      "docs routing changes",
+      "validation gates change",
+      "primary commands change",
+      "important workflows change",
+      "repo relationship changes",
+      "cleanup policy changes",
+      "ownership boundaries change"
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 .mypy_cache/
 .ruff_cache/
 .code/
+*.override.*
 .ab-av1-*/
 
 frontend/node_modules/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,14 +17,10 @@ Only session-start facts that are easy to miss belong here.
   media artifacts into the repo
 - `uv build` now auto-builds `frontend/` during wheel packaging; do not rely on
   stale checked-in or local `frontend/build/` artifacts
+- Use `.github/github-repo-workflow.json` for repo commands and quality gates
 
-## Defaults
+## Workflow Notes
 
-- Backend targeted tests:
-  `uv run --with pytest pytest tests/test_encode_queue_recovery.py tests/test_tuning_runtime.py`
-- Frontend checks: `cd frontend && npm run check`
-- Full local acceptance gate: `bash scripts/pre-commit-check.sh`
-- CLI smoke: `uv run mediaforce --help`
 - UI changes: validate in a real browser
 - Before changing primary operator surfaces, read
   `docs/style/workstation-ui.md`


### PR DESCRIPTION
## Summary
- expand `.github/github-repo-workflow.json` with docs routing, quality gates, IDE inspection preferences, GitHub security signal capabilities, cleanup policy, and metadata freshness triggers
- move repo command defaults out of `AGENTS.md` and point agents at the workflow metadata JSON
- ignore local `*.override.*` files for private/local workflow overrides

## Validation
- `uv run --with pytest pytest -q -k "not test_bootstrap_remote_macos_returns_noop_when_no_bootstrap_issues and not test_bootstrap_remote_macos_routes_xcode_issue_to_request_helper and not test_remote_host_status_targets_current_machine_without_ssh_probe and not test_ffmpeg_hwaccel_included_when_videotoolbox_available"`
- `uv run mediaforce --help`
- `npm --prefix frontend ci`
- `npm --prefix frontend run check`
- `npm --prefix frontend run lint`
- `npm --prefix frontend test`
- `npm --prefix frontend run build`
- pre-commit acceptance gate: 463 backend tests, CLI smoke, frontend check/lint/test/build
- `jq empty .github/github-repo-workflow.json`
- `bash /Users/cbusillo/.code/skills/github-repo-workflow/scripts/github-repo-snapshot.sh --json`
- `git diff --check`

## Notes
- Existing CodeQL findings are tracked in #7.
- Existing Dependabot findings are tracked in #8.
- `npm --prefix frontend ci` reports 3 low-severity npm audit findings; those are covered by the dependency follow-up rather than this metadata PR.
- JetBrains inspection was not run for this worktree because PyCharm has the primary `/Users/cbusillo/Developer/mediaforce` checkout open, not the metadata rollout worktree.
