### PR TITLE
Fix narrow workstation layouts

### DIFF
--- a/frontend/src/lib/components/settings/SettingsEditor.svelte
+++ b/frontend/src/lib/components/settings/SettingsEditor.svelte
@@ -1496,5 +1496,68 @@
 		.archive-actions .control {
 			flex: 1 1 auto;
 		}
+
+		.table-wrap {
+			overflow: visible;
+		}
+
+		.settings-table--libraries {
+			min-width: 0;
+		}
+
+		.settings-table--libraries thead {
+			display: none;
+		}
+
+		.settings-table--libraries tbody,
+		.settings-table--libraries tr,
+		.settings-table--libraries td {
+			display: block;
+			width: 100%;
+		}
+
+		.settings-table--libraries tr {
+			border-bottom: var(--mf-border-muted);
+			display: grid;
+			gap: var(--mf-space-3);
+			grid-template-columns: minmax(0, 1fr);
+			padding: var(--mf-space-4);
+		}
+
+		.settings-table--libraries td {
+			border-bottom: 0;
+			height: auto;
+			min-width: 0;
+			padding: 0;
+		}
+
+		.settings-table--libraries td:nth-child(1),
+		.settings-table--libraries td:nth-child(2),
+		.settings-table--libraries td:nth-child(3) {
+			display: grid;
+			gap: var(--mf-space-2);
+		}
+
+		.settings-table--libraries td:nth-child(1)::before,
+		.settings-table--libraries td:nth-child(2)::before,
+		.settings-table--libraries td:nth-child(3)::before {
+			color: var(--mf-fg-tertiary);
+			font-size: var(--mf-text-2xs);
+			font-weight: var(--mf-weight-semibold);
+			letter-spacing: 0.08em;
+			text-transform: uppercase;
+		}
+
+		.settings-table--libraries td:nth-child(1)::before {
+			content: 'Color';
+		}
+
+		.settings-table--libraries td:nth-child(2)::before {
+			content: 'Library';
+		}
+
+		.settings-table--libraries td:nth-child(3)::before {
+			content: 'Folder path';
+		}
 	}
 </style>

--- a/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
+++ b/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
@@ -985,4 +985,93 @@
 			grid-template-columns: 1fr;
 		}
 	}
+
+	@media (max-width: 680px) {
+		.table-wrap {
+			overflow: visible;
+		}
+
+		table {
+			min-width: 0;
+		}
+
+		thead {
+			display: none;
+		}
+
+		tbody,
+		tr,
+		td {
+			display: block;
+			width: 100%;
+		}
+
+		tr {
+			border-bottom: var(--mf-border-muted);
+			display: grid;
+			gap: var(--mf-space-3);
+			grid-template-columns: auto minmax(0, 1fr);
+			padding: var(--mf-space-4);
+		}
+
+		td {
+			border-bottom: 0;
+			height: auto;
+			min-width: 0;
+			padding: 0;
+		}
+
+		td:nth-child(1) {
+			grid-row: 1 / span 6;
+			width: 40px;
+		}
+
+		td:nth-child(2),
+		td:nth-child(3),
+		td:nth-child(4),
+		td:nth-child(5),
+		td:nth-child(6),
+		td:nth-child(7),
+		td:nth-child(8) {
+			grid-column: 2;
+		}
+
+		td:nth-child(4),
+		td:nth-child(5),
+		td:nth-child(6),
+		td:nth-child(7) {
+			align-items: baseline;
+			display: grid;
+			gap: var(--mf-space-3);
+			grid-template-columns: 72px minmax(0, 1fr);
+		}
+
+		td:nth-child(4)::before,
+		td:nth-child(5)::before,
+		td:nth-child(6)::before,
+		td:nth-child(7)::before {
+			color: var(--mf-fg-tertiary);
+			font-family: var(--mf-font-sans), sans-serif;
+			font-size: var(--mf-text-2xs);
+			font-weight: var(--mf-weight-semibold);
+			letter-spacing: 0.08em;
+			text-transform: uppercase;
+		}
+
+		td:nth-child(4)::before {
+			content: 'Pending';
+		}
+
+		td:nth-child(5)::before {
+			content: 'Source';
+		}
+
+		td:nth-child(6)::before {
+			content: 'Reclaim';
+		}
+
+		td:nth-child(7)::before {
+			content: 'Codec';
+		}
+	}
 </style>

--- a/frontend/src/lib/components/workstation/OperatorShell.svelte
+++ b/frontend/src/lib/components/workstation/OperatorShell.svelte
@@ -419,5 +419,20 @@
 		.routebar__crumb {
 			display: none;
 		}
+
+		.footer-strip {
+			gap: var(--mf-space-5);
+			overflow-x: auto;
+			padding: 0 var(--mf-space-4);
+			scrollbar-width: none;
+		}
+
+		.footer-strip::-webkit-scrollbar {
+			display: none;
+		}
+
+		.footer-strip__item {
+			flex: 0 0 auto;
+		}
 	}
 </style>

--- a/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
@@ -843,6 +843,10 @@
 		margin-top: var(--mf-space-4);
 	}
 
+	.history-disclosure:not([open]) .table-wrap {
+		display: none;
+	}
+
 	.blocker-row--fail {
 		background: var(--mf-fail-bg);
 		border-left-color: var(--mf-fail-fg);


### PR DESCRIPTION
## Summary
- Convert the Queue worklist and Settings media-folder tables into stacked mobile rows below narrow breakpoints.
- Let footer telemetry scroll horizontally instead of clipping on small screens.
- Hide closed Ops history table content so collapsed details do not keep a wide table in layout.

## Verification
- `node --input-type=module -e "...390x844 Playwright probe for /, /settings, /completed, /ops..."`
- `npm --prefix frontend run lint`
- `npm --prefix frontend test`
- `npm --prefix frontend run smoke:web -- --base-url http://127.0.0.1:5555`
- `UV_CACHE_DIR=/private/tmp/mediaforce-uv-cache bash scripts/pre-commit-check.sh`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files`

Closes #60