### PR TITLE
Rework Folder Studio next action

### DIFF
--- a/frontend/src/lib/components/workstation/FolderStudioView.svelte
+++ b/frontend/src/lib/components/workstation/FolderStudioView.svelte
@@ -28,6 +28,7 @@
 	import {
 		buildBenchMessages,
 		buildBenchHostOptions,
+		buildWorkflowSteps,
 		buildFooterSignals,
 		buildProposalRows,
 		buildSampleFacts,
@@ -62,6 +63,7 @@
 	let workflowPending = $state<WorkflowAction | null>(null);
 	let benchMessage = $state('');
 	let benchError = $state('');
+	let benchTextarea = $state<HTMLTextAreaElement | null>(null);
 	let localPendingProposal = $state<Record<string, unknown> | null | undefined>(undefined);
 	let localProposalPrefix = $state('');
 	const studioFolder = $derived({
@@ -106,6 +108,7 @@
 			encodeJob
 		)
 	);
+	const workflowSteps = $derived(buildWorkflowSteps(workflow));
 	const proposalRows = $derived(buildProposalRows(studioFolder, pendingProposal));
 	const statusTiles = $derived(buildStatusTiles(studioFolder, status, hosts, workflow));
 	const footerSignals = $derived(buildFooterSignals(studioFolder, status, hosts));
@@ -127,6 +130,7 @@
 	const reviewPackReady = $derived(
 		reviewArtifacts.length > 0 || reviewReadyCopy(calibration) === 'Ready'
 	);
+	const primaryActionState = $derived(workflowActionState(workflow.primaryAction));
 
 	function workflowActionState(action: WorkflowAction) {
 		return resolveWorkflowActionState(action, {
@@ -135,6 +139,11 @@
 			calibrationJob,
 			pendingAction: workflowPending
 		});
+	}
+
+	function focusBenchComposer() {
+		benchTextarea?.focus();
+		benchTextarea?.scrollIntoView({ block: 'center' });
 	}
 
 	async function sendBenchRequest() {
@@ -208,7 +217,7 @@
 					</div>
 					<div>
 						<span>Metric</span>
-						<strong>{studioFolder.metric_status_copy || resolvedMetricCopy(studioFolder)}</strong>
+						<strong>{resolvedMetricCopy(studioFolder)}</strong>
 					</div>
 				</div>
 			</header>
@@ -218,6 +227,11 @@
 					<StateBadge tone={workflow.tone} label={workflow.label} />
 					<h2 id="decision-title">{workflow.title}</h2>
 					<p>{workflow.copy}</p>
+				</div>
+				<div class="decision__next">
+					<span>Next action</span>
+					<strong>{workflow.primary}</strong>
+					<small>{primaryActionState.disabled ? primaryActionState.title : 'Ready now'}</small>
 				</div>
 				<div class="decision__metrics">
 					<div>
@@ -234,7 +248,14 @@
 					</div>
 				</div>
 				<div class="decision__actions">
-					{#if workflow.primaryAction === 'open-ops'}
+					{#if workflow.primaryAction === 'focus-bench'}
+						<button
+							class="control control--primary"
+							type="button"
+							onclick={focusBenchComposer}
+							data-mf-action={workflow.primaryAction}>{workflow.primary}</button
+						>
+					{:else if workflow.primaryAction === 'open-ops'}
 						<a
 							class="control control--primary"
 							href={resolve('/ops')}
@@ -270,7 +291,14 @@
 							data-mf-wire="pending">{workflow.primary}</button
 						>
 					{/if}
-					{#if workflow.secondaryAction === 'open-ops'}
+					{#if workflow.secondaryAction === 'focus-bench'}
+						<button
+							class="control"
+							type="button"
+							onclick={focusBenchComposer}
+							data-mf-action={workflow.secondaryAction}>{workflow.secondary}</button
+						>
+					{:else if workflow.secondaryAction === 'open-ops'}
 						<a class="control" href={resolve('/ops')} data-mf-action={workflow.secondaryAction}
 							>{workflow.secondary}</a
 						>
@@ -335,6 +363,7 @@
 							<textarea
 								rows="5"
 								placeholder="Ask Bench what to sample, revise, or validate for this folder."
+								bind:this={benchTextarea}
 								bind:value={benchNote}
 							></textarea>
 						</label>
@@ -526,6 +555,18 @@
 					{/if}
 				</div>
 			</WorkstationPanel>
+
+			<WorkstationPanel eyebrow="Flow" title="Folder steps">
+				<div class="step-list">
+					{#each workflowSteps as step (step.label)}
+						<div class:step-row--current={step.current} class="step-row step-row--{step.tone}">
+							<span>{step.label}</span>
+							<strong>{step.current ? 'Current' : 'Pending'}</strong>
+							<small>{step.detail}</small>
+						</div>
+					{/each}
+				</div>
+			</WorkstationPanel>
 		</aside>
 	</main>
 </OperatorShell>
@@ -575,6 +616,7 @@
 	}
 
 	.folder-header__facts,
+	.decision__next,
 	.decision__metrics,
 	.sample-facts {
 		display: flex;
@@ -585,6 +627,15 @@
 	.sample-facts {
 		display: grid;
 		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	.decision__next {
+		background: var(--mf-bg-panel-2);
+		border: var(--mf-border-muted);
+		border-left: 2px solid var(--decision-line);
+		display: grid;
+		gap: var(--mf-space-2);
+		padding: var(--mf-space-4);
 	}
 
 	.sample-facts div:first-child {
@@ -601,6 +652,7 @@
 	}
 
 	.folder-header__facts span,
+	.decision__next span,
 	.decision__metrics span,
 	.sample-facts span,
 	.context-list span {
@@ -612,6 +664,7 @@
 	}
 
 	.folder-header__facts strong,
+	.decision__next strong,
 	.decision__metrics strong,
 	.sample-facts strong,
 	.context-list strong {
@@ -621,6 +674,11 @@
 		overflow-wrap: anywhere;
 	}
 
+	.decision__next small {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-xs);
+	}
+
 	.decision {
 		--decision-line: var(--mf-idle-line);
 		background: var(--mf-bg-panel);
@@ -628,7 +686,7 @@
 		border-left: 3px solid var(--decision-line);
 		display: grid;
 		gap: var(--mf-space-6);
-		grid-template-columns: minmax(0, 1fr) minmax(160px, 260px) auto;
+		grid-template-columns: minmax(0, 1fr) minmax(180px, 240px) minmax(160px, 240px) auto;
 		padding: var(--mf-space-6);
 	}
 
@@ -891,7 +949,8 @@
 
 	.artifact-list,
 	.host-list,
-	.history-list {
+	.history-list,
+	.step-list {
 		display: grid;
 		gap: var(--mf-space-4);
 		padding: var(--mf-space-5);
@@ -918,6 +977,51 @@
 	.artifact-row span,
 	.host-row span,
 	.history-list span {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-xs);
+	}
+
+	.step-row {
+		border-left: 2px solid var(--mf-line-strong);
+		display: grid;
+		gap: var(--mf-space-2);
+		padding: var(--mf-space-3) var(--mf-space-4);
+	}
+
+	.step-row--current {
+		background: var(--mf-active-bg);
+	}
+
+	.step-row--active {
+		border-left-color: var(--mf-active-fg);
+	}
+
+	.step-row--ready {
+		border-left-color: var(--mf-ready-fg);
+	}
+
+	.step-row--wait {
+		border-left-color: var(--mf-wait-fg);
+	}
+
+	.step-row--fail {
+		border-left-color: var(--mf-fail-fg);
+	}
+
+	.step-row > span {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.step-row strong {
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-semibold);
+	}
+
+	.step-row small {
 		color: var(--mf-fg-tertiary);
 		font-size: var(--mf-text-xs);
 	}
@@ -1014,6 +1118,14 @@
 		.studio {
 			grid-template-columns: minmax(190px, 240px) minmax(0, 1fr);
 		}
+
+		.decision {
+			grid-template-columns: minmax(0, 1fr) minmax(180px, 240px);
+		}
+
+		.decision__actions {
+			grid-column: 1 / -1;
+		}
 	}
 
 	@media (max-width: 820px) {
@@ -1041,6 +1153,7 @@
 		}
 
 		.folder-header__facts,
+		.decision__next,
 		.decision__metrics,
 		.sample-facts,
 		.decision__actions {

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -1,11 +1,46 @@
 import { describe, expect, it } from 'vitest';
+import type { FolderPayload, FolderStatusPayload } from '$lib/api/types';
 import type { FolderCalibrationJob } from '$lib/folders/studio';
 import {
 	buildBenchHostOptions,
+	buildWorkflowSteps,
 	resolveBenchRequestState,
+	resolveWorkflow,
 	resolveWorkflowActionState
 } from './folder-studio-view';
 import type { PendingSampleProposal } from '$lib/folders/studio';
+
+function folderPayload(overrides: Partial<FolderPayload> = {}): FolderPayload {
+	return {
+		prefix: 'tv/Example/Season 1',
+		pending: true,
+		summary: {
+			prefix: 'tv/Example/Season 1',
+			item_count: 1,
+			total_size_bytes: 1,
+			statuses: {},
+			video_codecs: {},
+			audio_codecs: {},
+			seasons: {},
+			resolved_policy: {}
+		},
+		metric_support: { vmaf: true, xpsnr: false, ssim: false },
+		metric_status_copy: 'VMAF available',
+		...overrides
+	};
+}
+
+function folderStatusPayload(overrides: Partial<FolderStatusPayload> = {}): FolderStatusPayload {
+	return {
+		prefix: 'tv/Example/Season 1',
+		polling_active: false,
+		calibration_status: 'idle',
+		folder_scan_status: 'idle',
+		calibration_job: null,
+		folder_scan_job: null,
+		...overrides
+	};
+}
 
 describe('Folder Studio Bench request mapping', () => {
 	it('uses only folder-scoped host options and removes empty keys', () => {
@@ -64,6 +99,14 @@ describe('Folder Studio Bench request mapping', () => {
 
 	it('enables sample confirmation only for queueable Bench drafts', () => {
 		expect(
+			resolveWorkflowActionState('focus-bench', {
+				reviewPackReady: false,
+				pendingProposal: null,
+				calibrationJob: null
+			})
+		).toEqual({ disabled: false, title: '' });
+
+		expect(
 			resolveWorkflowActionState('start-sample', {
 				reviewPackReady: false,
 				pendingProposal: null,
@@ -104,5 +147,71 @@ describe('Folder Studio Bench request mapping', () => {
 			disabled: true,
 			title: 'A sample job is already active for this folder.'
 		});
+	});
+
+	it('keeps Bench drafts on the sample confirmation action', () => {
+		const workflow = resolveWorkflow(
+			folderPayload({
+				pending_proposal: {
+					proposal_id: 'draft-2',
+					can_queue: true,
+					message: 'Queue this representative sample.'
+				}
+			}),
+			folderStatusPayload(),
+			null,
+			{
+				proposal_id: 'draft-2',
+				can_queue: true,
+				message: 'Queue this representative sample.'
+			} as PendingSampleProposal,
+			null,
+			null,
+			null
+		);
+
+		expect(workflow).toMatchObject({
+			label: 'Draft ready',
+			primary: 'Start sample',
+			primaryAction: 'start-sample'
+		});
+	});
+
+	it('makes unsampled folders start with Bench instead of a disabled sample action', () => {
+		const workflow = resolveWorkflow(
+			folderPayload(),
+			folderStatusPayload(),
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+
+		expect(workflow).toMatchObject({
+			label: 'Not sampled',
+			primary: 'Ask Bench for draft',
+			primaryAction: 'focus-bench'
+		});
+	});
+
+	it('marks the current folder workflow step', () => {
+		const steps = buildWorkflowSteps({
+			tone: 'ready',
+			label: 'Draft ready',
+			title: 'Bench draft is ready to sample',
+			copy: 'Review the draft.',
+			primary: 'Start sample',
+			primaryAction: 'start-sample',
+			secondary: 'Revise',
+			secondaryAction: 'revise-proposal'
+		});
+
+		expect(steps.map((step) => [step.label, step.current])).toEqual([
+			['Sample', true],
+			['Review', false],
+			['Approve', false],
+			['Encode', false]
+		]);
 	});
 });

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -37,6 +37,7 @@ export type WorkflowState = {
 
 export type WorkflowAction =
 	| 'download-review-pack'
+	| 'focus-bench'
 	| 'open-ops'
 	| 'queue-encode'
 	| 'retry-encode'
@@ -81,6 +82,13 @@ export type BenchRequestState = {
 export type WorkflowActionState = {
 	disabled: boolean;
 	title: string;
+};
+
+export type WorkflowStep = {
+	label: string;
+	detail: string;
+	tone: ShellTone;
+	current: boolean;
 };
 
 export function record<T extends Record<string, unknown>>(value: unknown): T | null {
@@ -160,6 +168,7 @@ export function resolveWorkflowActionState(
 			title: pendingAction === action ? 'Action is running.' : 'Another folder action is running.'
 		};
 	}
+	if (action === 'focus-bench') return { disabled: false, title: '' };
 	if (action === 'open-ops') return { disabled: false, title: '' };
 	if (action === 'download-review-pack') {
 		return reviewPackReady
@@ -489,6 +498,20 @@ export function resolveWorkflow(
 			secondaryAction: 'revise-proposal'
 		};
 	}
+	if (pendingProposal?.proposal_id && pendingProposal.can_queue !== false) {
+		return {
+			tone: 'ready',
+			label: 'Draft ready',
+			title: 'Bench draft is ready to sample',
+			copy:
+				pendingProposal.message ??
+				'Review the Bench draft, then queue the representative sample when it looks right.',
+			primary: 'Start sample',
+			primaryAction: 'start-sample',
+			secondary: 'Revise',
+			secondaryAction: 'revise-proposal'
+		};
+	}
 	if (pendingProposal || calibration?.browser_review_ready || calibration?.review_media_ready) {
 		return {
 			tone: 'ready',
@@ -508,9 +531,9 @@ export function resolveWorkflow(
 			tone: 'idle',
 			label: 'Not sampled',
 			title: 'No representative sample yet',
-			copy: 'Start a sample before approving folder-wide settings. Host readiness and policy context remain visible while the sample is queued.',
-			primary: 'Start sample',
-			primaryAction: 'start-sample',
+			copy: 'Ask Bench for a sample draft before approving folder-wide settings. Host readiness and policy context stay visible while the sample is queued.',
+			primary: 'Ask Bench for draft',
+			primaryAction: 'focus-bench',
 			secondary: 'Open Ops',
 			secondaryAction: 'open-ops'
 		};
@@ -520,11 +543,52 @@ export function resolveWorkflow(
 		label: 'Waiting',
 		title: 'Folder is waiting for review evidence',
 		copy: 'A representative item exists, but the current review state is incomplete. Refresh status or rerun the sample if the evidence is stale.',
-		primary: 'Download review pack',
-		primaryAction: 'download-review-pack',
-		secondary: 'Re-sample',
-		secondaryAction: 'resample'
+		primary: 'Ask Bench to refresh',
+		primaryAction: 'focus-bench',
+		secondary: 'Open Ops',
+		secondaryAction: 'open-ops'
 	};
+}
+
+export function buildWorkflowSteps(workflow: WorkflowState): WorkflowStep[] {
+	const activeAction = workflow.primaryAction;
+	const activeLabel = workflow.label.toLowerCase();
+	const sampleCurrent =
+		['focus-bench', 'start-sample', 'retry-sample', 'stop-sample'].includes(activeAction) ||
+		['not sampled', 'sampling', 'retryable', 'draft ready'].includes(activeLabel);
+	const reviewCurrent =
+		['download-review-pack', 'revise-proposal'].includes(activeAction) ||
+		['review ready', 'check draft'].includes(activeLabel);
+	const approveCurrent = ['queue-encode'].includes(activeAction) || activeLabel === 'approved';
+	const encodeCurrent =
+		['open-ops', 'retry-encode'].includes(activeAction) ||
+		['processing', 'retry available'].includes(activeLabel);
+	return [
+		{
+			label: 'Sample',
+			detail: sampleCurrent ? workflow.title : 'Choose representative evidence',
+			tone: sampleCurrent ? workflow.tone : 'idle',
+			current: sampleCurrent
+		},
+		{
+			label: 'Review',
+			detail: reviewCurrent ? workflow.title : 'Compare the sample pack',
+			tone: reviewCurrent ? workflow.tone : 'idle',
+			current: reviewCurrent
+		},
+		{
+			label: 'Approve',
+			detail: approveCurrent ? workflow.title : 'Accept or revise policy',
+			tone: approveCurrent ? workflow.tone : 'idle',
+			current: approveCurrent
+		},
+		{
+			label: 'Encode',
+			detail: encodeCurrent ? workflow.title : 'Run approved folder work',
+			tone: encodeCurrent ? workflow.tone : 'idle',
+			current: encodeCurrent
+		}
+	];
 }
 
 export function buildProposalRows(


### PR DESCRIPTION
## Summary
- Make Folder Studio decision state expose an explicit next action and visible prerequisite text.
- Route unsampled/waiting states to Bench focus instead of disabled primary workflow buttons.
- Keep queueable Bench drafts on the real `Start sample` confirmation path and add workflow step context.
- Tighten the first-viewport metric copy to a concise metric summary.

Refs #55

## Validation
- `UV_CACHE_DIR=/private/tmp/mediaforce-uv-cache bash scripts/pre-commit-check.sh`
- `UV_CACHE_DIR=/private/tmp/mediaforce-uv-cache uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope touched_files`
- `npm --prefix frontend run smoke:web -- --base-url http://127.0.0.1:5555`
- In-app browser: loaded representative Folder Studio route, verified next action panel, no disabled primary action, concise metric copy, one current workflow step, and Bench focus behavior.
