### PR TITLE
Fix Folder Studio confirm and Settings draft state

### DIFF
--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -410,6 +410,13 @@ export interface FolderBenchPreviewResponse {
 	proposal?: Record<string, unknown> | null;
 }
 
+export interface FolderBenchConfirmResponse {
+	ok: boolean;
+	message?: string;
+	job?: Record<string, unknown> | null;
+	advice?: Record<string, unknown> | null;
+}
+
 export interface FolderStatusPayload {
 	prefix: string;
 	polling_active: boolean;

--- a/frontend/src/lib/components/settings/SettingsEditor.svelte
+++ b/frontend/src/lib/components/settings/SettingsEditor.svelte
@@ -79,8 +79,6 @@
 		if (!settings) {
 			if (!loadError) return;
 			lastSettingsKey = '';
-			savedSettings = null;
-			draft = emptyDraft;
 			saveMessage = '';
 			saveError = '';
 			clearArchiveArmed = false;

--- a/frontend/src/lib/components/workstation/FolderStudioView.svelte
+++ b/frontend/src/lib/components/workstation/FolderStudioView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { invalidateAll } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { postJson } from '$lib/api/client';
 	import { folderRoutePrefix } from '$lib/folder-display';
@@ -15,6 +16,7 @@
 		type ReviewGate
 	} from '$lib/folders/studio';
 	import type {
+		FolderBenchConfirmResponse,
 		FolderBenchPreviewResponse,
 		FolderPayload,
 		FolderStatusPayload,
@@ -37,6 +39,7 @@
 		resolvedMetricCopy,
 		resolveFolderTitle,
 		resolveReviewArtifacts,
+		resolveWorkflowActionState,
 		resolveWorkflow,
 		reviewReadyCopy,
 		summarizeStatuses,
@@ -56,6 +59,7 @@
 	let benchNote = $state('');
 	let selectedHostKey = $state('');
 	let benchPending = $state(false);
+	let workflowPending = $state<WorkflowAction | null>(null);
 	let benchMessage = $state('');
 	let benchError = $state('');
 	let localPendingProposal = $state<Record<string, unknown> | null | undefined>(undefined);
@@ -120,19 +124,17 @@
 		)
 	);
 	const benchRequestDisabled = $derived(benchRequestState.disabled);
+	const reviewPackReady = $derived(
+		reviewArtifacts.length > 0 || reviewReadyCopy(calibration) === 'Ready'
+	);
 
-	function workflowActionEnabled(action: WorkflowAction): boolean {
-		if (action === 'open-ops') return true;
-		if (action === 'download-review-pack') {
-			return reviewArtifacts.length > 0 || reviewReadyCopy(calibration) === 'Ready';
-		}
-		return false;
-	}
-
-	function workflowActionTitle(action: WorkflowAction): string {
-		if (workflowActionEnabled(action)) return '';
-		if (action === 'download-review-pack') return 'Review pack is not ready yet.';
-		return 'Wiring handoff pending for this workflow action.';
+	function workflowActionState(action: WorkflowAction) {
+		return resolveWorkflowActionState(action, {
+			reviewPackReady,
+			pendingProposal,
+			calibrationJob,
+			pendingAction: workflowPending
+		});
 	}
 
 	function handleBenchNoteInput(event: Event) {
@@ -158,6 +160,29 @@
 			benchError = error instanceof Error ? error.message : 'Bench request failed.';
 		} finally {
 			benchPending = false;
+		}
+	}
+
+	async function confirmBenchProposal(action: WorkflowAction) {
+		if (!['start-sample', 'retry-sample'].includes(action)) return;
+		const actionState = workflowActionState(action);
+		if (actionState.disabled) return;
+		workflowPending = action;
+		benchMessage = '';
+		benchError = '';
+		try {
+			const response = await postJson<FolderBenchConfirmResponse>(
+				`${resolve('/')}api/folders/${encodedPrefix}/ai-tune/confirm`,
+				{ proposal_id: pendingProposal?.proposal_id ?? '' }
+			);
+			localPendingProposal = null;
+			localProposalPrefix = prefix;
+			benchMessage = response.message || 'Queued the sample run from the bench draft.';
+			await invalidateAll();
+		} catch (error) {
+			benchError = error instanceof Error ? error.message : 'Sample could not be queued.';
+		} finally {
+			workflowPending = null;
 		}
 	}
 </script>
@@ -219,7 +244,7 @@
 							href={resolve('/ops')}
 							data-mf-action={workflow.primaryAction}>{workflow.primary}</a
 						>
-					{:else if workflow.primaryAction === 'download-review-pack' && workflowActionEnabled(workflow.primaryAction)}
+					{:else if workflow.primaryAction === 'download-review-pack' && !workflowActionState(workflow.primaryAction).disabled}
 						<form
 							class="action-form"
 							method="get"
@@ -228,12 +253,23 @@
 						>
 							<button class="control control--primary" type="submit">{workflow.primary}</button>
 						</form>
+					{:else if workflow.primaryAction === 'start-sample' || workflow.primaryAction === 'retry-sample'}
+						<button
+							class="control control--primary"
+							type="button"
+							disabled={workflowActionState(workflow.primaryAction).disabled}
+							title={workflowActionState(workflow.primaryAction).title}
+							onclick={() => confirmBenchProposal(workflow.primaryAction)}
+							data-mf-action={workflow.primaryAction}
+							data-mf-wire="live"
+							>{workflowPending === workflow.primaryAction ? 'Queueing' : workflow.primary}</button
+						>
 					{:else}
 						<button
 							class="control control--primary"
 							type="button"
-							disabled={!workflowActionEnabled(workflow.primaryAction)}
-							title={workflowActionTitle(workflow.primaryAction)}
+							disabled={workflowActionState(workflow.primaryAction).disabled}
+							title={workflowActionState(workflow.primaryAction).title}
 							data-mf-action={workflow.primaryAction}
 							data-mf-wire="pending">{workflow.primary}</button
 						>
@@ -242,7 +278,7 @@
 						<a class="control" href={resolve('/ops')} data-mf-action={workflow.secondaryAction}
 							>{workflow.secondary}</a
 						>
-					{:else if workflow.secondaryAction === 'download-review-pack' && workflowActionEnabled(workflow.secondaryAction)}
+					{:else if workflow.secondaryAction === 'download-review-pack' && !workflowActionState(workflow.secondaryAction).disabled}
 						<form
 							class="action-form"
 							method="get"
@@ -251,12 +287,25 @@
 						>
 							<button class="control" type="submit">{workflow.secondary}</button>
 						</form>
+					{:else if workflow.secondaryAction === 'start-sample' || workflow.secondaryAction === 'retry-sample'}
+						<button
+							class="control"
+							type="button"
+							disabled={workflowActionState(workflow.secondaryAction).disabled}
+							title={workflowActionState(workflow.secondaryAction).title}
+							onclick={() => confirmBenchProposal(workflow.secondaryAction)}
+							data-mf-action={workflow.secondaryAction}
+							data-mf-wire="live"
+							>{workflowPending === workflow.secondaryAction
+								? 'Queueing'
+								: workflow.secondary}</button
+						>
 					{:else}
 						<button
 							class="control"
 							type="button"
-							disabled={!workflowActionEnabled(workflow.secondaryAction)}
-							title={workflowActionTitle(workflow.secondaryAction)}
+							disabled={workflowActionState(workflow.secondaryAction).disabled}
+							title={workflowActionState(workflow.secondaryAction).title}
 							data-mf-action={workflow.secondaryAction}
 							data-mf-wire="pending">{workflow.secondary}</button
 						>

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { FolderCalibrationJob } from '$lib/folders/studio';
-import { buildBenchHostOptions, resolveBenchRequestState } from './folder-studio-view';
+import {
+	buildBenchHostOptions,
+	resolveBenchRequestState,
+	resolveWorkflowActionState
+} from './folder-studio-view';
+import type { PendingSampleProposal } from '$lib/folders/studio';
 
 describe('Folder Studio Bench request mapping', () => {
 	it('uses only folder-scoped host options and removes empty keys', () => {
@@ -55,5 +60,49 @@ describe('Folder Studio Bench request mapping', () => {
 				false
 			)
 		).toMatchObject({ disabled: false, blocker: '', activeCalibrationJob: false });
+	});
+
+	it('enables sample confirmation only for queueable Bench drafts', () => {
+		expect(
+			resolveWorkflowActionState('start-sample', {
+				reviewPackReady: false,
+				pendingProposal: null,
+				calibrationJob: null
+			})
+		).toMatchObject({
+			disabled: true,
+			title: 'Ask Bench for a draft before starting the sample.'
+		});
+
+		expect(
+			resolveWorkflowActionState('start-sample', {
+				reviewPackReady: false,
+				pendingProposal: {
+					proposal_id: 'draft-1',
+					can_queue: false,
+					message: 'Review the self-check first.'
+				} as PendingSampleProposal,
+				calibrationJob: null
+			})
+		).toMatchObject({ disabled: true, title: 'Review the self-check first.' });
+
+		expect(
+			resolveWorkflowActionState('start-sample', {
+				reviewPackReady: false,
+				pendingProposal: { proposal_id: 'draft-2', can_queue: true } as PendingSampleProposal,
+				calibrationJob: null
+			})
+		).toEqual({ disabled: false, title: '' });
+
+		expect(
+			resolveWorkflowActionState('start-sample', {
+				reviewPackReady: false,
+				pendingProposal: { proposal_id: 'draft-3', can_queue: true } as PendingSampleProposal,
+				calibrationJob: { status: 'queued' } as FolderCalibrationJob
+			})
+		).toMatchObject({
+			disabled: true,
+			title: 'A sample job is already active for this folder.'
+		});
 	});
 });

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -78,6 +78,11 @@ export type BenchRequestState = {
 	activeCalibrationJob: boolean;
 };
 
+export type WorkflowActionState = {
+	disabled: boolean;
+	title: string;
+};
+
 export function record<T extends Record<string, unknown>>(value: unknown): T | null {
 	return value && typeof value === 'object' ? (value as T) : null;
 }
@@ -133,6 +138,51 @@ export function resolveBenchRequestState(
 		selectedHost,
 		activeCalibrationJob
 	};
+}
+
+export function resolveWorkflowActionState(
+	action: WorkflowAction,
+	{
+		reviewPackReady,
+		pendingProposal,
+		calibrationJob,
+		pendingAction
+	}: {
+		reviewPackReady: boolean;
+		pendingProposal: PendingSampleProposal | null;
+		calibrationJob: FolderCalibrationJob | null;
+		pendingAction?: WorkflowAction | null;
+	}
+): WorkflowActionState {
+	if (pendingAction) {
+		return {
+			disabled: true,
+			title: pendingAction === action ? 'Action is running.' : 'Another folder action is running.'
+		};
+	}
+	if (action === 'open-ops') return { disabled: false, title: '' };
+	if (action === 'download-review-pack') {
+		return reviewPackReady
+			? { disabled: false, title: '' }
+			: { disabled: true, title: 'Review pack is not ready yet.' };
+	}
+	if (action === 'start-sample' || action === 'retry-sample') {
+		if (activeCalibrationStatus(calibrationJob?.status)) {
+			return { disabled: true, title: 'A sample job is already active for this folder.' };
+		}
+		if (action === 'retry-sample') return { disabled: false, title: '' };
+		if (!pendingProposal?.proposal_id) {
+			return { disabled: true, title: 'Ask Bench for a draft before starting the sample.' };
+		}
+		if (pendingProposal.can_queue === false) {
+			return {
+				disabled: true,
+				title: pendingProposal.message || 'The current bench draft is not ready to queue.'
+			};
+		}
+		return { disabled: false, title: '' };
+	}
+	return { disabled: true, title: 'Wiring handoff pending for this workflow action.' };
 }
 
 function requestSummary(request: FolderOperatorRequest | null | undefined): string {


### PR DESCRIPTION
## Summary
- preserve Settings editor drafts when a load refresh fails
- wire Folder Studio Start/Retry sample actions to the existing Bench confirm endpoint
- add action-state tests for queueable Bench drafts and active sample blockers

## Checks
- npm --prefix frontend run check
- npm --prefix frontend run test:unit -- --run
- bash scripts/pre-commit-check.sh