### PR TITLE
Preserve blank cleanup mode behavior

### DIFF
--- a/mediaforce/state_cleanup.py
+++ b/mediaforce/state_cleanup.py
@@ -327,7 +327,10 @@ def _remote_hosts_requiring_process_probe(
 ) -> list[dict[str, object]]:
     hosts: list[dict[str, object]] = []
     for host in config.remote_hosts:
-        mode = str(host.get("mode") or "ssh").strip().lower() or "ssh"
+        raw_mode = host.get("mode")
+        if raw_mode is not None and not str(raw_mode).strip():
+            continue
+        mode = str(raw_mode or "ssh").strip().lower() or "ssh"
         if mode != "ssh":
             continue
         if host_targets_current_machine(host):

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -5504,6 +5504,25 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         run_remote_mock.assert_called_once()
         self.assertEqual(snapshot.commands, ("remote-proc",))
 
+    def test_cleanup_process_snapshot_skips_remote_hosts_with_blank_mode(self) -> None:
+        self.config.raw["remote_hosts"] = [
+            {
+                "host": "cbusillo@example-host",
+                "label": "Remote",
+                "mode": "   ",
+                "capabilities": ["encode_queue"],
+            }
+        ]
+
+        with patch(
+                "mediaforce.state_cleanup._local_process_commands",
+                return_value=[],
+        ), patch("mediaforce.state_cleanup.run_remote_command") as run_remote_mock:
+            snapshot = state_cleanup._cleanup_process_snapshot(self.config)
+
+        run_remote_mock.assert_not_called()
+        self.assertEqual(snapshot.commands, ())
+
     def test_purge_transient_artifacts_prunes_orphaned_quality_temp_dirs_before_general_retention(self) -> None:
         temp_dir = self.config.paths.web_state_dir / "quality-temp" / ".mediaforce-ab-av1-orphan"
         temp_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- preserve the previous cleanup behavior for remote host rows with an explicitly blank or whitespace-only `mode`
- keep legacy remote host rows without a `mode` probing through SSH
- add regression coverage for the blank-mode skip behavior

## Validation

- `uv run --with pytest pytest tests/test_encode_queue_recovery.py::EncodeQueueRecoveryTests::test_purge_transient_artifacts_prunes_ab_av1_dirs_in_host_specific_staging_roots tests/test_encode_queue_recovery.py::EncodeQueueRecoveryTests::test_cleanup_process_snapshot_probes_remote_hosts_without_explicit_mode tests/test_encode_queue_recovery.py::EncodeQueueRecoveryTests::test_cleanup_process_snapshot_skips_remote_hosts_with_blank_mode`
- `uv run --with pytest pytest -q -k "not test_bootstrap_remote_macos_returns_noop_when_no_bootstrap_issues and not test_bootstrap_remote_macos_routes_xcode_issue_to_request_helper and not test_remote_host_status_targets_current_machine_without_ssh_probe and not test_ffmpeg_hwaccel_included_when_videotoolbox_available"`
- commit hook: `bash scripts/pre-commit-check.sh`

## Notes

Follow-up to the late auto-review finding after #19 merged.
