### PR TITLE
Prevent route-load hangs with web smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Install frontend dependencies
         run: npm --prefix frontend ci
 
+      - name: Install browser smoke dependencies
+        run: npm --prefix frontend exec playwright install --with-deps chromium
+
       - name: Install media tools
         run: |
           sudo apt-get update
@@ -64,3 +67,6 @@ jobs:
 
       - name: Build frontend
         run: npm --prefix frontend run build
+
+      - name: Run web route smoke
+        run: npm --prefix frontend run smoke:web

--- a/config/web-smoke.toml
+++ b/config/web-smoke.toml
@@ -1,0 +1,86 @@
+[state]
+db_path = "state/web-smoke/library.sqlite3"
+run_manifest_dir = "state/web-smoke/runs"
+web_state_dir = "state/web-smoke/web"
+review_dir = "state/web-smoke/review"
+runtime_settings_path = "state/web-smoke/runtime.json"
+
+[state.cleanup]
+transient_artifact_retention_days = 1
+orphan_temp_retention_minutes = 10
+periodic_sweep_minutes = 60
+
+[media]
+staging_root = "scratch/web-smoke/transcode"
+archive_root = "scratch/web-smoke/transcode/_replaced"
+output_container = "mkv"
+
+[media.source_roots]
+movies = "scratch/web-smoke/source/movies"
+tv = "scratch/web-smoke/source/tv"
+
+[video]
+encoder = "libsvtav1"
+pixel_format = "yuv420p10le"
+preset = 4
+crf_search = true
+quality_metric = "auto"
+target_vmaf = 95.0
+target_xpsnr = 41.0
+min_target_vmaf = 93.0
+min_target_xpsnr = 35.0
+target_relax_step_vmaf = 0.5
+target_relax_step_xpsnr = 1.0
+sample_every = "8m"
+sample_duration = "20s"
+min_crf = 18
+max_crf = 38
+max_encoded_percent = 80
+default_grain = 8
+grain_denoise = 0
+thorough = true
+max_height = 0
+downsample_algorithm = "lanczos"
+black_bar_handling = "off"
+black_bar_detect_samples = 3
+black_bar_detect_seconds = 12
+crop = ""
+
+[audio]
+keep_languages = ["eng"]
+copy_codecs = ["aac", "opus"]
+convert_to_opus_codecs = ["ac3", "eac3", "dts", "dtshd", "flac", "pcm_s16le", "pcm_s24le", "truehd"]
+stereo_opus_bitrate = "128k"
+surround_5_1_opus_bitrate = "256k"
+surround_7_1_opus_bitrate = "320k"
+
+[subtitle]
+keep_languages = ["eng"]
+prefer_text = true
+keep_forced = true
+default_mode = "first_english"
+
+[planning]
+default_limit = 20
+size_weight = 10
+large_file_gib = 4.0
+large_file_bonus = 25
+small_file_gib = 1.5
+small_file_penalty = -15
+multi_audio_bonus = 6
+english_subtitle_bonus = 3
+missing_english_audio_penalty = -30
+
+[validation]
+require_size_reduction = true
+
+[planning.codec_bonus]
+h264 = 40
+hevc = 12
+h265 = 12
+av1 = -45
+default = 18
+
+[planning.bucket_thresholds]
+priority_encode = 70
+review_encode = 35

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
 			"devDependencies": {
 				"@eslint/compat": "^2.1.0",
 				"@eslint/js": "^10.0.1",
+				"@playwright/test": "^1.60.0",
 				"@sveltejs/adapter-static": "^3.0.10",
 				"@sveltejs/kit": "^2.60.1",
 				"@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -341,6 +342,22 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.60.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -2358,6 +2375,53 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.60.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,11 +13,13 @@
 		"lint": "prettier --check . && eslint .",
 		"format": "prettier --write .",
 		"test:unit": "vitest",
-		"test": "npm run test:unit -- --run"
+		"test": "npm run test:unit -- --run",
+		"smoke:web": "node ../scripts/smoke-web-routes.mjs"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^2.1.0",
 		"@eslint/js": "^10.0.1",
+		"@playwright/test": "^1.60.0",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.60.1",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -31,8 +33,8 @@
 		"svelte": "^5.55.7",
 		"svelte-check": "^4.4.8",
 		"typescript": "^6.0.3",
-		"typescript-svelte-plugin": "^0.3.52",
 		"typescript-eslint": "^8.59.3",
+		"typescript-svelte-plugin": "^0.3.52",
 		"vite": "^8.0.13",
 		"vitest": "^4.1.6"
 	},

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -220,7 +220,6 @@ export interface DashboardSummaryPayload {
 		recent_failed_count?: number;
 	};
 	encode_queue: EncodeQueueSummary;
-	archive_cleanup?: ArchiveCleanupSummary;
 	catalog_empty: boolean;
 	folder_cache_key: string;
 	metric_support: MetricSupport;

--- a/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
+++ b/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
@@ -387,16 +387,14 @@
 				</div>
 			</WorkstationPanel>
 
-			<WorkstationPanel eyebrow="Cleanup" title="Originals waiting">
+			<WorkstationPanel eyebrow="Completed" title="Originals cleanup">
 				<dl class="kv">
-					<dt>Cleanup folder</dt>
-					<dd>{dashboard.archive_cleanup?.archive_root ?? '—'}</dd>
-					<dt>Files</dt>
-					<dd>{dashboard.archive_cleanup?.file_count?.toLocaleString('en-US') ?? '0'}</dd>
-					<dt>Size</dt>
-					<dd>{formatBytes(dashboard.archive_cleanup?.total_size_bytes)}</dd>
+					<dt>Route</dt>
+					<dd>Completed</dd>
+					<dt>Scope</dt>
+					<dd>Archived originals</dd>
 					<dt>Action</dt>
-					<dd>{dashboard.archive_cleanup?.has_cleanup ? 'review on Completed' : 'no action'}</dd>
+					<dd><a href={resolve('/completed')}>Review cleanup</a></dd>
 				</dl>
 			</WorkstationPanel>
 		</section>

--- a/frontend/src/lib/components/workstation/ops-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.test.ts
@@ -97,12 +97,6 @@ function dashboardFixture(): DashboardSummaryPayload {
 			},
 			telemetry: { eta_copy: '24m' }
 		},
-		archive_cleanup: {
-			archive_root: '/runtime/archive',
-			file_count: 0,
-			total_size_bytes: 0,
-			has_cleanup: false
-		},
 		catalog_empty: false,
 		folder_cache_key: 'fixture',
 		metric_support: { vmaf: true, xpsnr: false, ssim: true },

--- a/frontend/src/routes/settings/+page.ts
+++ b/frontend/src/routes/settings/+page.ts
@@ -17,7 +17,7 @@ async function settle<T>(promise: Promise<T>): Promise<SettledPayload<T>> {
 
 export async function load({ fetch }: { fetch: typeof window.fetch }) {
 	const [settings, hosts] = await Promise.all([
-		settle(fetchJson<SettingsPayload>('/api/settings', fetch)),
+		settle(fetchJson<SettingsPayload>('/api/settings?include_archive_cleanup=0', fetch)),
 		settle(fetchJson<HostsPayload>('/api/hosts?compact=1', fetch))
 	]);
 	const loadError = [settings.error, hosts.error].filter(Boolean).join(' · ') || null;

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -387,7 +387,6 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             maybe_schedule_scan=_maybe_schedule_scan,
             decorate_encode_queue_for_scheduler=_decorate_encode_queue_for_scheduler,
             library_color_map_for_config=_library_color_map_for_config,
-            archive_cleanup_summary_fn=archive_cleanup_summary,
         )
 
     def _dashboard_folders_payload() -> dict[str, Any]:

--- a/mediaforce/web/runtime/dashboard_payloads.py
+++ b/mediaforce/web/runtime/dashboard_payloads.py
@@ -15,7 +15,6 @@ def dashboard_summary_payload(
         maybe_schedule_scan: Any,
         decorate_encode_queue_for_scheduler: Any,
         library_color_map_for_config: Any,
-        archive_cleanup_summary_fn: Any,
 ) -> dict[str, Any]:
     cache_key = folder_card_cache_key(config)
     with open_db(config.paths.db_path) as connection:
@@ -28,7 +27,6 @@ def dashboard_summary_payload(
         "scan_job": scan_job,
         "calibration_queue": calibration_queue,
         "encode_queue": encode_queue,
-        "archive_cleanup": archive_cleanup_summary_fn(config),
         "folders_preview": [asdict(folder) for folder in preview_folders],
         "catalog_empty": not preview_folders,
         "folder_cache_key": _serialize_cache_key(cache_key),

--- a/mediaforce/web/runtime/folder_cards.py
+++ b/mediaforce/web/runtime/folder_cards.py
@@ -1,6 +1,7 @@
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -248,6 +249,7 @@ def list_folder_cards(
         select(
             library_items.c.rel_path,
             library_items.c.source_path,
+            library_items.c.mtime_ns,
             library_items.c.size_bytes,
             library_items.c.status,
             library_items.c.video_codec,
@@ -292,7 +294,9 @@ def list_folder_cards(
         card.item_count += 1
         size_bytes = int(row["size_bytes"])
         card.total_size_bytes += size_bytes
-        path_age_days = age_days(str(row["source_path"]))
+        path_age_days = _age_days_from_mtime_ns(row["mtime_ns"])
+        if path_age_days is None:
+            path_age_days = age_days(str(row["source_path"]))
         card.average_age_days += path_age_days
         status = str(row["status"] or "unknown")
         codec = str(row["video_codec"] or "unknown")
@@ -527,3 +531,19 @@ def _age_multiplier(age_days: float) -> float:
     if age_days >= 730:
         return 1.15
     return 1.0
+
+
+def _age_days_from_mtime_ns(value: object) -> float | None:
+    if isinstance(value, int):
+        mtime_ns = value
+    elif isinstance(value, str):
+        try:
+            mtime_ns = int(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    if mtime_ns <= 0:
+        return None
+    age_seconds = max(datetime.now(tz=UTC).timestamp() - (mtime_ns / 1_000_000_000), 0.0)
+    return age_seconds / 86400.0

--- a/scripts/pre-commit-check.sh
+++ b/scripts/pre-commit-check.sh
@@ -20,6 +20,7 @@ run_step "Frontend checks" npm --prefix frontend run check
 run_step "Frontend lint" npm --prefix frontend run lint
 run_step "Frontend unit tests" npm --prefix frontend test
 run_step "Frontend build" npm --prefix frontend run build
+run_step "Web route smoke" npm --prefix frontend run smoke:web
 
 echo
 echo "Pre-commit acceptance checks passed."

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import net from 'node:net';
+import { mkdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(path.join(rootDir, 'frontend', 'package.json'));
+const { chromium } = require('@playwright/test');
+
+const DEFAULT_ENDPOINT_TIMEOUT_MS = 2000;
+const DEFAULT_ROUTE_TIMEOUT_MS = 3500;
+const SERVER_START_TIMEOUT_MS = 12000;
+
+const endpointChecks = [
+	['Dashboard summary', '/api/dashboard'],
+	['Dashboard folders', '/api/dashboard/folders'],
+	['Host status', '/api/hosts?compact=1'],
+	['Settings initial payload', '/api/settings?include_archive_cleanup=0'],
+	['Completed payload', '/api/completed']
+];
+
+const routeChecks = [
+	['Queue', '/', 'Queue'],
+	['Folders', '/folders', 'Queue'],
+	['Ops', '/ops', 'Ops'],
+	['Settings', '/settings', 'Settings'],
+	['Completed', '/completed', 'Completed']
+];
+
+function parseArgs(argv) {
+	const parsed = {
+		baseUrl: '',
+		config: path.join(rootDir, 'config', 'web-smoke.toml'),
+		endpointTimeoutMs: DEFAULT_ENDPOINT_TIMEOUT_MS,
+		routeTimeoutMs: DEFAULT_ROUTE_TIMEOUT_MS
+	};
+	for (let index = 0; index < argv.length; index += 1) {
+		const arg = argv[index];
+		if (arg === '--base-url') {
+			parsed.baseUrl = argv[++index] ?? '';
+		} else if (arg === '--config') {
+			parsed.config = path.resolve(argv[++index] ?? parsed.config);
+		} else if (arg === '--endpoint-timeout-ms') {
+			parsed.endpointTimeoutMs = Number(argv[++index] ?? parsed.endpointTimeoutMs);
+		} else if (arg === '--route-timeout-ms') {
+			parsed.routeTimeoutMs = Number(argv[++index] ?? parsed.routeTimeoutMs);
+		} else {
+			throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+	return parsed;
+}
+
+function normalizeBaseUrl(value) {
+	return value.replace(/\/+$/, '');
+}
+
+async function pathExists(filePath) {
+	try {
+		await stat(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function freePort() {
+	return new Promise((resolve, reject) => {
+		const server = net.createServer();
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			const address = server.address();
+			server.close(() => {
+				if (address && typeof address === 'object') {
+					resolve(address.port);
+				} else {
+					reject(new Error('Could not allocate a local port.'));
+				}
+			});
+		});
+	});
+}
+
+async function prepareSmokeState() {
+	const paths = [
+		['scratch', 'web-smoke', 'source', 'movies'],
+		['scratch', 'web-smoke', 'source', 'tv'],
+		['scratch', 'web-smoke', 'transcode', '_replaced'],
+		['state', 'web-smoke', 'runs'],
+		['state', 'web-smoke', 'web'],
+		['state', 'web-smoke', 'review']
+	];
+	await Promise.all(paths.map((parts) => mkdir(path.join(rootDir, ...parts), { recursive: true })));
+}
+
+async function fetchWithTimeout(url, timeoutMs) {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), timeoutMs);
+	const started = performance.now();
+	let response;
+	try {
+		response = await fetch(url, { signal: controller.signal });
+	} catch (error) {
+		if (error instanceof Error && error.name === 'AbortError') {
+			throw new Error(`timed out after ${timeoutMs}ms`);
+		}
+		throw error;
+	} finally {
+		clearTimeout(timeout);
+	}
+	const elapsedMs = Math.round(performance.now() - started);
+	if (!response.ok) {
+		throw new Error(`${response.status} ${response.statusText}`);
+	}
+	await response.arrayBuffer();
+	return elapsedMs;
+}
+
+async function waitForServer(baseUrl, child) {
+	const deadline = Date.now() + SERVER_START_TIMEOUT_MS;
+	let lastError = null;
+	while (Date.now() < deadline) {
+		if (child.exitCode !== null) {
+			throw new Error(`mediaforce-web exited before serving routes with code ${child.exitCode}`);
+		}
+		try {
+			await fetchWithTimeout(`${baseUrl}/`, 1000);
+			return;
+		} catch (error) {
+			lastError = error;
+			await new Promise((resolve) => setTimeout(resolve, 200));
+		}
+	}
+	throw new Error(`mediaforce-web did not start within ${SERVER_START_TIMEOUT_MS}ms: ${lastError}`);
+}
+
+async function startServer(configPath) {
+	const indexPath = path.join(rootDir, 'frontend', 'build', 'index.html');
+	if (!(await pathExists(indexPath))) {
+		throw new Error('frontend/build/index.html is missing. Run npm --prefix frontend run build first.');
+	}
+	await prepareSmokeState();
+	const port = await freePort();
+	const child = spawn(
+		'uv',
+		[
+			'run',
+			'mediaforce-web',
+			'--config',
+			configPath,
+			'--host',
+			'127.0.0.1',
+			'--port',
+			String(port),
+			'--no-reload'
+		],
+		{
+			cwd: rootDir,
+			env: {
+				...process.env,
+				MEDIAFORCE_WEB_RELOAD: '0'
+			},
+			stdio: ['ignore', 'pipe', 'pipe']
+		}
+	);
+	const logs = [];
+	for (const stream of [child.stdout, child.stderr]) {
+		stream.setEncoding('utf8');
+		stream.on('data', (chunk) => {
+			logs.push(chunk);
+			if (logs.join('').length > 8000) logs.splice(0, logs.length - 20);
+		});
+	}
+	const baseUrl = `http://127.0.0.1:${port}`;
+	await waitForServer(baseUrl, child);
+	return {
+		baseUrl,
+			stop: async () => {
+				if (child.exitCode !== null) return;
+				child.kill('SIGTERM');
+				let exited = false;
+				await new Promise((resolve) => {
+					const timeout = setTimeout(resolve, 3000);
+					child.once('exit', () => {
+						exited = true;
+						clearTimeout(timeout);
+						resolve();
+					});
+				});
+				if (!exited) child.kill('SIGKILL');
+			},
+		logs: () => logs.join('')
+	};
+}
+
+async function checkEndpoints(baseUrl, timeoutMs) {
+	for (const [label, route] of endpointChecks) {
+		const elapsedMs = await fetchWithTimeout(`${baseUrl}${route}`, timeoutMs);
+		console.log(`endpoint ok: ${label} ${elapsedMs}ms`);
+	}
+}
+
+async function checkRoutes(baseUrl, timeoutMs) {
+	const browser = await chromium.launch();
+	try {
+		const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+		const pageErrors = [];
+		page.on('pageerror', (error) => pageErrors.push(error.message));
+		for (const [label, route, marker] of routeChecks) {
+			pageErrors.length = 0;
+			const started = performance.now();
+			await page.goto(`${baseUrl}${route}`, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
+			await page.waitForSelector('.operator-shell', { state: 'visible', timeout: timeoutMs });
+			await page.waitForSelector('main', { state: 'visible', timeout: timeoutMs });
+			const state = await page.evaluate((expectedMarker) => {
+				const bodyText = document.body.innerText.trim();
+				return {
+					bodyLength: bodyText.length,
+					hasMain: document.querySelector('main') !== null,
+					hasShell: document.querySelector('.operator-shell') !== null,
+					hasMarker: bodyText.includes(expectedMarker)
+				};
+			}, marker);
+			if (!state.hasShell || !state.hasMain || !state.hasMarker || state.bodyLength < 80) {
+				throw new Error(`${label} rendered an incomplete app shell: ${JSON.stringify(state)}`);
+			}
+			if (pageErrors.length > 0) {
+				throw new Error(`${label} raised browser errors: ${pageErrors.join(' | ')}`);
+			}
+			const elapsedMs = Math.round(performance.now() - started);
+			console.log(`route ok: ${label} ${elapsedMs}ms`);
+		}
+	} finally {
+		await browser.close();
+	}
+}
+
+async function main() {
+	const args = parseArgs(process.argv.slice(2));
+	let managedServer = null;
+	let targetUrl = args.baseUrl ? normalizeBaseUrl(args.baseUrl) : null;
+	try {
+		if (!targetUrl) {
+			managedServer = await startServer(args.config);
+			targetUrl = managedServer.baseUrl;
+		}
+		await checkEndpoints(targetUrl, args.endpointTimeoutMs);
+		await checkRoutes(targetUrl, args.routeTimeoutMs);
+		console.log(`web route smoke passed: ${targetUrl}`);
+	} catch (error) {
+		if (managedServer) {
+			const logs = managedServer.logs();
+			if (logs.trim()) {
+				console.error('\nmediaforce-web output:\n');
+				console.error(logs.trim());
+			}
+		}
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+	} finally {
+		if (managedServer) await managedServer.stop();
+	}
+}
+
+await main();

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -3622,6 +3622,35 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(card.review_badge_tone, "ok")
         self.assertEqual(card.review_badge_detail, "All staged outputs passed validation.")
 
+    def test_folder_cards_use_catalog_mtime_without_statting_source_paths(self) -> None:
+        source = self._create_source_file("episode-catalog-age.mkv")
+        age_days = Mock(side_effect=AssertionError("source path age lookup should not run"))
+
+        with open_db(self.config.paths.db_path) as connection:
+            item_id = self._insert_library_item(connection, source)
+            connection.execute(
+                update(library_items)
+                .where(library_items.c.id == item_id)
+                .values(
+                    size_bytes=2 * 1024 * 1024 * 1024,
+                    rel_path=f"tv/show/Season 10/{source.name}",
+                    parent_dir="tv/show/Season 10",
+                    mtime_ns=1_700_000_000_000_000_000,
+                )
+            )
+
+            cards = folder_cards_runtime.list_folder_cards(
+                connection,
+                minimum_recommended_savings_bytes=100 * 1024 * 1024,
+                folder_group=web_app._folder_group,
+                age_days=age_days,
+                estimate_savings_bytes=Mock(return_value=200 * 1024 * 1024),
+                review_badge_for_prefix=Mock(return_value={"label": None, "tone": None}),
+            )
+
+        self.assertEqual([card.prefix for card in cards], ["tv/show/Season 10"])
+        age_days.assert_not_called()
+
     def test_folder_delivery_badge_ignores_mixed_validated_and_encoded_items(self) -> None:
         card = self._folder_card_for_delivery_badge(
             item_count=4,

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -91,6 +91,7 @@ from mediaforce.web.runtime.completed_runtime import (
     completed_page_payload,
     confirm_originals_removed_action,
 )
+from mediaforce.web.runtime.dashboard_payloads import dashboard_summary_payload
 from mediaforce.web.runtime.folder_ai_tuning import (
     FolderAiTuneDeps,
     _proposal_can_queue,
@@ -986,6 +987,18 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertTrue(summary["has_cleanup"])
         self.assertEqual(summary["file_count"], 2)
         self.assertEqual(summary["total_size_bytes"], 8)
+
+    def test_dashboard_summary_payload_does_not_scan_archive_cleanup(self) -> None:
+        payload = dashboard_summary_payload(
+            self.config,
+            folder_card_cache_key=lambda _config: ("empty", 0, 0),
+            preview_folder_cards=lambda _config, _connection: [],
+            maybe_schedule_scan=lambda _connection, _config, prefix=None: None,
+            decorate_encode_queue_for_scheduler=lambda _config, summary: summary,
+            library_color_map_for_config=lambda _config: {},
+        )
+
+        self.assertNotIn("archive_cleanup", payload)
 
     def test_clear_archive_cleanup_action_removes_files_and_prunes_directories(self) -> None:
         archive_root = self.config.archive_root


### PR DESCRIPTION
## Summary
- remove the archive cleanup scan from the dashboard payload so Queue can render quickly
- avoid source-path stat calls in folder-card route loading by using catalog mtime
- add a Playwright-backed web route smoke gate to local acceptance and CI

## Validation
- UV_CACHE_DIR=/private/tmp/mediaforce-uv-cache bash scripts/pre-commit-check.sh
- npm --prefix frontend run smoke:web -- --base-url http://127.0.0.1:5555
- in-app browser renders http://127.0.0.1:5555/ with the Queue workstation shell

## Inspection
- PyCharm changed-files inspection still reports existing weak warnings in the large backend test file plus a duplicate-code weak warning in folder card aggregation; no blocking test/lint/type/build failures.
