### PR TITLE
Remove validatedThrough metadata

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -46,7 +46,11 @@
     "inspection": {
       "tool": "jetbrains",
       "ide": "PyCharm",
-      "scopePreference": ["changed_files", "directory", "whole_project"]
+      "scopePreference": [
+        "changed_files",
+        "directory",
+        "whole_project"
+      ]
     },
     "docsRequiredWhen": [
       "behavior changes",
@@ -59,26 +63,13 @@
       "media processing behavior changes"
     ]
   },
-  "importantWorkflows": ["CI"],
+  "importantWorkflows": [
+    "CI"
+  ],
   "qaLabels": [],
   "deployLabels": [],
   "healthUrls": [],
   "relatedRepos": [],
-  "validatedThrough": [
-    {
-      "date": "2026-05-10",
-      "source": "cbusillo/mediaforce#47",
-      "checks": [
-        "jq empty .github/github.json",
-        "rg github-repo-workflow\\.json",
-        "codex-skills github-repo-snapshot.sh --json",
-        "pre-commit acceptance gate"
-      ],
-      "caveats": [
-        "Metadata contents were not otherwise changed during the config-path migration."
-      ]
-    }
-  ],
   "githubSignals": {
     "postMerge": {
       "waitForActions": true,


### PR DESCRIPTION
## Summary
- remove `validatedThrough` from `.github/github.json`
- keep repo metadata focused on current static facts and freshness triggers
- leave validation/history evidence in GitHub PRs, issues, Actions, Launchplane records, or generated reports rather than tracked config

## Validation
- `jq empty .github/github.json`
- `jq -e 'has("validatedThrough") | not' .github/github.json`
- `rg validatedThrough` over `.github`, `AGENTS.md`, `README.md`, and `docs`
- `git diff --check`

Follow-up to cbusillo/codex-skills#33.
- pre-commit hook completed successfully, including backend pytest, CLI smoke checks, frontend lint/tests/build, and docs checks
