### PR TITLE
Fix Settings cleanup target and calibration summaries

### DIFF
--- a/frontend/src/lib/components/settings/SettingsEditor.svelte
+++ b/frontend/src/lib/components/settings/SettingsEditor.svelte
@@ -17,6 +17,7 @@
 		addHostDraft,
 		addLibraryDraft,
 		addScheduleDraft,
+		archiveCleanupTargetDirty,
 		buildArchiveCleanupClearPayload,
 		buildSettingsSavePayload,
 		draftFromSettings,
@@ -98,10 +99,9 @@
 	const readyHostCount = $derived(runtimeHosts.filter((host) => host.available).length);
 	const archiveCleanup = $derived(savedSettings?.archive_cleanup ?? null);
 	const dirty = $derived(savedSettings ? settingsDraftIsDirty(draft, savedSettings) : false);
-	const archiveRootCopy = $derived(
-		draft.transcode_root.trim()
-			? `${draft.transcode_root.trim().replace(/\/+$/, '')}/_replaced`
-			: ''
+	const savedArchiveRootCopy = $derived(savedSettings?.archive_root || 'unset');
+	const cleanupTargetDirty = $derived(
+		savedSettings ? archiveCleanupTargetDirty(draft, savedSettings) : false
 	);
 	const draftScheduleOptions = $derived([
 		{ key: 'always', label: 'Always', summary: 'Runs anytime.' },
@@ -283,7 +283,7 @@
 		archiveError = '';
 		if (!clearArchiveArmed) {
 			clearArchiveArmed = true;
-			archiveMessage = 'Confirm archive cleanup with a second click.';
+			archiveMessage = `Confirm archive cleanup for ${savedArchiveRootCopy} with a second click.`;
 			return;
 		}
 		clearArchivePending = true;
@@ -457,9 +457,10 @@
 						</label>
 						<div class="storage-readout">
 							<span>Archive cleanup root</span>
-							<strong class="mf-path"
-								>{archiveRootCopy || savedSettings.archive_root || 'unset'}</strong
-							>
+							<strong class="mf-path">{savedArchiveRootCopy}</strong>
+							{#if cleanupTargetDirty}
+								<small>Save settings before clearing a changed archive target.</small>
+							{/if}
 						</div>
 						<div class="storage-readout">
 							<span>Archived originals</span>
@@ -475,8 +476,11 @@
 								type="button"
 								class="control control--danger"
 								class:control--armed={clearArchiveArmed}
-								disabled={!archiveCleanup?.has_cleanup || clearArchivePending}
+								disabled={!archiveCleanup?.has_cleanup || clearArchivePending || cleanupTargetDirty}
 								onclick={clearArchiveCleanup}
+								title={cleanupTargetDirty
+									? 'Save the changed transcode root before clearing archived originals.'
+									: undefined}
 							>
 								{clearArchivePending ? 'Clearing' : clearArchiveArmed ? 'Confirm' : 'Clear archive'}
 							</button>
@@ -841,9 +845,7 @@
 						</div>
 						<div class="rail-row">
 							<span>Review/archive output</span>
-							<strong class="mf-path"
-								>{archiveRootCopy || savedSettings.archive_root || 'unset'}</strong
-							>
+							<strong class="mf-path">{savedArchiveRootCopy}</strong>
 						</div>
 					</div>
 				</WorkstationPanel>

--- a/frontend/src/lib/settings/editor.test.ts
+++ b/frontend/src/lib/settings/editor.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	DEFAULT_SCHEDULE_DAYS,
 	addScheduleDraft,
+	archiveCleanupTargetDirty,
 	buildArchiveCleanupClearPayload,
 	buildSettingsSavePayload,
 	cloneScheduleProfile,
@@ -182,6 +183,18 @@ describe('settings draft helpers', () => {
 		expect(buildArchiveCleanupClearPayload(payload)).toEqual({
 			transcode_root: '/Volumes/Transcode'
 		});
+	});
+
+	it('flags archive cleanup as dirty when the cleanup target is edited but unsaved', () => {
+		const draft = draftFromSettings(payload);
+
+		expect(archiveCleanupTargetDirty(draft, payload)).toBe(false);
+
+		draft.transcode_root = ' /Volumes/Transcode ';
+		expect(archiveCleanupTargetDirty(draft, payload)).toBe(false);
+
+		draft.transcode_root = '/Volumes/UnsavedTranscode';
+		expect(archiveCleanupTargetDirty(draft, payload)).toBe(true);
 	});
 
 	it('toggles host library assignment without duplicating selected keys', () => {

--- a/frontend/src/lib/settings/editor.ts
+++ b/frontend/src/lib/settings/editor.ts
@@ -175,6 +175,13 @@ export function settingsDraftIsDirty(draft: SettingsDraft, settings: SettingsPay
 	);
 }
 
+export function archiveCleanupTargetDirty(
+	draft: SettingsDraft,
+	settings: SettingsPayload
+): boolean {
+	return draft.transcode_root.trim() !== settings.transcode_root.trim();
+}
+
 export function buildArchiveCleanupClearPayload(
 	settings: SettingsPayload
 ): ArchiveCleanupClearPayload {

--- a/mediaforce/tuning/calibration_jobs.py
+++ b/mediaforce/tuning/calibration_jobs.py
@@ -123,6 +123,7 @@ def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict
         .order_by(calibration_jobs.c.created_at.asc(), _rowid_column().asc())
     ).mappings().fetchall()
     recent_terminal_rows = []
+    recent_terminal_limit = limit_per_lane * 4 if limit_per_lane > 0 else 0
     for lane in ("sample", "full"):
         recent_terminal_rows.extend(
             connection.execute(
@@ -130,7 +131,7 @@ def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict
                 .where(calibration_jobs.c.lane == lane)
                 .where(calibration_jobs.c.status.in_(("failed", "stopped")))
                 .order_by(calibration_jobs.c.updated_at.desc(), _rowid_column().desc())
-                .limit(limit_per_lane)
+                .limit(recent_terminal_limit)
             ).mappings().fetchall()
         )
     summary: dict[str, Any] = {
@@ -158,14 +159,14 @@ def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict
         payload = _hydrate_job(row)
         lane = str(payload.get("lane") or "sample")
         lane_summary = summary[lane]
-        lane_summary["recent_failed_count"] += 1
-        summary["recent_failed_count"] += 1
         prefix_lane = (str(payload.get("prefix") or ""), lane)
         if prefix_lane in seen_terminal_prefix_lanes:
             continue
         seen_terminal_prefix_lanes.add(prefix_lane)
         if len(lane_summary["recent_failed"]) < limit_per_lane:
             lane_summary["recent_failed"].append(payload)
+            lane_summary["recent_failed_count"] += 1
+            summary["recent_failed_count"] += 1
     return summary
 
 

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -13569,6 +13569,49 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(len(summary["sample"]["recent_failed"]), 2)
         self.assertEqual(summary["full"]["recent_failed"][0]["prefix"], "tv/proof-failed")
 
+    def test_calibration_queue_summary_deduplicates_failed_prefixes_before_limit(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            for job_id, prefix, updated_at in (
+                    ("sample-duplicate-newer", "tv/duplicate", "2026-05-05T12:03:00+00:00"),
+                    ("sample-duplicate-older", "tv/duplicate", "2026-05-05T12:02:00+00:00"),
+                    ("sample-distinct", "tv/distinct", "2026-05-05T12:01:00+00:00"),
+            ):
+                web_app._save_job_state(
+                    connection,
+                    self.config,
+                    prefix,
+                    {
+                        "job_id": job_id,
+                        "prefix": prefix,
+                        "status": "failed",
+                        "lane": "sample",
+                        "action": "baseline",
+                        "host": {"key": "cbusillo@localhost", "label": "M4 Studio"},
+                        "notes": "",
+                        "policy": {},
+                        "sample_item": {},
+                        "owner_pid": None,
+                        "created_at": updated_at,
+                        "started_at": updated_at,
+                        "finished_at": updated_at,
+                        "error": "sample failed detail",
+                    },
+                )
+                connection.execute(
+                    calibration_jobs.update()
+                    .where(calibration_jobs.c.job_id == job_id)
+                    .values(updated_at=updated_at)
+                )
+            connection.commit()
+
+            summary = list_queue_summary(connection, limit_per_lane=2)
+
+        self.assertEqual(summary["sample"]["recent_failed_count"], 2)
+        self.assertEqual(
+            [job["prefix"] for job in summary["sample"]["recent_failed"]],
+            ["tv/duplicate", "tv/distinct"],
+        )
+
     def test_run_remote_status_probe_retries_timeout_once(self) -> None:
         host: dict[str, object] = {"host": "cbusillo@chris-mini.local"}
         timeout_exc = subprocess.TimeoutExpired(cmd=["ssh"], timeout=8)


### PR DESCRIPTION
## Summary
- show the saved archive cleanup target and disable destructive cleanup while the transcode root has unsaved edits
- fetch extra recent calibration terminal rows so duplicate failed prefixes do not hide distinct failures
- add regression coverage for cleanup target dirtiness and calibration failure deduping

## Checks
- bash scripts/pre-commit-check.sh