### PR TITLE
Add browser QA fixture matrix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,3 +36,5 @@ Use this directory for guidance that should not live in `AGENTS.md`.
   legacy-bridge notes, and migration validation commands
 - `docs/development/browser-review-guidance.md`: browser-review subagent launch
   contract for UI exploration and critique
+- `docs/development/browser-qa-matrix.md`: repeatable browser route, fixture,
+  and narrow-layout validation matrix

--- a/docs/development/browser-qa-matrix.md
+++ b/docs/development/browser-qa-matrix.md
@@ -1,0 +1,80 @@
+# Browser QA Matrix
+
+Use this matrix when signing off operator-facing UI work. The goal is to prove
+the app fully loads and remains usable across route and workflow states, not just
+that a single live machine state happens to render.
+
+## Commands
+
+- Full route and fixture smoke: `npm --prefix frontend run smoke:web`
+- Existing live app smoke: `npm --prefix frontend run smoke:web -- --base-url http://127.0.0.1:5555`
+- Skip narrow checks only for non-UI diagnostics: `npm --prefix frontend run smoke:web -- --skip-narrow`
+
+The default managed smoke uses `config/web-smoke.toml`, seeds deterministic
+fixture state, starts `mediaforce-web` on a temporary port, checks API endpoints,
+loads route shells in a desktop browser, then repeats route loading at a 390px
+narrow viewport. When `--base-url` is provided, the script does not seed data or
+mutate the target app.
+
+## Seeded Fixture States
+
+The managed smoke seeds a compact but non-empty workflow dataset:
+
+- Queue density: two pending `tv/Example Show/Season 1` items and one lower
+  priority movie folder.
+- Folder Studio: `/folders/tv/Example%20Show/Season%201`, including enough item
+  metadata to render policy comparison, sample facts, queue state, and side
+  context.
+- Sampling state: `/folders/tv/Sampling%20Show/Season%201`, with a queued
+  sample job.
+- Retryable state: `/folders/tv/Retry%20Show/Season%201`, with a failed sample
+  job that exposes retry copy.
+- Completed cleanup: one promoted `movies/Archive Ready` item with an archived
+  original under the smoke archive root, so `/completed` has cleanup-ready work.
+- Blocked cleanup: one promoted `movies/Blocked Cleanup` item with an archived
+  original outside the configured archive root, so `/completed` exposes a
+  blocked cleanup state.
+
+Seeded rows use `last_scan_id = web-smoke-fixtures` and are replaced on each
+managed smoke run. Runtime state remains under `state/web-smoke/` and
+`scratch/web-smoke/`.
+
+## Required Route Coverage
+
+Every browser QA pass should cover these routes:
+
+- `/`: Queue worklist and selected folder context.
+- `/folders`: Folder queue entry point.
+- `/folders/tv/Example%20Show/Season%201`: representative Folder Studio state.
+- `/folders/tv/Sampling%20Show/Season%201`: active sample queue state.
+- `/folders/tv/Retry%20Show/Season%201`: retryable sample state.
+- `/ops`: blockers, worker readiness, queues, and collapsed history.
+- `/completed`: no-action history and cleanup-ready work.
+- `/settings`: basic, advanced, and danger-zone settings sections.
+
+## Layout Expectations
+
+The automated narrow smoke uses a 390px viewport and fails when:
+
+- the app shell or `<main>` does not render quickly;
+- the expected route marker text is missing;
+- the document has horizontal page overflow;
+- a visible table is wider than the viewport.
+
+Those checks are intentionally short and mechanical. For visual redesign or
+interaction work, add a manual browser review with screenshots under
+`scratch/ui-checks/` and inspect the actual starting viewport, post-interaction
+state, and narrow layout.
+
+## State Gaps
+
+The current fixture covers non-empty queue, waiting Folder Studio, queued sample,
+retryable sample, cleanup-ready Completed, blocked Completed, idle Ops, and
+narrow layout. Future UI work should extend this fixture or add dedicated
+fixture modes for:
+
+- approved review pack;
+- active encode running;
+- failed or retryable encode;
+- empty library;
+- unreachable or unavailable worker hosts.

--- a/docs/development/browser-review-guidance.md
+++ b/docs/development/browser-review-guidance.md
@@ -3,6 +3,10 @@
 Use this contract when launching browser-review subagents for UI exploration or
 critique.
 
+For repeatable route and fixture coverage, start from
+`docs/development/browser-qa-matrix.md`. Browser-review subagents should add
+visual and interaction judgment on top of that automated matrix, not replace it.
+
 ## Launch Contract
 
 - For the first browser-review subagent in a session, run a tiny smoke pass

--- a/docs/policies/acceptance-gate.md
+++ b/docs/policies/acceptance-gate.md
@@ -9,6 +9,8 @@ We do not stop at "it works." We stop when we fully like the result.
 - Run the full available test suite before commits or ending a session
 - Run browser validation for UI changes; for primary operator surfaces, read
   `docs/style/workstation-ui.md` together with `docs/style/frontend.md`
+- Use `docs/development/browser-qa-matrix.md` for route, fixture, and narrow
+  browser coverage expectations
 - Use the `qualityGate` section in `.github/github.json` as the
   canonical source for repo validation commands
 

--- a/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
@@ -405,7 +405,7 @@
 			>
 				{#if queueRows.length > 0}
 					<div class="table-wrap">
-						<table>
+						<table class="ops-table ops-table--jobs">
 							<thead>
 								<tr>
 									<th>State</th>
@@ -419,8 +419,10 @@
 							<tbody>
 								{#each queueRows as row (row.key)}
 									<tr class:job-row--blocked={row.tone === 'fail'}>
-										<td><StateBadge compact tone={row.tone} label={row.status} /></td>
-										<td>
+										<td data-label="State"
+											><StateBadge compact tone={row.tone} label={row.status} /></td
+										>
+										<td data-label="Work">
 											{#if canOpenFolder(row)}
 												<a class="work-link" href={resolve(folderRoutePath(row.prefix))}>
 													<strong>{row.prefix}</strong>
@@ -433,13 +435,13 @@
 												</div>
 											{/if}
 										</td>
-										<td>{row.host}</td>
-										<td>
+										<td data-label="Host">{row.host}</td>
+										<td data-label="Progress">
 											<strong>{row.progress}</strong>
 											<span>{row.detail}</span>
 										</td>
-										<td>{row.scheduler}</td>
-										<td>
+										<td data-label="Scheduler">{row.scheduler}</td>
+										<td data-label="Recovery">
 											{#if row.action}
 												{@const action = row.action}
 												<button
@@ -482,7 +484,7 @@
 							<span>Past sample/proof issues are not blocking current encoding.</span>
 						</summary>
 						<div class="table-wrap table-wrap--history">
-							<table>
+							<table class="ops-table ops-table--history">
 								<thead>
 									<tr>
 										<th>State</th>
@@ -495,8 +497,10 @@
 								<tbody>
 									{#each historyRows as row (row.key)}
 										<tr class="job-row--history">
-											<td><StateBadge compact tone={row.tone} label={row.status} /></td>
-											<td>
+											<td data-label="State"
+												><StateBadge compact tone={row.tone} label={row.status} /></td
+											>
+											<td data-label="Work">
 												{#if canOpenFolder(row)}
 													<a class="work-link" href={resolve(folderRoutePath(row.prefix))}>
 														<strong>{row.prefix}</strong>
@@ -509,12 +513,12 @@
 													</div>
 												{/if}
 											</td>
-											<td>{row.host}</td>
-											<td>
+											<td data-label="Host">{row.host}</td>
+											<td data-label="Last note">
 												<strong>{row.progress}</strong>
 												<span>{row.detail}</span>
 											</td>
-											<td>{row.scheduler}</td>
+											<td data-label="When">{row.scheduler}</td>
 										</tr>
 									{/each}
 								</tbody>
@@ -1073,6 +1077,70 @@
 		color: var(--mf-fg-tertiary);
 		font-size: var(--mf-text-sm);
 		padding: var(--mf-space-5);
+	}
+
+	@media (max-width: 720px) {
+		.table-wrap {
+			overflow: visible;
+		}
+
+		.ops-table {
+			border-collapse: separate;
+			border-spacing: 0;
+			min-width: 0;
+		}
+
+		.ops-table thead {
+			display: none;
+		}
+
+		.ops-table tbody,
+		.ops-table tr,
+		.ops-table td {
+			display: block;
+			width: 100%;
+		}
+
+		.ops-table tr {
+			background: var(--mf-bg-panel-2);
+			border: var(--mf-border-muted);
+			display: grid;
+			margin-bottom: var(--mf-space-3);
+		}
+
+		.ops-table td {
+			align-items: start;
+			border-bottom: var(--mf-border-muted);
+			display: grid;
+			gap: var(--mf-space-3);
+			grid-template-columns: minmax(72px, 0.32fr) minmax(0, 1fr);
+			height: auto;
+			min-height: var(--mf-control-md);
+			padding: var(--mf-space-3);
+		}
+
+		.ops-table td:last-child {
+			border-bottom: 0;
+		}
+
+		.ops-table td::before {
+			color: var(--mf-fg-tertiary);
+			content: attr(data-label);
+			font-family: var(--mf-font-sans), sans-serif;
+			font-size: var(--mf-text-2xs);
+			font-weight: var(--mf-weight-semibold);
+			text-transform: uppercase;
+		}
+
+		.ops-table td:nth-child(4) {
+			display: grid;
+		}
+
+		.ops-table .control {
+			justify-self: start;
+			max-width: 100%;
+			white-space: normal;
+		}
 	}
 
 	@media (max-width: 980px) {

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from typing import Any
+
+from mediaforce.core.config import load_config
+from mediaforce.core.db import open_db
+from mediaforce.core.db_tables import (
+    calibration_jobs,
+    item_events,
+    library_items,
+    staged_artifacts,
+)
+
+FIXTURE_SCAN_ID = "web-smoke-fixtures"
+FOLDER_PREFIX = "tv/Example Show/Season 1"
+SAMPLING_PREFIX = "tv/Sampling Show/Season 1"
+RETRY_PREFIX = "tv/Retry Show/Season 1"
+COMPLETED_PREFIX = "movies/Archive Ready"
+BLOCKED_COMPLETED_PREFIX = "movies/Blocked Cleanup"
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def _resolve_under_project(project_root: Path, value: Path) -> Path:
+    return value if value.is_absolute() else (project_root / value).resolve()
+
+
+def _library_item(
+    *,
+    project_root: Path,
+    media_root: str,
+    rel_path: str,
+    size_bytes: int,
+    status: str,
+    video_codec: str,
+    priority_score: int,
+    recommendation: str,
+    recommendation_reason: str,
+) -> dict[str, Any]:
+    timestamp = _now()
+    source_path = _resolve_under_project(
+        project_root, Path("scratch/web-smoke/source") / rel_path
+    )
+    return {
+        "source_path": str(source_path),
+        "rel_path": rel_path,
+        "media_root": media_root,
+        "parent_dir": str(Path(rel_path).parent),
+        "file_name": Path(rel_path).name,
+        "container": Path(rel_path).suffix.lstrip(".") or "mkv",
+        "size_bytes": size_bytes,
+        "mtime_ns": 1_700_000_000_000_000_000,
+        "fingerprint": f"fixture:{rel_path}",
+        "duration_seconds": 3_600.0,
+        "video_codec": video_codec,
+        "video_bitrate": 8_000_000 if video_codec == "h264" else 4_500_000,
+        "width": 1920,
+        "height": 1080,
+        "pix_fmt": "yuv420p",
+        "audio_track_count": 1,
+        "subtitle_track_count": 1,
+        "english_audio_count": 1,
+        "english_subtitle_count": 1,
+        "default_audio_language": "eng",
+        "default_subtitle_language": "eng",
+        "audio_summary_json": json.dumps(
+            [{"index": 1, "codec_name": "dts", "channels": 6, "language": "eng"}]
+        ),
+        "subtitle_summary_json": json.dumps(
+            [
+                {
+                    "index": 2,
+                    "codec_name": "subrip",
+                    "language": "eng",
+                    "forced": False,
+                    "default": False,
+                }
+            ]
+        ),
+        "status": status,
+        "priority_score": priority_score,
+        "recommendation": recommendation,
+        "recommendation_reason": recommendation_reason,
+        "last_scan_id": FIXTURE_SCAN_ID,
+        "discovered_at": timestamp,
+        "last_seen_at": timestamp,
+        "updated_at": timestamp,
+    }
+
+
+def _job(
+    *,
+    job_id: str,
+    prefix: str,
+    status: str,
+    sample_item: dict[str, Any],
+    error: str | None = None,
+) -> dict[str, Any]:
+    timestamp = _now()
+    return {
+        "job_id": job_id,
+        "prefix": prefix,
+        "status": status,
+        "lane": "sample",
+        "action": "ai_tune",
+        "host_json": json.dumps({"key": "web-smoke", "label": "Smoke fixture"}),
+        "notes": "Seeded browser QA fixture.",
+        "policy_json": json.dumps(sample_item["resolved_policy"], sort_keys=True),
+        "sample_item_json": json.dumps(sample_item, sort_keys=True),
+        "error": error,
+        "created_at": timestamp,
+        "started_at": timestamp if status in {"running", "failed", "stopped"} else None,
+        "finished_at": timestamp
+        if status in {"failed", "stopped", "completed"}
+        else None,
+        "updated_at": timestamp,
+    }
+
+
+def seed(config_path: Path) -> dict[str, Any]:
+    config = load_config(config_path)
+    project_root = config.paths.project_root
+    archive_root = _resolve_under_project(project_root, config.archive_root)
+    staging_root = _resolve_under_project(project_root, config.staging_root)
+    archive_root.mkdir(parents=True, exist_ok=True)
+    staging_root.mkdir(parents=True, exist_ok=True)
+    archived_source = archive_root / "movies" / "Archive Ready" / "Feature.mkv"
+    archived_source.parent.mkdir(parents=True, exist_ok=True)
+    archived_source.write_bytes(b"mediaforce smoke archived original\n")
+
+    with open_db(config.paths.db_path) as connection:
+        connection.execute(
+            calibration_jobs.delete().where(
+                calibration_jobs.c.job_id.like("web-smoke-%")
+            )
+        )
+        fixture_ids = [
+            int(row["id"])
+            for row in connection.execute(
+                library_items.select()
+                .with_only_columns(library_items.c.id)
+                .where(library_items.c.last_scan_id == FIXTURE_SCAN_ID)
+            )
+            .mappings()
+            .fetchall()
+        ]
+        if fixture_ids:
+            connection.execute(
+                item_events.delete().where(
+                    item_events.c.library_item_id.in_(fixture_ids)
+                )
+            )
+            connection.execute(
+                staged_artifacts.delete().where(
+                    staged_artifacts.c.library_item_id.in_(fixture_ids)
+                )
+            )
+            connection.execute(
+                library_items.delete().where(library_items.c.id.in_(fixture_ids))
+            )
+
+        rows = [
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
+                rel_path="tv/Example Show/Season 1/Episode 01.mkv",
+                size_bytes=8 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=92,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture high-priority H.264 episode for browser QA.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
+                rel_path="tv/Example Show/Season 1/Episode 02.mkv",
+                size_bytes=6 * 1024**3,
+                status="planned",
+                video_codec="h264",
+                priority_score=76,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture second episode keeps the queue non-empty and grouped.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="movies",
+                rel_path="movies/Blocked Queue/Feature.mkv",
+                size_bytes=5 * 1024**3,
+                status="discovered",
+                video_codec="hevc",
+                priority_score=44,
+                recommendation="review_encode",
+                recommendation_reason="Fixture lower-priority movie for list density.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="movies",
+                rel_path="movies/Archive Ready/Feature.mkv",
+                size_bytes=7 * 1024**3,
+                status="promoted",
+                video_codec="h264",
+                priority_score=10,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture promoted item for completed cleanup state.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
+                rel_path="tv/Sampling Show/Season 1/Episode 01.mkv",
+                size_bytes=7 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=88,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture queued sample state for browser QA.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
+                rel_path="tv/Retry Show/Season 1/Episode 01.mkv",
+                size_bytes=7 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=86,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture retryable sample state for browser QA.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="movies",
+                rel_path="movies/Blocked Cleanup/Feature.mkv",
+                size_bytes=5 * 1024**3,
+                status="promoted",
+                video_codec="h264",
+                priority_score=9,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture blocked completed cleanup state.",
+            ),
+        ]
+        inserted_ids: list[int] = []
+        for row in rows:
+            result = connection.execute(library_items.insert().values(**row))
+            inserted_ids.append(int(result.inserted_primary_key[0]))
+
+        completed_id = inserted_ids[3]
+        blocked_completed_id = inserted_ids[-1]
+        timestamp = _now()
+        for item_id, row, archived_path in (
+            (completed_id, rows[3], str(archived_source)),
+            (
+                blocked_completed_id,
+                rows[-1],
+                str(
+                    Path(
+                        "/tmp/mediaforce-web-smoke-outside/Blocked Cleanup/Feature.mkv"
+                    )
+                ),
+            ),
+        ):
+            connection.execute(
+                staged_artifacts.insert().values(
+                    library_item_id=item_id,
+                    manifest_run_id="web-smoke-run",
+                    manifest_path=str(
+                        project_root / "state/web-smoke/runs/web-smoke-run.json"
+                    ),
+                    item_index=0,
+                    encode_origin="web-smoke",
+                    source_path=row["source_path"],
+                    source_rel_path=row["rel_path"],
+                    source_size_bytes=row["size_bytes"],
+                    source_duration_seconds=row["duration_seconds"],
+                    source_video_codec=row["video_codec"],
+                    source_fingerprint=row["fingerprint"],
+                    staging_path=str(staging_root / row["rel_path"]),
+                    staging_size_bytes=3 * 1024**3,
+                    bytes_saved=4 * 1024**3,
+                    size_ratio=0.43,
+                    chosen_crf=28,
+                    quality_metric="vmaf",
+                    quality_target=95.0,
+                    quality_score=96.1,
+                    audio_summary_json=row["audio_summary_json"],
+                    subtitle_summary_json=row["subtitle_summary_json"],
+                    validation_json=json.dumps({"ok": True, "source": "web-smoke"}),
+                    staged_at=timestamp,
+                    validated_at=timestamp,
+                    promoted_at=timestamp,
+                    promoted_path=str(
+                        project_root
+                        / "scratch/web-smoke/source"
+                        / Path(row["rel_path"]).with_suffix(".av1.mkv")
+                    ),
+                    archived_source_path=archived_path,
+                    updated_at=timestamp,
+                )
+            )
+            connection.execute(
+                item_events.insert().values(
+                    library_item_id=item_id,
+                    created_at=timestamp,
+                    event_type="promotion_completed",
+                    details_json=json.dumps(
+                        {
+                            "prefix": COMPLETED_PREFIX
+                            if item_id == completed_id
+                            else BLOCKED_COMPLETED_PREFIX,
+                            "bytes_saved": 4 * 1024**3,
+                            "note": "Fixture promoted item for browser QA.",
+                        }
+                    ),
+                )
+            )
+
+        policy = config.resolve_policy(rows[0]["rel_path"])
+        for item_id, row, job in (
+            (
+                inserted_ids[4],
+                rows[4],
+                _job(
+                    job_id="web-smoke-sampling",
+                    prefix=SAMPLING_PREFIX,
+                    status="queued",
+                    sample_item={
+                        "library_item_id": inserted_ids[4],
+                        **rows[4],
+                        "source_size_bytes": rows[4]["size_bytes"],
+                        "resolved_policy": policy,
+                    },
+                ),
+            ),
+            (
+                inserted_ids[5],
+                rows[5],
+                _job(
+                    job_id="web-smoke-retry",
+                    prefix=RETRY_PREFIX,
+                    status="failed",
+                    sample_item={
+                        "library_item_id": inserted_ids[5],
+                        **rows[5],
+                        "source_size_bytes": rows[5]["size_bytes"],
+                        "resolved_policy": policy,
+                    },
+                    error="Fixture sample failed so retry state is inspectable.",
+                ),
+            ),
+        ):
+            _ = item_id, row
+            connection.execute(calibration_jobs.insert().values(**job))
+
+    return {
+        "folderPrefix": FOLDER_PREFIX,
+        "folderRoute": "/folders/tv/Example%20Show/Season%201",
+        "folderRoutes": [
+            {
+                "label": "Folder Studio waiting fixture",
+                "route": "/folders/tv/Example%20Show/Season%201",
+                "marker": "Example Show",
+            },
+            {
+                "label": "Folder Studio sampling fixture",
+                "route": "/folders/tv/Sampling%20Show/Season%201",
+                "marker": "Sampling",
+            },
+            {
+                "label": "Folder Studio retry fixture",
+                "route": "/folders/tv/Retry%20Show/Season%201",
+                "marker": "Retry sample",
+            },
+            {
+                "label": "Completed cleanup fixture",
+                "route": "/completed",
+                "marker": "Blocked Cleanup",
+            },
+        ],
+        "completedPrefix": COMPLETED_PREFIX,
+        "libraryItems": len(rows),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Seed deterministic web smoke fixture state."
+    )
+    parser.add_argument("--config", required=True, type=Path)
+    args = parser.parse_args()
+    print(json.dumps(seed(args.config), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -1,20 +1,23 @@
 #!/usr/bin/env node
 
-import { spawn } from 'node:child_process';
+import { execFile as execFileCallback, spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import net from 'node:net';
 import { mkdir, stat } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const require = createRequire(path.join(rootDir, 'frontend', 'package.json'));
 const { chromium } = require('@playwright/test');
+const execFile = promisify(execFileCallback);
 
 const DEFAULT_ENDPOINT_TIMEOUT_MS = 2000;
 const DEFAULT_ROUTE_TIMEOUT_MS = 3500;
 const SERVER_START_TIMEOUT_MS = 12000;
+const NARROW_VIEWPORT = { width: 390, height: 844 };
 
 const endpointChecks = [
 	['Dashboard summary', '/api/dashboard'],
@@ -37,7 +40,9 @@ function parseArgs(argv) {
 		baseUrl: '',
 		config: path.join(rootDir, 'config', 'web-smoke.toml'),
 		endpointTimeoutMs: DEFAULT_ENDPOINT_TIMEOUT_MS,
-		routeTimeoutMs: DEFAULT_ROUTE_TIMEOUT_MS
+		routeTimeoutMs: DEFAULT_ROUTE_TIMEOUT_MS,
+		seedFixtures: null,
+		narrow: true
 	};
 	for (let index = 0; index < argv.length; index += 1) {
 		const arg = argv[index];
@@ -49,6 +54,12 @@ function parseArgs(argv) {
 			parsed.endpointTimeoutMs = Number(argv[++index] ?? parsed.endpointTimeoutMs);
 		} else if (arg === '--route-timeout-ms') {
 			parsed.routeTimeoutMs = Number(argv[++index] ?? parsed.routeTimeoutMs);
+		} else if (arg === '--seed-fixtures') {
+			parsed.seedFixtures = true;
+		} else if (arg === '--skip-fixture-seed') {
+			parsed.seedFixtures = false;
+		} else if (arg === '--skip-narrow') {
+			parsed.narrow = false;
 		} else {
 			throw new Error(`Unknown argument: ${arg}`);
 		}
@@ -98,6 +109,24 @@ async function prepareSmokeState() {
 	await Promise.all(paths.map((parts) => mkdir(path.join(rootDir, ...parts), { recursive: true })));
 }
 
+async function seedSmokeFixtures(configPath) {
+	const { stdout, stderr } = await execFile(
+		'uv',
+		['run', 'python', 'scripts/seed-web-smoke-fixtures.py', '--config', configPath],
+		{
+			cwd: rootDir,
+			timeout: 15000,
+			maxBuffer: 1024 * 1024
+		}
+	);
+	if (stderr.trim()) {
+		console.error(stderr.trim());
+	}
+	const result = JSON.parse(stdout.trim());
+	console.log(`fixture ok: ${result.libraryItems} items seeded`);
+	return result;
+}
+
 async function fetchWithTimeout(url, timeoutMs) {
 	const controller = new AbortController();
 	const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -142,7 +171,9 @@ async function waitForServer(baseUrl, child) {
 async function startServer(configPath) {
 	const indexPath = path.join(rootDir, 'frontend', 'build', 'index.html');
 	if (!(await pathExists(indexPath))) {
-		throw new Error('frontend/build/index.html is missing. Run npm --prefix frontend run build first.');
+		throw new Error(
+			'frontend/build/index.html is missing. Run npm --prefix frontend run build first.'
+		);
 	}
 	await prepareSmokeState();
 	const port = await freePort();
@@ -180,20 +211,20 @@ async function startServer(configPath) {
 	await waitForServer(baseUrl, child);
 	return {
 		baseUrl,
-			stop: async () => {
-				if (child.exitCode !== null) return;
-				child.kill('SIGTERM');
-				let exited = false;
-				await new Promise((resolve) => {
-					const timeout = setTimeout(resolve, 3000);
-					child.once('exit', () => {
-						exited = true;
-						clearTimeout(timeout);
-						resolve();
-					});
+		stop: async () => {
+			if (child.exitCode !== null) return;
+			child.kill('SIGTERM');
+			let exited = false;
+			await new Promise((resolve) => {
+				const timeout = setTimeout(resolve, 3000);
+				child.once('exit', () => {
+					exited = true;
+					clearTimeout(timeout);
+					resolve();
 				});
-				if (!exited) child.kill('SIGKILL');
-			},
+			});
+			if (!exited) child.kill('SIGKILL');
+		},
 		logs: () => logs.join('')
 	};
 }
@@ -205,18 +236,29 @@ async function checkEndpoints(baseUrl, timeoutMs) {
 	}
 }
 
-async function checkRoutes(baseUrl, timeoutMs) {
+async function checkRoutes(baseUrl, routeChecksForBrowser, timeoutMs) {
 	const browser = await chromium.launch();
 	try {
-		const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+		const page = await browser.newPage({
+			viewport: { width: 1440, height: 1000 }
+		});
 		const pageErrors = [];
 		page.on('pageerror', (error) => pageErrors.push(error.message));
-		for (const [label, route, marker] of routeChecks) {
+		for (const [label, route, marker] of routeChecksForBrowser) {
 			pageErrors.length = 0;
 			const started = performance.now();
-			await page.goto(`${baseUrl}${route}`, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
-			await page.waitForSelector('.operator-shell', { state: 'visible', timeout: timeoutMs });
-			await page.waitForSelector('main', { state: 'visible', timeout: timeoutMs });
+			await page.goto(`${baseUrl}${route}`, {
+				waitUntil: 'domcontentloaded',
+				timeout: timeoutMs
+			});
+			await page.waitForSelector('.operator-shell', {
+				state: 'visible',
+				timeout: timeoutMs
+			});
+			await page.waitForSelector('main', {
+				state: 'visible',
+				timeout: timeoutMs
+			});
 			const state = await page.evaluate((expectedMarker) => {
 				const bodyText = document.body.innerText.trim();
 				return {
@@ -240,17 +282,97 @@ async function checkRoutes(baseUrl, timeoutMs) {
 	}
 }
 
+async function checkNarrowRoutes(baseUrl, routeChecksForNarrow, timeoutMs) {
+	const browser = await chromium.launch();
+	try {
+		const page = await browser.newPage({
+			viewport: NARROW_VIEWPORT,
+			deviceScaleFactor: 2,
+			isMobile: true
+		});
+		const pageErrors = [];
+		page.on('pageerror', (error) => pageErrors.push(error.message));
+		for (const [label, route, marker] of routeChecksForNarrow) {
+			pageErrors.length = 0;
+			const started = performance.now();
+			await page.goto(`${baseUrl}${route}`, {
+				waitUntil: 'domcontentloaded',
+				timeout: timeoutMs
+			});
+			await page.waitForSelector('.operator-shell', {
+				state: 'visible',
+				timeout: timeoutMs
+			});
+			await page.waitForSelector('main', {
+				state: 'visible',
+				timeout: timeoutMs
+			});
+			const state = await page.evaluate((expectedMarker) => {
+				const bodyText = document.body.innerText.trim();
+				const visibleWideTables = [...document.querySelectorAll('table')]
+					.map((el) => {
+						const rect = el.getBoundingClientRect();
+						return {
+							text: el.textContent?.trim().replace(/\s+/g, ' ').slice(0, 80) ?? '',
+							width: Math.round(rect.width),
+							height: Math.round(rect.height),
+							display: getComputedStyle(el).display
+						};
+					})
+					.filter((item) => item.width > window.innerWidth + 2 && item.height > 0);
+				return {
+					bodyLength: bodyText.length,
+					hasMarker: bodyText.includes(expectedMarker),
+					pageOverflow: document.documentElement.scrollWidth > window.innerWidth + 2,
+					scrollWidth: document.documentElement.scrollWidth,
+					visibleWideTables
+				};
+			}, marker);
+			if (
+				state.bodyLength < 80 ||
+				!state.hasMarker ||
+				state.pageOverflow ||
+				state.visibleWideTables.length
+			) {
+				throw new Error(`${label} narrow layout failed: ${JSON.stringify(state)}`);
+			}
+			if (pageErrors.length > 0) {
+				throw new Error(
+					`${label} raised browser errors in narrow layout: ${pageErrors.join(' | ')}`
+				);
+			}
+			const elapsedMs = Math.round(performance.now() - started);
+			console.log(`narrow route ok: ${label} ${elapsedMs}ms`);
+		}
+	} finally {
+		await browser.close();
+	}
+}
+
 async function main() {
 	const args = parseArgs(process.argv.slice(2));
 	let managedServer = null;
 	let targetUrl = args.baseUrl ? normalizeBaseUrl(args.baseUrl) : null;
+	let fixtures = null;
+	const shouldSeedFixtures = args.seedFixtures ?? !targetUrl;
 	try {
+		if (shouldSeedFixtures) {
+			await prepareSmokeState();
+			fixtures = await seedSmokeFixtures(args.config);
+		}
 		if (!targetUrl) {
 			managedServer = await startServer(args.config);
 			targetUrl = managedServer.baseUrl;
 		}
+		const browserRouteChecks = [...routeChecks];
+		for (const fixtureRoute of fixtures?.folderRoutes ?? []) {
+			browserRouteChecks.push([fixtureRoute.label, fixtureRoute.route, fixtureRoute.marker]);
+		}
 		await checkEndpoints(targetUrl, args.endpointTimeoutMs);
-		await checkRoutes(targetUrl, args.routeTimeoutMs);
+		await checkRoutes(targetUrl, browserRouteChecks, args.routeTimeoutMs);
+		if (args.narrow) {
+			await checkNarrowRoutes(targetUrl, browserRouteChecks, args.routeTimeoutMs);
+		}
 		console.log(`web route smoke passed: ${targetUrl}`);
 	} catch (error) {
 		if (managedServer) {


### PR DESCRIPTION
## Summary
- seed deterministic web-smoke fixture data before the managed browser smoke run
- expand browser smoke to cover seeded Folder Studio and Completed cleanup routes on desktop and 390px narrow viewports
- make Ops job/history tables collapse into labeled narrow rows so seeded sample/retry work cannot create page overflow
- document the repeatable browser QA matrix and wire it into acceptance guidance

## Validation
- `npm --prefix frontend run check && npm --prefix frontend run build && npm --prefix frontend run smoke:web`
- commit hook: `bash scripts/pre-commit-check.sh`
- PyCharm touched-file inspection clean before commit

Refs #61
