### PR TITLE
Fix Settings cleanup and stale Ops retry actions

### DIFF
--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -87,7 +87,9 @@ export interface EncodeQueueJob {
 	error?: string | null;
 	last_failure_kind?: string | null;
 	last_failure_at?: string | null;
+	created_at?: string | null;
 	finished_at?: string | null;
+	updated_at?: string | null;
 	attempt_summary?: string | null;
 	active_hosts?: Array<Record<string, unknown>>;
 	running_shard_count?: number;

--- a/frontend/src/lib/components/settings/SettingsEditor.svelte
+++ b/frontend/src/lib/components/settings/SettingsEditor.svelte
@@ -17,6 +17,7 @@
 		addHostDraft,
 		addLibraryDraft,
 		addScheduleDraft,
+		buildArchiveCleanupClearPayload,
 		buildSettingsSavePayload,
 		draftFromSettings,
 		hostDraftRuntimeKey,
@@ -289,7 +290,7 @@
 		try {
 			const response = await postJson<ArchiveClearResponse>(
 				`${resolve('/')}api/archive-cleanup/clear`,
-				{ transcode_root: draft.transcode_root }
+				buildArchiveCleanupClearPayload(savedSettings)
 			);
 			if (!response.ok) {
 				throw new Error(response.message || 'Archive cleanup failed.');

--- a/frontend/src/lib/components/workstation/ops-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.test.ts
@@ -9,7 +9,8 @@ import {
 	hostStateCopy,
 	hostTone,
 	rowRecoveryLabel,
-	rowRecoveryTitle
+	rowRecoveryTitle,
+	retryableEncodeJobIds
 } from './ops-workstation';
 
 function dashboardFixture(): DashboardSummaryPayload {
@@ -245,5 +246,34 @@ describe('Ops workstation mapping', () => {
 		expect(hostPrepareTitle(passwordHost)).toBe('Enter the prepare password for this host.');
 		expect(hostPrepareDisabled(unsupportedHost, 'secret')).toBe(true);
 		expect(hostPrepareTitle(unsupportedHost)).toBe('Prepare is unavailable for this host.');
+	});
+
+	it('does not expose prefix retry for stale historical encode rows', () => {
+		const dashboard = dashboardFixture();
+		dashboard.encode_queue.queued.push({
+			job_id: 'encode-newer',
+			prefix: 'tv/show/season 3',
+			status: 'queued',
+			created_at: '2026-05-05T12:00:00Z',
+			updated_at: '2026-05-05T12:00:00Z'
+		});
+		dashboard.encode_queue.recent = [
+			{
+				job_id: 'encode-stale',
+				prefix: 'tv/show/season 3',
+				status: 'needs_attention',
+				error: 'older quality target miss',
+				created_at: '2026-05-05T11:00:00Z',
+				updated_at: '2026-05-05T11:00:00Z'
+			}
+		];
+
+		const rows = buildOpsQueueRows(dashboard);
+		const staleRow = rows.find((row) => row.key === 'encode:encode-stale');
+
+		expect(staleRow).toMatchObject({ action: undefined, actionScope: undefined });
+		expect(
+			retryableEncodeJobIds([...dashboard.encode_queue.queued, ...dashboard.encode_queue.recent])
+		).not.toContain('encode-stale');
 	});
 });

--- a/frontend/src/lib/components/workstation/ops-workstation.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.ts
@@ -135,6 +135,33 @@ export function encodeJobDetail(job: EncodeQueueJob): string {
 	);
 }
 
+function encodeJobTimestamp(job: EncodeQueueJob): number {
+	const raw = job.updated_at || job.finished_at || job.created_at || '';
+	const timestamp = Date.parse(raw);
+	return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+export function retryableEncodeJobIds(jobs: EncodeQueueJob[]): Set<string> {
+	const prefixRetryStatuses = new Set(['failed', 'needs_attention', 'stopped']);
+	const latestJobByPrefix = new Map<string, EncodeQueueJob>();
+	for (const job of jobs) {
+		const prefix = String(job.prefix ?? '').trim();
+		if (!prefix) continue;
+		const current = latestJobByPrefix.get(prefix);
+		if (!current || encodeJobTimestamp(job) >= encodeJobTimestamp(current)) {
+			latestJobByPrefix.set(prefix, job);
+		}
+	}
+
+	const retryableJobIds = new Set<string>();
+	for (const job of latestJobByPrefix.values()) {
+		if (prefixRetryStatuses.has(String(job.status ?? '').toLowerCase())) {
+			retryableJobIds.add(job.job_id);
+		}
+	}
+	return retryableJobIds;
+}
+
 export function buildEncodeRows(
 	dashboard: DashboardSummaryPayload | null | undefined
 ): OpsQueueRow[] {
@@ -144,9 +171,11 @@ export function buildEncodeRows(
 	const recentAttention = (queue.recent ?? []).filter((job) =>
 		prefixRetryStatuses.has(String(job.status ?? '').toLowerCase())
 	);
-	return [...queue.running, ...queue.queued, ...recentAttention].map((job) => {
+	const displayJobs = [...queue.running, ...queue.queued, ...recentAttention];
+	const retryableJobIds = retryableEncodeJobIds(displayJobs);
+	return displayJobs.map((job) => {
 		const status = String(job.status ?? '').toLowerCase();
-		const canRetryPrefix = prefixRetryStatuses.has(status);
+		const canRetryPrefix = prefixRetryStatuses.has(status) && retryableJobIds.has(job.job_id);
 		return {
 			key: `encode:${job.job_id}`,
 			kind: 'encode',

--- a/frontend/src/lib/settings/editor.test.ts
+++ b/frontend/src/lib/settings/editor.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	DEFAULT_SCHEDULE_DAYS,
 	addScheduleDraft,
+	buildArchiveCleanupClearPayload,
 	buildSettingsSavePayload,
 	cloneScheduleProfile,
 	draftFromSettings,
@@ -172,6 +173,15 @@ describe('settings draft helpers', () => {
 
 		draft.libraries[0] = { ...draft.libraries[0], path: '/Volumes/TV2' };
 		expect(settingsDraftIsDirty(draft, payload)).toBe(true);
+	});
+
+	it('uses the saved transcode root for destructive archive cleanup', () => {
+		const draft = draftFromSettings(payload);
+		draft.transcode_root = '/Volumes/UnsavedTranscode';
+
+		expect(buildArchiveCleanupClearPayload(payload)).toEqual({
+			transcode_root: '/Volumes/Transcode'
+		});
 	});
 
 	it('toggles host library assignment without duplicating selected keys', () => {

--- a/frontend/src/lib/settings/editor.ts
+++ b/frontend/src/lib/settings/editor.ts
@@ -42,6 +42,9 @@ export type SettingsSavePayload = {
 	encode_queue_scheduler: SettingsPayload['encode_queue_scheduler'];
 	schedule_profiles: ScheduleProfile[];
 };
+export type ArchiveCleanupClearPayload = {
+	transcode_root: string;
+};
 
 export function cloneScheduleProfile(profile: ScheduleProfile): ScheduleProfile {
 	return normalizeScheduleProfile(profile);
@@ -170,6 +173,12 @@ export function settingsDraftIsDirty(draft: SettingsDraft, settings: SettingsPay
 		JSON.stringify(buildSettingsSavePayload(draft, settings)) !==
 		JSON.stringify(buildSettingsSavePayload(draftFromSettings(settings), settings))
 	);
+}
+
+export function buildArchiveCleanupClearPayload(
+	settings: SettingsPayload
+): ArchiveCleanupClearPayload {
+	return { transcode_root: settings.transcode_root };
 }
 
 export function hostDraftRuntimeKey(host: SettingsHost): string {


### PR DESCRIPTION
## Summary
- Make Settings archive cleanup post the saved transcode root instead of the editable draft root, so unsaved transcode-root edits cannot redirect a destructive cleanup action.
- Hide per-prefix Ops retry buttons for stale historical encode rows when a newer displayed job for the same prefix is active, queued, or otherwise not terminal.
- Add frontend regression coverage for both review findings.

## Validation
- `npm --prefix frontend run test:unit -- --run src/lib/settings/editor.test.ts src/lib/components/workstation/ops-workstation.test.ts`
- `npm --prefix frontend run check`
- `npm --prefix frontend run lint`
- `bash scripts/pre-commit-check.sh`

## Notes
- Follow-up to the Settings/Ops/Queue workstation work after auto-review findings.
