### PR TITLE
Normalize cleanup remote host mode handling

### DIFF
--- a/mediaforce/hosts/config.py
+++ b/mediaforce/hosts/config.py
@@ -91,6 +91,14 @@ def execution_mode_for_host(host: dict[str, object] | None) -> str:
     return mode
 
 
+def configured_remote_host_execution_mode(host: dict[str, object]) -> str:
+    host_payload = object_dict(host)
+    mode = str(host_payload.get("mode") or "ssh").strip().lower() or "ssh"
+    if mode == "ssh" and host_targets_current_machine(host_payload):
+        return "local"
+    return mode
+
+
 def _ssh_lookup_host(ssh_host: str) -> str:
     host_part = ssh_host.rsplit("@", 1)[-1].strip()
     if host_part.startswith("[") and "]" in host_part:
@@ -123,6 +131,7 @@ __all__ = [
     "_host_supports_capability",
     "_parse_utc_offset_minutes",
     "_ssh_lookup_host",
+    "configured_remote_host_execution_mode",
     "execution_mode_for_host",
     "host_media_access_for_host",
     "host_status_targets_current_machine",

--- a/mediaforce/state_cleanup.py
+++ b/mediaforce/state_cleanup.py
@@ -17,7 +17,7 @@ from mediaforce.encoding.quality import (
     previous_local_quality_temp_root,
 )
 from mediaforce.hosts import DEFAULT_HOST_CAPABILITIES
-from mediaforce.hosts.config import host_targets_current_machine
+from mediaforce.hosts.config import configured_remote_host_execution_mode
 from mediaforce.remote import run_remote_command
 
 SECONDS_PER_DAY = 86400
@@ -327,10 +327,7 @@ def _remote_hosts_requiring_process_probe(
 ) -> list[dict[str, object]]:
     hosts: list[dict[str, object]] = []
     for host in config.remote_hosts:
-        mode = str(host.get("mode") or "ssh").strip().lower() or "ssh"
-        if mode != "ssh":
-            continue
-        if host_targets_current_machine(host):
+        if configured_remote_host_execution_mode(host) != "ssh":
             continue
         capabilities = {
             str(capability).strip().lower()

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -65,6 +65,7 @@ from mediaforce.execution import (
 from mediaforce.library.folder_profiles import inspect_prefix
 from mediaforce.library.planner import build_manifest_item
 from mediaforce.hosts.types import HostSetupResult
+from mediaforce.hosts.config import configured_remote_host_execution_mode
 from mediaforce.core.process_control import ManagedProcessController
 from mediaforce.encoding.quality import run_sample_encode, select_quality_metric
 from mediaforce.remote import (
@@ -2924,7 +2925,7 @@ def _sweep_orphaned_encode_processes(config: MediaforceConfig, *, prefixes: list
         }
         if "encode_queue" not in capabilities:
             continue
-        if str(host.get("mode") or "ssh").strip().lower() != "ssh":
+        if configured_remote_host_execution_mode(host) != "ssh":
             continue
         try:
             path_filter = path_filter_for_host(host)

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -10256,6 +10256,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
     def test_sweep_orphaned_encode_processes_only_targets_ssh_encode_hosts(self) -> None:
         self.config.raw["remote_hosts"] = [
             {"host": "encode-a", "label": "Encode A", "mode": "ssh", "capabilities": ["encode_queue"]},
+            {"host": "encode-b", "label": "Encode B", "capabilities": ["encode_queue"]},
+            {"host": "encode-c", "label": "Encode C", "mode": "   ", "capabilities": ["encode_queue"]},
             {"host": "sample-only", "label": "Sample Only", "mode": "ssh", "capabilities": ["sample_calibration"]},
             {"host": "local-ish", "label": "Local-ish", "mode": "local", "capabilities": ["encode_queue"]},
         ]
@@ -10263,10 +10265,12 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         with patch("mediaforce.web.app.run_remote_command") as run_remote_command_mock:
             web_app._sweep_orphaned_encode_processes(self.config)
 
-        run_remote_command_mock.assert_called_once()
-        host_payload = run_remote_command_mock.call_args.args[0]
+        self.assertEqual(run_remote_command_mock.call_count, 3)
+        self.assertEqual(
+            [call.args[0]["host"] for call in run_remote_command_mock.call_args_list],
+            ["encode-a", "encode-b", "encode-c"],
+        )
         command_payload = run_remote_command_mock.call_args.args[1]
-        self.assertEqual(host_payload["host"], "encode-a")
         self.assertEqual(command_payload[:2], ["sh", "-lc"])
         self.assertIn("self_pgid=$(ps -o pgid= -p \"$self_pid\"", command_payload[2])
         self.assertIn("kill_tree() ( signal=$1; target=$2;", command_payload[2])


### PR DESCRIPTION
## Summary
- add a shared helper for configured remote host execution mode
- use it in both transient cleanup process probes and orphan encode sweeps
- cover omitted and whitespace-only host modes in orphan sweep tests

## Verification
- uv run --with pytest pytest tests/test_encode_queue_recovery.py -q -k "cleanup_process_snapshot or sweep_orphaned_encode_processes"
- uv run --with pytest pytest tests/test_encode_queue_recovery.py tests/test_tuning_runtime.py -q
- bash scripts/pre-commit-check.sh
- PyCharm inspections on changed files: existing weak warnings only