### PR TITLE
Harden Ops runtime controls

### DIFF
--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -29,9 +29,11 @@ export interface QueueLane {
 	running: Array<Record<string, unknown>>;
 	queued: Array<Record<string, unknown>>;
 	pending_review: Array<Record<string, unknown>>;
+	recent_failed?: Array<Record<string, unknown>>;
 	running_count: number;
 	queued_count: number;
 	pending_review_count: number;
+	recent_failed_count?: number;
 }
 
 export interface EncodeJobProgressTelemetry {
@@ -150,6 +152,7 @@ export interface DashboardSummaryPayload {
 		sample: QueueLane;
 		full: QueueLane;
 		active_count: number;
+		recent_failed_count?: number;
 	};
 	encode_queue: EncodeQueueSummary;
 	archive_cleanup?: {

--- a/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
+	import { onDestroy, onMount } from 'svelte';
 	import { resolve } from '$app/paths';
 	import { postJson } from '$lib/api/client';
 	import type { DashboardSummaryPayload, HostRuntime, HostsPayload } from '$lib/api/types';
@@ -12,11 +13,17 @@
 		buildOpsFooterSignals,
 		buildOpsQueueRows,
 		buildOpsStatusTiles,
+		hostPrepareDisabled,
+		hostPrepareTitle,
 		hostStateCopy,
 		hostTone,
+		rowRecoveryLabel,
+		rowRecoveryTitle,
 		type OpsActionId,
 		type OpsQueueRow
 	} from './ops-workstation';
+
+	const OPS_REFRESH_INTERVAL_MS = 15_000;
 
 	let {
 		dashboard,
@@ -48,6 +55,11 @@
 	let confirmationAction = $state<OpsActionId | null>(null);
 	let actionMessage = $state('');
 	let actionError = $state('');
+	let refreshPending = $state(false);
+	let refreshError = $state('');
+	let lastRefreshAt = $state<Date | null>(null);
+	let hostPasswords = $state<Record<string, string>>({});
+	let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
 	const actionEndpoints: Record<OpsActionId, string> = {
 		'pause-encode': '/api/encode-queue/pause',
@@ -76,8 +88,13 @@
 		return 'Reset stored trust for this host';
 	}
 
-	function actionBody(host?: HostRuntime): Record<string, unknown> {
-		return host ? { host_key: host.key } : {};
+	function actionBody(action: OpsActionId, host?: HostRuntime): Record<string, unknown> {
+		if (!host) return {};
+		const body: Record<string, unknown> = { host_key: host.key };
+		if (action === 'prepare-host' && host.setup_requires_password) {
+			body.remote_password = hostPasswords[host.key] ?? '';
+		}
+		return body;
 	}
 
 	async function runAction(action: OpsActionId, host?: HostRuntime) {
@@ -92,17 +109,50 @@
 		actionPending = action;
 		try {
 			const endpoint = `${resolve('/')}${actionEndpoints[action].slice(1)}`;
-			const response = await postJson<Record<string, unknown>>(endpoint, actionBody(host));
+			const response = await postJson<Record<string, unknown>>(endpoint, actionBody(action, host));
 			actionMessage =
 				typeof response.message === 'string' && response.message.trim()
 					? response.message
 					: 'Action completed.';
+			if (action === 'prepare-host' && host) {
+				hostPasswords = { ...hostPasswords, [host.key]: '' };
+			}
 			await invalidateAll();
 		} catch (error) {
 			actionError = error instanceof Error ? error.message : 'Action failed.';
 		} finally {
 			actionPending = null;
 		}
+	}
+
+	async function refreshOps({ quiet = false }: { quiet?: boolean } = {}) {
+		if (refreshPending) return;
+		refreshPending = true;
+		if (!quiet) {
+			actionMessage = '';
+			actionError = '';
+		}
+		refreshError = '';
+		try {
+			await invalidateAll();
+			lastRefreshAt = new Date();
+			if (!quiet) actionMessage = 'Ops runtime refreshed.';
+		} catch (error) {
+			refreshError = error instanceof Error ? error.message : 'Refresh failed.';
+			if (!quiet) actionError = refreshError;
+		} finally {
+			refreshPending = false;
+		}
+	}
+
+	function refreshCopy(): string {
+		if (refreshPending) return 'refreshing';
+		if (!lastRefreshAt) return 'auto-refresh every 15s';
+		return `refreshed ${lastRefreshAt.toLocaleTimeString([], {
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit'
+		})}`;
 	}
 
 	function rowActionDisabled(row: OpsQueueRow): boolean {
@@ -112,9 +162,18 @@
 	function hostActionDisabled(action: OpsActionId, host: HostRuntime): boolean {
 		if (actionPending !== null) return true;
 		if (action === 'start-host') return host.available || !host.setup_supported;
-		if (action === 'prepare-host') return host.setup_requires_password || !host.setup_supported;
+		if (action === 'prepare-host') {
+			return hostPrepareDisabled(host, hostPasswords[host.key] ?? '');
+		}
 		if (action === 'reset-host-trust') return !host.trust_reset_supported;
 		return false;
+	}
+
+	function handleHostPasswordInput(host: HostRuntime, event: Event) {
+		hostPasswords = {
+			...hostPasswords,
+			[host.key]: (event.currentTarget as HTMLInputElement).value
+		};
 	}
 
 	function queueActionLabel(action: OpsActionId): string {
@@ -134,6 +193,15 @@
 	function canOpenFolder(row: OpsQueueRow): boolean {
 		return row.prefix !== 'runtime scope';
 	}
+
+	onMount(() => {
+		lastRefreshAt = new Date();
+		refreshTimer = setInterval(() => void refreshOps({ quiet: true }), OPS_REFRESH_INTERVAL_MS);
+	});
+
+	onDestroy(() => {
+		if (refreshTimer) clearInterval(refreshTimer);
+	});
 </script>
 
 <OperatorShell route="ops" subject="Ops" crumb="/ops" {statusTiles} {footerSignals}>
@@ -161,6 +229,13 @@
 						<span>Hosts ready</span>
 						<strong>{readyHosts.toLocaleString('en-US')}</strong>
 					</div>
+					<button
+						type="button"
+						class="control control--compact"
+						disabled={refreshPending}
+						title="Refresh Ops runtime state now"
+						onclick={() => refreshOps()}>{refreshPending ? 'Refreshing' : 'Refresh'}</button
+					>
 				</div>
 			</header>
 
@@ -248,6 +323,9 @@
 					{#if actionError}
 						<p class="action-error">{actionError}</p>
 					{/if}
+					<p class="refresh-note" class:refresh-note--error={Boolean(refreshError)}>
+						{refreshError || refreshCopy()}
+					</p>
 				</div>
 			</WorkstationPanel>
 
@@ -329,11 +407,11 @@
 												type="button"
 												class="control control--compact"
 												disabled={rowActionDisabled(row)}
-												title={actionTitle(action)}
-												onclick={() => runAction(action)}>{queueActionLabel(action)}</button
+												title={rowRecoveryTitle(row)}
+												onclick={() => runAction(action)}>{rowRecoveryLabel(row)}</button
 											>
 										{:else}
-											<span class="disabled-copy">No action</span>
+											<span class="disabled-copy">{rowRecoveryLabel(row)}</span>
 										{/if}
 									</td>
 								</tr>
@@ -374,6 +452,18 @@
 								<dt>Reason</dt>
 								<dd>{host.message || host.active_reason || 'ready'}</dd>
 							</dl>
+							{#if host.setup_requires_password && host.setup_supported}
+								<label class="host-password">
+									<span>Prepare password</span>
+									<input
+										type="password"
+										autocomplete="current-password"
+										value={hostPasswords[host.key] ?? ''}
+										placeholder="Required for setup"
+										oninput={(event) => handleHostPasswordInput(host, event)}
+									/>
+								</label>
+							{/if}
 							<div class="host-row__actions" aria-label={`${host.label} controls`}>
 								<button
 									type="button"
@@ -388,9 +478,7 @@
 									type="button"
 									class="control control--compact"
 									disabled={hostActionDisabled('prepare-host', host)}
-									title={host.setup_requires_password
-										? 'Prepare requires a password from Settings.'
-										: actionTitle('prepare-host')}
+									title={hostPrepareTitle(host)}
 									onclick={() => runAction('prepare-host', host)}>Prepare</button
 								>
 								<button
@@ -571,6 +659,16 @@
 		color: var(--mf-fail-fg);
 	}
 
+	.refresh-note {
+		color: var(--mf-fg-tertiary);
+		font-family: var(--mf-font-mono);
+		font-size: var(--mf-text-2xs);
+	}
+
+	.refresh-note--error {
+		color: var(--mf-fail-fg);
+	}
+
 	.blocker-row {
 		background: var(--mf-bg-panel-2);
 		border: var(--mf-border-muted);
@@ -726,6 +824,31 @@
 		display: grid;
 		grid-template-columns: 72px minmax(0, 1fr);
 		row-gap: var(--mf-space-3);
+	}
+
+	.host-password {
+		display: grid;
+		gap: var(--mf-space-2);
+	}
+
+	.host-password span {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.host-password input {
+		background: var(--mf-bg-input);
+		border: var(--mf-border);
+		border-radius: var(--mf-radius-1);
+		color: var(--mf-fg-primary);
+		font: inherit;
+		min-height: var(--mf-control-md);
+		min-width: 0;
+		padding: 0 var(--mf-space-3);
+		width: 100%;
 	}
 
 	.host-row dd {

--- a/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
@@ -65,6 +65,7 @@
 		'pause-encode': '/api/encode-queue/pause',
 		'resume-encode': '/api/encode-queue/resume',
 		'retry-failed-encode': '/api/encode-queue/retry-failed',
+		'retry-encode-prefix': '/api/encode-queue/retry-prefix',
 		'stop-encode': '/api/encode-queue/stop',
 		'stop-calibration': '/api/calibration-queue/stop',
 		'start-host': '/api/hosts/start',
@@ -81,6 +82,7 @@
 		if (action === 'stop-calibration') return 'Stop running and queued sample/proof jobs';
 		if (action === 'retry-failed-encode')
 			return 'Retry failed folder encodes that are still approved';
+		if (action === 'retry-encode-prefix') return 'Retry this failed folder encode';
 		if (action === 'pause-encode') return 'Pause the encode scheduler';
 		if (action === 'resume-encode') return 'Resume the encode scheduler and clear stop request';
 		if (action === 'start-host') return 'Start or wake this host';
@@ -88,7 +90,12 @@
 		return 'Reset stored trust for this host';
 	}
 
-	function actionBody(action: OpsActionId, host?: HostRuntime): Record<string, unknown> {
+	function actionBody(
+		action: OpsActionId,
+		host?: HostRuntime,
+		row?: OpsQueueRow
+	): Record<string, unknown> {
+		if (action === 'retry-encode-prefix' && row) return { prefix: row.prefix };
 		if (!host) return {};
 		const body: Record<string, unknown> = { host_key: host.key };
 		if (action === 'prepare-host' && host.setup_requires_password) {
@@ -97,7 +104,7 @@
 		return body;
 	}
 
-	async function runAction(action: OpsActionId, host?: HostRuntime) {
+	async function runAction(action: OpsActionId, host?: HostRuntime, row?: OpsQueueRow) {
 		actionMessage = '';
 		actionError = '';
 		if (actionRequiresConfirmation(action) && confirmationAction !== action) {
@@ -109,7 +116,10 @@
 		actionPending = action;
 		try {
 			const endpoint = `${resolve('/')}${actionEndpoints[action].slice(1)}`;
-			const response = await postJson<Record<string, unknown>>(endpoint, actionBody(action, host));
+			const response = await postJson<Record<string, unknown>>(
+				endpoint,
+				actionBody(action, host, row)
+			);
 			actionMessage =
 				typeof response.message === 'string' && response.message.trim()
 					? response.message
@@ -182,6 +192,7 @@
 		if (action === 'pause-encode') return 'Pause';
 		if (action === 'resume-encode') return 'Resume';
 		if (action === 'retry-failed-encode') return 'Retry failed';
+		if (action === 'retry-encode-prefix') return 'Retry folder';
 		if (action === 'stop-encode') return 'Stop encode';
 		if (action === 'stop-calibration') return 'Stop samples';
 		if (action === 'start-host') return 'Start';
@@ -408,7 +419,8 @@
 												class="control control--compact"
 												disabled={rowActionDisabled(row)}
 												title={rowRecoveryTitle(row)}
-												onclick={() => runAction(action)}>{rowRecoveryLabel(row)}</button
+												onclick={() => runAction(action, undefined, row)}
+												>{rowRecoveryLabel(row)}</button
 											>
 										{:else}
 											<span class="disabled-copy">{rowRecoveryLabel(row)}</span>
@@ -506,6 +518,7 @@
 						<small
 							>{queuedWaitingCount.toLocaleString('en-US')} encode jobs waiting on schedule</small
 						>
+						<a class="inline-link" href={resolve('/settings')}>Edit schedule</a>
 					</div>
 					{#each closedHosts as host (host.key)}
 						<div class="scope-row scope-row--wait">
@@ -752,9 +765,19 @@
 	}
 
 	.work-link span,
-	.disabled-copy {
+	.disabled-copy,
+	.inline-link {
 		color: var(--mf-fg-tertiary);
 		font-size: var(--mf-text-2xs);
+	}
+
+	.inline-link {
+		font-weight: var(--mf-weight-semibold);
+		text-transform: uppercase;
+	}
+
+	.inline-link:hover {
+		color: var(--mf-active-fg);
 	}
 
 	.control {

--- a/frontend/src/lib/components/workstation/ops-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.test.ts
@@ -4,8 +4,12 @@ import {
 	buildOpsBlockers,
 	buildOpsQueueRows,
 	buildOpsStatusTiles,
+	hostPrepareDisabled,
+	hostPrepareTitle,
 	hostStateCopy,
-	hostTone
+	hostTone,
+	rowRecoveryLabel,
+	rowRecoveryTitle
 } from './ops-workstation';
 
 function dashboardFixture(): DashboardSummaryPayload {
@@ -150,13 +154,18 @@ describe('Ops workstation mapping', () => {
 		expect(rows[1]).toMatchObject({
 			tone: 'wait',
 			action: 'retry-failed-encode',
+			actionScope: 'global',
 			detail: 'transient worker fault'
 		});
 		expect(rows[2]).toMatchObject({
 			tone: 'fail',
 			action: 'retry-failed-encode',
+			actionScope: 'global',
 			detail: 'quality target missed'
 		});
+		expect(rowRecoveryLabel(rows[1])).toBe('Retry all');
+		expect(rowRecoveryTitle(rows[1])).toContain('global retry');
+		expect(rowRecoveryLabel(rows[3])).toBe('No action');
 	});
 
 	it('surfaces runtime partials, failed encodes, and closed schedules as blockers', () => {
@@ -193,5 +202,25 @@ describe('Ops workstation mapping', () => {
 		expect(hostStateCopy(scheduledOff)).toBe('Off window');
 		expect(hostTone(unavailable)).toBe('fail');
 		expect(hostStateCopy(unavailable)).toBe('Unavailable');
+	});
+
+	it('keeps password-gated host prepare disabled until a password is present', () => {
+		const [ready] = hostsFixture().hosts;
+		const passwordHost = {
+			...ready,
+			setup_supported: true,
+			setup_requires_password: true
+		};
+		const unsupportedHost = {
+			...ready,
+			setup_supported: false,
+			setup_requires_password: false
+		};
+
+		expect(hostPrepareDisabled(passwordHost, '')).toBe(true);
+		expect(hostPrepareDisabled(passwordHost, 'secret')).toBe(false);
+		expect(hostPrepareTitle(passwordHost)).toBe('Enter the prepare password for this host.');
+		expect(hostPrepareDisabled(unsupportedHost, 'secret')).toBe(true);
+		expect(hostPrepareTitle(unsupportedHost)).toBe('Prepare is unavailable for this host.');
 	});
 });

--- a/frontend/src/lib/components/workstation/ops-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.test.ts
@@ -31,7 +31,17 @@ function dashboardFixture(): DashboardSummaryPayload {
 				pending_review: [],
 				running_count: 1,
 				queued_count: 0,
-				pending_review_count: 0
+				pending_review_count: 0,
+				recent_failed: [
+					{
+						job_id: 'sample-failed-1',
+						prefix: 'tv/show/season 4',
+						status: 'failed',
+						error: 'could not find a viable sample',
+						host: { label: 'studio-mini' }
+					}
+				],
+				recent_failed_count: 1
 			},
 			full: {
 				running: [],
@@ -39,9 +49,12 @@ function dashboardFixture(): DashboardSummaryPayload {
 				pending_review: [],
 				running_count: 0,
 				queued_count: 0,
-				pending_review_count: 0
+				pending_review_count: 0,
+				recent_failed: [],
+				recent_failed_count: 0
 			},
-			active_count: 1
+			active_count: 1,
+			recent_failed_count: 1
 		},
 		encode_queue: {
 			running_count: 1,
@@ -149,23 +162,31 @@ describe('Ops workstation mapping', () => {
 			'encode:encode-1',
 			'encode:encode-2',
 			'encode:encode-3',
-			'sample:sample-1'
+			'sample:sample-1',
+			'sample:sample-failed-1'
 		]);
 		expect(rows[1]).toMatchObject({
 			tone: 'wait',
-			action: 'retry-failed-encode',
-			actionScope: 'global',
+			action: 'retry-encode-prefix',
+			actionScope: 'row',
 			detail: 'transient worker fault'
 		});
 		expect(rows[2]).toMatchObject({
 			tone: 'fail',
-			action: 'retry-failed-encode',
-			actionScope: 'global',
+			action: 'retry-encode-prefix',
+			actionScope: 'row',
 			detail: 'quality target missed'
 		});
-		expect(rowRecoveryLabel(rows[1])).toBe('Retry all');
-		expect(rowRecoveryTitle(rows[1])).toContain('global retry');
+		expect(rowRecoveryLabel(rows[1])).toBe('Retry folder');
+		expect(rowRecoveryTitle(rows[1])).toContain('folder prefix only');
 		expect(rowRecoveryLabel(rows[3])).toBe('No action');
+		expect(rows[4]).toMatchObject({
+			tone: 'fail',
+			status: 'failed',
+			prefix: 'tv/show/season 4',
+			detail: 'could not find a viable sample'
+		});
+		expect(rowRecoveryLabel(rows[4])).toBe('No action');
 	});
 
 	it('surfaces runtime partials, failed encodes, and closed schedules as blockers', () => {

--- a/frontend/src/lib/components/workstation/ops-workstation.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.ts
@@ -11,6 +11,7 @@ export type OpsActionId =
 	| 'pause-encode'
 	| 'resume-encode'
 	| 'retry-failed-encode'
+	| 'retry-encode-prefix'
 	| 'stop-encode'
 	| 'stop-calibration'
 	| 'start-host'
@@ -75,12 +76,19 @@ function calibrationPrefix(job: CalibrationJob): string {
 }
 
 function calibrationDetail(job: CalibrationJob): string {
-	return (
+	const raw =
 		compactText(job.error) ||
 		compactText(job.notes) ||
 		compactText(job.operator_note) ||
 		compactText(job.created_at) ||
-		'waiting for worker update'
+		'waiting for worker update';
+	return (
+		raw
+			.split('\n')
+			.map((line) => line.trim())
+			.filter(Boolean)
+			.at(-1)
+			?.slice(0, 180) ?? 'waiting for worker update'
 	);
 }
 
@@ -147,10 +155,10 @@ export function buildEncodeRows(
 		scheduler: job.scheduler_status_copy || (job.schedule_waiting ? 'schedule waiting' : 'ready'),
 		detail: encodeJobDetail(job),
 		action: ['failed', 'needs_attention', 'stopped', 'retry_backoff'].includes(job.status)
-			? 'retry-failed-encode'
+			? 'retry-encode-prefix'
 			: undefined,
 		actionScope: ['failed', 'needs_attention', 'stopped', 'retry_backoff'].includes(job.status)
-			? 'global'
+			? 'row'
 			: undefined
 	}));
 }
@@ -177,6 +185,7 @@ function buildCalibrationLaneRows(
 
 export function rowRecoveryLabel(row: OpsQueueRow): string {
 	if (!row.action) return 'No action';
+	if (row.action === 'retry-encode-prefix') return 'Retry folder';
 	if (row.action === 'retry-failed-encode') return 'Retry all';
 	if (row.action === 'stop-calibration') return 'Stop samples';
 	return row.actionScope === 'global' ? 'Global action' : 'Run action';
@@ -184,8 +193,11 @@ export function rowRecoveryLabel(row: OpsQueueRow): string {
 
 export function rowRecoveryTitle(row: OpsQueueRow): string {
 	if (!row.action) return 'No runtime action is available for this row.';
+	if (row.action === 'retry-encode-prefix') {
+		return 'Retry the failed encode for this folder prefix only.';
+	}
 	if (row.action === 'retry-failed-encode') {
-		return 'Runs the global retry for all approved failed folder encodes. Per-row retry is not wired yet.';
+		return 'Runs the global retry for all approved failed folder encodes.';
 	}
 	return row.actionScope === 'global'
 		? 'Runs a global queue action; this is not scoped to one row.'
@@ -213,9 +225,11 @@ export function buildCalibrationRows(
 		...buildCalibrationLaneRows('sample', queue.sample.running, 'running'),
 		...buildCalibrationLaneRows('sample', queue.sample.queued, 'queued'),
 		...buildCalibrationLaneRows('sample', queue.sample.pending_review, 'pending_review'),
+		...buildCalibrationLaneRows('sample', queue.sample.recent_failed, 'failed'),
 		...buildCalibrationLaneRows('proof', queue.full.running, 'running'),
 		...buildCalibrationLaneRows('proof', queue.full.queued, 'queued'),
-		...buildCalibrationLaneRows('proof', queue.full.pending_review, 'pending_review')
+		...buildCalibrationLaneRows('proof', queue.full.pending_review, 'pending_review'),
+		...buildCalibrationLaneRows('proof', queue.full.recent_failed, 'failed')
 	];
 }
 

--- a/frontend/src/lib/components/workstation/ops-workstation.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.ts
@@ -29,6 +29,7 @@ export type OpsQueueRow = {
 	scheduler: string;
 	detail: string;
 	action?: OpsActionId;
+	actionScope?: 'global' | 'row';
 };
 
 export type OpsBlocker = {
@@ -147,6 +148,9 @@ export function buildEncodeRows(
 		detail: encodeJobDetail(job),
 		action: ['failed', 'needs_attention', 'stopped', 'retry_backoff'].includes(job.status)
 			? 'retry-failed-encode'
+			: undefined,
+		actionScope: ['failed', 'needs_attention', 'stopped', 'retry_backoff'].includes(job.status)
+			? 'global'
 			: undefined
 	}));
 }
@@ -167,9 +171,37 @@ function buildCalibrationLaneRows(
 		progress: compactText(job.progress) || compactText(job.stage) || '—',
 		scheduler:
 			compactText(job.scheduler_status_copy) || compactText(job.created_at) || 'queued order',
-		detail: calibrationDetail(job),
-		action: ['failed', 'stopped'].includes(status) ? 'stop-calibration' : undefined
+		detail: calibrationDetail(job)
 	}));
+}
+
+export function rowRecoveryLabel(row: OpsQueueRow): string {
+	if (!row.action) return 'No action';
+	if (row.action === 'retry-failed-encode') return 'Retry all';
+	if (row.action === 'stop-calibration') return 'Stop samples';
+	return row.actionScope === 'global' ? 'Global action' : 'Run action';
+}
+
+export function rowRecoveryTitle(row: OpsQueueRow): string {
+	if (!row.action) return 'No runtime action is available for this row.';
+	if (row.action === 'retry-failed-encode') {
+		return 'Runs the global retry for all approved failed folder encodes. Per-row retry is not wired yet.';
+	}
+	return row.actionScope === 'global'
+		? 'Runs a global queue action; this is not scoped to one row.'
+		: 'Runs the action for this row.';
+}
+
+export function hostPrepareDisabled(host: HostRuntime, password: string): boolean {
+	return (
+		host.setup_supported === false || (Boolean(host.setup_requires_password) && !password.trim())
+	);
+}
+
+export function hostPrepareTitle(host: HostRuntime): string {
+	if (host.setup_supported === false) return 'Prepare is unavailable for this host.';
+	if (host.setup_requires_password) return 'Enter the prepare password for this host.';
+	return 'Prepare this host for Mediaforce work';
 }
 
 export function buildCalibrationRows(

--- a/mediaforce/tuning/calibration_jobs.py
+++ b/mediaforce/tuning/calibration_jobs.py
@@ -117,19 +117,26 @@ def claim_next_queued_calibration_job(
 
 
 def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict[str, Any]:
-    rows = connection.execute(
+    active_rows = connection.execute(
         _calibration_job_select()
         .where(calibration_jobs.c.status.in_(("queued", "running", "pending_review")))
         .order_by(calibration_jobs.c.created_at.asc(), _rowid_column().asc())
     ).mappings().fetchall()
+    recent_terminal_rows = connection.execute(
+        _calibration_job_select()
+        .where(calibration_jobs.c.status.in_(("failed", "stopped")))
+        .order_by(calibration_jobs.c.updated_at.desc(), _rowid_column().desc())
+        .limit(limit_per_lane * 2)
+    ).mappings().fetchall()
     summary: dict[str, Any] = {
         "sample": {"running": [], "queued": [], "pending_review": [], "running_count": 0, "queued_count": 0,
-                   "pending_review_count": 0},
+                   "pending_review_count": 0, "recent_failed": [], "recent_failed_count": 0},
         "full": {"running": [], "queued": [], "pending_review": [], "running_count": 0, "queued_count": 0,
-                 "pending_review_count": 0},
+                 "pending_review_count": 0, "recent_failed": [], "recent_failed_count": 0},
         "active_count": 0,
+        "recent_failed_count": 0,
     }
-    for row in rows:
+    for row in active_rows:
         payload = _hydrate_job(row)
         lane = str(payload.get("lane") or "sample")
         lane_summary = summary[lane]
@@ -141,6 +148,19 @@ def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict
             summary["active_count"] += 1
         if status in lane_summary and len(lane_summary[status]) < limit_per_lane:
             lane_summary[status].append(payload)
+    seen_terminal_prefix_lanes: set[tuple[str, str]] = set()
+    for row in recent_terminal_rows:
+        payload = _hydrate_job(row)
+        lane = str(payload.get("lane") or "sample")
+        lane_summary = summary[lane]
+        lane_summary["recent_failed_count"] += 1
+        summary["recent_failed_count"] += 1
+        prefix_lane = (str(payload.get("prefix") or ""), lane)
+        if prefix_lane in seen_terminal_prefix_lanes:
+            continue
+        seen_terminal_prefix_lanes.add(prefix_lane)
+        if len(lane_summary["recent_failed"]) < limit_per_lane:
+            lane_summary["recent_failed"].append(payload)
     return summary
 
 

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -110,7 +110,7 @@ from mediaforce.web.runtime import FolderCard, cached_folder_cards, dashboard_fo
     approve_measured_encode_recovery_action, \
     queue_folder_encode_action, recent_tuning_sessions, \
     refresh_host_status_cache, reset_folder_card_cache, resume_encode_queue_action, \
-    retry_failed_encode_queue_action, review_media_context, \
+    retry_failed_encode_prefix_action, retry_failed_encode_queue_action, review_media_context, \
     review_pack_dir, review_pair_key, review_pairs, safe_collect_host_statuses, save_advice_state, \
     save_calibration_state, save_pending_proposal, save_profile_action, \
     sample_calibration_host_statuses, sample_host_options, sample_host_options_from_statuses, \
@@ -857,6 +857,16 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             queue_folder_encode_action=_queue_folder_encode_action,
         )
 
+    def _retry_failed_encode_prefix_action(prefix: str) -> dict[str, Any]:
+        return retry_failed_encode_prefix_action(
+            connection_factory=lambda: open_db(config.paths.db_path),
+            config=config,
+            prefix=prefix,
+            load_calibration_state=_load_calibration_state,
+            review_gate=_review_gate,
+            queue_folder_encode_action=_queue_folder_encode_action,
+        )
+
     def _stop_calibration_queue_action() -> dict[str, Any]:
         return stop_calibration_queue_action(
             connection_factory=lambda: open_db(config.paths.db_path),
@@ -898,6 +908,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         pause_encode_queue_action=_pause_encode_queue_action,
         resume_encode_queue_action=_resume_encode_queue_action,
         retry_failed_encode_queue_action=_retry_failed_encode_queue_action,
+        retry_failed_encode_prefix_action=_retry_failed_encode_prefix_action,
         stop_encode_queue_action=_stop_encode_queue_action,
         stop_calibration_queue_action=_stop_calibration_queue_action,
     )

--- a/mediaforce/web/routes/queues.py
+++ b/mediaforce/web/routes/queues.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from typing import Any
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
 
@@ -11,6 +11,7 @@ def register_queue_routes(
         pause_encode_queue_action: Callable[[], dict[str, Any]],
         resume_encode_queue_action: Callable[[], dict[str, Any]],
         retry_failed_encode_queue_action: Callable[[], dict[str, Any]],
+        retry_failed_encode_prefix_action: Callable[[str], dict[str, Any]],
         stop_encode_queue_action: Callable[[], dict[str, Any]],
         stop_calibration_queue_action: Callable[[], dict[str, Any]],
 ) -> None:
@@ -25,6 +26,11 @@ def register_queue_routes(
     @app.post("/api/encode-queue/retry-failed")
     def api_retry_failed_encode_queue() -> JSONResponse:
         return JSONResponse(retry_failed_encode_queue_action())
+
+    @app.post("/api/encode-queue/retry-prefix")
+    async def api_retry_failed_encode_prefix(request: Request) -> JSONResponse:
+        body = await request.json()
+        return JSONResponse(retry_failed_encode_prefix_action(str(body.get("prefix", "")).strip()))
 
     @app.post("/api/encode-queue/stop")
     def api_stop_encode_queue() -> JSONResponse:

--- a/mediaforce/web/runtime/__init__.py
+++ b/mediaforce/web/runtime/__init__.py
@@ -31,7 +31,8 @@ from mediaforce.web.runtime.job_runtime import JobRuntimeDeps, active_scan_from_
     save_job_state, save_scan_job_state as save_scan_job_state_runtime, scan_is_stale, \
     scan_job_belongs_to_current_process, scan_process_is_alive
 from mediaforce.web.runtime.queue_actions import pause_encode_queue_action, resume_encode_queue_action, \
-    retry_failed_encode_queue_action, stop_calibration_queue_action, stop_encode_queue_action
+    retry_failed_encode_prefix_action, retry_failed_encode_queue_action, stop_calibration_queue_action, \
+    stop_encode_queue_action
 from mediaforce.web.runtime.settings_payloads import settings_page_payload
 
 __all__ = [
@@ -91,6 +92,7 @@ __all__ = [
     "proposal_alignment_issue",
     "proposal_signal_copy",
     "resume_encode_queue_action",
+    "retry_failed_encode_prefix_action",
     "retry_failed_encode_queue_action",
     "review_pack_dir",
     "review_media_context",

--- a/mediaforce/web/runtime/queue_actions.py
+++ b/mediaforce/web/runtime/queue_actions.py
@@ -65,6 +65,55 @@ def retry_failed_encode_queue_action(
         review_gate: Any,
         queue_folder_encode_action: Any,
 ) -> dict[str, Any]:
+    terminal_prefixes = _retryable_terminal_encode_prefixes(connection_factory=connection_factory)
+    if not terminal_prefixes:
+        return {"ok": True, "message": "No failed folder encodes were ready to retry.", "queued_count": 0}
+
+    return _retry_failed_encode_prefixes(
+        terminal_prefixes,
+        config=config,
+        load_calibration_state=load_calibration_state,
+        review_gate=review_gate,
+        queue_folder_encode_action=queue_folder_encode_action,
+    )
+
+
+def retry_failed_encode_prefix_action(
+        *,
+        connection_factory: Any,
+        config: MediaforceConfig,
+        prefix: str,
+        load_calibration_state: Any,
+        review_gate: Any,
+        queue_folder_encode_action: Any,
+) -> dict[str, Any]:
+    normalized_prefix = prefix.strip("/").strip()
+    if not normalized_prefix:
+        raise HTTPException(status_code=400, detail="A folder prefix is required.")
+
+    retryable_prefixes = set(_retryable_terminal_encode_prefixes(connection_factory=connection_factory))
+    if normalized_prefix not in retryable_prefixes:
+        return {
+            "ok": True,
+            "message": f"No failed folder encode was ready to retry for {normalized_prefix}.",
+            "queued_count": 0,
+            "queued_prefixes": [],
+            "review_blocked_count": 0,
+            "review_blocked_prefixes": [],
+            "blocked_count": 0,
+            "blocked": [],
+        }
+
+    return _retry_failed_encode_prefixes(
+        [normalized_prefix],
+        config=config,
+        load_calibration_state=load_calibration_state,
+        review_gate=review_gate,
+        queue_folder_encode_action=queue_folder_encode_action,
+    )
+
+
+def _retryable_terminal_encode_prefixes(*, connection_factory: Any) -> list[str]:
     with connection_factory() as connection:
         rows = connection.execute(
             select(encode_jobs.c.prefix, encode_jobs.c.status)
@@ -79,13 +128,21 @@ def retry_failed_encode_queue_action(
             continue
         latest_status_by_prefix[prefix] = str(row["status"] or "").strip()
 
-    terminal_prefixes = [
+    return [
         prefix
         for prefix, status in latest_status_by_prefix.items()
         if status in RETRYABLE_TERMINAL_ENCODE_JOB_STATUSES
     ]
-    if not terminal_prefixes:
-        return {"ok": True, "message": "No failed folder encodes were ready to retry.", "queued_count": 0}
+
+
+def _retry_failed_encode_prefixes(
+        terminal_prefixes: list[str],
+        *,
+        config: MediaforceConfig,
+        load_calibration_state: Any,
+        review_gate: Any,
+        queue_folder_encode_action: Any,
+) -> dict[str, Any]:
 
     queued_prefixes: list[str] = []
     review_blocked_prefixes: list[str] = []

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -43,6 +43,7 @@ from mediaforce.encoding.encode_queue import clear_terminal_encode_jobs_for_pref
 from mediaforce.encoding.quality import QualitySearchResult, SampleEncodeResult
 from mediaforce.hosts import status_runtime as host_status_runtime
 from mediaforce.remote import HostStatus
+from mediaforce.tuning.calibration_jobs import list_queue_summary
 from mediaforce.review import BrowserReviewClip, CompareClip, EncodedPreviewClip
 from mediaforce.web import app as web_app
 from mediaforce.web import settings_runtime
@@ -4451,6 +4452,85 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(result["queued_count"], 2)
         self.assertEqual(result["review_blocked_count"], 1)
         self.assertEqual(result["review_blocked_prefixes"], ["tv/review-blocked"])
+
+    def test_retry_failed_encode_prefix_action_retries_only_requested_prefix(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            now = web_app._now_iso()
+            for prefix in ("tv/approved-a", "tv/approved-b"):
+                save_encode_job(
+                    connection,
+                    {
+                        "job_id": f"job-{prefix.rsplit('/', 1)[-1]}",
+                        "prefix": prefix,
+                        "job_kind": "folder",
+                        "parent_job_id": None,
+                        "status": "needs_attention",
+                        "manifest_path": str(self.root / "runs" / f"{prefix.rsplit('/', 1)[-1]}.json"),
+                        "item_count": 1,
+                        "saved_profile_path": None,
+                        "host": {},
+                        "last_host": {},
+                        "notes": "",
+                        "bypass_schedule": False,
+                        "attempt_count": 3,
+                        "process_pid": None,
+                        "error": None,
+                        "leased_at": None,
+                        "lease_expires_at": None,
+                        "heartbeat_at": None,
+                        "worker_id": None,
+                        "retry_not_before": None,
+                        "waiting_reason": None,
+                        "terminal_reason": None,
+                        "last_failure_kind": None,
+                        "last_failure_at": None,
+                        "host_cooldown_until": None,
+                        "created_at": now,
+                        "started_at": None,
+                        "finished_at": now,
+                        "updated_at": now,
+                    },
+                )
+
+        queued_prefixes: list[str] = []
+
+        def queue_folder_encode_action(prefix: str, _notes: str,
+                                       _bypass_schedule: bool) -> folder_actions_runtime.ActionPayload:
+            queued_prefixes.append(prefix)
+            return {"ok": True, "message": "Queued the full folder encode."}
+
+        result = queue_actions_runtime.retry_failed_encode_prefix_action(
+            connection_factory=lambda: open_db(self.config.paths.db_path),
+            config=self.config,
+            prefix="tv/approved-b",
+            load_calibration_state=lambda _config, _prefix: {
+                "policy": {},
+                "accepted_at": web_app._now_iso(),
+                "accepted_sample_job_id": "sample-1",
+                "job_id": "sample-1",
+            },
+            review_gate=self._accepted_review_gate,
+            queue_folder_encode_action=queue_folder_encode_action,
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(queued_prefixes, ["tv/approved-b"])
+        self.assertEqual(result["queued_prefixes"], ["tv/approved-b"])
+
+    def test_retry_failed_encode_prefix_action_reports_non_retryable_prefix(self) -> None:
+        result = queue_actions_runtime.retry_failed_encode_prefix_action(
+            connection_factory=lambda: open_db(self.config.paths.db_path),
+            config=self.config,
+            prefix="tv/not-failed",
+            load_calibration_state=lambda _config, _prefix: None,
+            review_gate=self._accepted_review_gate,
+            queue_folder_encode_action=lambda _prefix, _notes, _bypass_schedule: {"ok": True},
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["queued_count"], 0)
+        self.assertEqual(result["queued_prefixes"], [])
+        self.assertIn("No failed folder encode was ready", result["message"])
 
     def test_save_profile_action_requires_high_impact_confirmation(self) -> None:
         calibration_payload: folder_actions_runtime.ActionPayload = {
@@ -13392,6 +13472,46 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             controller.cancel.assert_called_once_with()
         finally:
             web_app.CALIBRATION_QUEUE_PROCESSES.clear()
+
+    def test_calibration_queue_summary_surfaces_recent_failed_jobs(self) -> None:
+        now = web_app._now_iso()
+        with open_db(self.config.paths.db_path) as connection:
+            for job_id, prefix, lane, status in (
+                    ("sample-failed", "tv/sample-failed", "sample", "failed"),
+                    ("proof-stopped", "tv/proof-stopped", "full", "stopped"),
+                    ("sample-running", "tv/sample-running", "sample", "running"),
+            ):
+                web_app._save_job_state(
+                    connection,
+                    self.config,
+                    prefix,
+                    {
+                        "job_id": job_id,
+                        "prefix": prefix,
+                        "status": status,
+                        "lane": lane,
+                        "action": "baseline" if lane == "sample" else "full",
+                        "host": {"key": "cbusillo@localhost", "label": "M4 Studio"},
+                        "notes": "",
+                        "policy": {},
+                        "sample_item": {},
+                        "owner_pid": None,
+                        "created_at": now,
+                        "started_at": now,
+                        "finished_at": now if status in {"failed", "stopped"} else None,
+                        "error": f"{job_id} failed detail" if status == "failed" else "Stopped by operator.",
+                    },
+                )
+            connection.commit()
+
+            summary = list_queue_summary(connection)
+
+        self.assertEqual(summary["active_count"], 1)
+        self.assertEqual(summary["recent_failed_count"], 2)
+        self.assertEqual(summary["sample"]["recent_failed_count"], 1)
+        self.assertEqual(summary["full"]["recent_failed_count"], 1)
+        self.assertEqual(summary["sample"]["recent_failed"][0]["prefix"], "tv/sample-failed")
+        self.assertEqual(summary["full"]["recent_failed"][0]["prefix"], "tv/proof-stopped")
 
     def test_run_remote_status_probe_retries_timeout_once(self) -> None:
         host: dict[str, object] = {"host": "cbusillo@chris-mini.local"}


### PR DESCRIPTION
## Summary
- Add manual Refresh plus a 15-second Ops runtime refresh loop with visible refreshed/error state.
- Make Ops runtime actions honest about scope: global retry remains global, while failed encode rows now use a per-prefix retry endpoint and label it `Retry folder`.
- Surface the existing password-backed host prepare path in Ops and keep Prepare disabled until required password input is present.
- Surface recent failed/stopped sample/proof calibration work in Ops as blocked history with compact diagnostics and Folder Studio links, while leaving sample/proof retry ownership with Folder Studio.
- Keep schedule editing in Settings and add an Ops link there instead of building runtime schedule overrides into Ops.
- Remove the stale local Codex handoff after consuming the agreed next slice here.

Refs #33

## Validation
- `uv run --with pytest pytest -q tests/test_encode_queue_recovery.py -k "retry_failed_encode_prefix_action or retry_failed_encode_queue_action_retries_latest_approved_failures_only or calibration_queue_summary_surfaces_recent_failed_jobs"`
- `npm --prefix frontend run check`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:unit -- --run src/lib/components/workstation/ops-workstation.test.ts`
- `bash scripts/pre-commit-check.sh`
- Browser QA on `http://127.0.0.1:4173/ops` at desktop and 390px mobile widths.
- Browser metrics confirmed no page-level horizontal overflow, compact failed sample/proof messages instead of raw logs, visible Settings schedule link, and mobile source/visual order starts with active Ops work before host rail.

## Notes For Review
- `Refresh` is SvelteKit data invalidation, not a browser page reload.
- Encode Stop remains global for this slice.
- Failed sample/proof retry is intentionally not an Ops row action yet; Ops shows the blocker and sends the operator to Folder Studio.
- Runtime schedule override controls are intentionally deferred; Ops links to Settings for durable schedule edits.
