### PR TITLE
Polish workstation visual system

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -14,10 +14,15 @@ Read this file first before using any design brief as implementation guidance.
   calmer hierarchy, tokens, surfaces, actions, and route-level browser review.
 - `docs/design/operator-workstation-shell-brief.md`: current cross-route shell,
   route-role, state-color, and copy posture reference.
-- GitHub issue `#62`: active execution plan for the basic-user UI/UX reset.
+- GitHub issue `#74`: current parent plan for the basic-user workstation UI/UX
+  cleanup.
+- GitHub issue `#80`: current final cross-page visual-system, copy, and stale
+  brief reconciliation pass.
 
 Current route implementation work should start from those references plus the
-active GitHub sub-issue for the route or foundation track being changed.
+active GitHub sub-issue for the route or foundation track being changed. Do not
+revive older issue numbers or handoff briefs when they conflict with `#74` and
+its child issues.
 
 ## Historical Or Superseded Briefs
 
@@ -29,10 +34,14 @@ plans:
   current issue-backed plan and should not override the current source of truth.
 - `docs/design/workstation-home-screen-brief.md`: superseded home-specific
   first-pass brief. It should not be used as the current Queue/Home execution
-  plan; use GitHub issue `#56` for that work.
+  plan; use GitHub issue `#76` and the merged Queue/Folders implementation as
+  the current route record.
 - `docs/design/workstation-home-screen-inventory.md`: historical inventory from
   an earlier home-screen reset. Use only as background when checking old
   component decisions.
 
 If a brief conflicts with the current source-of-truth list above, treat the
 brief as stale and update the relevant GitHub plan issue before implementation.
+Historical briefs may explain why the product moved away from dashboard-style
+layouts, but they are not instructions to revert current route wording,
+navigation, or layout.

--- a/docs/design/basic-user-vocabulary.md
+++ b/docs/design/basic-user-vocabulary.md
@@ -159,16 +159,16 @@ Disabled action titles and inline blockers should use this pattern:
 Do not expose raw state names such as `missing_sample`, `polling`, `can_queue`,
 or `archive_cleanup.has_cleanup` in visible UI.
 
-## Known Current Leaks To Reconcile
+## Reconciliation Status
 
-- Folder Studio still uses `Bench`, `calibration`, `draft`, and `host` in
-  visible copy and helper text.
-- Ops still mixes `host`, `worker`, `sample/proof`, `scheduler`, and `encode`
-  labels in first-level surfaces.
-- Completed uses `cleanup` heavily where the user's decision is deleting
-  archived originals.
-- Settings exposes `transcode root`, `archive cleanup`, `SSH host`, `staging
-  root`, and similar setup terms before a basic user has a working mental model.
+- The route-level cleanup issues `#75` through `#79` moved the primary pages
+  toward this vocabulary. Do not use the older leak list as a reason to revert
+  those route decisions.
+- GitHub issue `#80` owns the final cross-page sweep for remaining visible copy
+  and shared component polish.
+- Keep technical terms when they are the clearest table column, advanced
+  setting, or diagnostic value. Replace them in first-glance headings,
+  empty-state copy, and primary action labels.
 
 Track route-specific copy replacement in the active GitHub route issues rather
 than editing this reference to explain one-off exceptions.

--- a/docs/design/calm-workstation-visual-system.md
+++ b/docs/design/calm-workstation-visual-system.md
@@ -19,15 +19,14 @@ is calmer because hierarchy is clearer, not because it is softer or emptier.
 1. Adjust shared tokens and shell primitives first: `tokens.css`,
    `OperatorShell.svelte`, `WorkstationPanel.svelte`, `StateBadge.svelte`, and
    common button/table patterns.
-2. Apply the system in Folder Studio while redesigning the core workflow in
-   GitHub issue `#55`; it is the best stress test because it contains chat,
-   evidence, proposal, actions, worker state, and post-approval processing.
-3. Carry the same rules through Queue, Ops, Completed, and Settings in their
-   route issues.
+2. Keep route-level changes in their issue-backed lanes: Settings `#75`,
+   Queue/Folders `#76`, Folder Studio `#77`, Ops `#78`, and Completed `#79`.
+3. Use GitHub issue `#80` for the final cross-page visual rhythm, vocabulary,
+   browser evidence, and stale-brief reconciliation pass.
 
-This answers the planning question for `#54`: define shared shell/tokens first,
-then ground them immediately in Folder Studio rather than doing a purely
-abstract polish pass.
+This supersedes older route-reset planning notes that referenced `#54` or
+`#55`. Those older notes remain useful background, but `#74` and its child
+issues are the current implementation record.
 
 ## Surface Hierarchy
 
@@ -65,9 +64,10 @@ hard on repeated dark panels and bright borders. Future token work should:
 
 ## Typography
 
-- Use sentence case for most labels and headings.
-- Reserve uppercase for compact machine labels, route/system telemetry, and
-  very small table metadata where it materially improves scanning.
+- Use sentence case for most labels, badges, and headings.
+- Reserve uppercase for compact machine labels, route/system telemetry,
+  eyebrows, and very small table metadata where it materially improves
+  scanning.
 - Route `h1` should be direct and short; avoid product-marketing scale.
 - Panel headings should stay compact. If a panel title needs a full sentence,
   the panel likely needs a clearer purpose.

--- a/docs/design/operator-workstation-shell-brief.md
+++ b/docs/design/operator-workstation-shell-brief.md
@@ -46,12 +46,12 @@ completed, settings, and folder studio.
 
 - Home: the main workbench. The ranked queue is the primary surface, with a
   compact system strip above and an adjacent operational rail.
-- Ops: the fleet console. Lead with queue, workers, calibration, and cleanup
-  state in one scan-friendly strip, then keep queue lanes and host readiness in
+- Ops: the fleet console. Lead with readiness, workers, sample work, and retry
+  state in one scan-friendly strip, then keep queue lanes and worker readiness in
   list/table-first control surfaces rather than separate dashboard cards.
-- Completed: the archive cleanup and history surface. Keep cleanup readiness,
+- Completed: the archived-originals and history surface. Keep cleanup readiness,
   selected versus global destructive scope, archive-root health, and recent
-  encode/cleanup events visible in one route so the operator can remove
+  processing/deletion events visible in one route so the operator can delete
   archived originals without treating it like another active queue.
 - Settings: the runtime configuration surface. It may stay more utilitarian and
   form-heavy than the other routes, but it should still inherit the same shell,
@@ -63,9 +63,9 @@ completed, settings, and folder studio.
 
 - Folder studio is the canonical operator route because it contains the core
   loop: run a representative sample, inspect the evidence, and approve the
-  folder draft.
+  folder proposal.
 - The first viewport should make the folder, library, parent context, current
-  sample or draft state, review readiness, main next action, proposed settings
+  sample or proposal state, review readiness, main next action, proposed settings
   or important deltas, and any block or waiting reason clear without scrolling.
 - Before approval, keep the request thread as a persistent left column and keep
   the main pane focused on evidence and decision support.

--- a/frontend/src/lib/components/workstation/StateBadge.svelte
+++ b/frontend/src/lib/components/workstation/StateBadge.svelte
@@ -35,7 +35,6 @@
 		line-height: 1;
 		min-height: 22px;
 		padding: 0 var(--mf-space-4);
-		text-transform: uppercase;
 		white-space: nowrap;
 	}
 

--- a/frontend/src/lib/components/workstation/WorkstationPanel.svelte
+++ b/frontend/src/lib/components/workstation/WorkstationPanel.svelte
@@ -34,14 +34,15 @@
 <style>
 	.panel {
 		background: var(--mf-bg-panel);
-		border: var(--mf-border);
+		border: var(--mf-border-muted);
 		min-width: 0;
 		overflow: hidden;
 	}
 
 	.panel__header {
 		align-items: center;
-		border-bottom: var(--mf-border);
+		background: var(--mf-bg-strip);
+		border-bottom: var(--mf-border-muted);
 		display: flex;
 		gap: var(--mf-space-4);
 		min-height: 38px;
@@ -49,7 +50,8 @@
 	}
 
 	.panel__header h3 {
-		font-size: var(--mf-text-md);
+		font-size: var(--mf-text-sm);
+		letter-spacing: 0;
 	}
 
 	.panel__meta {


### PR DESCRIPTION
## Summary
- soften shared workstation panel chrome and reduce panel-header weight
- switch state badges to sentence case instead of forced uppercase
- reconcile current design docs around #74/#80 and mark older route/reset briefs as historical context
- update vocabulary and shell docs so future agents do not revive stale route issue numbers or old copy guidance

Refs #80

## Validation
- npm --prefix frontend run check
- npm --prefix frontend run lint
- npm --prefix frontend test
- npm --prefix frontend run build
- npm --prefix frontend run smoke:web
- git diff --check
- backend-served browser sweep at http://127.0.0.1:8777 across /, /folders, /ops, /completed, /settings desktop and narrow: all rendered, no horizontal overflow
- pre-commit hook acceptance stack passed during commit