### PR TITLE
Build completed cleanup workstation

### DIFF
--- a/docs/design/operator-workstation-shell-brief.md
+++ b/docs/design/operator-workstation-shell-brief.md
@@ -41,8 +41,10 @@ completed, settings, and folder studio.
 - Ops: the fleet console. Lead with queue, workers, calibration, and cleanup
   state in one scan-friendly strip, then keep queue lanes and host readiness in
   list/table-first control surfaces rather than separate dashboard cards.
-- Completed: the archive cleanup surface. Keep the header light and route users
-  directly into cleanup decisions instead of repeating summary pills.
+- Completed: the archive cleanup and history surface. Keep cleanup readiness,
+  selected versus global destructive scope, archive-root health, and recent
+  encode/cleanup events visible in one route so the operator can remove
+  archived originals without treating it like another active queue.
 - Settings: the runtime configuration surface. It may stay more utilitarian and
   form-heavy than the other routes, but it should still inherit the same shell,
   typography, and navigation language.

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -146,6 +146,60 @@ export interface DashboardScanJob {
 	} | null;
 }
 
+export interface ArchiveCleanupSummary {
+	archive_root: string;
+	file_count: number;
+	total_size_bytes: number;
+	has_cleanup: boolean;
+}
+
+export interface CompletedFolderRow {
+	prefix: string;
+	title: string;
+	subtitle: string;
+	scope_label: string;
+	promoted_item_count: number;
+	archived_backup_count: number;
+	archived_backup_size_bytes: number;
+	total_bytes_saved: number;
+	latest_promoted_at: string | null;
+	cleanup_state?: 'ready' | 'blocked' | 'unknown' | 'cleaned' | string;
+	cleanup_detail?: string;
+	missing_backup_count?: number;
+	outside_archive_root_count?: number;
+}
+
+export interface CompletedHistoryEvent {
+	id: number;
+	event_type: string;
+	label: string;
+	tone: 'active' | 'ready' | 'wait' | 'fail' | 'idle' | string;
+	prefix: string;
+	title: string;
+	subtitle: string;
+	scope_label: string;
+	created_at: string;
+	detail: string;
+	size_bytes?: number | null;
+}
+
+export interface CompletedPayload {
+	folders: CompletedFolderRow[];
+	completed_count: number;
+	folders_with_backups_count: number;
+	archive_cleanup: ArchiveCleanupSummary;
+	history?: CompletedHistoryEvent[];
+}
+
+export interface CompletedCleanupResult {
+	ok: boolean;
+	message: string;
+	removed_count: number;
+	removed_size_bytes: number;
+	removed_prefix_count: number;
+	completed?: CompletedPayload;
+}
+
 export interface DashboardSummaryPayload {
 	folders_preview: FolderCard[];
 	library_colors: Record<string, string>;
@@ -157,12 +211,7 @@ export interface DashboardSummaryPayload {
 		recent_failed_count?: number;
 	};
 	encode_queue: EncodeQueueSummary;
-	archive_cleanup?: {
-		archive_root: string;
-		file_count: number;
-		total_size_bytes: number;
-		has_cleanup: boolean;
-	};
+	archive_cleanup?: ArchiveCleanupSummary;
 	catalog_empty: boolean;
 	folder_cache_key: string;
 	metric_support: MetricSupport;

--- a/frontend/src/lib/components/workstation/CompletedWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/CompletedWorkstationView.svelte
@@ -103,6 +103,8 @@
 	);
 	const counts = $derived(cleanupStateCounts(folders, archive));
 	const recommendedFolder = $derived(cleanupReadyFolders[0] ?? null);
+	const cleanupWorkAvailable = $derived(archive.has_cleanup || cleanupReadyFolders.length > 0);
+	const cleanupReviewCount = $derived(counts.blocked + counts.unknown);
 	const historyRows = $derived([
 		...localHistory.map((event) => ({ ...event, source: 'api' as const })),
 		...(completed ? buildCompletedHistoryRows(completed) : [])
@@ -424,7 +426,10 @@
 					</div>
 				</WorkstationPanel>
 
-				<WorkstationPanel eyebrow="Action" title="Cleanup command">
+				<WorkstationPanel
+					eyebrow="Action"
+					title={cleanupWorkAvailable ? 'Cleanup command' : 'Cleanup review'}
+				>
 					<div class="cleanup-command">
 						<div class="cleanup-command__state">
 							<StateBadge
@@ -451,36 +456,52 @@
 							</div>
 						</div>
 
-						<div class="cleanup-command__actions" aria-label="Cleanup actions">
-							<button
-								type="button"
-								class="control"
-								disabled={filteredReadyFolders.length === 0}
-								onclick={selectVisibleReady}>Select visible ready</button
-							>
-							<button
-								type="button"
-								class="control"
-								disabled={selectedFolders.length === 0}
-								onclick={clearSelection}>Clear selection</button
-							>
-							<button
-								type="button"
-								class="control control--danger"
-								class:armed={armedScope === 'selected'}
-								disabled={cleanupDisabled('selected')}
-								onclick={() => armCleanup('selected')}
-								>{armedScope === 'selected' ? 'Selected armed' : 'Clear selected backups'}</button
-							>
-							<button
-								type="button"
-								class="control control--danger"
-								class:armed={armedScope === 'global'}
-								disabled={cleanupDisabled('global')}
-								onclick={() => armCleanup('global')}
-								>{armedScope === 'global' ? 'Global armed' : 'Clear entire archive'}</button
-							>
-						</div>
+						{#if cleanupWorkAvailable}
+							<div class="cleanup-command__actions" aria-label="Cleanup actions">
+								<button
+									type="button"
+									class="control"
+									disabled={filteredReadyFolders.length === 0}
+									onclick={selectVisibleReady}>Select visible ready</button
+								>
+								<button
+									type="button"
+									class="control"
+									disabled={selectedFolders.length === 0}
+									onclick={clearSelection}>Clear selection</button
+								>
+								<button
+									type="button"
+									class="control control--danger"
+									class:armed={armedScope === 'selected'}
+									disabled={cleanupDisabled('selected')}
+									onclick={() => armCleanup('selected')}
+									>{armedScope === 'selected' ? 'Selected armed' : 'Clear selected backups'}</button
+								>
+								<button
+									type="button"
+									class="control control--danger"
+									class:armed={armedScope === 'global'}
+									disabled={cleanupDisabled('global')}
+									onclick={() => armCleanup('global')}
+									>{armedScope === 'global' ? 'Global armed' : 'Clear entire archive'}</button
+								>
+							</div>
+						{:else}
+							<div class="cleanup-standby" aria-label="Cleanup standby state">
+								<span>No destructive action is available</span>
+								<strong
+									>{cleanupReviewCount > 0
+										? `${cleanupReviewCount.toLocaleString('en-US')} completed folders need backup review.`
+										: `${folders.length.toLocaleString('en-US')} completed folders are clean.`}</strong
+								>
+								<small
+									>{cleanupReviewCount > 0
+										? 'Resolve missing or unverifiable archived originals before cleanup controls appear.'
+										: 'When archived originals appear, selected cleanup controls return here.'}</small
+								>
+							</div>
+						{/if}
 
 						{#if armedScope}
 							{@const scope = armedScope}
@@ -676,7 +697,7 @@
 			>
 				<div class="history-list">
 					{#each historyRows.slice(0, 8) as event (`rail:${event.source}:${event.id}:${event.created_at}`)}
-						<div class="history-row">
+						<div class="history-row history-row--rail">
 							<StateBadge compact tone={eventTone(event.tone)} label={event.label} />
 							<div>
 								<strong>{event.title}</strong>
@@ -948,6 +969,33 @@
 		gap: var(--mf-space-3);
 	}
 
+	.cleanup-standby {
+		background: var(--mf-bg-panel-2);
+		border: var(--mf-border-muted);
+		border-left: 2px solid var(--mf-line-strong);
+		display: grid;
+		gap: var(--mf-space-2);
+		padding: var(--mf-space-4);
+	}
+
+	.cleanup-standby span {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.cleanup-standby strong {
+		font-size: var(--mf-text-sm);
+		font-weight: var(--mf-weight-semibold);
+	}
+
+	.cleanup-standby small {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-xs);
+	}
+
 	.confirm-panel {
 		align-items: center;
 		background: var(--mf-fail-bg);
@@ -1166,6 +1214,17 @@
 
 	.history-list--wide .history-row {
 		grid-template-columns: minmax(150px, auto) minmax(0, 1fr) minmax(180px, 0.7fr) auto;
+	}
+
+	.history-row--rail {
+		gap: var(--mf-space-2);
+		grid-template-columns: 1fr;
+		min-height: 0;
+		padding: var(--mf-space-3);
+	}
+
+	.history-row--rail time {
+		white-space: normal;
 	}
 
 	.history-row > div {

--- a/frontend/src/lib/components/workstation/CompletedWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/CompletedWorkstationView.svelte
@@ -1,0 +1,1324 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import { postJson } from '$lib/api/client';
+	import type {
+		CompletedCleanupResult,
+		CompletedFolderRow,
+		CompletedHistoryEvent,
+		CompletedPayload
+	} from '$lib/api/types';
+	import { folderRoutePath } from '$lib/folder-display';
+	import { formatBytes } from './folder-studio-view';
+	import OperatorShell from './OperatorShell.svelte';
+	import StateBadge from './StateBadge.svelte';
+	import WorkstationPanel from './WorkstationPanel.svelte';
+	import {
+		buildCompletedFooterSignals,
+		buildCompletedHistoryRows,
+		buildCompletedStatusTiles,
+		cleanupDetail,
+		cleanupLabel,
+		cleanupState,
+		cleanupStateCounts,
+		cleanupTone,
+		completedLibraryOptions,
+		completedStateOptions,
+		folderCanBeSelected,
+		folderSearchText,
+		readyFolders,
+		totalArchivedBackupSize,
+		totalSavedSize,
+		type CleanupState
+	} from './completed-workstation';
+	import type { ShellTone } from './OperatorShell.svelte';
+
+	type WorkstationMode = 'completed' | 'history';
+	type CleanupScope = 'selected' | 'global';
+
+	let {
+		completed: loadedCompleted,
+		loadError
+	}: {
+		completed: CompletedPayload | null;
+		loadError: string | null;
+	} = $props();
+
+	let completed = $state<CompletedPayload | null>(null);
+	let mode = $state<WorkstationMode>('completed');
+	let searchQuery = $state('');
+	let historyQuery = $state('');
+	let libraryFilters = $state<Record<string, boolean>>({});
+	let stateFilters = $state<Record<string, boolean>>({});
+	let selectedPrefixes = $state<Record<string, boolean>>({});
+	let armedScope = $state<CleanupScope | null>(null);
+	let cleanupPending = $state(false);
+	let actionMessage = $state('');
+	let actionError = $state('');
+	let lastCleanupResult = $state<CompletedCleanupResult | null>(null);
+	let localHistory = $state<CompletedHistoryEvent[]>([]);
+
+	$effect(() => {
+		completed = loadedCompleted;
+		actionError = loadError ?? '';
+	});
+
+	const folders = $derived(completed?.folders ?? []);
+	const archive = $derived(
+		completed?.archive_cleanup ?? {
+			archive_root: '',
+			file_count: 0,
+			total_size_bytes: 0,
+			has_cleanup: false
+		}
+	);
+	const statusTiles = $derived(buildCompletedStatusTiles(completed, actionError || loadError));
+	const footerSignals = $derived(buildCompletedFooterSignals(completed));
+	const libraryOptions = $derived(completedLibraryOptions(folders));
+	const stateOptions = $derived(completedStateOptions(folders, archive));
+	const normalizedSearchQuery = $derived(searchQuery.trim().toLowerCase());
+	const filteredFolders = $derived(
+		folders.filter((folder) => {
+			const searchMatches =
+				normalizedSearchQuery.length === 0 ||
+				folderSearchText(folder, archive).includes(normalizedSearchQuery);
+			return (
+				searchMatches &&
+				libraryIncluded(libraryKey(folder.scope_label || folder.prefix.split('/')[0])) &&
+				stateIncluded(cleanupState(folder, archive))
+			);
+		})
+	);
+	const cleanupReadyFolders = $derived(readyFolders(folders, archive));
+	const filteredReadyFolders = $derived(
+		filteredFolders.filter((folder) => folderCanBeSelected(folder, archive))
+	);
+	const selectedFolders = $derived(
+		folders.filter(
+			(folder) => selectedPrefixes[folder.prefix] && folderCanBeSelected(folder, archive)
+		)
+	);
+	const selectedBackupSize = $derived(totalArchivedBackupSize(selectedFolders));
+	const selectedBackupCount = $derived(
+		selectedFolders.reduce((total, folder) => total + Math.max(folder.archived_backup_count, 0), 0)
+	);
+	const counts = $derived(cleanupStateCounts(folders, archive));
+	const recommendedFolder = $derived(cleanupReadyFolders[0] ?? null);
+	const historyRows = $derived([
+		...localHistory.map((event) => ({ ...event, source: 'api' as const })),
+		...(completed ? buildCompletedHistoryRows(completed) : [])
+	]);
+	const normalizedHistoryQuery = $derived(historyQuery.trim().toLowerCase());
+	const visibleHistory = $derived(
+		historyRows.filter((event) => {
+			if (normalizedHistoryQuery.length === 0) return true;
+			return [
+				event.label,
+				event.prefix,
+				event.title,
+				event.subtitle,
+				event.detail,
+				event.event_type
+			]
+				.join(' ')
+				.toLowerCase()
+				.includes(normalizedHistoryQuery);
+		})
+	);
+	const selectedSummary = $derived(
+		selectedFolders.length
+			? `${selectedFolders.length.toLocaleString('en-US')} folders · ${selectedBackupCount.toLocaleString('en-US')} files · ${formatBytes(selectedBackupSize)}`
+			: 'No cleanup-ready folders selected'
+	);
+	const globalSummary = $derived(
+		`${archive.file_count.toLocaleString('en-US')} archived files · ${formatBytes(archive.total_size_bytes)} under ${archive.archive_root || 'missing archive root'}`
+	);
+
+	function libraryKey(label: string): string {
+		return label.trim().toLowerCase() || 'library';
+	}
+
+	function libraryIncluded(key: string): boolean {
+		return libraryFilters[key] ?? true;
+	}
+
+	function stateIncluded(state: CleanupState): boolean {
+		return stateFilters[state] ?? true;
+	}
+
+	function handleSearchInput(event: Event) {
+		searchQuery = (event.currentTarget as HTMLInputElement).value;
+	}
+
+	function handleHistorySearchInput(event: Event) {
+		historyQuery = (event.currentTarget as HTMLInputElement).value;
+	}
+
+	function handleLibraryFilterChange(key: string, event: Event) {
+		libraryFilters = {
+			...libraryFilters,
+			[key]: (event.currentTarget as HTMLInputElement).checked
+		};
+	}
+
+	function handleStateFilterChange(key: string, event: Event) {
+		stateFilters = { ...stateFilters, [key]: (event.currentTarget as HTMLInputElement).checked };
+	}
+
+	function setAllLibraries(included: boolean) {
+		libraryFilters = Object.fromEntries(libraryOptions.map((option) => [option.key, included]));
+	}
+
+	function setAllStates(included: boolean) {
+		stateFilters = Object.fromEntries(stateOptions.map((option) => [option.key, included]));
+	}
+
+	function selected(folder: CompletedFolderRow): boolean {
+		return Boolean(selectedPrefixes[folder.prefix]);
+	}
+
+	function setFolderSelected(folder: CompletedFolderRow, value: boolean) {
+		if (!folderCanBeSelected(folder, archive)) return;
+		selectedPrefixes = { ...selectedPrefixes, [folder.prefix]: value };
+		armedScope = null;
+	}
+
+	function handleRowSelection(folder: CompletedFolderRow, event: Event) {
+		setFolderSelected(folder, (event.currentTarget as HTMLInputElement).checked);
+	}
+
+	function selectVisibleReady() {
+		selectedPrefixes = {
+			...selectedPrefixes,
+			...Object.fromEntries(filteredReadyFolders.map((folder) => [folder.prefix, true]))
+		};
+		armedScope = null;
+	}
+
+	function clearSelection() {
+		selectedPrefixes = {};
+		armedScope = null;
+	}
+
+	function cleanupDisabled(scope: CleanupScope): boolean {
+		if (!completed || cleanupPending) return true;
+		if (scope === 'selected') return selectedFolders.length === 0;
+		return !archive.has_cleanup || archive.file_count <= 0 || !archive.archive_root;
+	}
+
+	function armCleanup(scope: CleanupScope) {
+		actionMessage = '';
+		actionError = '';
+		lastCleanupResult = null;
+		armedScope = armedScope === scope ? null : scope;
+	}
+
+	async function confirmCleanup(scope: CleanupScope) {
+		if (cleanupDisabled(scope)) return;
+		cleanupPending = true;
+		actionMessage = '';
+		actionError = '';
+		try {
+			const cleanupFolders = selectedFolders;
+			const body =
+				scope === 'selected' ? { prefixes: cleanupFolders.map((folder) => folder.prefix) } : {};
+			const result = await postJson<CompletedCleanupResult>(
+				`${resolve('/')}api/completed/backups/clear`,
+				body
+			);
+			lastCleanupResult = result;
+			actionMessage = result.message || 'Cleanup completed.';
+			if (result.completed) {
+				completed = result.completed;
+			}
+			localHistory = [
+				{
+					id: Date.now(),
+					event_type: 'cleanup_completed',
+					label: scope === 'selected' ? 'Selected cleanup completed' : 'Global cleanup completed',
+					tone: 'ready',
+					prefix:
+						scope === 'selected' ? `${cleanupFolders.length} selected folders` : 'archive root',
+					title: scope === 'selected' ? 'Selected cleanup' : 'Global cleanup',
+					subtitle: result.message,
+					scope_label: 'cleanup',
+					created_at: new Date().toISOString(),
+					detail: `${result.removed_count.toLocaleString('en-US')} files removed · ${formatBytes(result.removed_size_bytes)}`,
+					size_bytes: result.removed_size_bytes
+				},
+				...localHistory
+			];
+			selectedPrefixes = {};
+			armedScope = null;
+		} catch (error) {
+			actionError = error instanceof Error ? error.message : 'Cleanup failed.';
+		} finally {
+			cleanupPending = false;
+		}
+	}
+
+	function formatTimestamp(value: string | null | undefined): string {
+		if (!value) return '—';
+		const date = new Date(value);
+		if (Number.isNaN(date.getTime())) return value;
+		return date.toLocaleString([], {
+			month: 'short',
+			day: '2-digit',
+			hour: '2-digit',
+			minute: '2-digit'
+		});
+	}
+
+	function eventTone(value: string): ShellTone {
+		if (value === 'active' || value === 'ready' || value === 'wait' || value === 'fail') {
+			return value;
+		}
+		return 'idle';
+	}
+</script>
+
+<OperatorShell
+	route="completed"
+	subject="Completed"
+	crumb="/completed"
+	{statusTiles}
+	{footerSignals}
+>
+	<main class="completed">
+		<section class="completed__main" aria-label="Completed cleanup workstation">
+			<header class="completed-header">
+				<div>
+					<span class="mf-eyebrow">Completed</span>
+					<h1>Archive cleanup and history</h1>
+					<p>
+						Review promoted folders, select cleanup-ready backups, and scan recent encode history
+						without returning to the active queue.
+					</p>
+				</div>
+				<div class="completed-header__facts" aria-label="Completed cleanup totals">
+					<div>
+						<span>Completed</span>
+						<strong>{completed?.completed_count.toLocaleString('en-US') ?? '—'}</strong>
+					</div>
+					<div>
+						<span>Ready</span>
+						<strong>{counts.ready.toLocaleString('en-US')}</strong>
+					</div>
+					<div>
+						<span>Risk</span>
+						<strong>{(counts.blocked + counts.unknown).toLocaleString('en-US')}</strong>
+					</div>
+					<div>
+						<span>Saved</span>
+						<strong>{formatBytes(totalSavedSize(folders))}</strong>
+					</div>
+				</div>
+			</header>
+
+			<div class="modebar" role="tablist" aria-label="Completed workstation modes">
+				<button
+					type="button"
+					role="tab"
+					aria-selected={mode === 'completed'}
+					class:active={mode === 'completed'}
+					onclick={() => (mode = 'completed')}>Cleanup</button
+				>
+				<button
+					type="button"
+					role="tab"
+					aria-selected={mode === 'history'}
+					class:active={mode === 'history'}
+					onclick={() => (mode = 'history')}>History</button
+				>
+			</div>
+
+			{#if !completed}
+				<WorkstationPanel eyebrow="Runtime" title="Completed payload unavailable">
+					<div class="empty-note empty-note--error">
+						{actionError || 'Completed data is loading or unavailable.'}
+					</div>
+				</WorkstationPanel>
+			{:else if mode === 'completed'}
+				<WorkstationPanel eyebrow="Filters" title="Cleanup scope">
+					<div class="completed-filter" aria-label="Completed cleanup filters">
+						<div class="completed-filter__summary">
+							<span>Visible cleanup</span>
+							<strong
+								>{filteredFolders.length.toLocaleString('en-US')} / {folders.length.toLocaleString(
+									'en-US'
+								)}
+								folders</strong
+							>
+							<small>{selectedSummary}</small>
+						</div>
+
+						<label class="completed-filter__search">
+							<span>Search</span>
+							<input
+								type="search"
+								value={searchQuery}
+								placeholder="Title, path, state, or blocker"
+								oninput={handleSearchInput}
+							/>
+						</label>
+
+						<div class="completed-filter__group">
+							<div class="completed-filter__group-head">
+								<span>Libraries</span>
+								<div class="completed-filter__actions" aria-label="Bulk library filters">
+									<button type="button" onclick={() => setAllLibraries(true)}>All</button>
+									<button type="button" onclick={() => setAllLibraries(false)}>None</button>
+								</div>
+							</div>
+							{#each libraryOptions as option (option.key)}
+								<label class="completed-filter__row" class:excluded={!libraryIncluded(option.key)}>
+									<input
+										type="checkbox"
+										checked={libraryIncluded(option.key)}
+										onchange={(event) => handleLibraryFilterChange(option.key, event)}
+									/>
+									<span>
+										<strong>{option.label}</strong>
+										<small
+											>{option.folders.toLocaleString('en-US')} folders · {option.backups.toLocaleString(
+												'en-US'
+											)}
+											backups</small
+										>
+									</span>
+									<em>{formatBytes(option.size)}</em>
+								</label>
+							{/each}
+						</div>
+
+						<div class="completed-filter__group">
+							<div class="completed-filter__group-head">
+								<span>Cleanup states</span>
+								<div class="completed-filter__actions" aria-label="Bulk cleanup state filters">
+									<button type="button" onclick={() => setAllStates(true)}>All</button>
+									<button type="button" onclick={() => setAllStates(false)}>None</button>
+								</div>
+							</div>
+							{#each stateOptions as option (option.key)}
+								<label
+									class="completed-filter__row"
+									class:excluded={!stateIncluded(option.key as CleanupState)}
+								>
+									<input
+										type="checkbox"
+										checked={stateIncluded(option.key as CleanupState)}
+										onchange={(event) => handleStateFilterChange(option.key, event)}
+									/>
+									<span>
+										<strong>{option.label}</strong>
+										<small
+											>{option.folders.toLocaleString('en-US')} folders · {option.backups.toLocaleString(
+												'en-US'
+											)}
+											backups</small
+										>
+									</span>
+									<em>{formatBytes(option.size)}</em>
+								</label>
+							{/each}
+						</div>
+					</div>
+				</WorkstationPanel>
+
+				<WorkstationPanel eyebrow="Action" title="Cleanup command">
+					<div class="cleanup-command">
+						<div class="cleanup-command__state">
+							<StateBadge
+								tone={recommendedFolder ? 'ready' : archive.has_cleanup ? 'wait' : 'idle'}
+								label={recommendedFolder
+									? 'Selected cleanup'
+									: archive.has_cleanup
+										? 'Review'
+										: 'Idle'}
+							/>
+							<div>
+								<strong
+									>{recommendedFolder
+										? `Safest next cleanup: ${recommendedFolder.title}`
+										: archive.has_cleanup
+											? 'Backups exist, but no cleanup-ready folder is visible'
+											: 'No archived originals are waiting'}</strong
+								>
+								<span
+									>{recommendedFolder
+										? cleanupDetail(recommendedFolder, archive)
+										: archive.archive_root || 'Archive root is not configured'}</span
+								>
+							</div>
+						</div>
+
+						<div class="cleanup-command__actions" aria-label="Cleanup actions">
+							<button
+								type="button"
+								class="control"
+								disabled={filteredReadyFolders.length === 0}
+								onclick={selectVisibleReady}>Select visible ready</button
+							>
+							<button
+								type="button"
+								class="control"
+								disabled={selectedFolders.length === 0}
+								onclick={clearSelection}>Clear selection</button
+							>
+							<button
+								type="button"
+								class="control control--danger"
+								class:armed={armedScope === 'selected'}
+								disabled={cleanupDisabled('selected')}
+								onclick={() => armCleanup('selected')}
+								>{armedScope === 'selected' ? 'Selected armed' : 'Clear selected backups'}</button
+							>
+							<button
+								type="button"
+								class="control control--danger"
+								class:armed={armedScope === 'global'}
+								disabled={cleanupDisabled('global')}
+								onclick={() => armCleanup('global')}
+								>{armedScope === 'global' ? 'Global armed' : 'Clear entire archive'}</button
+							>
+						</div>
+
+						{#if armedScope}
+							{@const scope = armedScope}
+							<div
+								class="confirm-panel"
+								role="alertdialog"
+								aria-label="Confirm destructive cleanup"
+							>
+								<div>
+									<strong
+										>{scope === 'selected'
+											? 'Confirm selected cleanup'
+											: 'Confirm global cleanup'}</strong
+									>
+									<span>{scope === 'selected' ? selectedSummary : globalSummary}</span>
+								</div>
+								<div class="confirm-panel__actions">
+									<button
+										type="button"
+										class="control control--danger armed"
+										disabled={cleanupPending}
+										onclick={() => confirmCleanup(scope)}
+										>{cleanupPending ? 'Working' : 'Confirm delete'}</button
+									>
+									<button
+										type="button"
+										class="control"
+										disabled={cleanupPending}
+										onclick={() => (armedScope = null)}>Cancel</button
+									>
+								</div>
+							</div>
+						{/if}
+
+						{#if actionMessage}
+							<p class="action-message">{actionMessage}</p>
+						{/if}
+						{#if actionError}
+							<p class="action-error">{actionError}</p>
+						{/if}
+						{#if lastCleanupResult}
+							<div class="result-strip">
+								<span>{lastCleanupResult.removed_count.toLocaleString('en-US')} files removed</span>
+								<span>{formatBytes(lastCleanupResult.removed_size_bytes)}</span>
+								<span
+									>{lastCleanupResult.removed_prefix_count.toLocaleString('en-US')} folders affected</span
+								>
+							</div>
+						{/if}
+					</div>
+				</WorkstationPanel>
+
+				<WorkstationPanel
+					eyebrow="Folders"
+					title="Completed folder groups"
+					meta={`${filteredFolders.length.toLocaleString('en-US')} visible`}
+				>
+					<div class="table-wrap">
+						<table>
+							<thead>
+								<tr>
+									<th>Select</th>
+									<th>State</th>
+									<th>Folder</th>
+									<th>Backups</th>
+									<th>Reclaim</th>
+									<th>Saved</th>
+									<th>Latest</th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each filteredFolders as folder (folder.prefix)}
+									{@const state = cleanupState(folder, archive)}
+									<tr class:selected={selected(folder)} class:blocked={state === 'blocked'}>
+										<td>
+											<input
+												type="checkbox"
+												checked={selected(folder)}
+												disabled={!folderCanBeSelected(folder, archive)}
+												aria-label={`Select ${folder.title} for cleanup`}
+												onchange={(event) => handleRowSelection(folder, event)}
+											/>
+										</td>
+										<td>
+											<StateBadge compact tone={cleanupTone(state)} label={cleanupLabel(state)} />
+											<span class="state-detail">{cleanupDetail(folder, archive)}</span>
+										</td>
+										<td>
+											<a class="folder-link" href={resolve(folderRoutePath(folder.prefix))}>
+												<strong>{folder.title}</strong>
+												<span>{folder.prefix}</span>
+											</a>
+											<small>{folder.subtitle || folder.scope_label}</small>
+										</td>
+										<td>
+											<strong>{folder.archived_backup_count.toLocaleString('en-US')}</strong>
+											<span>{folder.promoted_item_count.toLocaleString('en-US')} promoted</span>
+										</td>
+										<td>{formatBytes(folder.archived_backup_size_bytes)}</td>
+										<td>{formatBytes(folder.total_bytes_saved)}</td>
+										<td>{formatTimestamp(folder.latest_promoted_at)}</td>
+									</tr>
+								{:else}
+									<tr>
+										<td colspan="7">No completed folders match the active filters.</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				</WorkstationPanel>
+			{:else}
+				<WorkstationPanel
+					eyebrow="History"
+					title="Recent encode and cleanup events"
+					meta={`${visibleHistory.length.toLocaleString('en-US')} visible`}
+				>
+					<div class="history-workspace">
+						<label class="history-search">
+							<span>Search history</span>
+							<input
+								type="search"
+								value={historyQuery}
+								placeholder="Event, path, folder, or detail"
+								oninput={handleHistorySearchInput}
+							/>
+						</label>
+						<div class="history-list history-list--wide">
+							{#each visibleHistory as event (`${event.source}:${event.id}:${event.created_at}`)}
+								<div class="history-row">
+									<StateBadge compact tone={eventTone(event.tone)} label={event.label} />
+									<div>
+										<strong>{event.title}</strong>
+										<span>{event.prefix}</span>
+									</div>
+									<p>{event.detail}</p>
+									<time>{formatTimestamp(event.created_at)}</time>
+								</div>
+							{:else}
+								<div class="empty-note">No history events match the active search.</div>
+							{/each}
+						</div>
+					</div>
+				</WorkstationPanel>
+			{/if}
+		</section>
+
+		<aside class="completed__rail" aria-label="Completed cleanup context">
+			<WorkstationPanel eyebrow="Archive" title="Cleanup root">
+				<dl class="kv">
+					<dt>Root</dt>
+					<dd>{archive.archive_root || 'not configured'}</dd>
+					<dt>Files</dt>
+					<dd>{archive.file_count.toLocaleString('en-US')}</dd>
+					<dt>Size</dt>
+					<dd>{formatBytes(archive.total_size_bytes)}</dd>
+					<dt>State</dt>
+					<dd>{archive.has_cleanup ? 'cleanup available' : 'no cleanup files'}</dd>
+				</dl>
+			</WorkstationPanel>
+
+			<WorkstationPanel eyebrow="State" title="Cleanup readiness">
+				<div class="scope-list">
+					<div class="scope-row scope-row--ready">
+						<span>Ready</span>
+						<strong>{counts.ready.toLocaleString('en-US')} folders</strong>
+						<small
+							>{formatBytes(totalArchivedBackupSize(cleanupReadyFolders))} selected-cleanup candidates</small
+						>
+					</div>
+					<div class="scope-row" class:scope-row--fail={counts.blocked > 0}>
+						<span>Blocked</span>
+						<strong>{counts.blocked.toLocaleString('en-US')} folders</strong>
+						<small>outside root or archive root unavailable</small>
+					</div>
+					<div class="scope-row" class:scope-row--wait={counts.unknown > 0}>
+						<span>Risky</span>
+						<strong>{counts.unknown.toLocaleString('en-US')} folders</strong>
+						<small>missing backup evidence or unknown cleanup state</small>
+					</div>
+					<div class="scope-row">
+						<span>Cleaned</span>
+						<strong>{counts.cleaned.toLocaleString('en-US')} folders</strong>
+						<small>completed work without archived backups waiting</small>
+					</div>
+				</div>
+			</WorkstationPanel>
+
+			<WorkstationPanel
+				eyebrow="History"
+				title="Recent signal"
+				meta={`${historyRows.length.toLocaleString('en-US')} events`}
+			>
+				<div class="history-list">
+					{#each historyRows.slice(0, 8) as event (`rail:${event.source}:${event.id}:${event.created_at}`)}
+						<div class="history-row">
+							<StateBadge compact tone={eventTone(event.tone)} label={event.label} />
+							<div>
+								<strong>{event.title}</strong>
+								<span>{event.prefix}</span>
+							</div>
+							<time>{formatTimestamp(event.created_at)}</time>
+						</div>
+					{:else}
+						<div class="empty-note">No completed-history events are available yet.</div>
+					{/each}
+				</div>
+			</WorkstationPanel>
+		</aside>
+	</main>
+</OperatorShell>
+
+<style>
+	.completed {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) var(--mf-workstation-rail-width);
+		min-height: calc(100vh - 178px);
+	}
+
+	.completed__main {
+		align-content: start;
+		display: grid;
+		gap: var(--mf-space-5);
+		min-width: 0;
+		padding: var(--mf-space-6);
+	}
+
+	.completed__rail {
+		align-content: start;
+		background: var(--mf-bg-shell);
+		border-left: var(--mf-border);
+		display: flex;
+		flex-direction: column;
+		gap: var(--mf-space-5);
+		min-width: 0;
+		padding: var(--mf-space-5);
+	}
+
+	.completed-header {
+		align-items: end;
+		border-bottom: var(--mf-border);
+		display: grid;
+		gap: var(--mf-space-6);
+		grid-template-columns: minmax(0, 1fr) auto;
+		padding-bottom: var(--mf-space-5);
+	}
+
+	.completed-header h1 {
+		margin-top: var(--mf-space-3);
+	}
+
+	.completed-header p {
+		margin-top: var(--mf-space-3);
+		max-width: 78ch;
+	}
+
+	.completed-header__facts {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--mf-space-5);
+	}
+
+	.completed-header__facts div {
+		display: grid;
+		gap: var(--mf-space-2);
+		min-width: 82px;
+	}
+
+	.completed-header__facts span,
+	.completed-filter__summary span,
+	.completed-filter__search span,
+	.completed-filter__group-head > span,
+	.completed-filter__row small,
+	.history-search span,
+	.scope-row span,
+	.kv dt {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.completed-header__facts strong,
+	.completed-filter__summary strong,
+	.kv dd {
+		font-family: var(--mf-font-mono);
+		font-size: var(--mf-text-sm);
+		font-weight: var(--mf-weight-medium);
+	}
+
+	.modebar {
+		background: var(--mf-bg-panel);
+		border: var(--mf-border);
+		display: inline-grid;
+		grid-template-columns: repeat(2, minmax(110px, 1fr));
+		justify-self: start;
+	}
+
+	.modebar button {
+		border-right: var(--mf-border);
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-semibold);
+		min-height: var(--mf-control-md);
+		padding: 0 var(--mf-space-5);
+		text-transform: uppercase;
+	}
+
+	.modebar button:last-child {
+		border-right: 0;
+	}
+
+	.modebar button.active {
+		background: var(--mf-active-bg);
+		color: var(--mf-active-fg-bright);
+	}
+
+	.completed-filter,
+	.cleanup-command,
+	.scope-list,
+	.history-workspace,
+	.history-list {
+		display: grid;
+		gap: var(--mf-space-4);
+		padding: var(--mf-space-5);
+	}
+
+	.completed-filter {
+		align-items: start;
+		grid-template-columns:
+			minmax(170px, 0.7fr) minmax(240px, 1fr) minmax(220px, 0.85fr)
+			minmax(220px, 0.85fr);
+	}
+
+	.completed-filter__summary,
+	.completed-filter__search,
+	.completed-filter__group,
+	.cleanup-command__state > div {
+		min-width: 0;
+	}
+
+	.completed-filter__summary {
+		border-left: 2px solid var(--mf-active-fg);
+		display: grid;
+		gap: var(--mf-space-2);
+		padding: var(--mf-space-3) var(--mf-space-4);
+	}
+
+	.completed-filter__summary small,
+	.cleanup-command__state span,
+	.scope-row small,
+	.folder-link span,
+	.folder-link + small,
+	.state-detail,
+	.history-row span,
+	.history-row p {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-xs);
+	}
+
+	.completed-filter__search,
+	.completed-filter__group,
+	.history-search {
+		display: grid;
+		gap: var(--mf-space-2);
+	}
+
+	.completed-filter__search input,
+	.history-search input {
+		background: var(--mf-bg-input);
+		border: var(--mf-border);
+		border-radius: var(--mf-radius-1);
+		color: var(--mf-fg-primary);
+		font: inherit;
+		min-height: var(--mf-control-lg);
+		padding: 0 var(--mf-space-4);
+		width: 100%;
+	}
+
+	.completed-filter__group-head {
+		align-items: center;
+		display: flex;
+		gap: var(--mf-space-3);
+		justify-content: space-between;
+	}
+
+	.completed-filter__actions {
+		display: grid;
+		gap: var(--mf-space-2);
+		grid-template-columns: 1fr 1fr;
+	}
+
+	.completed-filter__actions button {
+		background: var(--mf-bg-panel-2);
+		border: var(--mf-border);
+		border-radius: var(--mf-radius-1);
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-semibold);
+		min-height: var(--mf-control-sm);
+		padding: 0 var(--mf-space-3);
+	}
+
+	.completed-filter__row {
+		align-items: center;
+		background: var(--mf-bg-panel-2);
+		border: var(--mf-border-muted);
+		border-radius: var(--mf-radius-1);
+		display: grid;
+		gap: var(--mf-space-3);
+		grid-template-columns: auto minmax(0, 1fr) auto;
+		min-height: var(--mf-row-default);
+		padding: var(--mf-space-3);
+	}
+
+	.completed-filter__row.excluded {
+		opacity: 0.52;
+	}
+
+	.completed-filter__row input,
+	td input {
+		accent-color: var(--mf-active-solid);
+		height: 16px;
+		width: 16px;
+	}
+
+	.completed-filter__row > span {
+		display: grid;
+		gap: var(--mf-space-1);
+		min-width: 0;
+	}
+
+	.completed-filter__row small {
+		letter-spacing: 0;
+		text-transform: none;
+	}
+
+	.completed-filter__row em {
+		color: var(--mf-fg-tertiary);
+		font-family: var(--mf-font-mono);
+		font-size: var(--mf-text-2xs);
+		font-style: normal;
+	}
+
+	.cleanup-command__state {
+		align-items: center;
+		display: grid;
+		gap: var(--mf-space-4);
+		grid-template-columns: auto minmax(0, 1fr);
+	}
+
+	.cleanup-command__state strong,
+	.scope-row strong,
+	.history-row strong {
+		font-size: var(--mf-text-sm);
+		font-weight: var(--mf-weight-semibold);
+		overflow-wrap: anywhere;
+	}
+
+	.cleanup-command__actions,
+	.confirm-panel__actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--mf-space-3);
+	}
+
+	.confirm-panel {
+		align-items: center;
+		background: var(--mf-fail-bg);
+		border: 1px solid var(--mf-fail-line);
+		border-left: 3px solid var(--mf-fail-fg);
+		display: grid;
+		gap: var(--mf-space-4);
+		grid-template-columns: minmax(0, 1fr) auto;
+		padding: var(--mf-space-4);
+	}
+
+	.confirm-panel > div:first-child {
+		display: grid;
+		gap: var(--mf-space-1);
+		min-width: 0;
+	}
+
+	.confirm-panel span {
+		color: var(--mf-fg-secondary);
+		font-family: var(--mf-font-mono);
+		font-size: var(--mf-text-xs);
+		overflow-wrap: anywhere;
+	}
+
+	.control {
+		align-items: center;
+		background: var(--mf-bg-panel-2);
+		border: var(--mf-border-strong);
+		border-radius: var(--mf-radius-1);
+		color: var(--mf-fg-primary);
+		display: inline-flex;
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-semibold);
+		justify-content: center;
+		min-height: var(--mf-control-md);
+		padding: 0 var(--mf-space-4);
+		white-space: nowrap;
+	}
+
+	.control:hover:not(:disabled) {
+		background: var(--mf-bg-raised);
+	}
+
+	.control:disabled {
+		border-color: var(--mf-line-muted);
+	}
+
+	.control--danger {
+		border-color: var(--mf-fail-line);
+		color: var(--mf-fail-fg);
+	}
+
+	.control--danger.armed {
+		background: var(--mf-fail-bg-strong);
+		border-color: var(--mf-fail-fg);
+		color: var(--mf-fail-fg-bright);
+	}
+
+	.action-message,
+	.action-error {
+		border-left: 2px solid var(--mf-ready-fg);
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-xs);
+		padding-left: var(--mf-space-4);
+	}
+
+	.action-error,
+	.empty-note--error {
+		border-left-color: var(--mf-fail-fg);
+		color: var(--mf-fail-fg);
+	}
+
+	.result-strip {
+		background: var(--mf-ready-bg);
+		border: 1px solid var(--mf-ready-line);
+		color: var(--mf-ready-fg);
+		display: flex;
+		flex-wrap: wrap;
+		font-family: var(--mf-font-mono);
+		font-size: var(--mf-text-xs);
+		gap: var(--mf-space-5);
+		padding: var(--mf-space-3) var(--mf-space-4);
+	}
+
+	.table-wrap {
+		overflow: auto;
+	}
+
+	table {
+		border-collapse: collapse;
+		min-width: 980px;
+		width: 100%;
+	}
+
+	th,
+	td {
+		border-bottom: var(--mf-border-muted);
+		font-size: var(--mf-text-xs);
+		height: var(--mf-row-default);
+		padding: var(--mf-space-2) var(--mf-space-5);
+		text-align: left;
+		vertical-align: middle;
+	}
+
+	th {
+		background: var(--mf-bg-strip);
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0.08em;
+		position: sticky;
+		text-transform: uppercase;
+		top: 0;
+	}
+
+	tr.selected {
+		background: var(--mf-active-bg);
+	}
+
+	tr.blocked {
+		background: var(--mf-fail-bg);
+	}
+
+	td:nth-child(2) {
+		display: grid;
+		gap: var(--mf-space-1);
+		min-width: 160px;
+	}
+
+	td:nth-child(4),
+	td:nth-child(5),
+	td:nth-child(6),
+	td:nth-child(7) {
+		font-family: var(--mf-font-mono);
+	}
+
+	td:nth-child(4) {
+		display: grid;
+		gap: var(--mf-space-1);
+	}
+
+	td:nth-child(4) span {
+		color: var(--mf-fg-tertiary);
+		font-family: var(--mf-font-sans);
+	}
+
+	.folder-link {
+		display: grid;
+		gap: var(--mf-space-1);
+		min-width: 0;
+	}
+
+	.folder-link strong {
+		font-size: var(--mf-text-sm);
+		font-weight: var(--mf-weight-semibold);
+		overflow-wrap: anywhere;
+	}
+
+	.folder-link span {
+		font-family: var(--mf-font-mono);
+		font-size: var(--mf-text-2xs);
+		overflow-wrap: anywhere;
+	}
+
+	.kv {
+		display: grid;
+		grid-template-columns: minmax(62px, auto) minmax(0, 1fr);
+		padding: var(--mf-space-5);
+		row-gap: var(--mf-space-4);
+	}
+
+	.kv dd {
+		overflow-wrap: anywhere;
+	}
+
+	.scope-row {
+		border-left: 2px solid var(--mf-line-strong);
+		display: grid;
+		gap: var(--mf-space-2);
+		padding: var(--mf-space-4);
+	}
+
+	.scope-row--ready {
+		background: var(--mf-ready-bg);
+		border-left-color: var(--mf-ready-fg);
+	}
+
+	.scope-row--fail {
+		background: var(--mf-fail-bg);
+		border-left-color: var(--mf-fail-fg);
+	}
+
+	.scope-row--wait {
+		background: var(--mf-wait-bg);
+		border-left-color: var(--mf-wait-fg);
+	}
+
+	.history-list {
+		padding: var(--mf-space-4);
+	}
+
+	.history-list--wide {
+		max-height: none;
+		padding: 0;
+	}
+
+	.history-row {
+		background: var(--mf-bg-panel-2);
+		border: var(--mf-border-muted);
+		display: grid;
+		gap: var(--mf-space-3);
+		grid-template-columns: minmax(120px, auto) minmax(0, 1fr) auto;
+		min-height: var(--mf-row-comfy);
+		padding: var(--mf-space-4);
+	}
+
+	.history-list--wide .history-row {
+		grid-template-columns: minmax(150px, auto) minmax(0, 1fr) minmax(180px, 0.7fr) auto;
+	}
+
+	.history-row > div {
+		display: grid;
+		gap: var(--mf-space-1);
+		min-width: 0;
+	}
+
+	.history-row p {
+		margin: 0;
+		min-width: 0;
+		overflow-wrap: anywhere;
+	}
+
+	.history-row time {
+		color: var(--mf-fg-tertiary);
+		font-family: var(--mf-font-mono);
+		font-size: var(--mf-text-2xs);
+		white-space: nowrap;
+	}
+
+	.empty-note {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-sm);
+		padding: var(--mf-space-5);
+	}
+
+	@media (max-width: 1080px) {
+		.completed {
+			grid-template-columns: 1fr;
+		}
+
+		.completed__rail {
+			border-left: 0;
+			border-top: var(--mf-border);
+		}
+
+		.completed-header,
+		.confirm-panel {
+			grid-template-columns: 1fr;
+		}
+
+		.completed-filter {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	@media (max-width: 680px) {
+		.completed__main,
+		.completed__rail {
+			padding: var(--mf-space-4);
+		}
+
+		.cleanup-command__state,
+		.history-row,
+		.history-list--wide .history-row {
+			align-items: start;
+			grid-template-columns: 1fr;
+		}
+
+		.modebar {
+			justify-self: stretch;
+		}
+
+		.table-wrap {
+			overflow: visible;
+		}
+
+		table {
+			min-width: 0;
+		}
+
+		thead {
+			display: none;
+		}
+
+		tbody,
+		tr,
+		td {
+			display: block;
+			width: 100%;
+		}
+
+		tr {
+			border-bottom: var(--mf-border-muted);
+			display: grid;
+			gap: var(--mf-space-3);
+			grid-template-columns: auto minmax(0, 1fr);
+			padding: var(--mf-space-4);
+		}
+
+		td {
+			border-bottom: 0;
+			height: auto;
+			min-width: 0;
+			padding: 0;
+		}
+
+		td:nth-child(1) {
+			grid-row: 1 / span 6;
+			padding-top: var(--mf-space-1);
+			width: 32px;
+		}
+
+		td:nth-child(2),
+		td:nth-child(3),
+		td:nth-child(4),
+		td:nth-child(5),
+		td:nth-child(6),
+		td:nth-child(7) {
+			grid-column: 2;
+		}
+
+		td:nth-child(4),
+		td:nth-child(5),
+		td:nth-child(6),
+		td:nth-child(7) {
+			align-items: baseline;
+			display: grid;
+			gap: var(--mf-space-3);
+			grid-template-columns: 68px minmax(0, 1fr);
+		}
+
+		td:nth-child(4)::before,
+		td:nth-child(5)::before,
+		td:nth-child(6)::before,
+		td:nth-child(7)::before {
+			color: var(--mf-fg-tertiary);
+			font-family: var(--mf-font-sans);
+			font-size: var(--mf-text-2xs);
+			font-weight: var(--mf-weight-semibold);
+			letter-spacing: 0.08em;
+			text-transform: uppercase;
+		}
+
+		td:nth-child(4)::before {
+			content: 'Backups';
+		}
+
+		td:nth-child(5)::before {
+			content: 'Reclaim';
+		}
+
+		td:nth-child(6)::before {
+			content: 'Saved';
+		}
+
+		td:nth-child(7)::before {
+			content: 'Latest';
+		}
+
+		td:nth-child(4) span {
+			grid-column: 2;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/workstation/OperatorShell.svelte
+++ b/frontend/src/lib/components/workstation/OperatorShell.svelte
@@ -2,7 +2,7 @@
 	import { resolve } from '$app/paths';
 	import type { Snippet } from 'svelte';
 
-	export type ShellRouteId = 'queue' | 'ops' | 'settings' | 'studio';
+	export type ShellRouteId = 'queue' | 'ops' | 'completed' | 'settings' | 'studio';
 	export type ShellTone = 'active' | 'ready' | 'wait' | 'fail' | 'idle';
 	export type StatusTile = {
 		label: string;
@@ -20,10 +20,11 @@
 	const navItems: Array<{
 		id: ShellRouteId;
 		label: string;
-		href: '/' | '/folders' | '/ops' | '/settings';
+		href: '/' | '/folders' | '/ops' | '/completed' | '/settings';
 	}> = [
 		{ id: 'queue', label: 'Queue', href: '/' },
 		{ id: 'ops', label: 'Ops', href: '/ops' },
+		{ id: 'completed', label: 'Completed', href: '/completed' },
 		{ id: 'settings', label: 'Settings', href: '/settings' }
 	];
 

--- a/frontend/src/lib/components/workstation/completed-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/completed-workstation.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { CompletedFolderRow, CompletedPayload } from '$lib/api/types';
+import {
+	buildCompletedHistoryRows,
+	buildCompletedStatusTiles,
+	cleanupState,
+	completedStateOptions,
+	folderCanBeSelected
+} from './completed-workstation';
+
+const archive = {
+	archive_root: '/runtime/archive',
+	file_count: 4,
+	total_size_bytes: 4096,
+	has_cleanup: true
+};
+
+function folder(overrides: Partial<CompletedFolderRow>): CompletedFolderRow {
+	return {
+		prefix: 'tv/show/season 1',
+		title: 'Season 1',
+		subtitle: 'Show',
+		scope_label: 'tv',
+		promoted_item_count: 2,
+		archived_backup_count: 0,
+		archived_backup_size_bytes: 0,
+		total_bytes_saved: 2048,
+		latest_promoted_at: '2026-04-10T10:00:00+00:00',
+		...overrides
+	};
+}
+
+function payload(folders: CompletedFolderRow[]): CompletedPayload {
+	return {
+		folders,
+		completed_count: folders.length,
+		folders_with_backups_count: folders.filter((item) => item.archived_backup_count > 0).length,
+		archive_cleanup: archive,
+		history: []
+	};
+}
+
+describe('Completed workstation mapping', () => {
+	it('maps ready, blocked, unknown, and cleaned states from folder evidence', () => {
+		const ready = folder({ archived_backup_count: 2, archived_backup_size_bytes: 1024 });
+		const blocked = folder({ prefix: 'tv/show/season 2', outside_archive_root_count: 1 });
+		const unknown = folder({ prefix: 'tv/show/season 3', missing_backup_count: 1 });
+		const cleaned = folder({ prefix: 'tv/show/season 4' });
+
+		expect(cleanupState(ready, archive)).toBe('ready');
+		expect(cleanupState(blocked, archive)).toBe('blocked');
+		expect(cleanupState(unknown, archive)).toBe('unknown');
+		expect(cleanupState(cleaned, archive)).toBe('cleaned');
+		expect(folderCanBeSelected(ready, archive)).toBe(true);
+		expect(folderCanBeSelected(unknown, archive)).toBe(false);
+	});
+
+	it('builds status tiles around cleanup readiness and archive health', () => {
+		const tiles = buildCompletedStatusTiles(
+			payload([
+				folder({ archived_backup_count: 1, archived_backup_size_bytes: 1024 }),
+				folder({ prefix: 'tv/show/season 2', outside_archive_root_count: 1 })
+			]),
+			null
+		);
+
+		expect(tiles).toMatchObject([
+			{ label: 'Completed folders', tone: 'ready' },
+			{ label: 'Backups waiting', tone: 'wait' },
+			{ label: 'Reclaimable', tone: 'ready' },
+			{ label: 'Ready / blocked', value: '1 / 1', tone: 'fail' },
+			{ label: 'Archive root', tone: 'ready' }
+		]);
+	});
+
+	it('orders cleanup state filter options by operator risk sequence', () => {
+		const options = completedStateOptions(
+			[
+				folder({ prefix: 'tv/show/season 4' }),
+				folder({ prefix: 'tv/show/season 3', missing_backup_count: 1 }),
+				folder({ prefix: 'tv/show/season 1', archived_backup_count: 2 }),
+				folder({ prefix: 'tv/show/season 2', outside_archive_root_count: 1 })
+			],
+			archive
+		);
+
+		expect(options.map((option) => option.label)).toEqual(['Ready', 'Blocked', 'Risky', 'Cleaned']);
+		expect(options.map((option) => option.key)).toEqual(['ready', 'blocked', 'unknown', 'cleaned']);
+	});
+
+	it('falls back to promotion rows when the API has not supplied history events', () => {
+		const rows = buildCompletedHistoryRows(
+			payload([folder({ title: 'Season 1', promoted_item_count: 2, total_bytes_saved: 2048 })])
+		);
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			source: 'folder',
+			label: 'Promotion completed',
+			title: 'Season 1'
+		});
+	});
+});

--- a/frontend/src/lib/components/workstation/completed-workstation.ts
+++ b/frontend/src/lib/components/workstation/completed-workstation.ts
@@ -1,0 +1,269 @@
+import type {
+	ArchiveCleanupSummary,
+	CompletedFolderRow,
+	CompletedHistoryEvent,
+	CompletedPayload
+} from '$lib/api/types';
+import type { FooterSignal, ShellTone, StatusTile } from './OperatorShell.svelte';
+import { formatBytes } from './folder-studio-view';
+
+export type CleanupState = 'ready' | 'blocked' | 'unknown' | 'cleaned';
+
+export type CompletedHistoryRow = CompletedHistoryEvent & {
+	source: 'api' | 'folder';
+};
+
+export type CompletedFilterOption = {
+	key: string;
+	label: string;
+	folders: number;
+	backups: number;
+	size: number;
+};
+
+export function cleanupState(
+	folder: CompletedFolderRow,
+	archive: ArchiveCleanupSummary
+): CleanupState {
+	const explicit = String(folder.cleanup_state ?? '').toLowerCase();
+	if (
+		explicit === 'ready' ||
+		explicit === 'blocked' ||
+		explicit === 'unknown' ||
+		explicit === 'cleaned'
+	) {
+		return explicit;
+	}
+	if (!archive.archive_root && folder.promoted_item_count > 0) return 'blocked';
+	if ((folder.outside_archive_root_count ?? 0) > 0) return 'blocked';
+	if ((folder.missing_backup_count ?? 0) > 0) return 'unknown';
+	if (folder.archived_backup_count > 0) return 'ready';
+	return 'cleaned';
+}
+
+export function cleanupTone(state: CleanupState): ShellTone {
+	if (state === 'ready') return 'ready';
+	if (state === 'blocked') return 'fail';
+	if (state === 'unknown') return 'wait';
+	return 'idle';
+}
+
+export function cleanupLabel(state: CleanupState): string {
+	if (state === 'ready') return 'Ready';
+	if (state === 'blocked') return 'Blocked';
+	if (state === 'unknown') return 'Risky';
+	return 'Cleaned';
+}
+
+export function cleanupDetail(folder: CompletedFolderRow, archive: ArchiveCleanupSummary): string {
+	if (folder.cleanup_detail?.trim()) return folder.cleanup_detail.trim();
+	const state = cleanupState(folder, archive);
+	if (state === 'ready') return 'Archived originals are present and eligible for selected cleanup.';
+	if (state === 'blocked')
+		return 'Cleanup cannot safely verify this folder against the archive root.';
+	if (state === 'unknown')
+		return 'Cleanup needs operator review before deleting archived originals.';
+	return 'No archived originals are waiting for cleanup.';
+}
+
+export function folderCanBeSelected(
+	folder: CompletedFolderRow,
+	archive: ArchiveCleanupSummary
+): boolean {
+	return cleanupState(folder, archive) === 'ready' && folder.archived_backup_count > 0;
+}
+
+export function readyFolders(
+	folders: CompletedFolderRow[],
+	archive: ArchiveCleanupSummary
+): CompletedFolderRow[] {
+	return folders.filter((folder) => folderCanBeSelected(folder, archive));
+}
+
+export function totalArchivedBackupSize(folders: CompletedFolderRow[]): number {
+	return folders.reduce(
+		(total, folder) => total + Math.max(folder.archived_backup_size_bytes ?? 0, 0),
+		0
+	);
+}
+
+export function totalSavedSize(folders: CompletedFolderRow[]): number {
+	return folders.reduce((total, folder) => total + Math.max(folder.total_bytes_saved ?? 0, 0), 0);
+}
+
+export function cleanupStateCounts(folders: CompletedFolderRow[], archive: ArchiveCleanupSummary) {
+	return folders.reduce(
+		(counts, folder) => {
+			counts[cleanupState(folder, archive)] += 1;
+			return counts;
+		},
+		{ ready: 0, blocked: 0, unknown: 0, cleaned: 0 } satisfies Record<CleanupState, number>
+	);
+}
+
+export function buildCompletedStatusTiles(
+	payload: CompletedPayload | null,
+	loadError: string | null
+): StatusTile[] {
+	if (!payload) {
+		return [
+			{
+				label: 'Completed',
+				value: loadError ? 'Unavailable' : 'Loading',
+				detail: loadError ?? 'waiting for completed payload',
+				tone: loadError ? 'fail' : 'idle'
+			}
+		];
+	}
+	const folders = payload.folders;
+	const archive = payload.archive_cleanup;
+	const counts = cleanupStateCounts(folders, archive);
+	return [
+		{
+			label: 'Completed folders',
+			value: payload.completed_count.toLocaleString('en-US'),
+			detail: `${folders.reduce((total, folder) => total + folder.promoted_item_count, 0).toLocaleString('en-US')} promoted items`,
+			tone: payload.completed_count > 0 ? 'ready' : 'idle'
+		},
+		{
+			label: 'Backups waiting',
+			value: payload.folders_with_backups_count.toLocaleString('en-US'),
+			detail: `${archive.file_count.toLocaleString('en-US')} archive files`,
+			tone: payload.folders_with_backups_count > 0 ? 'wait' : 'idle'
+		},
+		{
+			label: 'Reclaimable',
+			value: formatBytes(archive.total_size_bytes),
+			detail: archive.has_cleanup ? 'cleanup available' : 'no cleanup files',
+			tone: archive.has_cleanup ? 'ready' : 'idle',
+			mono: true
+		},
+		{
+			label: 'Ready / blocked',
+			value: `${counts.ready} / ${counts.blocked + counts.unknown}`,
+			detail: 'folders eligible versus needs review',
+			tone:
+				counts.blocked > 0
+					? 'fail'
+					: counts.unknown > 0
+						? 'wait'
+						: counts.ready > 0
+							? 'ready'
+							: 'idle'
+		},
+		{
+			label: 'Archive root',
+			value: archive.archive_root ? 'Configured' : 'Missing',
+			detail: archive.archive_root || 'cleanup root unavailable',
+			tone: archive.archive_root ? 'ready' : 'fail'
+		}
+	];
+}
+
+export function buildCompletedFooterSignals(payload: CompletedPayload | null): FooterSignal[] {
+	if (!payload) return [{ label: 'Completed', value: 'unavailable', tone: 'fail' }];
+	const counts = cleanupStateCounts(payload.folders, payload.archive_cleanup);
+	return [
+		{ label: 'Completed', value: String(payload.completed_count), tone: 'ready' },
+		{ label: 'Waiting', value: String(payload.folders_with_backups_count), tone: 'wait' },
+		{ label: 'Ready', value: String(counts.ready), tone: counts.ready > 0 ? 'ready' : 'idle' },
+		{
+			label: 'Risk',
+			value: String(counts.blocked + counts.unknown),
+			tone: counts.blocked > 0 ? 'fail' : 'wait'
+		},
+		{
+			label: 'Reclaimable',
+			value: formatBytes(payload.archive_cleanup.total_size_bytes),
+			tone: 'ready'
+		}
+	];
+}
+
+export function completedLibraryOptions(folders: CompletedFolderRow[]): CompletedFilterOption[] {
+	const byLibrary = new Map<string, CompletedFilterOption>();
+	for (const folder of folders) {
+		const label = folder.scope_label || folder.prefix.split('/')[0] || 'Library';
+		const key = label.trim().toLowerCase() || 'library';
+		const existing = byLibrary.get(key) ?? {
+			key,
+			label,
+			folders: 0,
+			backups: 0,
+			size: 0
+		};
+		existing.folders += 1;
+		existing.backups += Math.max(folder.archived_backup_count ?? 0, 0);
+		existing.size += Math.max(folder.archived_backup_size_bytes ?? 0, 0);
+		byLibrary.set(key, existing);
+	}
+	return [...byLibrary.values()].sort(
+		(left, right) => right.size - left.size || left.label.localeCompare(right.label)
+	);
+}
+
+export function completedStateOptions(
+	folders: CompletedFolderRow[],
+	archive: ArchiveCleanupSummary
+): CompletedFilterOption[] {
+	const byState = new Map<string, CompletedFilterOption>();
+	for (const folder of folders) {
+		const state = cleanupState(folder, archive);
+		const label = cleanupLabel(state);
+		const existing = byState.get(state) ?? {
+			key: state,
+			label,
+			folders: 0,
+			backups: 0,
+			size: 0
+		};
+		existing.folders += 1;
+		existing.backups += Math.max(folder.archived_backup_count ?? 0, 0);
+		existing.size += Math.max(folder.archived_backup_size_bytes ?? 0, 0);
+		byState.set(state, existing);
+	}
+	const order: CleanupState[] = ['ready', 'blocked', 'unknown', 'cleaned'];
+	return [...byState.values()].sort(
+		(left, right) =>
+			order.indexOf(left.key as CleanupState) - order.indexOf(right.key as CleanupState)
+	);
+}
+
+export function folderSearchText(
+	folder: CompletedFolderRow,
+	archive: ArchiveCleanupSummary
+): string {
+	return [
+		folder.title,
+		folder.subtitle,
+		folder.prefix,
+		folder.scope_label,
+		cleanupLabel(cleanupState(folder, archive)),
+		cleanupDetail(folder, archive)
+	]
+		.join(' ')
+		.toLowerCase();
+}
+
+export function buildCompletedHistoryRows(payload: CompletedPayload): CompletedHistoryRow[] {
+	if (payload.history?.length) {
+		return payload.history.map((event) => ({ ...event, source: 'api' }));
+	}
+	return payload.folders
+		.filter((folder) => folder.latest_promoted_at)
+		.slice(0, 80)
+		.map((folder, index) => ({
+			id: index,
+			event_type: 'promotion_completed',
+			label: 'Promotion completed',
+			tone: 'ready',
+			prefix: folder.prefix,
+			title: folder.title,
+			subtitle: folder.subtitle,
+			scope_label: folder.scope_label,
+			created_at: folder.latest_promoted_at ?? '',
+			detail: `${folder.promoted_item_count.toLocaleString('en-US')} promoted items · ${formatBytes(folder.total_bytes_saved)} saved`,
+			size_bytes: folder.total_bytes_saved,
+			source: 'folder'
+		}));
+}

--- a/frontend/src/routes/completed/+page.svelte
+++ b/frontend/src/routes/completed/+page.svelte
@@ -1,70 +1,11 @@
 <script lang="ts">
-	const preservedContracts = [
-		'Completed backup inventory',
-		'Cleanup readiness',
-		'Blocked cleanup reasons',
-		'Size and reclaim totals',
-		'Explicit cleanup actions'
-	];
+	import CompletedWorkstationView from '$lib/components/workstation/CompletedWorkstationView.svelte';
+
+	let { data } = $props();
 </script>
 
 <svelte:head>
-	<title>Completed Reset · Mediaforce</title>
+	<title>Mediaforce Completed</title>
 </svelte:head>
 
-<main class="reset-stage">
-	<p class="kicker">Archive cleanup reset</p>
-	<h1>Completed cleanup will be rebuilt from the workflow.</h1>
-	<p class="lede">
-		The prior completed-backup surface has been removed so cleanup decisions can be redesigned as an
-		operator task instead of a page of inherited controls.
-	</p>
-
-	<section aria-labelledby="preserved-contracts">
-		<h2 id="preserved-contracts">Contracts to rebuild against</h2>
-		<ul>
-			{#each preservedContracts as contract (contract)}
-				<li>{contract}</li>
-			{/each}
-		</ul>
-	</section>
-</main>
-
-<style>
-	.reset-stage {
-		display: grid;
-		gap: 1.5rem;
-		max-width: 760px;
-		padding: 4rem max(1.25rem, calc((100vw - 760px) / 2));
-	}
-
-	.kicker {
-		font-size: 0.78rem;
-		font-weight: 800;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: #9fb2c7;
-	}
-
-	h1 {
-		font-size: clamp(2rem, 5vw, 4rem);
-		line-height: 1;
-	}
-
-	.lede,
-	li {
-		color: #c6d0da;
-		line-height: 1.65;
-	}
-
-	section {
-		display: grid;
-		gap: 0.75rem;
-		padding-top: 1rem;
-		border-top: 1px solid rgba(255, 255, 255, 0.18);
-	}
-
-	h2 {
-		font-size: 0.95rem;
-	}
-</style>
+<CompletedWorkstationView completed={data.completed} loadError={data.loadError} />

--- a/frontend/src/routes/completed/+page.ts
+++ b/frontend/src/routes/completed/+page.ts
@@ -1,0 +1,25 @@
+import { fetchJson } from '$lib/api/client';
+import type { CompletedPayload } from '$lib/api/types';
+
+type SettledPayload<T> = { data: T; error: null } | { data: null; error: string };
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : 'Request failed.';
+}
+
+async function settle<T>(promise: Promise<T>): Promise<SettledPayload<T>> {
+	try {
+		return { data: await promise, error: null };
+	} catch (error) {
+		return { data: null, error: errorMessage(error) };
+	}
+}
+
+export async function load({ fetch }: { fetch: typeof window.fetch }) {
+	const completed = await settle(fetchJson<CompletedPayload>('/api/completed', fetch));
+
+	return {
+		completed: completed.data,
+		loadError: completed.error
+	};
+}

--- a/mediaforce/web/runtime/completed_runtime.py
+++ b/mediaforce/web/runtime/completed_runtime.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
+import json
 from pathlib import Path
 from typing import Any
 
@@ -7,7 +8,7 @@ from sqlalchemy import select
 
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
-from mediaforce.core.db_tables import library_items, staged_artifacts
+from mediaforce.core.db_tables import item_events, library_items, staged_artifacts
 from mediaforce.encoding.staging import safe_unlink
 from mediaforce.web.runtime.archive_cleanup import archive_cleanup_summary
 
@@ -25,6 +26,25 @@ class CompletedFolder:
     archived_backup_size_bytes: int
     total_bytes_saved: int
     latest_promoted_at: str | None
+    cleanup_state: str
+    cleanup_detail: str
+    missing_backup_count: int
+    outside_archive_root_count: int
+
+
+@dataclass(slots=True)
+class CompletedHistoryEvent:
+    id: int
+    event_type: str
+    label: str
+    tone: str
+    prefix: str
+    title: str
+    subtitle: str
+    scope_label: str
+    created_at: str
+    detail: str
+    size_bytes: int | None = None
 
 
 def completed_page_payload(
@@ -34,13 +54,6 @@ def completed_page_payload(
         folder_group: Callable[[str], FolderGroup | None],
 ) -> dict[str, Any]:
     archive_root = _configured_archive_root(config)
-    if archive_root is None:
-        return {
-            "folders": [],
-            "completed_count": 0,
-            "folders_with_backups_count": 0,
-            "archive_cleanup": archive_cleanup_summary(config),
-        }
     folders = list_completed_folders(
         connection,
         folder_group=folder_group,
@@ -52,6 +65,10 @@ def completed_page_payload(
         "completed_count": len(folders),
         "folders_with_backups_count": folders_with_backups_count,
         "archive_cleanup": archive_cleanup_summary(config),
+        "history": [
+            asdict(event)
+            for event in list_completed_history_events(connection, folder_group=folder_group)
+        ],
     }
 
 
@@ -98,6 +115,10 @@ def list_completed_folders(
                 archived_backup_size_bytes=0,
                 total_bytes_saved=0,
                 latest_promoted_at=None,
+                cleanup_state="cleaned",
+                cleanup_detail="No archived originals are waiting for cleanup.",
+                missing_backup_count=0,
+                outside_archive_root_count=0,
             )
             grouped[prefix] = folder
         folder.promoted_item_count += 1
@@ -109,15 +130,27 @@ def list_completed_folders(
         if not archived_source_path:
             continue
         archived_path = Path(archived_source_path)
-        if resolved_archive_root is not None and not _path_is_within_root(archived_path, resolved_archive_root):
+        if resolved_archive_root is None:
+            folder.missing_backup_count += 1
+            continue
+        if not _path_is_within_root(archived_path, resolved_archive_root):
+            folder.outside_archive_root_count += 1
             continue
         if not archived_path.is_file():
+            folder.missing_backup_count += 1
             continue
         folder.archived_backup_count += 1
         try:
             folder.archived_backup_size_bytes += archived_path.stat().st_size
         except FileNotFoundError:
             folder.archived_backup_count -= 1
+            folder.missing_backup_count += 1
+
+    for folder in grouped.values():
+        folder.cleanup_state, folder.cleanup_detail = _folder_cleanup_state(
+            folder,
+            archive_root_configured=archive_root is not None,
+        )
 
     return sorted(
         grouped.values(),
@@ -129,6 +162,70 @@ def list_completed_folders(
         ),
         reverse=True,
     )
+
+
+def list_completed_history_events(
+        connection: DBClient,
+        *,
+        folder_group: Callable[[str], FolderGroup | None],
+        limit: int = 80,
+) -> list[CompletedHistoryEvent]:
+    rows = connection.execute(
+        select(
+            item_events.c.id,
+            item_events.c.created_at,
+            item_events.c.event_type,
+            item_events.c.details_json,
+            library_items.c.rel_path,
+        )
+        .select_from(
+            item_events.join(
+                library_items,
+                item_events.c.library_item_id == library_items.c.id,
+            )
+        )
+        .where(
+            item_events.c.event_type.in_(
+                [
+                    "encoding_started",
+                    "encoding_completed",
+                    "encoding_failed",
+                    "validation_completed",
+                    "promotion_completed",
+                ]
+            )
+        )
+        .order_by(item_events.c.created_at.desc(), item_events.c.id.desc())
+        .limit(limit * 2)
+    ).mappings().fetchall()
+
+    history: list[CompletedHistoryEvent] = []
+    for row in rows:
+        group = folder_group(str(row["rel_path"] or ""))
+        if group is None:
+            continue
+        prefix, title, subtitle, scope_label = group
+        event_type = _clean_text(row["event_type"])
+        details = _event_details(row["details_json"])
+        label, tone, detail, size_bytes = _history_event_copy(event_type, details)
+        history.append(
+            CompletedHistoryEvent(
+                id=int(row["id"]),
+                event_type=event_type,
+                label=label,
+                tone=tone,
+                prefix=prefix,
+                title=title,
+                subtitle=subtitle,
+                scope_label=scope_label,
+                created_at=_clean_text(row["created_at"]),
+                detail=detail,
+                size_bytes=size_bytes,
+            )
+        )
+        if len(history) >= limit:
+            break
+    return history
 
 
 def clear_completed_backups_action(
@@ -240,6 +337,86 @@ def _configured_archive_root(config: MediaforceConfig) -> Path | None:
         return config.archive_root
     except KeyError:
         return None
+
+
+def _folder_cleanup_state(folder: CompletedFolder, *, archive_root_configured: bool) -> tuple[str, str]:
+    if not archive_root_configured and folder.missing_backup_count > 0:
+        return "blocked", "Archive root is not configured; cleanup cannot verify archived originals."
+    if folder.outside_archive_root_count > 0:
+        return "blocked", "One or more archived originals are outside the configured archive root."
+    if folder.missing_backup_count > 0:
+        return "unknown", "One or more archived originals are missing from the archive root."
+    if folder.archived_backup_count > 0:
+        return "ready", "Archived originals are present and eligible for selected cleanup."
+    return "cleaned", "No archived originals are waiting for cleanup."
+
+
+def _event_details(raw_details: object) -> dict[str, Any]:
+    try:
+        parsed = json.loads(str(raw_details or "{}"))
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _history_event_copy(event_type: str, details: dict[str, Any]) -> tuple[str, str, str, int | None]:
+    if event_type == "promotion_completed":
+        return (
+            "Promotion completed",
+            "ready",
+            _path_detail(details.get("promoted_path"), "Encoded file promoted into the source library."),
+            None,
+        )
+    if event_type == "encoding_completed":
+        return (
+            "Encoding completed",
+            "ready",
+            _bytes_detail(details.get("bytes_saved"), "Encoded item completed."),
+            _int_or_none(details.get("bytes_saved")),
+        )
+    if event_type == "encoding_failed":
+        return (
+            "Encoding failed",
+            "fail",
+            _clean_text(details.get("error")) or "Encode failed before promotion.",
+            None,
+        )
+    if event_type == "validation_completed":
+        return (
+            "Validation completed",
+            "active",
+            _validation_detail(details),
+            None,
+        )
+    return ("Encoding started", "idle", "Encode worker started processing an item.", None)
+
+
+def _path_detail(path: object, fallback: str) -> str:
+    cleaned = _clean_text(path)
+    return cleaned or fallback
+
+
+def _bytes_detail(value: object, fallback: str) -> str:
+    parsed = _int_or_none(value)
+    if parsed is None:
+        return fallback
+    return f"{parsed} bytes saved by the encoded item."
+
+
+def _validation_detail(details: dict[str, Any]) -> str:
+    metric = _clean_text(details.get("metric") or details.get("quality_metric"))
+    score = _clean_text(details.get("score") or details.get("quality_score"))
+    if metric and score:
+        return f"{metric.upper()} {score}"
+    return "Validation completed for encoded output."
+
+
+def _int_or_none(value: object) -> int | None:
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
 
 
 def _prune_empty_dirs(root: Path) -> None:

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -45,6 +45,7 @@ from mediaforce.advisor import (
 from mediaforce.core.config import ConfigPaths, MediaforceConfig, load_config, save_runtime_settings
 from mediaforce.core.db import open_db
 from mediaforce.core.db_tables import calibration_jobs
+from mediaforce.core.db_tables import item_events
 from mediaforce.core.db_tables import learning_artifacts
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.db_tables import staged_artifacts
@@ -1051,9 +1052,12 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(first_folder["archived_backup_count"], 2)
         self.assertEqual(first_folder["archived_backup_size_bytes"], 8)
         self.assertEqual(first_folder["total_bytes_saved"], 30)
+        self.assertEqual(first_folder["cleanup_state"], "ready")
         second_folder = payload["folders"][1]
         self.assertEqual(second_folder["prefix"], "tv/Example Show/Season 2")
         self.assertEqual(second_folder["archived_backup_count"], 0)
+        self.assertEqual(second_folder["cleanup_state"], "unknown")
+        self.assertEqual(second_folder["missing_backup_count"], 1)
 
     def test_completed_page_payload_ignores_archived_paths_outside_active_archive_root(self) -> None:
         from mediaforce.web import app as web_app
@@ -1078,6 +1082,34 @@ class TuningRuntimeTests(unittest.TestCase):
 
         self.assertEqual(payload["archive_cleanup"]["file_count"], 1)
         self.assertEqual(payload["folders"][0]["archived_backup_count"], 0)
+        self.assertEqual(payload["folders"][0]["cleanup_state"], "blocked")
+        self.assertEqual(payload["folders"][0]["outside_archive_root_count"], 1)
+
+    def test_completed_page_payload_includes_recent_history_events(self) -> None:
+        from mediaforce.web import app as web_app
+
+        self._insert_promoted_artifact(
+            rel_path="tv/Example Show/Season 1/Episode 01.mkv",
+            promoted_at="2026-04-10T10:00:00+00:00",
+            archived_size_bytes=3,
+            bytes_saved=12,
+        )
+        with open_db(self.config.paths.db_path) as connection:
+            library_item_id = connection.execute(select(library_items.c.id)).scalar_one()
+            connection.execute(
+                item_events.insert().values(
+                    library_item_id=library_item_id,
+                    created_at="2026-04-10T10:01:00+00:00",
+                    event_type="promotion_completed",
+                    details_json=json.dumps({"promoted_path": "/media/tv/Example Show/Episode 01.mkv"}),
+                )
+            )
+            connection.commit()
+            payload = completed_page_payload(self.config, connection, folder_group=web_app._folder_group)
+
+        self.assertEqual(payload["history"][0]["event_type"], "promotion_completed")
+        self.assertEqual(payload["history"][0]["prefix"], "tv/Example Show/Season 1")
+        self.assertEqual(payload["history"][0]["tone"], "ready")
 
     def test_completed_page_payload_tolerates_missing_archive_root(self) -> None:
         from mediaforce.web import app as web_app


### PR DESCRIPTION
## Summary
- Rebuild `/completed` as a dense Completed/History workstation with cleanup filters, readiness states, selected/global destructive confirmation, and responsive stacked rows.
- Add completed payload cleanup state/detail fields plus recent encode/validation/promotion history events.
- Add frontend mapping tests and backend completed-runtime coverage; update workstation shell docs.

## Validation
- `bash scripts/pre-commit-check.sh`
- Browser QA screenshots captured under `scratch/ui-checks/` during local validation, including desktop, selected confirmation, history search, and 390px layout.

Refs #28