### PR TITLE
Record metadata validation evidence

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -64,7 +64,21 @@
   "deployLabels": [],
   "healthUrls": [],
   "relatedRepos": [],
-  "validatedThrough": [],
+  "validatedThrough": [
+    {
+      "date": "2026-05-10",
+      "source": "cbusillo/mediaforce#47",
+      "checks": [
+        "jq empty .github/github.json",
+        "rg github-repo-workflow\\.json",
+        "codex-skills github-repo-snapshot.sh --json",
+        "pre-commit acceptance gate"
+      ],
+      "caveats": [
+        "Metadata contents were not otherwise changed during the config-path migration."
+      ]
+    }
+  ],
   "githubSignals": {
     "postMerge": {
       "waitForActions": true,


### PR DESCRIPTION
## Summary
- add a compact `validatedThrough` evidence record to `.github/github.json`
- point the record at the config-path migration PR and the checks used to validate the metadata
- keep the evidence scoped to metadata/config validation so expensive runtime gates remain explicit caveats where applicable

## Validation
- `jq` shape check for non-empty `validatedThrough`
- codex-skills `github-repo-snapshot.sh --json` confirms `.github/github.json` and non-empty `validatedThrough`
- `git diff --check`

Part of cbusillo/codex-skills#23.

Additional local validation from commit hook:
- backend pytest: 538 passed
- CLI smoke
- frontend check/lint/unit tests/build
