### PR TITLE
Wire Folder Studio Bench preview requests

### DIFF
--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -404,6 +404,12 @@ export interface FolderPayload {
 	encode_queue_scheduler?: Record<string, unknown>;
 }
 
+export interface FolderBenchPreviewResponse {
+	ok: boolean;
+	message?: string;
+	proposal?: Record<string, unknown> | null;
+}
+
 export interface FolderStatusPayload {
 	prefix: string;
 	polling_active: boolean;

--- a/frontend/src/lib/components/workstation/FolderStudioView.svelte
+++ b/frontend/src/lib/components/workstation/FolderStudioView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import { postJson } from '$lib/api/client';
 	import { folderRoutePrefix } from '$lib/folder-display';
 	import {
 		codecLabel,
@@ -13,12 +14,18 @@
 		type PendingSampleProposal,
 		type ReviewGate
 	} from '$lib/folders/studio';
-	import type { FolderPayload, FolderStatusPayload, HostsPayload } from '$lib/api/types';
+	import type {
+		FolderBenchPreviewResponse,
+		FolderPayload,
+		FolderStatusPayload,
+		HostsPayload
+	} from '$lib/api/types';
 	import OperatorShell from './OperatorShell.svelte';
 	import StateBadge from './StateBadge.svelte';
 	import WorkstationPanel from './WorkstationPanel.svelte';
 	import {
 		buildBenchMessages,
+		buildBenchHostOptions,
 		buildFooterSignals,
 		buildProposalRows,
 		buildSampleFacts,
@@ -26,6 +33,7 @@
 		formatBytes,
 		projectedReclaimBytes,
 		record,
+		resolveBenchRequestState,
 		resolvedMetricCopy,
 		resolveFolderTitle,
 		resolveReviewArtifacts,
@@ -45,18 +53,45 @@
 		hosts: HostsPayload;
 	} = $props();
 
-	const prefix = $derived(folder.prefix);
+	let benchNote = $state('');
+	let selectedHostKey = $state('');
+	let benchPending = $state(false);
+	let benchMessage = $state('');
+	let benchError = $state('');
+	let localPendingProposal = $state<Record<string, unknown> | null | undefined>(undefined);
+	let localProposalPrefix = $state('');
+	const studioFolder = $derived({
+		...folder,
+		pending_proposal:
+			localPendingProposal === undefined || localProposalPrefix !== folder.prefix
+				? folder.pending_proposal
+				: localPendingProposal
+	});
+	const prefix = $derived(studioFolder.prefix);
 	const encodedPrefix = $derived(folderRoutePrefix(prefix));
-	const summary = $derived(folder.summary);
+	const sampleHostOptions = $derived(
+		buildBenchHostOptions(studioFolder.sample_host_options, hosts.hosts)
+	);
+	const folderSampleHostKey = $derived(String(folder.sample_host_key ?? '').trim());
+	const fallbackHostKey = $derived(folderSampleHostKey || sampleHostOptions[0]?.key || '');
+
+	$effect(() => {
+		if (!selectedHostKey || !sampleHostOptions.some((host) => host.key === selectedHostKey)) {
+			selectedHostKey = fallbackHostKey;
+		}
+		benchMessage = '';
+		benchError = '';
+	});
+	const summary = $derived(studioFolder.summary);
 	const title = $derived(resolveFolderTitle(prefix));
 	const library = $derived(prefix.split('/')[0] || 'Library');
-	const sampleItem = $derived(record<FolderSampleItem>(folder.sample_item));
-	const calibration = $derived(record<FolderCalibrationState>(folder.calibration));
-	const pendingProposal = $derived(record<PendingSampleProposal>(folder.pending_proposal));
-	const reviewGate = $derived(record<ReviewGate>(folder.review_gate));
-	const calibrationJob = $derived(record<FolderCalibrationJob>(folder.calibration_job));
+	const sampleItem = $derived(record<FolderSampleItem>(studioFolder.sample_item));
+	const calibration = $derived(record<FolderCalibrationState>(studioFolder.calibration));
+	const pendingProposal = $derived(record<PendingSampleProposal>(studioFolder.pending_proposal));
+	const reviewGate = $derived(record<ReviewGate>(studioFolder.review_gate));
+	const calibrationJob = $derived(record<FolderCalibrationJob>(studioFolder.calibration_job));
 	const retryableSampleJob = $derived(record<FolderCalibrationJob>(status.retryable_sample_job));
-	const encodeJob = $derived(folder.encode_job ?? null);
+	const encodeJob = $derived(studioFolder.encode_job ?? null);
 	const reviewArtifacts = $derived(resolveReviewArtifacts(calibration, pendingProposal));
 	const workflow = $derived(
 		resolveWorkflow(
@@ -69,13 +104,24 @@
 			encodeJob
 		)
 	);
-	const proposalRows = $derived(buildProposalRows(folder, pendingProposal));
-	const statusTiles = $derived(buildStatusTiles(folder, status, hosts, workflow));
-	const footerSignals = $derived(buildFooterSignals(folder, status, hosts));
+	const proposalRows = $derived(buildProposalRows(studioFolder, pendingProposal));
+	const statusTiles = $derived(buildStatusTiles(studioFolder, status, hosts, workflow));
+	const footerSignals = $derived(buildFooterSignals(studioFolder, status, hosts));
 	const sampleFacts = $derived(buildSampleFacts(sampleItem, summary));
 	const benchMessages = $derived(
 		buildBenchMessages(calibration, pendingProposal, retryableSampleJob)
 	);
+	const trimmedBenchNote = $derived(benchNote.trim());
+	const benchRequestState = $derived(
+		resolveBenchRequestState(
+			benchNote,
+			selectedHostKey,
+			sampleHostOptions,
+			calibrationJob,
+			benchPending
+		)
+	);
+	const benchRequestDisabled = $derived(benchRequestState.disabled);
 
 	function workflowActionEnabled(action: WorkflowAction): boolean {
 		if (action === 'open-ops') return true;
@@ -89,6 +135,32 @@
 		if (workflowActionEnabled(action)) return '';
 		if (action === 'download-review-pack') return 'Review pack is not ready yet.';
 		return 'Wiring handoff pending for this workflow action.';
+	}
+
+	function handleBenchNoteInput(event: Event) {
+		benchNote = (event.currentTarget as HTMLTextAreaElement).value;
+	}
+
+	async function sendBenchRequest() {
+		if (benchRequestDisabled) return;
+		benchPending = true;
+		benchMessage = '';
+		benchError = '';
+		try {
+			const response = await postJson<FolderBenchPreviewResponse>(
+				`${resolve('/')}api/folders/${encodedPrefix}/ai-tune/preview`,
+				{ note: trimmedBenchNote, host_key: selectedHostKey }
+			);
+			localPendingProposal = response.proposal ?? studioFolder.pending_proposal ?? null;
+			localProposalPrefix = prefix;
+			benchMessage =
+				response.message || 'Bench draft ready. Nothing is queued until you confirm it.';
+			benchNote = '';
+		} catch (error) {
+			benchError = error instanceof Error ? error.message : 'Bench request failed.';
+		} finally {
+			benchPending = false;
+		}
 	}
 </script>
 
@@ -113,11 +185,11 @@
 					</div>
 					<div>
 						<span>Projected reclaim</span>
-						<strong>{formatBytes(projectedReclaimBytes(folder))}</strong>
+						<strong>{formatBytes(projectedReclaimBytes(studioFolder))}</strong>
 					</div>
 					<div>
 						<span>Metric</span>
-						<strong>{folder.metric_status_copy || resolvedMetricCopy(folder)}</strong>
+						<strong>{studioFolder.metric_status_copy || resolvedMetricCopy(studioFolder)}</strong>
 					</div>
 				</div>
 			</header>
@@ -220,26 +292,38 @@
 							<textarea
 								rows="5"
 								placeholder="Ask Bench what to sample, revise, or validate for this folder."
+								value={benchNote}
+								oninput={handleBenchNoteInput}
 							></textarea>
 						</label>
 						<div class="bench__controls">
 							<label>
 								<span>Host</span>
-								<select>
-									{#each hosts.hosts as host (host.key)}
-										<option value={host.key}>{host.label}</option>
+								<select bind:value={selectedHostKey}>
+									{#each sampleHostOptions as host (host.key)}
+										<option value={host.key}
+											>{host.label}{host.available ? '' : ' · unavailable'}</option
+										>
 									{/each}
 								</select>
 							</label>
 							<button
 								class="control control--primary"
 								type="button"
-								disabled
-								title="Bench request wiring is pending."
+								disabled={benchRequestDisabled}
+								title={benchRequestDisabled ? benchRequestState.blocker : ''}
+								onclick={sendBenchRequest}
 								data-mf-action="bench-request"
-								data-mf-wire="pending">Send to Bench</button
+								data-mf-wire="live">{benchPending ? 'Sending' : 'Send to Bench'}</button
 							>
 						</div>
+						{#if benchError}
+							<p class="bench__status bench__status--fail">{benchError}</p>
+						{:else if benchMessage}
+							<p class="bench__status bench__status--ready">{benchMessage}</p>
+						{:else if benchRequestState.blocker}
+							<p class="bench__status">{benchRequestState.blocker}</p>
+						{/if}
 					</div>
 				</div>
 			</WorkstationPanel>
@@ -254,7 +338,7 @@
 						<dt>Approval</dt>
 						<dd>{reviewGate?.status ?? '—'}</dd>
 						<dt>Encode</dt>
-						<dd>{encodeJob?.status ?? folder.encode_queue_summary ?? '—'}</dd>
+						<dd>{encodeJob?.status ?? studioFolder.encode_queue_summary ?? '—'}</dd>
 					</dl>
 				</WorkstationPanel>
 
@@ -267,13 +351,13 @@
 						<dt>Bitrate</dt>
 						<dd>{formatBitrateCopy(sampleItem?.video_bitrate) ?? '—'}</dd>
 						<dt>Metric</dt>
-						<dd>{resolvedMetricCopy(folder)}</dd>
+						<dd>{resolvedMetricCopy(studioFolder)}</dd>
 					</dl>
 				</WorkstationPanel>
 
 				<WorkstationPanel title="Recent">
 					<div class="history-list history-list--compact">
-						{#each (folder.recent_tuning_sessions ?? []).slice(0, 3) as session, index (`${session.session_id ?? session.created_at ?? index}`)}
+						{#each (studioFolder.recent_tuning_sessions ?? []).slice(0, 3) as session, index (`${session.session_id ?? session.created_at ?? index}`)}
 							<div>
 								<span>{formatDateTimeCopy(String(session.created_at ?? '')) || '—'}</span>
 								<strong>{String(session.summary ?? session.note ?? 'Tuning session')}</strong>
@@ -701,6 +785,24 @@
 		display: grid;
 		gap: var(--mf-space-4);
 		grid-template-columns: minmax(0, 1fr) auto;
+	}
+
+	.bench__status {
+		border-left: 2px solid var(--mf-idle-fg);
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-xs);
+		line-height: var(--mf-leading-normal);
+		padding-left: var(--mf-space-3);
+	}
+
+	.bench__status--ready {
+		border-left-color: var(--mf-ready-fg);
+		color: var(--mf-ready-fg);
+	}
+
+	.bench__status--fail {
+		border-left-color: var(--mf-fail-fg);
+		color: var(--mf-fail-fg);
 	}
 
 	.support-grid {

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { HostRuntime } from '$lib/api/types';
+import type { FolderCalibrationJob } from '$lib/folders/studio';
+import { buildBenchHostOptions, resolveBenchRequestState } from './folder-studio-view';
+
+function host(overrides: Partial<HostRuntime>): HostRuntime {
+	return {
+		key: 'studio-mini',
+		label: 'Studio Mini',
+		available: true,
+		message: 'ready',
+		missing_paths: [],
+		issues: [],
+		detail: null,
+		capabilities: ['folder_ai_tuning'],
+		priority: 1,
+		max_parallel_encodes: 1,
+		active_encode_count: 0,
+		schedule_profile_label: 'always',
+		schedule_detail: 'open',
+		active_flag: 'ready',
+		active_reason: 'ready',
+		...overrides
+	};
+}
+
+describe('Folder Studio Bench request mapping', () => {
+	it('prefers folder-scoped host options and removes empty keys', () => {
+		const options = buildBenchHostOptions(
+			[
+				{ key: 'sample-host', label: 'Sample host', detail: 'folder match', available: true },
+				{ key: 'offline', label: 'Offline host', message: 'missing media', available: false },
+				{ key: '   ', label: 'Invalid host', available: true }
+			],
+			[host({ key: 'fallback', label: 'Fallback' })]
+		);
+
+		expect(options).toEqual([
+			{ key: 'sample-host', label: 'Sample host', detail: 'folder match', available: true },
+			{ key: 'offline', label: 'Offline host', detail: 'missing media', available: false }
+		]);
+	});
+
+	it('enables send only for a note, available host, and inactive sample job', () => {
+		const options = buildBenchHostOptions(undefined, [
+			host({}),
+			host({ key: 'offline', available: false })
+		]);
+
+		expect(resolveBenchRequestState('', 'studio-mini', options, null, false)).toMatchObject({
+			disabled: true,
+			blocker: 'Describe the Bench request before sending.'
+		});
+		expect(
+			resolveBenchRequestState('try a smaller sample', 'offline', options, null, false)
+		).toMatchObject({
+			disabled: true,
+			blocker: 'Selected host is not available right now.'
+		});
+		expect(
+			resolveBenchRequestState(
+				'try a smaller sample',
+				'studio-mini',
+				options,
+				{ status: 'running' } as FolderCalibrationJob,
+				false
+			)
+		).toMatchObject({
+			disabled: true,
+			blocker: 'A sample job is already active for this folder.',
+			activeCalibrationJob: true
+		});
+		expect(
+			resolveBenchRequestState(
+				'try a smaller sample',
+				'studio-mini',
+				options,
+				{ status: 'failed' } as FolderCalibrationJob,
+				false
+			)
+		).toMatchObject({ disabled: false, blocker: '', activeCalibrationJob: false });
+	});
+});

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -20,6 +20,7 @@ import type {
 	EncodeQueueJob,
 	FolderPayload,
 	FolderStatusPayload,
+	HostRuntime,
 	HostsPayload
 } from '$lib/api/types';
 import type { FooterSignal, ShellTone, StatusTile } from './OperatorShell.svelte';
@@ -64,12 +65,77 @@ export type BenchMessage = {
 	tone?: ShellTone | 'neutral';
 };
 
+export type BenchHostOption = {
+	key: string;
+	label: string;
+	detail: string;
+	available: boolean;
+};
+
+export type BenchRequestState = {
+	disabled: boolean;
+	blocker: string;
+	selectedHost: BenchHostOption | null;
+	activeCalibrationJob: boolean;
+};
+
 export function record<T extends Record<string, unknown>>(value: unknown): T | null {
 	return value && typeof value === 'object' ? (value as T) : null;
 }
 
 function compactText(value: unknown): string {
 	return typeof value === 'string' ? value.trim() : '';
+}
+
+function activeCalibrationStatus(value: unknown): boolean {
+	return ['queued', 'running', 'pending_review'].includes(String(value ?? '').toLowerCase());
+}
+
+export function buildBenchHostOptions(
+	folderOptions: Array<Record<string, unknown>> | undefined,
+	hosts: HostRuntime[]
+): BenchHostOption[] {
+	const source = folderOptions && folderOptions.length > 0 ? folderOptions : hosts;
+	return source
+		.map((host) => {
+			const key = compactText(host.key);
+			return {
+				key,
+				label: compactText(host.label) || key || 'Host',
+				detail: compactText(host.detail) || compactText(host.message),
+				available: host.available !== false
+			};
+		})
+		.filter((host) => host.key);
+}
+
+export function resolveBenchRequestState(
+	note: string,
+	selectedHostKey: string,
+	hostOptions: BenchHostOption[],
+	calibrationJob: FolderCalibrationJob | null,
+	pending: boolean
+): BenchRequestState {
+	const selectedHost = hostOptions.find((host) => host.key === selectedHostKey) ?? null;
+	const activeCalibrationJob = activeCalibrationStatus(calibrationJob?.status);
+	let blocker = '';
+	if (!note.trim()) {
+		blocker = 'Describe the Bench request before sending.';
+	} else if (!selectedHostKey) {
+		blocker = 'Choose an available host before sending.';
+	} else if (!selectedHost) {
+		blocker = 'Selected host is no longer available for this folder.';
+	} else if (!selectedHost.available) {
+		blocker = 'Selected host is not available right now.';
+	} else if (activeCalibrationJob) {
+		blocker = 'A sample job is already active for this folder.';
+	}
+	return {
+		disabled: pending || Boolean(blocker),
+		blocker: pending ? 'Sending request to Bench.' : blocker,
+		selectedHost,
+		activeCalibrationJob
+	};
 }
 
 function requestSummary(request: FolderOperatorRequest | null | undefined): string {


### PR DESCRIPTION
## Summary
- wire the Folder Studio Bench composer to the existing preview endpoint
- persist returned preview proposals locally so the transcript and draft table update immediately
- add host/request blocker logic with focused unit coverage

Closes #30

## Validation
- bash scripts/pre-commit-check.sh
- Browser QA at http://127.0.0.1:4281/folders/tv/Terminator%20-%20The%20Sarah%20Connor%20Chronicles/Season%202: verified Bench composer renders, no horizontal overflow, unavailable host remains visible, Send is disabled with the correct blocker after typing