### PR TITLE
Fix review follow-up queue and settings state

### DIFF
--- a/frontend/src/lib/components/settings/SettingsEditor.svelte
+++ b/frontend/src/lib/components/settings/SettingsEditor.svelte
@@ -81,8 +81,11 @@
 			lastSettingsKey = '';
 			savedSettings = null;
 			draft = emptyDraft;
+			saveMessage = '';
+			saveError = '';
 			clearArchiveArmed = false;
 			archiveMessage = '';
+			archiveError = '';
 			return;
 		}
 		const nextSettingsKey = settingsKey(settings);

--- a/mediaforce/tuning/calibration_jobs.py
+++ b/mediaforce/tuning/calibration_jobs.py
@@ -123,7 +123,6 @@ def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict
         .order_by(calibration_jobs.c.created_at.asc(), _rowid_column().asc())
     ).mappings().fetchall()
     recent_terminal_rows = []
-    recent_terminal_limit = limit_per_lane * 4 if limit_per_lane > 0 else 0
     for lane in ("sample", "full"):
         recent_terminal_rows.extend(
             connection.execute(
@@ -131,7 +130,6 @@ def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict
                 .where(calibration_jobs.c.lane == lane)
                 .where(calibration_jobs.c.status.in_(("failed", "stopped")))
                 .order_by(calibration_jobs.c.updated_at.desc(), _rowid_column().desc())
-                .limit(recent_terminal_limit)
             ).mappings().fetchall()
         )
     summary: dict[str, Any] = {

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -13614,8 +13614,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
     def test_calibration_queue_summary_counts_recent_failures_beyond_display_limit(self) -> None:
         with open_db(self.config.paths.db_path) as connection:
-            for index in range(5):
-                updated_at = f"2026-05-05T12:0{index}:00+00:00"
+            for index in range(11):
+                updated_at = f"2026-05-05T12:{index:02d}:00+00:00"
                 prefix = f"tv/count-failed-{index}"
                 web_app._save_job_state(
                     connection,
@@ -13647,8 +13647,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
             summary = list_queue_summary(connection, limit_per_lane=2)
 
-        self.assertEqual(summary["sample"]["recent_failed_count"], 5)
-        self.assertEqual(summary["recent_failed_count"], 5)
+        self.assertEqual(summary["sample"]["recent_failed_count"], 11)
+        self.assertEqual(summary["recent_failed_count"], 11)
         self.assertEqual(len(summary["sample"]["recent_failed"]), 2)
 
     def test_run_remote_status_probe_retries_timeout_once(self) -> None:


### PR DESCRIPTION
## Summary
- count all distinct recent calibration terminal prefixes, while keeping the displayed rows lane-limited
- clear stale settings save/archive feedback when the settings payload disappears after a load failure
- strengthen queue summary regression coverage beyond the old prefetch window

## Validation
- uv run --with pytest pytest tests/test_encode_queue_recovery.py -k 'calibration_queue_summary_counts_recent_failures_beyond_display_limit or calibration_queue_summary_limits_recent_failed_jobs_per_lane or calibration_queue_summary_deduplicates_failed_prefixes_before_limit'
- npm --prefix frontend run check
- bash scripts/pre-commit-check.sh