### PR TITLE
Fix late review Bench and queue summary regressions

### DIFF
--- a/frontend/src/lib/components/workstation/FolderStudioView.svelte
+++ b/frontend/src/lib/components/workstation/FolderStudioView.svelte
@@ -69,9 +69,7 @@
 	});
 	const prefix = $derived(studioFolder.prefix);
 	const encodedPrefix = $derived(folderRoutePrefix(prefix));
-	const sampleHostOptions = $derived(
-		buildBenchHostOptions(studioFolder.sample_host_options, hosts.hosts)
-	);
+	const sampleHostOptions = $derived(buildBenchHostOptions(studioFolder.sample_host_options));
 	const folderSampleHostKey = $derived(String(folder.sample_host_key ?? '').trim());
 	const fallbackHostKey = $derived(folderSampleHostKey || sampleHostOptions[0]?.key || '');
 
@@ -95,7 +93,7 @@
 	const reviewArtifacts = $derived(resolveReviewArtifacts(calibration, pendingProposal));
 	const workflow = $derived(
 		resolveWorkflow(
-			folder,
+			studioFolder,
 			status,
 			calibration,
 			pendingProposal,

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -1,50 +1,26 @@
 import { describe, expect, it } from 'vitest';
-import type { HostRuntime } from '$lib/api/types';
 import type { FolderCalibrationJob } from '$lib/folders/studio';
 import { buildBenchHostOptions, resolveBenchRequestState } from './folder-studio-view';
 
-function host(overrides: Partial<HostRuntime>): HostRuntime {
-	return {
-		key: 'studio-mini',
-		label: 'Studio Mini',
-		available: true,
-		message: 'ready',
-		missing_paths: [],
-		issues: [],
-		detail: null,
-		capabilities: ['folder_ai_tuning'],
-		priority: 1,
-		max_parallel_encodes: 1,
-		active_encode_count: 0,
-		schedule_profile_label: 'always',
-		schedule_detail: 'open',
-		active_flag: 'ready',
-		active_reason: 'ready',
-		...overrides
-	};
-}
-
 describe('Folder Studio Bench request mapping', () => {
-	it('prefers folder-scoped host options and removes empty keys', () => {
-		const options = buildBenchHostOptions(
-			[
-				{ key: 'sample-host', label: 'Sample host', detail: 'folder match', available: true },
-				{ key: 'offline', label: 'Offline host', message: 'missing media', available: false },
-				{ key: '   ', label: 'Invalid host', available: true }
-			],
-			[host({ key: 'fallback', label: 'Fallback' })]
-		);
+	it('uses only folder-scoped host options and removes empty keys', () => {
+		const options = buildBenchHostOptions([
+			{ key: 'sample-host', label: 'Sample host', detail: 'folder match', available: true },
+			{ key: 'offline', label: 'Offline host', message: 'missing media', available: false },
+			{ key: '   ', label: 'Invalid host', available: true }
+		]);
 
 		expect(options).toEqual([
 			{ key: 'sample-host', label: 'Sample host', detail: 'folder match', available: true },
 			{ key: 'offline', label: 'Offline host', detail: 'missing media', available: false }
 		]);
+		expect(buildBenchHostOptions(undefined)).toEqual([]);
 	});
 
 	it('enables send only for a note, available host, and inactive sample job', () => {
-		const options = buildBenchHostOptions(undefined, [
-			host({}),
-			host({ key: 'offline', available: false })
+		const options = buildBenchHostOptions([
+			{ key: 'studio-mini', label: 'Studio Mini', available: true },
+			{ key: 'offline', label: 'Offline', available: false }
 		]);
 
 		expect(resolveBenchRequestState('', 'studio-mini', options, null, false)).toMatchObject({

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -20,7 +20,6 @@ import type {
 	EncodeQueueJob,
 	FolderPayload,
 	FolderStatusPayload,
-	HostRuntime,
 	HostsPayload
 } from '$lib/api/types';
 import type { FooterSignal, ShellTone, StatusTile } from './OperatorShell.svelte';
@@ -92,11 +91,9 @@ function activeCalibrationStatus(value: unknown): boolean {
 }
 
 export function buildBenchHostOptions(
-	folderOptions: Array<Record<string, unknown>> | undefined,
-	hosts: HostRuntime[]
+	folderOptions: Array<Record<string, unknown>> | undefined
 ): BenchHostOption[] {
-	const source = folderOptions && folderOptions.length > 0 ? folderOptions : hosts;
-	return source
+	return (folderOptions ?? [])
 		.map((host) => {
 			const key = compactText(host.key);
 			return {

--- a/mediaforce/tuning/calibration_jobs.py
+++ b/mediaforce/tuning/calibration_jobs.py
@@ -6,6 +6,7 @@ from sqlalchemy import func
 from sqlalchemy import literal_column
 from sqlalchemy import select
 from sqlalchemy import update
+from sqlalchemy import distinct
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from mediaforce.core.db import DBClient
@@ -122,14 +123,26 @@ def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict
         .where(calibration_jobs.c.status.in_(("queued", "running", "pending_review")))
         .order_by(calibration_jobs.c.created_at.asc(), _rowid_column().asc())
     ).mappings().fetchall()
+    recent_terminal_counts = {
+        str(row["lane"]): int(row["count"])
+        for row in connection.execute(
+            select(calibration_jobs.c.lane, func.count(distinct(calibration_jobs.c.prefix)).label("count"))
+            .where(calibration_jobs.c.status.in_(("failed", "stopped")))
+            .group_by(calibration_jobs.c.lane)
+        ).mappings()
+    }
     recent_terminal_rows = []
+    recent_terminal_limit = max(limit_per_lane * 4, limit_per_lane) if limit_per_lane > 0 else 0
     for lane in ("sample", "full"):
+        if recent_terminal_limit <= 0:
+            continue
         recent_terminal_rows.extend(
             connection.execute(
                 _calibration_job_select()
                 .where(calibration_jobs.c.lane == lane)
                 .where(calibration_jobs.c.status.in_(("failed", "stopped")))
                 .order_by(calibration_jobs.c.updated_at.desc(), _rowid_column().desc())
+                .limit(recent_terminal_limit)
             ).mappings().fetchall()
         )
     summary: dict[str, Any] = {
@@ -152,6 +165,10 @@ def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict
             summary["active_count"] += 1
         if status in lane_summary and len(lane_summary[status]) < limit_per_lane:
             lane_summary[status].append(payload)
+    for lane in ("sample", "full"):
+        count = recent_terminal_counts.get(lane, 0)
+        summary[lane]["recent_failed_count"] = count
+        summary["recent_failed_count"] += count
     seen_terminal_prefix_lanes: set[tuple[str, str]] = set()
     for row in recent_terminal_rows:
         payload = _hydrate_job(row)
@@ -161,8 +178,6 @@ def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict
         if prefix_lane in seen_terminal_prefix_lanes:
             continue
         seen_terminal_prefix_lanes.add(prefix_lane)
-        lane_summary["recent_failed_count"] += 1
-        summary["recent_failed_count"] += 1
         if len(lane_summary["recent_failed"]) < limit_per_lane:
             lane_summary["recent_failed"].append(payload)
     return summary

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -13614,7 +13614,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
     def test_calibration_queue_summary_counts_recent_failures_beyond_display_limit(self) -> None:
         with open_db(self.config.paths.db_path) as connection:
-            for index in range(11):
+            for index in range(13):
                 updated_at = f"2026-05-05T12:{index:02d}:00+00:00"
                 prefix = f"tv/count-failed-{index}"
                 web_app._save_job_state(
@@ -13647,8 +13647,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
             summary = list_queue_summary(connection, limit_per_lane=2)
 
-        self.assertEqual(summary["sample"]["recent_failed_count"], 11)
-        self.assertEqual(summary["recent_failed_count"], 11)
+        self.assertEqual(summary["sample"]["recent_failed_count"], 13)
+        self.assertEqual(summary["recent_failed_count"], 13)
         self.assertEqual(len(summary["sample"]["recent_failed"]), 2)
 
     def test_run_remote_status_probe_retries_timeout_once(self) -> None:


### PR DESCRIPTION
## Summary
- resolve Folder Studio workflow state against the local Bench proposal overlay
- keep Bench host choices folder-scoped instead of falling back to unrelated global hosts
- count all distinct recent terminal calibration prefixes with SQL-side counts while keeping displayed history rows bounded

## Validation
- uv run --with pytest pytest tests/test_encode_queue_recovery.py -k 'calibration_queue_summary_counts_recent_failures_beyond_display_limit or calibration_queue_summary_limits_recent_failed_jobs_per_lane or calibration_queue_summary_deduplicates_failed_prefixes_before_limit'
- npm --prefix frontend run check
- npm --prefix frontend run test:unit -- --run src/lib/components/workstation/folder-studio-view.test.ts
- bash scripts/pre-commit-check.sh