### PR TITLE
Build Ops workstation

### DIFF
--- a/frontend/src/lib/components/workstation/OperatorShell.svelte
+++ b/frontend/src/lib/components/workstation/OperatorShell.svelte
@@ -2,7 +2,7 @@
 	import { resolve } from '$app/paths';
 	import type { Snippet } from 'svelte';
 
-	export type ShellRouteId = 'queue' | 'studio';
+	export type ShellRouteId = 'queue' | 'ops' | 'studio';
 	export type ShellTone = 'active' | 'ready' | 'wait' | 'fail' | 'idle';
 	export type StatusTile = {
 		label: string;
@@ -20,8 +20,11 @@
 	const navItems: Array<{
 		id: ShellRouteId;
 		label: string;
-		href: '/' | '/folders';
-	}> = [{ id: 'queue', label: 'Queue', href: '/' }];
+		href: '/' | '/folders' | '/ops';
+	}> = [
+		{ id: 'queue', label: 'Queue', href: '/' },
+		{ id: 'ops', label: 'Ops', href: '/ops' }
+	];
 
 	let {
 		route,

--- a/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
@@ -1,0 +1,780 @@
+<script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { postJson } from '$lib/api/client';
+	import type { DashboardSummaryPayload, HostRuntime, HostsPayload } from '$lib/api/types';
+	import { folderRoutePath } from '$lib/folder-display';
+	import OperatorShell from './OperatorShell.svelte';
+	import StateBadge from './StateBadge.svelte';
+	import WorkstationPanel from './WorkstationPanel.svelte';
+	import {
+		buildOpsBlockers,
+		buildOpsFooterSignals,
+		buildOpsQueueRows,
+		buildOpsStatusTiles,
+		hostStateCopy,
+		hostTone,
+		type OpsActionId,
+		type OpsQueueRow
+	} from './ops-workstation';
+
+	let {
+		dashboard,
+		hosts,
+		loadError
+	}: {
+		dashboard: DashboardSummaryPayload | null;
+		hosts: HostsPayload | null;
+		loadError: string | null;
+	} = $props();
+
+	const queueRows = $derived(buildOpsQueueRows(dashboard));
+	const blockers = $derived(buildOpsBlockers(dashboard, hosts, loadError));
+	const statusTiles = $derived(buildOpsStatusTiles(dashboard, hosts, loadError));
+	const footerSignals = $derived(buildOpsFooterSignals(dashboard, hosts));
+	const encodeQueue = $derived(dashboard?.encode_queue ?? null);
+	const calibrationQueue = $derived(dashboard?.calibration_queue ?? null);
+	const activeJobCount = $derived(
+		(encodeQueue?.running_count ?? 0) +
+			(encodeQueue?.queued_count ?? 0) +
+			(calibrationQueue?.active_count ?? 0)
+	);
+	const queuedWaitingCount = $derived(encodeQueue?.queued_waiting_count ?? 0);
+	const needsAttentionCount = $derived(encodeQueue?.needs_attention_count ?? 0);
+	const readyHosts = $derived(hosts?.hosts.filter((host) => host.available).length ?? 0);
+	const closedHosts = $derived(hosts?.hosts.filter((host) => host.schedule_open === false) ?? []);
+
+	let actionPending = $state<OpsActionId | null>(null);
+	let confirmationAction = $state<OpsActionId | null>(null);
+	let actionMessage = $state('');
+	let actionError = $state('');
+
+	const actionEndpoints: Record<OpsActionId, string> = {
+		'pause-encode': '/api/encode-queue/pause',
+		'resume-encode': '/api/encode-queue/resume',
+		'retry-failed-encode': '/api/encode-queue/retry-failed',
+		'stop-encode': '/api/encode-queue/stop',
+		'stop-calibration': '/api/calibration-queue/stop',
+		'start-host': '/api/hosts/start',
+		'prepare-host': '/api/hosts/prepare',
+		'reset-host-trust': '/api/hosts/reset-trust'
+	};
+
+	function actionRequiresConfirmation(action: OpsActionId): boolean {
+		return action === 'stop-encode' || action === 'stop-calibration';
+	}
+
+	function actionTitle(action: OpsActionId): string {
+		if (action === 'stop-encode') return 'Stop running encode workers and pause the queue';
+		if (action === 'stop-calibration') return 'Stop running and queued sample/proof jobs';
+		if (action === 'retry-failed-encode')
+			return 'Retry failed folder encodes that are still approved';
+		if (action === 'pause-encode') return 'Pause the encode scheduler';
+		if (action === 'resume-encode') return 'Resume the encode scheduler and clear stop request';
+		if (action === 'start-host') return 'Start or wake this host';
+		if (action === 'prepare-host') return 'Prepare this host for Mediaforce work';
+		return 'Reset stored trust for this host';
+	}
+
+	function actionBody(host?: HostRuntime): Record<string, unknown> {
+		return host ? { host_key: host.key } : {};
+	}
+
+	async function runAction(action: OpsActionId, host?: HostRuntime) {
+		actionMessage = '';
+		actionError = '';
+		if (actionRequiresConfirmation(action) && confirmationAction !== action) {
+			confirmationAction = action;
+			actionMessage = 'Confirm the interrupting action with a second click.';
+			return;
+		}
+		confirmationAction = null;
+		actionPending = action;
+		try {
+			const endpoint = `${resolve('/')}${actionEndpoints[action].slice(1)}`;
+			const response = await postJson<Record<string, unknown>>(endpoint, actionBody(host));
+			actionMessage =
+				typeof response.message === 'string' && response.message.trim()
+					? response.message
+					: 'Action completed.';
+			await invalidateAll();
+		} catch (error) {
+			actionError = error instanceof Error ? error.message : 'Action failed.';
+		} finally {
+			actionPending = null;
+		}
+	}
+
+	function rowActionDisabled(row: OpsQueueRow): boolean {
+		return actionPending !== null || !row.action;
+	}
+
+	function hostActionDisabled(action: OpsActionId, host: HostRuntime): boolean {
+		if (actionPending !== null) return true;
+		if (action === 'start-host') return host.available || !host.setup_supported;
+		if (action === 'prepare-host') return host.setup_requires_password || !host.setup_supported;
+		if (action === 'reset-host-trust') return !host.trust_reset_supported;
+		return false;
+	}
+
+	function queueActionLabel(action: OpsActionId): string {
+		if (confirmationAction === action) return 'Confirm';
+		if (actionPending === action) return 'Working';
+		if (action === 'pause-encode') return 'Pause';
+		if (action === 'resume-encode') return 'Resume';
+		if (action === 'retry-failed-encode') return 'Retry failed';
+		if (action === 'stop-encode') return 'Stop encode';
+		if (action === 'stop-calibration') return 'Stop samples';
+		if (action === 'start-host') return 'Start';
+		if (action === 'prepare-host') return 'Prepare';
+		if (action === 'reset-host-trust') return 'Trust';
+		return 'Run';
+	}
+
+	function canOpenFolder(row: OpsQueueRow): boolean {
+		return row.prefix !== 'runtime scope';
+	}
+</script>
+
+<OperatorShell route="ops" subject="Ops" crumb="/ops" {statusTiles} {footerSignals}>
+	<main class="ops">
+		<section class="ops__main" aria-label="Ops workstation">
+			<header class="ops-header">
+				<div>
+					<span class="mf-eyebrow">Ops</span>
+					<h1>Encode and sample control</h1>
+					<p>
+						Monitor active work, scheduler pressure, blocked retries, and host readiness from the
+						workstation shell.
+					</p>
+				</div>
+				<div class="ops-header__facts">
+					<div>
+						<span>Active work</span>
+						<strong>{activeJobCount.toLocaleString('en-US')}</strong>
+					</div>
+					<div>
+						<span>Blocked</span>
+						<strong>{needsAttentionCount.toLocaleString('en-US')}</strong>
+					</div>
+					<div>
+						<span>Hosts ready</span>
+						<strong>{readyHosts.toLocaleString('en-US')}</strong>
+					</div>
+				</div>
+			</header>
+
+			<WorkstationPanel eyebrow="Control" title="Scheduler and recovery">
+				<div class="scheduler-console">
+					<div class="scheduler-console__state">
+						<StateBadge
+							tone={encodeQueue?.state.stop_requested
+								? 'fail'
+								: encodeQueue?.state.is_paused
+									? 'wait'
+									: 'ready'}
+							label={encodeQueue?.state.stop_requested
+								? 'Stopping'
+								: encodeQueue?.state.is_paused
+									? 'Paused'
+									: 'Open'}
+						/>
+						<div>
+							<strong>{encodeQueue?.state.scheduler_summary ?? 'Scheduler data unavailable'}</strong
+							>
+							<span
+								>{queuedWaitingCount.toLocaleString('en-US')} waiting · {needsAttentionCount.toLocaleString(
+									'en-US'
+								)}
+								need attention</span
+							>
+						</div>
+					</div>
+					<div class="scheduler-console__actions" aria-label="Scheduler controls">
+						<button
+							type="button"
+							class="control"
+							disabled={!encodeQueue ||
+								encodeQueue.state.is_paused ||
+								encodeQueue.state.stop_requested ||
+								actionPending !== null}
+							title={actionTitle('pause-encode')}
+							onclick={() => runAction('pause-encode')}>{queueActionLabel('pause-encode')}</button
+						>
+						<button
+							type="button"
+							class="control control--ready"
+							disabled={!encodeQueue ||
+								(!encodeQueue.state.is_paused && !encodeQueue.state.stop_requested) ||
+								actionPending !== null}
+							title={actionTitle('resume-encode')}
+							onclick={() => runAction('resume-encode')}>{queueActionLabel('resume-encode')}</button
+						>
+						<button
+							type="button"
+							class="control control--warn"
+							disabled={!encodeQueue || needsAttentionCount === 0 || actionPending !== null}
+							title={actionTitle('retry-failed-encode')}
+							onclick={() => runAction('retry-failed-encode')}
+							>{queueActionLabel('retry-failed-encode')}</button
+						>
+						<button
+							type="button"
+							class="control control--danger"
+							class:control--armed={confirmationAction === 'stop-encode'}
+							disabled={!encodeQueue ||
+								(encodeQueue.running_count === 0 &&
+									encodeQueue.queued_count === 0 &&
+									!encodeQueue.state.is_paused) ||
+								actionPending !== null}
+							title={actionTitle('stop-encode')}
+							onclick={() => runAction('stop-encode')}>{queueActionLabel('stop-encode')}</button
+						>
+						<button
+							type="button"
+							class="control control--danger"
+							class:control--armed={confirmationAction === 'stop-calibration'}
+							disabled={!calibrationQueue ||
+								calibrationQueue.active_count === 0 ||
+								actionPending !== null}
+							title={actionTitle('stop-calibration')}
+							onclick={() => runAction('stop-calibration')}
+							>{queueActionLabel('stop-calibration')}</button
+						>
+					</div>
+					{#if actionMessage}
+						<p class="action-message">{actionMessage}</p>
+					{/if}
+					{#if actionError}
+						<p class="action-error">{actionError}</p>
+					{/if}
+				</div>
+			</WorkstationPanel>
+
+			<WorkstationPanel eyebrow="Blockers" title="Blocked and retryable work">
+				<div class="blocker-list">
+					{#each blockers.slice(0, 6) as blocker (blocker.key)}
+						<div class="blocker-row blocker-row--{blocker.tone}">
+							<StateBadge
+								tone={blocker.tone}
+								label={blocker.tone === 'fail' ? 'Blocked' : 'Waiting'}
+							/>
+							<div>
+								<strong>{blocker.title}</strong>
+								<span>{blocker.detail}</span>
+							</div>
+							{#if blocker.action}
+								{@const action = blocker.action}
+								<button
+									type="button"
+									class="control"
+									disabled={actionPending !== null}
+									title={actionTitle(action)}
+									onclick={() => runAction(action)}>{queueActionLabel(action)}</button
+								>
+							{/if}
+						</div>
+					{:else}
+						<div class="empty-note">
+							No blocked or retryable work is visible in the runtime payload.
+						</div>
+					{/each}
+				</div>
+			</WorkstationPanel>
+
+			<WorkstationPanel
+				eyebrow="Jobs"
+				title="Running, queued, and recovery queue"
+				meta={`${queueRows.length.toLocaleString('en-US')} visible`}
+			>
+				<div class="table-wrap">
+					<table>
+						<thead>
+							<tr>
+								<th>State</th>
+								<th>Work</th>
+								<th>Host</th>
+								<th>Progress</th>
+								<th>Scheduler</th>
+								<th>Recovery</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each queueRows as row (row.key)}
+								<tr class:job-row--blocked={row.tone === 'fail'}>
+									<td><StateBadge compact tone={row.tone} label={row.status} /></td>
+									<td>
+										{#if canOpenFolder(row)}
+											<a class="work-link" href={resolve(folderRoutePath(row.prefix))}>
+												<strong>{row.prefix}</strong>
+												<span>{row.kind} · {row.phase}</span>
+											</a>
+										{:else}
+											<div class="work-link">
+												<strong>{row.prefix}</strong>
+												<span>{row.kind} · {row.phase}</span>
+											</div>
+										{/if}
+									</td>
+									<td>{row.host}</td>
+									<td>
+										<strong>{row.progress}</strong>
+										<span>{row.detail}</span>
+									</td>
+									<td>{row.scheduler}</td>
+									<td>
+										{#if row.action}
+											{@const action = row.action}
+											<button
+												type="button"
+												class="control control--compact"
+												disabled={rowActionDisabled(row)}
+												title={actionTitle(action)}
+												onclick={() => runAction(action)}>{queueActionLabel(action)}</button
+											>
+										{:else}
+											<span class="disabled-copy">No action</span>
+										{/if}
+									</td>
+								</tr>
+							{:else}
+								<tr>
+									<td colspan="6">
+										No active encode, sample, or proof jobs are visible. Scheduler controls remain
+										available when runtime data is present.
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+			</WorkstationPanel>
+		</section>
+
+		<aside class="ops__rail" aria-label="Host readiness">
+			<WorkstationPanel
+				eyebrow="Hosts"
+				title="Readiness"
+				meta={`${readyHosts.toLocaleString('en-US')}/${hosts?.hosts.length ?? 0}`}
+			>
+				<div class="host-list">
+					{#each hosts?.hosts ?? [] as host (host.key)}
+						<div class="host-row">
+							<div class="host-row__head">
+								<StateBadge compact tone={hostTone(host)} label={hostStateCopy(host)} />
+								<strong>{host.label}</strong>
+							</div>
+							<dl>
+								<dt>Capability</dt>
+								<dd>{host.capabilities.join(' · ') || 'none'}</dd>
+								<dt>Schedule</dt>
+								<dd>{host.schedule_detail || host.schedule_profile_label}</dd>
+								<dt>Active</dt>
+								<dd>{host.active_encode_count.toLocaleString('en-US')} encodes</dd>
+								<dt>Reason</dt>
+								<dd>{host.message || host.active_reason || 'ready'}</dd>
+							</dl>
+							<div class="host-row__actions" aria-label={`${host.label} controls`}>
+								<button
+									type="button"
+									class="control control--compact"
+									disabled={hostActionDisabled('start-host', host)}
+									title={hostActionDisabled('start-host', host)
+										? 'Start is unavailable for this host state.'
+										: actionTitle('start-host')}
+									onclick={() => runAction('start-host', host)}>Start</button
+								>
+								<button
+									type="button"
+									class="control control--compact"
+									disabled={hostActionDisabled('prepare-host', host)}
+									title={host.setup_requires_password
+										? 'Prepare requires a password from Settings.'
+										: actionTitle('prepare-host')}
+									onclick={() => runAction('prepare-host', host)}>Prepare</button
+								>
+								<button
+									type="button"
+									class="control control--compact"
+									disabled={hostActionDisabled('reset-host-trust', host)}
+									title={host.trust_reset_supported
+										? actionTitle('reset-host-trust')
+										: 'Trust reset is unavailable for this host.'}
+									onclick={() => runAction('reset-host-trust', host)}>Trust</button
+								>
+							</div>
+						</div>
+					{:else}
+						<div class="empty-note">Host runtime data is missing.</div>
+					{/each}
+				</div>
+			</WorkstationPanel>
+
+			<WorkstationPanel eyebrow="Schedule" title="Window state">
+				<div class="schedule-list">
+					<div class="scope-row scope-row--active">
+						<span>Policy</span>
+						<strong>{encodeQueue?.state.scheduler_summary ?? 'unknown'}</strong>
+						<small
+							>{queuedWaitingCount.toLocaleString('en-US')} encode jobs waiting on schedule</small
+						>
+					</div>
+					{#each closedHosts as host (host.key)}
+						<div class="scope-row scope-row--wait">
+							<span>{host.label}</span>
+							<strong>Closed</strong>
+							<small>{host.schedule_detail}</small>
+						</div>
+					{:else}
+						<div class="scope-row">
+							<span>Host windows</span>
+							<strong>Open or unavailable</strong>
+							<small>No scheduled-off host reported by the runtime payload</small>
+						</div>
+					{/each}
+				</div>
+			</WorkstationPanel>
+		</aside>
+	</main>
+</OperatorShell>
+
+<style>
+	.ops {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) var(--mf-workstation-rail-width);
+		min-height: calc(100vh - 178px);
+	}
+
+	.ops__main {
+		align-content: start;
+		display: grid;
+		gap: var(--mf-space-5);
+		min-width: 0;
+		padding: var(--mf-space-6);
+	}
+
+	.ops__rail {
+		align-content: start;
+		background: var(--mf-bg-shell);
+		border-left: var(--mf-border);
+		display: flex;
+		flex-direction: column;
+		gap: var(--mf-space-5);
+		min-width: 0;
+		padding: var(--mf-space-5);
+	}
+
+	.ops-header {
+		align-items: end;
+		border-bottom: var(--mf-border);
+		display: grid;
+		gap: var(--mf-space-6);
+		grid-template-columns: minmax(0, 1fr) auto;
+		padding-bottom: var(--mf-space-5);
+	}
+
+	.ops-header h1 {
+		margin-top: var(--mf-space-3);
+	}
+
+	.ops-header p {
+		margin-top: var(--mf-space-3);
+		max-width: 74ch;
+	}
+
+	.ops-header__facts {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--mf-space-5);
+	}
+
+	.ops-header__facts div {
+		display: grid;
+		gap: var(--mf-space-2);
+		min-width: 88px;
+	}
+
+	.ops-header__facts span,
+	.scope-row span,
+	.host-row dt {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.ops-header__facts strong,
+	.host-row dd {
+		font-family: var(--mf-font-mono);
+		font-size: var(--mf-text-sm);
+		font-weight: var(--mf-weight-medium);
+	}
+
+	.scheduler-console,
+	.blocker-list,
+	.host-list,
+	.schedule-list {
+		display: grid;
+		gap: var(--mf-space-4);
+		padding: var(--mf-space-5);
+	}
+
+	.scheduler-console__state,
+	.blocker-row {
+		align-items: center;
+		display: grid;
+		gap: var(--mf-space-4);
+		grid-template-columns: auto minmax(0, 1fr) auto;
+	}
+
+	.scheduler-console__state > div,
+	.blocker-row > div {
+		display: grid;
+		gap: var(--mf-space-1);
+		min-width: 0;
+	}
+
+	.scheduler-console__state strong,
+	.blocker-row strong,
+	.host-row strong,
+	.scope-row strong {
+		font-size: var(--mf-text-sm);
+		font-weight: var(--mf-weight-semibold);
+		overflow-wrap: anywhere;
+	}
+
+	.scheduler-console__state span,
+	.blocker-row span,
+	.scope-row small {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-xs);
+	}
+
+	.scheduler-console__actions,
+	.host-row__actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--mf-space-3);
+	}
+
+	.action-message,
+	.action-error {
+		border-left: 2px solid var(--mf-ready-fg);
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-xs);
+		padding-left: var(--mf-space-4);
+	}
+
+	.action-error {
+		border-left-color: var(--mf-fail-fg);
+		color: var(--mf-fail-fg);
+	}
+
+	.blocker-row {
+		background: var(--mf-bg-panel-2);
+		border: var(--mf-border-muted);
+		border-left: 2px solid var(--mf-line-strong);
+		min-height: var(--mf-row-comfy);
+		padding: var(--mf-space-4);
+	}
+
+	.blocker-row--fail {
+		background: var(--mf-fail-bg);
+		border-left-color: var(--mf-fail-fg);
+	}
+
+	.blocker-row--wait {
+		background: var(--mf-wait-bg);
+		border-left-color: var(--mf-wait-fg);
+	}
+
+	.table-wrap {
+		overflow: auto;
+	}
+
+	table {
+		border-collapse: collapse;
+		min-width: 860px;
+		width: 100%;
+	}
+
+	th,
+	td {
+		border-bottom: var(--mf-border-muted);
+		font-size: var(--mf-text-xs);
+		height: var(--mf-row-default);
+		padding: var(--mf-space-2) var(--mf-space-5);
+		text-align: left;
+		vertical-align: middle;
+	}
+
+	th {
+		background: var(--mf-bg-strip);
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0.08em;
+		position: sticky;
+		text-transform: uppercase;
+		top: 0;
+	}
+
+	td:nth-child(3),
+	td:nth-child(4),
+	td:nth-child(5) {
+		font-family: var(--mf-font-mono);
+	}
+
+	td:nth-child(4) {
+		display: grid;
+		gap: var(--mf-space-1);
+	}
+
+	td:nth-child(4) span {
+		color: var(--mf-fg-tertiary);
+		font-family: var(--mf-font-sans);
+		overflow-wrap: anywhere;
+	}
+
+	.job-row--blocked {
+		background: var(--mf-fail-bg);
+	}
+
+	.work-link {
+		display: grid;
+		gap: var(--mf-space-1);
+		min-width: 0;
+	}
+
+	.work-link strong {
+		font-size: var(--mf-text-sm);
+		font-weight: var(--mf-weight-semibold);
+		overflow-wrap: anywhere;
+	}
+
+	.work-link span,
+	.disabled-copy {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+	}
+
+	.control {
+		align-items: center;
+		background: var(--mf-bg-panel-2);
+		border: var(--mf-border-strong);
+		border-radius: var(--mf-radius-1);
+		color: var(--mf-fg-primary);
+		display: inline-flex;
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-semibold);
+		justify-content: center;
+		min-height: var(--mf-control-md);
+		padding: 0 var(--mf-space-4);
+		white-space: nowrap;
+	}
+
+	.control:hover:not(:disabled) {
+		background: var(--mf-bg-raised);
+	}
+
+	.control:disabled {
+		border-color: var(--mf-line-muted);
+	}
+
+	.control--compact {
+		min-height: var(--mf-control-sm);
+	}
+
+	.control--ready {
+		border-color: var(--mf-ready-line);
+		color: var(--mf-ready-fg);
+	}
+
+	.control--warn {
+		border-color: var(--mf-wait-line);
+		color: var(--mf-wait-fg);
+	}
+
+	.control--danger {
+		border-color: var(--mf-fail-line);
+		color: var(--mf-fail-fg);
+	}
+
+	.control--armed {
+		background: var(--mf-fail-bg-strong);
+		border-color: var(--mf-fail-fg);
+		color: var(--mf-fail-fg-bright);
+	}
+
+	.host-row {
+		background: var(--mf-bg-panel-2);
+		border: var(--mf-border-muted);
+		display: grid;
+		gap: var(--mf-space-4);
+		padding: var(--mf-space-4);
+	}
+
+	.host-row__head {
+		align-items: center;
+		display: grid;
+		gap: var(--mf-space-3);
+		grid-template-columns: auto minmax(0, 1fr);
+	}
+
+	.host-row dl {
+		display: grid;
+		grid-template-columns: 72px minmax(0, 1fr);
+		row-gap: var(--mf-space-3);
+	}
+
+	.host-row dd {
+		overflow-wrap: anywhere;
+	}
+
+	.scope-row {
+		border-left: 2px solid var(--mf-line-strong);
+		display: grid;
+		gap: var(--mf-space-2);
+		padding: var(--mf-space-4);
+	}
+
+	.scope-row--active {
+		background: var(--mf-active-bg);
+		border-left-color: var(--mf-active-fg);
+	}
+
+	.scope-row--wait {
+		background: var(--mf-wait-bg);
+		border-left-color: var(--mf-wait-fg);
+	}
+
+	.empty-note {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-sm);
+		padding: var(--mf-space-5);
+	}
+
+	@media (max-width: 980px) {
+		.ops {
+			grid-template-columns: 1fr;
+		}
+
+		.ops__rail {
+			border-left: 0;
+			border-top: var(--mf-border);
+		}
+
+		.ops-header {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 680px) {
+		.scheduler-console__state,
+		.blocker-row {
+			align-items: start;
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/workstation/ops-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+import type { DashboardSummaryPayload, HostsPayload } from '$lib/api/types';
+import {
+	buildOpsBlockers,
+	buildOpsQueueRows,
+	buildOpsStatusTiles,
+	hostStateCopy,
+	hostTone
+} from './ops-workstation';
+
+function dashboardFixture(): DashboardSummaryPayload {
+	return {
+		folders_preview: [],
+		library_colors: {},
+		scan_job: null,
+		calibration_queue: {
+			sample: {
+				running: [
+					{
+						job_id: 'sample-1',
+						prefix: 'tv/show/season 1',
+						status: 'running',
+						host: { label: 'studio-mini' }
+					}
+				],
+				queued: [],
+				pending_review: [],
+				running_count: 1,
+				queued_count: 0,
+				pending_review_count: 0
+			},
+			full: {
+				running: [],
+				queued: [],
+				pending_review: [],
+				running_count: 0,
+				queued_count: 0,
+				pending_review_count: 0
+			},
+			active_count: 1
+		},
+		encode_queue: {
+			running_count: 1,
+			queued_count: 1,
+			queued_waiting_count: 1,
+			needs_attention_count: 1,
+			running: [
+				{
+					job_id: 'encode-1',
+					prefix: 'movies/feature',
+					status: 'running',
+					host: { label: 'worker-1' },
+					progress: { percent_complete: 42, current_item_number: 2, total_item_count: 4 },
+					scheduler_status_copy: 'inside encode window'
+				}
+			],
+			queued: [
+				{
+					job_id: 'encode-2',
+					prefix: 'tv/show/season 2',
+					status: 'retry_backoff',
+					error: 'transient worker fault',
+					scheduler_status_copy: 'retry backoff'
+				}
+			],
+			recent: [
+				{
+					job_id: 'encode-3',
+					prefix: 'tv/show/season 3',
+					status: 'needs_attention',
+					error: 'quality target missed'
+				}
+			],
+			state: {
+				is_paused: false,
+				stop_requested: false,
+				scheduler_summary: 'weekdays 09:00-22:00'
+			},
+			telemetry: { eta_copy: '24m' }
+		},
+		archive_cleanup: {
+			archive_root: '/runtime/archive',
+			file_count: 0,
+			total_size_bytes: 0,
+			has_cleanup: false
+		},
+		catalog_empty: false,
+		folder_cache_key: 'fixture',
+		metric_support: { vmaf: true, xpsnr: false, ssim: true },
+		metric_status_copy: 'VMAF · SSIM'
+	};
+}
+
+function hostsFixture(): HostsPayload {
+	return {
+		compact: true,
+		hosts: [
+			{
+				key: 'worker-1',
+				label: 'worker-1',
+				available: true,
+				message: 'ready',
+				missing_paths: [],
+				issues: [],
+				detail: null,
+				capabilities: ['encode_queue'],
+				priority: 1,
+				max_parallel_encodes: 2,
+				active_encode_count: 1,
+				schedule_profile_label: 'day shift',
+				schedule_detail: 'open until 22:00',
+				schedule_open: true,
+				active_flag: 'ready',
+				active_reason: 'ready',
+				queue_active: true
+			},
+			{
+				key: 'overnight',
+				label: 'overnight',
+				available: true,
+				message: 'schedule closed',
+				missing_paths: [],
+				issues: [],
+				detail: null,
+				capabilities: ['encode_queue'],
+				priority: 2,
+				max_parallel_encodes: 1,
+				active_encode_count: 0,
+				schedule_profile_label: 'overnight',
+				schedule_detail: 'opens at 23:00',
+				schedule_open: false,
+				active_flag: 'scheduled',
+				active_reason: 'outside schedule',
+				queue_active: true
+			}
+		]
+	};
+}
+
+describe('Ops workstation mapping', () => {
+	it('prioritizes running, queued, retryable encode, and sample rows', () => {
+		const rows = buildOpsQueueRows(dashboardFixture());
+
+		expect(rows.map((row) => row.key)).toEqual([
+			'encode:encode-1',
+			'encode:encode-2',
+			'encode:encode-3',
+			'sample:sample-1'
+		]);
+		expect(rows[1]).toMatchObject({
+			tone: 'wait',
+			action: 'retry-failed-encode',
+			detail: 'transient worker fault'
+		});
+		expect(rows[2]).toMatchObject({
+			tone: 'fail',
+			action: 'retry-failed-encode',
+			detail: 'quality target missed'
+		});
+	});
+
+	it('surfaces runtime partials, failed encodes, and closed schedules as blockers', () => {
+		const blockers = buildOpsBlockers(dashboardFixture(), hostsFixture(), 'Dashboard unavailable');
+
+		expect(blockers.map((blocker) => blocker.key)).toEqual([
+			'runtime-load',
+			'needs-attention',
+			'host:overnight'
+		]);
+		expect(blockers[0]).toMatchObject({ tone: 'fail', title: 'Runtime data partial' });
+		expect(blockers[1]).toMatchObject({ action: 'retry-failed-encode' });
+		expect(blockers[2]).toMatchObject({ tone: 'wait', detail: 'opens at 23:00' });
+	});
+
+	it('keeps scheduler, attention, sample, and host tones semantic', () => {
+		const tiles = buildOpsStatusTiles(dashboardFixture(), hostsFixture(), null);
+
+		expect(tiles).toMatchObject([
+			{ label: 'Scheduler', tone: 'ready' },
+			{ label: 'Encode jobs', tone: 'fail' },
+			{ label: 'Samples', tone: 'active' },
+			{ label: 'Hosts', tone: 'ready' }
+		]);
+	});
+
+	it('distinguishes available, scheduled-off, and unavailable host states', () => {
+		const [ready, scheduledOff] = hostsFixture().hosts;
+		const unavailable = { ...ready, available: false, active_encode_count: 0 };
+
+		expect(hostTone(ready)).toBe('active');
+		expect(hostStateCopy(ready)).toBe('Encoding');
+		expect(hostTone(scheduledOff)).toBe('wait');
+		expect(hostStateCopy(scheduledOff)).toBe('Off window');
+		expect(hostTone(unavailable)).toBe('fail');
+		expect(hostStateCopy(unavailable)).toBe('Unavailable');
+	});
+});

--- a/frontend/src/lib/components/workstation/ops-workstation.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.ts
@@ -1,0 +1,356 @@
+import type {
+	DashboardSummaryPayload,
+	EncodeQueueJob,
+	HostRuntime,
+	HostsPayload
+} from '$lib/api/types';
+import type { FooterSignal, ShellTone, StatusTile } from './OperatorShell.svelte';
+
+export type OpsQueueKind = 'encode' | 'sample' | 'proof';
+export type OpsActionId =
+	| 'pause-encode'
+	| 'resume-encode'
+	| 'retry-failed-encode'
+	| 'stop-encode'
+	| 'stop-calibration'
+	| 'start-host'
+	| 'prepare-host'
+	| 'reset-host-trust';
+
+export type OpsQueueRow = {
+	key: string;
+	kind: OpsQueueKind;
+	tone: ShellTone;
+	status: string;
+	prefix: string;
+	host: string;
+	phase: string;
+	progress: string;
+	scheduler: string;
+	detail: string;
+	action?: OpsActionId;
+};
+
+export type OpsBlocker = {
+	key: string;
+	tone: ShellTone;
+	title: string;
+	detail: string;
+	action?: OpsActionId;
+};
+
+type CalibrationJob = Record<string, unknown>;
+
+function compactText(value: unknown): string {
+	return typeof value === 'string' ? value.trim() : '';
+}
+
+function numberValue(value: unknown): number {
+	return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function percentCopy(value: unknown): string {
+	if (typeof value !== 'number' || !Number.isFinite(value)) return '—';
+	return `${Math.round(value)}%`;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}
+
+function hostCopy(value: unknown): string {
+	const host = record(value);
+	if (!host) return 'unassigned';
+	return compactText(host.label) || compactText(host.key) || compactText(host.host) || 'host';
+}
+
+function calibrationHostCopy(job: CalibrationJob): string {
+	const host = record(job.host);
+	return hostCopy(host) || compactText(job.host_key) || 'unassigned';
+}
+
+function calibrationPrefix(job: CalibrationJob): string {
+	return compactText(job.prefix) || compactText(job.folder_prefix) || 'runtime scope';
+}
+
+function calibrationDetail(job: CalibrationJob): string {
+	return (
+		compactText(job.error) ||
+		compactText(job.notes) ||
+		compactText(job.operator_note) ||
+		compactText(job.created_at) ||
+		'waiting for worker update'
+	);
+}
+
+function statusTone(status: string): ShellTone {
+	if (['failed', 'needs_attention', 'stopped', 'error'].includes(status)) return 'fail';
+	if (['running', 'processing', 'active'].includes(status)) return 'active';
+	if (['queued', 'pending_review', 'retry_backoff', 'waiting'].includes(status)) return 'wait';
+	if (['completed', 'ready'].includes(status)) return 'ready';
+	return 'idle';
+}
+
+function statusCopy(status: string): string {
+	return status.replaceAll('_', ' ');
+}
+
+export function encodeJobTone(job: EncodeQueueJob): ShellTone {
+	if (job.status === 'retry_backoff') return 'wait';
+	return statusTone(String(job.status ?? '').toLowerCase());
+}
+
+export function encodeJobProgress(job: EncodeQueueJob): string {
+	const progress = job.progress;
+	if (!progress) {
+		const completed = numberValue(job.completed_shard_count);
+		const total = numberValue(job.shard_count);
+		return total > 0 ? `${completed}/${total} shards` : '—';
+	}
+	const percent = percentCopy(progress.percent_complete);
+	const item =
+		progress.current_item_number && progress.total_item_count
+			? `${progress.current_item_number}/${progress.total_item_count}`
+			: '';
+	return [percent, item].filter((part) => part && part !== '—').join(' · ') || percent;
+}
+
+export function encodeJobDetail(job: EncodeQueueJob): string {
+	return (
+		job.error ||
+		job.attempt_summary ||
+		job.telemetry_summary ||
+		job.progress?.current_item_rel_path ||
+		job.progress?.failure_analysis?.summary ||
+		'waiting for queue telemetry'
+	);
+}
+
+export function buildEncodeRows(
+	dashboard: DashboardSummaryPayload | null | undefined
+): OpsQueueRow[] {
+	const queue = dashboard?.encode_queue;
+	if (!queue) return [];
+	const recentAttention = (queue.recent ?? []).filter((job) =>
+		['failed', 'needs_attention', 'stopped'].includes(String(job.status ?? '').toLowerCase())
+	);
+	return [...queue.running, ...queue.queued, ...recentAttention].map((job) => ({
+		key: `encode:${job.job_id}`,
+		kind: 'encode',
+		tone: encodeJobTone(job),
+		status: statusCopy(job.status || 'unknown'),
+		prefix: job.prefix || 'runtime scope',
+		host: job.active_hosts?.map(hostCopy).filter(Boolean).join(', ') || hostCopy(job.host),
+		phase: job.running_shard_count ? `${job.running_shard_count} active shards` : 'encode queue',
+		progress: encodeJobProgress(job),
+		scheduler: job.scheduler_status_copy || (job.schedule_waiting ? 'schedule waiting' : 'ready'),
+		detail: encodeJobDetail(job),
+		action: ['failed', 'needs_attention', 'stopped', 'retry_backoff'].includes(job.status)
+			? 'retry-failed-encode'
+			: undefined
+	}));
+}
+
+function buildCalibrationLaneRows(
+	laneName: OpsQueueKind,
+	jobs: CalibrationJob[] | undefined,
+	status: string
+): OpsQueueRow[] {
+	return (jobs ?? []).map((job, index) => ({
+		key: `${laneName}:${compactText(job.job_id) || compactText(job.prefix) || `${status}:${index}`}`,
+		kind: laneName,
+		tone: statusTone(status),
+		status: statusCopy(status),
+		prefix: calibrationPrefix(job),
+		host: calibrationHostCopy(job),
+		phase: laneName === 'sample' ? 'sample calibration' : 'proof encode',
+		progress: compactText(job.progress) || compactText(job.stage) || '—',
+		scheduler:
+			compactText(job.scheduler_status_copy) || compactText(job.created_at) || 'queued order',
+		detail: calibrationDetail(job),
+		action: ['failed', 'stopped'].includes(status) ? 'stop-calibration' : undefined
+	}));
+}
+
+export function buildCalibrationRows(
+	dashboard: DashboardSummaryPayload | null | undefined
+): OpsQueueRow[] {
+	const queue = dashboard?.calibration_queue;
+	if (!queue) return [];
+	return [
+		...buildCalibrationLaneRows('sample', queue.sample.running, 'running'),
+		...buildCalibrationLaneRows('sample', queue.sample.queued, 'queued'),
+		...buildCalibrationLaneRows('sample', queue.sample.pending_review, 'pending_review'),
+		...buildCalibrationLaneRows('proof', queue.full.running, 'running'),
+		...buildCalibrationLaneRows('proof', queue.full.queued, 'queued'),
+		...buildCalibrationLaneRows('proof', queue.full.pending_review, 'pending_review')
+	];
+}
+
+export function buildOpsQueueRows(
+	dashboard: DashboardSummaryPayload | null | undefined
+): OpsQueueRow[] {
+	return [...buildEncodeRows(dashboard), ...buildCalibrationRows(dashboard)];
+}
+
+export function buildOpsBlockers(
+	dashboard: DashboardSummaryPayload | null | undefined,
+	hosts: HostsPayload | null | undefined,
+	loadError: string | null
+): OpsBlocker[] {
+	const blockers: OpsBlocker[] = [];
+	const queue = dashboard?.encode_queue;
+	const attentionCount = queue?.needs_attention_count ?? 0;
+	if (loadError) {
+		blockers.push({
+			key: 'runtime-load',
+			tone: 'fail',
+			title: 'Runtime data partial',
+			detail: loadError
+		});
+	}
+	if (queue?.state.stop_requested) {
+		blockers.push({
+			key: 'stop-requested',
+			tone: 'fail',
+			title: 'Encode stop requested',
+			detail: 'Workers are draining current encode work before the queue can resume.',
+			action: 'resume-encode'
+		});
+	}
+	if (queue?.state.is_paused) {
+		blockers.push({
+			key: 'paused',
+			tone: 'wait',
+			title: 'Encode scheduler paused',
+			detail: queue.state.scheduler_summary ?? 'No new encode jobs will start.',
+			action: 'resume-encode'
+		});
+	}
+	if (attentionCount > 0) {
+		blockers.push({
+			key: 'needs-attention',
+			tone: 'fail',
+			title: `${attentionCount} encode ${attentionCount === 1 ? 'job needs' : 'jobs need'} attention`,
+			detail: 'Retry after reviewing the failed rows in the queue table.',
+			action: 'retry-failed-encode'
+		});
+	}
+	for (const host of hosts?.hosts ?? []) {
+		if (!host.available || host.schedule_open === false || host.queue_active === false) {
+			blockers.push({
+				key: `host:${host.key}`,
+				tone: host.available ? 'wait' : 'fail',
+				title: `${host.label} not ready`,
+				detail:
+					host.schedule_open === false ? host.schedule_detail : host.message || host.active_reason,
+				action: !host.available && host.setup_supported !== false ? 'start-host' : undefined
+			});
+		}
+	}
+	return blockers;
+}
+
+export function buildOpsStatusTiles(
+	dashboard: DashboardSummaryPayload | null | undefined,
+	hosts: HostsPayload | null | undefined,
+	loadError: string | null
+): StatusTile[] {
+	const encode = dashboard?.encode_queue;
+	const calibration = dashboard?.calibration_queue;
+	const readyHosts = hosts?.hosts.filter((host) => host.available).length ?? 0;
+	const totalHosts = hosts?.hosts.length ?? 0;
+	return [
+		{
+			label: 'Scheduler',
+			value: encode?.state.is_paused
+				? 'paused'
+				: encode?.state.stop_requested
+					? 'stopping'
+					: 'open',
+			detail:
+				encode?.state.scheduler_summary ?? (loadError ? 'runtime partial' : 'scheduler state'),
+			tone: loadError
+				? 'fail'
+				: encode?.state.stop_requested
+					? 'fail'
+					: encode?.state.is_paused
+						? 'wait'
+						: 'ready'
+		},
+		{
+			label: 'Encode jobs',
+			value: `${encode?.running_count ?? 0} running · ${encode?.queued_count ?? 0} queued`,
+			detail: encode?.telemetry?.eta_copy ?? `${encode?.needs_attention_count ?? 0} need attention`,
+			tone:
+				(encode?.needs_attention_count ?? 0) > 0
+					? 'fail'
+					: (encode?.running_count ?? 0) > 0
+						? 'active'
+						: (encode?.queued_count ?? 0) > 0
+							? 'wait'
+							: 'idle'
+		},
+		{
+			label: 'Samples',
+			value: `${calibration?.sample.running_count ?? 0} running · ${calibration?.sample.queued_count ?? 0} queued`,
+			detail: `${calibration?.sample.pending_review_count ?? 0} waiting for review`,
+			tone: (calibration?.active_count ?? 0) > 0 ? 'active' : 'idle'
+		},
+		{
+			label: 'Hosts',
+			value: `${readyHosts} ready / ${totalHosts}`,
+			detail: totalHosts ? 'compact runtime probe' : 'no host payload',
+			tone: readyHosts > 0 ? 'ready' : totalHosts > 0 ? 'wait' : 'idle'
+		}
+	];
+}
+
+export function buildOpsFooterSignals(
+	dashboard: DashboardSummaryPayload | null | undefined,
+	hosts: HostsPayload | null | undefined
+): FooterSignal[] {
+	const encode = dashboard?.encode_queue;
+	const calibration = dashboard?.calibration_queue;
+	return [
+		{
+			label: 'Encode',
+			value: `${encode?.running_count ?? 0}/${encode?.queued_count ?? 0}`,
+			tone:
+				(encode?.running_count ?? 0) > 0
+					? 'active'
+					: (encode?.queued_count ?? 0) > 0
+						? 'wait'
+						: 'idle'
+		},
+		{
+			label: 'Attention',
+			value: String(encode?.needs_attention_count ?? 0),
+			tone: (encode?.needs_attention_count ?? 0) > 0 ? 'fail' : 'idle'
+		},
+		{
+			label: 'Samples',
+			value: String(calibration?.active_count ?? 0),
+			tone: (calibration?.active_count ?? 0) > 0 ? 'active' : 'idle'
+		},
+		{
+			label: 'Hosts',
+			value: `${hosts?.hosts.filter((host) => host.available).length ?? 0}/${hosts?.hosts.length ?? 0}`
+		}
+	];
+}
+
+export function hostTone(host: HostRuntime): ShellTone {
+	if (!host.available) return 'fail';
+	if (host.schedule_open === false || host.queue_active === false) return 'wait';
+	if (host.active_encode_count > 0) return 'active';
+	return 'ready';
+}
+
+export function hostStateCopy(host: HostRuntime): string {
+	if (!host.available) return 'Unavailable';
+	if (host.schedule_open === false) return 'Off window';
+	if (host.queue_active === false) return 'Idle';
+	if (host.active_encode_count > 0) return 'Encoding';
+	return 'Ready';
+}

--- a/frontend/src/routes/ops/+page.svelte
+++ b/frontend/src/routes/ops/+page.svelte
@@ -1,70 +1,11 @@
 <script lang="ts">
-	const preservedContracts = [
-		'Encode queue control',
-		'Calibration queue control',
-		'Host readiness and capabilities',
-		'Schedule windows and off-window reasons',
-		'Blocked, failed, retry, pause, and stop states'
-	];
+	import OpsWorkstationView from '$lib/components/workstation/OpsWorkstationView.svelte';
+
+	let { data } = $props();
 </script>
 
 <svelte:head>
-	<title>Ops Reset · Mediaforce</title>
+	<title>Mediaforce Ops</title>
 </svelte:head>
 
-<main class="reset-stage">
-	<p class="kicker">Fleet console reset</p>
-	<h1>Ops is waiting for the new workstation design.</h1>
-	<p class="lede">
-		The old queue and host modules were removed to prevent the next fleet console from inheriting
-		the failed dashboard composition.
-	</p>
-
-	<section aria-labelledby="preserved-contracts">
-		<h2 id="preserved-contracts">Contracts to rebuild against</h2>
-		<ul>
-			{#each preservedContracts as contract (contract)}
-				<li>{contract}</li>
-			{/each}
-		</ul>
-	</section>
-</main>
-
-<style>
-	.reset-stage {
-		display: grid;
-		gap: 1.5rem;
-		max-width: 760px;
-		padding: 4rem max(1.25rem, calc((100vw - 760px) / 2));
-	}
-
-	.kicker {
-		font-size: 0.78rem;
-		font-weight: 800;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #9fb2c7;
-	}
-
-	h1 {
-		font-size: clamp(2rem, 5vw, 4rem);
-		line-height: 1;
-	}
-
-	.lede,
-	li {
-		color: #c6d0da;
-		line-height: 1.65;
-	}
-
-	section {
-		display: grid;
-		gap: 0.75rem;
-		padding-top: 1rem;
-		border-top: 1px solid rgba(255, 255, 255, 0.18);
-	}
-
-	h2 {
-		font-size: 0.95rem;
-	}
-</style>
+<OpsWorkstationView dashboard={data.dashboard} hosts={data.hosts} loadError={data.loadError} />

--- a/frontend/src/routes/ops/+page.ts
+++ b/frontend/src/routes/ops/+page.ts
@@ -1,3 +1,30 @@
-export function load() {
-	return {};
+import { fetchJson } from '$lib/api/client';
+import type { DashboardSummaryPayload, HostsPayload } from '$lib/api/types';
+
+type SettledPayload<T> = { data: T; error: null } | { data: null; error: string };
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : 'Request failed.';
+}
+
+async function settle<T>(promise: Promise<T>): Promise<SettledPayload<T>> {
+	try {
+		return { data: await promise, error: null };
+	} catch (error) {
+		return { data: null, error: errorMessage(error) };
+	}
+}
+
+export async function load({ fetch }: { fetch: typeof window.fetch }) {
+	const [dashboard, hosts] = await Promise.all([
+		settle(fetchJson<DashboardSummaryPayload>('/api/dashboard', fetch)),
+		settle(fetchJson<HostsPayload>('/api/hosts?compact=1', fetch))
+	]);
+	const loadError = [dashboard.error, hosts.error].filter(Boolean).join(' · ') || null;
+
+	return {
+		dashboard: dashboard.data,
+		hosts: hosts.data,
+		loadError
+	};
 }


### PR DESCRIPTION
## Summary
- Rebuild `/ops` into the workstation shell with Ops primary navigation.
- Add a dense scheduler/recovery surface, blocked-work strip, jobs table, and compact host readiness rail.
- Map encode/sample/proof runtime state into semantic tones and recovery actions, with partial API failure handling and confirm state for interrupting queue stops.

Refs #27

## Follow-up
- Deeper runtime wiring and action QA is tracked in #33 and should start after this UI slice lands.
- Local handoff for Every Code: `handoff-to-every-code.md` (gitignored, not part of this PR).

## Validation
- `bash scripts/pre-commit-check.sh`
- Browser QA on `http://127.0.0.1:4173/ops` with no page-level horizontal overflow at desktop and 390px mobile.
- Screenshots: `scratch/ui-checks/ops-desktop-fixed.png`, `scratch/ui-checks/ops-mobile-live-empty.png`, `scratch/ui-checks/ops-desktop-fixture-active-failed-paused.png`, `scratch/ui-checks/ops-mobile-fixture-active-failed-paused.png`, `scratch/ui-checks/ops-mobile-fixture-table-confirm.png`
