### PR TITLE
Fix Ops retry and calibration summaries

### DIFF
--- a/frontend/src/lib/components/workstation/ops-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.test.ts
@@ -167,8 +167,8 @@ describe('Ops workstation mapping', () => {
 		]);
 		expect(rows[1]).toMatchObject({
 			tone: 'wait',
-			action: 'retry-encode-prefix',
-			actionScope: 'row',
+			action: undefined,
+			actionScope: undefined,
 			detail: 'transient worker fault'
 		});
 		expect(rows[2]).toMatchObject({
@@ -177,8 +177,10 @@ describe('Ops workstation mapping', () => {
 			actionScope: 'row',
 			detail: 'quality target missed'
 		});
-		expect(rowRecoveryLabel(rows[1])).toBe('Retry folder');
-		expect(rowRecoveryTitle(rows[1])).toContain('folder prefix only');
+		expect(rowRecoveryLabel(rows[1])).toBe('No action');
+		expect(rowRecoveryTitle(rows[1])).toBe('No runtime action is available for this row.');
+		expect(rowRecoveryLabel(rows[2])).toBe('Retry folder');
+		expect(rowRecoveryTitle(rows[2])).toContain('folder prefix only');
 		expect(rowRecoveryLabel(rows[3])).toBe('No action');
 		expect(rows[4]).toMatchObject({
 			tone: 'fail',

--- a/frontend/src/lib/components/workstation/ops-workstation.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.ts
@@ -140,27 +140,28 @@ export function buildEncodeRows(
 ): OpsQueueRow[] {
 	const queue = dashboard?.encode_queue;
 	if (!queue) return [];
+	const prefixRetryStatuses = new Set(['failed', 'needs_attention', 'stopped']);
 	const recentAttention = (queue.recent ?? []).filter((job) =>
-		['failed', 'needs_attention', 'stopped'].includes(String(job.status ?? '').toLowerCase())
+		prefixRetryStatuses.has(String(job.status ?? '').toLowerCase())
 	);
-	return [...queue.running, ...queue.queued, ...recentAttention].map((job) => ({
-		key: `encode:${job.job_id}`,
-		kind: 'encode',
-		tone: encodeJobTone(job),
-		status: statusCopy(job.status || 'unknown'),
-		prefix: job.prefix || 'runtime scope',
-		host: job.active_hosts?.map(hostCopy).filter(Boolean).join(', ') || hostCopy(job.host),
-		phase: job.running_shard_count ? `${job.running_shard_count} active shards` : 'encode queue',
-		progress: encodeJobProgress(job),
-		scheduler: job.scheduler_status_copy || (job.schedule_waiting ? 'schedule waiting' : 'ready'),
-		detail: encodeJobDetail(job),
-		action: ['failed', 'needs_attention', 'stopped', 'retry_backoff'].includes(job.status)
-			? 'retry-encode-prefix'
-			: undefined,
-		actionScope: ['failed', 'needs_attention', 'stopped', 'retry_backoff'].includes(job.status)
-			? 'row'
-			: undefined
-	}));
+	return [...queue.running, ...queue.queued, ...recentAttention].map((job) => {
+		const status = String(job.status ?? '').toLowerCase();
+		const canRetryPrefix = prefixRetryStatuses.has(status);
+		return {
+			key: `encode:${job.job_id}`,
+			kind: 'encode',
+			tone: encodeJobTone(job),
+			status: statusCopy(job.status || 'unknown'),
+			prefix: job.prefix || 'runtime scope',
+			host: job.active_hosts?.map(hostCopy).filter(Boolean).join(', ') || hostCopy(job.host),
+			phase: job.running_shard_count ? `${job.running_shard_count} active shards` : 'encode queue',
+			progress: encodeJobProgress(job),
+			scheduler: job.scheduler_status_copy || (job.schedule_waiting ? 'schedule waiting' : 'ready'),
+			detail: encodeJobDetail(job),
+			action: canRetryPrefix ? 'retry-encode-prefix' : undefined,
+			actionScope: canRetryPrefix ? 'row' : undefined
+		};
+	});
 }
 
 function buildCalibrationLaneRows(

--- a/mediaforce/tuning/calibration_jobs.py
+++ b/mediaforce/tuning/calibration_jobs.py
@@ -122,12 +122,17 @@ def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict
         .where(calibration_jobs.c.status.in_(("queued", "running", "pending_review")))
         .order_by(calibration_jobs.c.created_at.asc(), _rowid_column().asc())
     ).mappings().fetchall()
-    recent_terminal_rows = connection.execute(
-        _calibration_job_select()
-        .where(calibration_jobs.c.status.in_(("failed", "stopped")))
-        .order_by(calibration_jobs.c.updated_at.desc(), _rowid_column().desc())
-        .limit(limit_per_lane * 2)
-    ).mappings().fetchall()
+    recent_terminal_rows = []
+    for lane in ("sample", "full"):
+        recent_terminal_rows.extend(
+            connection.execute(
+                _calibration_job_select()
+                .where(calibration_jobs.c.lane == lane)
+                .where(calibration_jobs.c.status.in_(("failed", "stopped")))
+                .order_by(calibration_jobs.c.updated_at.desc(), _rowid_column().desc())
+                .limit(limit_per_lane)
+            ).mappings().fetchall()
+        )
     summary: dict[str, Any] = {
         "sample": {"running": [], "queued": [], "pending_review": [], "running_count": 0, "queued_count": 0,
                    "pending_review_count": 0, "recent_failed": [], "recent_failed_count": 0},

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -13513,6 +13513,62 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(summary["sample"]["recent_failed"][0]["prefix"], "tv/sample-failed")
         self.assertEqual(summary["full"]["recent_failed"][0]["prefix"], "tv/proof-stopped")
 
+    def test_calibration_queue_summary_limits_recent_failed_jobs_per_lane(self) -> None:
+        now = web_app._now_iso()
+        with open_db(self.config.paths.db_path) as connection:
+            for index in range(4):
+                prefix = f"tv/sample-failed-{index}"
+                web_app._save_job_state(
+                    connection,
+                    self.config,
+                    prefix,
+                    {
+                        "job_id": f"sample-failed-{index}",
+                        "prefix": prefix,
+                        "status": "failed",
+                        "lane": "sample",
+                        "action": "baseline",
+                        "host": {"key": "cbusillo@localhost", "label": "M4 Studio"},
+                        "notes": "",
+                        "policy": {},
+                        "sample_item": {},
+                        "owner_pid": None,
+                        "created_at": now,
+                        "started_at": now,
+                        "finished_at": now,
+                        "error": "sample failed detail",
+                    },
+                )
+            web_app._save_job_state(
+                connection,
+                self.config,
+                "tv/proof-failed",
+                {
+                    "job_id": "proof-failed",
+                    "prefix": "tv/proof-failed",
+                    "status": "failed",
+                    "lane": "full",
+                    "action": "full",
+                    "host": {"key": "cbusillo@localhost", "label": "M4 Studio"},
+                    "notes": "",
+                    "policy": {},
+                    "sample_item": {},
+                    "owner_pid": None,
+                    "created_at": now,
+                    "started_at": now,
+                    "finished_at": now,
+                    "error": "proof failed detail",
+                },
+            )
+            connection.commit()
+
+            summary = list_queue_summary(connection, limit_per_lane=2)
+
+        self.assertEqual(summary["sample"]["recent_failed_count"], 2)
+        self.assertEqual(summary["full"]["recent_failed_count"], 1)
+        self.assertEqual(len(summary["sample"]["recent_failed"]), 2)
+        self.assertEqual(summary["full"]["recent_failed"][0]["prefix"], "tv/proof-failed")
+
     def test_run_remote_status_probe_retries_timeout_once(self) -> None:
         host: dict[str, object] = {"host": "cbusillo@chris-mini.local"}
         timeout_exc = subprocess.TimeoutExpired(cmd=["ssh"], timeout=8)


### PR DESCRIPTION
## Summary
- Remove the per-prefix retry action from encode rows still in `retry_backoff`, since that backend endpoint only accepts terminal failed/needs-attention/stopped prefixes.
- Fetch recent failed/stopped calibration jobs per lane so sample failures cannot crowd out proof failures from the Ops summary.
- Add regression coverage for both review findings.

## Validation
- `uv run --with pytest pytest -q tests/test_encode_queue_recovery.py -k "retry_failed_encode_prefix_action or calibration_queue_summary_surfaces_recent_failed_jobs or calibration_queue_summary_limits_recent_failed_jobs_per_lane"`
- `npm --prefix frontend run test:unit -- --run src/lib/components/workstation/ops-workstation.test.ts`
- `npm --prefix frontend run check`
- `npm --prefix frontend run lint`
- `bash scripts/pre-commit-check.sh`

## Notes
- Follow-up to the Ops runtime work from PR #34.
- This is intentionally separate from PR #35 so the Settings workstation review stays focused.
