### PR TITLE
Polish final UI copy and QA record

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -19,6 +19,7 @@
       "docs/design/README.md",
       "docs/design/basic-user-vocabulary.md",
       "docs/design/calm-workstation-visual-system.md",
+      "docs/design/final-love-pass-qa.md",
       "docs/design/operator-workstation-shell-brief.md"
     ]
   },

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -12,6 +12,8 @@ Read this file first before using any design brief as implementation guidance.
   reference for route copy.
 - `docs/design/calm-workstation-visual-system.md`: visual-system reference for
   calmer hierarchy, tokens, surfaces, actions, and route-level browser review.
+- `docs/design/final-love-pass-qa.md`: final issue `#87` QA record for the
+  route sweep, basic-user walkthrough, and last vocabulary polish.
 - `docs/design/operator-workstation-shell-brief.md`: current cross-route shell,
   route-role, state-color, and copy posture reference.
 - GitHub issue `#74`: current parent plan for the basic-user workstation UI/UX

--- a/docs/design/final-love-pass-qa.md
+++ b/docs/design/final-love-pass-qa.md
@@ -1,0 +1,57 @@
+# Final Love Pass QA
+
+This is the final visual and basic-user confidence pass for GitHub issue `#87`.
+The screenshot artifacts are intentionally local-only under
+`scratch/ui-checks/final-love-pass/` because live Folder Studio data can include
+private media titles.
+
+## Routes Checked
+
+- `/`: Queue opens with the first decision in plain language: choose the next
+  folder.
+- `/folders`: Folders opens as a search/browse surface instead of a second
+  dashboard.
+- `/folders/[real-prefix]`: Folder Studio keeps the workflow visible: request a
+  sample draft, review evidence, approve, then process.
+- `/ops`: Ops answers whether Mediaforce can work now and what needs operator
+  attention.
+- `/completed`: Completed focuses on handled work and archive cleanup decisions.
+- `/settings`: Settings groups libraries, storage, schedules, workers, and
+  cleanup without making dangerous cleanup feel routine.
+
+## Evidence
+
+- Desktop and narrow screenshots were captured for every route above.
+- Each checked route rendered a distinct `h1` and avoided horizontal overflow at
+  desktop and narrow viewports.
+- The frontend smoke gate covers every top-level route with a short timeout so a
+  blank page or indefinitely spinning app shell fails before signoff.
+- A first-viewport vocabulary sweep found remaining internal wording. The pass
+  changed visible `Bench` language to review-assistant language and changed
+  first-glance `host` language to worker language while leaving API/internal
+  model names alone.
+
+## Basic-User Walkthrough
+
+- Queue: start here when the user wants Mediaforce to suggest the next folder.
+  The next action is to open Folder Studio.
+- Folders: use this when the user already knows what library or folder they want
+  to inspect. Search and folder cards should lead back to Folder Studio.
+- Folder Studio: follow the workflow strip from draft to sample, review,
+  approval, and processing. The review assistant is there to produce or revise a
+  sample proposal; nothing queues until the operator confirms.
+- Ops: use this to answer "can work run now?" and "what is blocking work?" The
+  worker rail should be readable without understanding host internals.
+- Completed: use this to audit handled folders and decide whether cleanup is
+  still waiting.
+- Settings: make configuration changes here, then save. Cleanup remains guarded
+  and separate from everyday settings.
+
+## Current Judgment
+
+The app is now cohesive enough to use as the primary operator surface. The
+visual system is calm, route roles are clearer, first-glance copy is substantially
+less internal, and the blank-page regression class is covered by smoke checks.
+Future improvements can be incremental rather than another reset: automated
+accessibility coverage, more realistic fixture states for screenshots, and
+eventual internal model renames if the API vocabulary changes.

--- a/frontend/src/lib/components/settings/SettingsEditor.svelte
+++ b/frontend/src/lib/components/settings/SettingsEditor.svelte
@@ -139,9 +139,9 @@
 			mono: true
 		},
 		{
-			label: 'Hosts',
+			label: 'Workers',
 			value: `${readyHostCount}/${configuredHosts.length}`,
-			detail: loadError || 'Ready hosts from latest status check',
+			detail: loadError || 'Ready workers from latest status check',
 			tone: (loadError ? 'fail' : readyHostCount > 0 ? 'ready' : 'idle') as BadgeTone,
 			mono: true
 		},
@@ -671,7 +671,7 @@
 							title="Remote workers"
 							meta={`${configuredHosts.length.toLocaleString('en-US')} configured`}
 						>
-							<div class="host-runtime-board" aria-label="Host status check">
+							<div class="host-runtime-board" aria-label="Worker status check">
 								{#each configuredHosts as host, index (`probe-host-${host.index}-${index}`)}
 									{@const runtime = hostRuntime(host)}
 									<div class="host-runtime-card host-runtime-card--{runtimeTone(runtime)}">
@@ -686,14 +686,14 @@
 										<span
 											>{runtime?.schedule_detail ||
 												runtime?.schedule_profile_label ||
-												'No host status yet'}</span
+												'No worker status yet'}</span
 										>
 										<small
 											>{runtime?.message || runtime?.active_reason || 'Status check pending'}</small
 										>
 									</div>
 								{:else}
-									<p class="empty-note">No remote hosts are configured.</p>
+									<p class="empty-note">No remote workers are configured.</p>
 								{/each}
 							</div>
 							<div class="host-editor-list">
@@ -734,7 +734,7 @@
 												/>
 											</label>
 											<label>
-												<span>SSH host</span>
+												<span>SSH address</span>
 												<input
 													class="field"
 													value={host.host}
@@ -911,7 +911,7 @@
 									onclick={() =>
 										(draft.remote_hosts = addHostDraft(draft.remote_hosts, draftScheduleOptions))}
 								>
-									Add host
+									Add worker
 								</button>
 							</div>
 						</WorkstationPanel>

--- a/frontend/src/lib/components/workstation/FolderStudioView.svelte
+++ b/frontend/src/lib/components/workstation/FolderStudioView.svelte
@@ -164,11 +164,10 @@
 			);
 			localPendingProposal = response.proposal ?? studioFolder.pending_proposal ?? null;
 			localProposalPrefix = prefix;
-			benchMessage =
-				response.message || 'Bench draft ready. Nothing is queued until you confirm it.';
+			benchMessage = response.message || 'Draft ready. Nothing is queued until you confirm it.';
 			benchNote = '';
 		} catch (error) {
-			benchError = error instanceof Error ? error.message : 'Bench request failed.';
+			benchError = error instanceof Error ? error.message : 'Review request failed.';
 		} finally {
 			benchPending = false;
 		}
@@ -188,7 +187,7 @@
 			);
 			localPendingProposal = null;
 			localProposalPrefix = prefix;
-			benchMessage = response.message || 'Queued the sample run from the bench draft.';
+			benchMessage = response.message || 'Queued the sample run from the draft.';
 			await invalidateAll();
 		} catch (error) {
 			benchError = error instanceof Error ? error.message : 'Sample could not be queued.';
@@ -361,9 +360,9 @@
 				</div>
 			</section>
 
-			<WorkstationPanel title="Bench">
+			<WorkstationPanel title="Review assistant">
 				<div class="bench">
-					<div class="bench__thread" aria-label="Bench conversation">
+					<div class="bench__thread" aria-label="Review assistant conversation">
 						{#each benchMessages as message (message.id)}
 							<div
 								class="bench-message bench-message--{message.role} bench-message--tone-{message.tone ??
@@ -381,19 +380,19 @@
 						{/each}
 					</div>
 
-					<div class="bench__composer" aria-label="Bench request composer">
+					<div class="bench__composer" aria-label="Review request composer">
 						<label>
 							<span>Request</span>
 							<textarea
 								rows="5"
-								placeholder="Ask Bench what to sample, revise, or validate for this folder."
+								placeholder="Ask what to sample, revise, or validate for this folder."
 								bind:this={benchTextarea}
 								bind:value={benchNote}
 							></textarea>
 						</label>
 						<div class="bench__controls">
 							<label>
-								<span>Host</span>
+								<span>Worker</span>
 								<select bind:value={selectedHostKey}>
 									{#each sampleHostOptions as host (host.key)}
 										<option value={host.key}
@@ -409,7 +408,7 @@
 								title={benchRequestDisabled ? benchRequestState.blocker : ''}
 								onclick={sendBenchRequest}
 								data-mf-action="bench-request"
-								data-mf-wire="live">{benchPending ? 'Sending' : 'Send to Bench'}</button
+								data-mf-wire="live">{benchPending ? 'Sending' : 'Send request'}</button
 							>
 						</div>
 						{#if benchError}
@@ -570,7 +569,7 @@
 				</div>
 			</WorkstationPanel>
 
-			<WorkstationPanel eyebrow="Hosts" title="Sample readiness">
+			<WorkstationPanel eyebrow="Workers" title="Sample readiness">
 				<div class="host-list">
 					{#each hosts.hosts.slice(0, 6) as host (host.key)}
 						<div class="host-row">
@@ -583,7 +582,7 @@
 						</div>
 					{/each}
 					{#if hosts.hosts.length === 0}
-						<div class="empty-note">Host status is unavailable.</div>
+						<div class="empty-note">Worker status is unavailable.</div>
 					{/if}
 				</div>
 			</WorkstationPanel>

--- a/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
@@ -143,9 +143,9 @@
 		if (action === 'retry-encode-prefix') return 'Retry this folder encode';
 		if (action === 'pause-encode') return 'Pause the encode scheduler';
 		if (action === 'resume-encode') return 'Resume the encode scheduler and clear stop request';
-		if (action === 'start-host') return 'Start or wake this host';
-		if (action === 'prepare-host') return 'Prepare this host for Mediaforce work';
-		return 'Reset stored trust for this host';
+		if (action === 'start-host') return 'Start or wake this worker';
+		if (action === 'prepare-host') return 'Prepare this worker for Mediaforce work';
+		return 'Reset stored trust for this worker';
 	}
 
 	function actionBody(
@@ -259,7 +259,7 @@
 		if (host.setup_supported === false) {
 			return host.message || 'Unavailable and cannot be prepared from this screen.';
 		}
-		return host.message || 'Unavailable; start or prepare this host when it should be working.';
+		return host.message || 'Unavailable; start or prepare this worker when it should be working.';
 	}
 
 	function handleHostPasswordInput(host: HostRuntime, event: Event) {
@@ -351,7 +351,7 @@
 							<StateBadge compact tone="ready" label="Clear" />
 							<div>
 								<strong>No operator action is needed right now.</strong>
-								<span>Schedule waits and covered host issues stay in the readiness rail.</span>
+								<span>Schedule waits and covered worker issues stay in the readiness rail.</span>
 							</div>
 						</div>
 					{/each}
@@ -567,9 +567,9 @@
 			{/if}
 		</section>
 
-		<aside class="ops__rail" aria-label="Host readiness">
+		<aside class="ops__rail" aria-label="Worker readiness">
 			<WorkstationPanel
-				eyebrow="Hosts"
+				eyebrow="Workers"
 				title="Readiness"
 				meta={`${readyHosts.toLocaleString('en-US')}/${hosts?.hosts.length ?? 0}`}
 			>
@@ -636,7 +636,7 @@
 							<p class="host-row__reason">{hostReadinessReason(host)}</p>
 						</div>
 					{:else}
-						<div class="empty-note">Host status is unavailable.</div>
+						<div class="empty-note">Worker status is unavailable.</div>
 					{/each}
 				</div>
 			</WorkstationPanel>
@@ -659,9 +659,9 @@
 						</div>
 					{:else}
 						<div class="scope-row">
-							<span>Host windows</span>
+							<span>Worker windows</span>
 							<strong>Open or not reported</strong>
-							<small>No host is currently scheduled off</small>
+							<small>No worker is currently scheduled off</small>
 						</div>
 					{/each}
 				</div>

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -42,7 +42,7 @@ function folderStatusPayload(overrides: Partial<FolderStatusPayload> = {}): Fold
 	};
 }
 
-describe('Folder Studio Bench request mapping', () => {
+describe('Folder Studio review request mapping', () => {
 	it('uses only folder-scoped host options and removes empty keys', () => {
 		const options = buildBenchHostOptions([
 			{ key: 'sample-host', label: 'Sample host', detail: 'folder match', available: true },
@@ -65,13 +65,13 @@ describe('Folder Studio Bench request mapping', () => {
 
 		expect(resolveBenchRequestState('', 'studio-mini', options, null, false)).toMatchObject({
 			disabled: true,
-			blocker: 'Describe the Bench request before sending.'
+			blocker: 'Describe the review request before sending.'
 		});
 		expect(
 			resolveBenchRequestState('try a smaller sample', 'offline', options, null, false)
 		).toMatchObject({
 			disabled: true,
-			blocker: 'Selected host is not available right now.'
+			blocker: 'Selected worker is not available right now.'
 		});
 		expect(
 			resolveBenchRequestState(
@@ -97,7 +97,7 @@ describe('Folder Studio Bench request mapping', () => {
 		).toMatchObject({ disabled: false, blocker: '', activeCalibrationJob: false });
 	});
 
-	it('enables sample confirmation only for queueable Bench drafts', () => {
+	it('enables sample confirmation only for queueable review drafts', () => {
 		expect(
 			resolveWorkflowActionState('focus-bench', {
 				reviewPackReady: false,
@@ -114,7 +114,7 @@ describe('Folder Studio Bench request mapping', () => {
 			})
 		).toMatchObject({
 			disabled: true,
-			title: 'Ask Bench for a draft before starting the sample.'
+			title: 'Ask the review assistant for a draft before starting the sample.'
 		});
 
 		expect(
@@ -149,7 +149,7 @@ describe('Folder Studio Bench request mapping', () => {
 		});
 	});
 
-	it('keeps Bench drafts on the sample confirmation action', () => {
+	it('keeps review drafts on the sample confirmation action', () => {
 		const workflow = resolveWorkflow(
 			folderPayload({
 				pending_proposal: {
@@ -177,7 +177,7 @@ describe('Folder Studio Bench request mapping', () => {
 		});
 	});
 
-	it('makes unsampled folders start with Bench instead of a disabled sample action', () => {
+	it('makes unsampled folders start with the review assistant instead of a disabled sample action', () => {
 		const workflow = resolveWorkflow(
 			folderPayload(),
 			folderStatusPayload(),
@@ -190,7 +190,7 @@ describe('Folder Studio Bench request mapping', () => {
 
 		expect(workflow).toMatchObject({
 			label: 'Not sampled',
-			primary: 'Ask Bench for draft',
+			primary: 'Ask for draft',
 			primaryAction: 'focus-bench'
 		});
 	});
@@ -199,7 +199,7 @@ describe('Folder Studio Bench request mapping', () => {
 		const steps = buildWorkflowSteps({
 			tone: 'ready',
 			label: 'Draft ready',
-			title: 'Bench draft is ready to sample',
+			title: 'Review draft is ready to sample',
 			copy: 'Review the draft.',
 			primary: 'Start sample',
 			primaryAction: 'start-sample',

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -130,19 +130,19 @@ export function resolveBenchRequestState(
 	const activeCalibrationJob = activeCalibrationStatus(calibrationJob?.status);
 	let blocker = '';
 	if (!note.trim()) {
-		blocker = 'Describe the Bench request before sending.';
+		blocker = 'Describe the review request before sending.';
 	} else if (!selectedHostKey) {
-		blocker = 'Choose an available host before sending.';
+		blocker = 'Choose an available worker before sending.';
 	} else if (!selectedHost) {
-		blocker = 'Selected host is no longer available for this folder.';
+		blocker = 'Selected worker is no longer available for this folder.';
 	} else if (!selectedHost.available) {
-		blocker = 'Selected host is not available right now.';
+		blocker = 'Selected worker is not available right now.';
 	} else if (activeCalibrationJob) {
 		blocker = 'A sample job is already active for this folder.';
 	}
 	return {
 		disabled: pending || Boolean(blocker),
-		blocker: pending ? 'Sending request to Bench.' : blocker,
+		blocker: pending ? 'Sending request to the review assistant.' : blocker,
 		selectedHost,
 		activeCalibrationJob
 	};
@@ -181,12 +181,15 @@ export function resolveWorkflowActionState(
 		}
 		if (action === 'retry-sample') return { disabled: false, title: '' };
 		if (!pendingProposal?.proposal_id) {
-			return { disabled: true, title: 'Ask Bench for a draft before starting the sample.' };
+			return {
+				disabled: true,
+				title: 'Ask the review assistant for a draft before starting the sample.'
+			};
 		}
 		if (pendingProposal.can_queue === false) {
 			return {
 				disabled: true,
-				title: pendingProposal.message || 'The current bench draft is not ready to queue.'
+				title: pendingProposal.message || 'The current draft is not ready to queue.'
 			};
 		}
 		return { disabled: false, title: '' };
@@ -240,7 +243,7 @@ export function buildBenchMessages(
 			role: 'operator',
 			label: 'Operator',
 			title: 'No request sent',
-			body: 'Use the composer to ask Bench for a representative sample, a revision, or a validation pass.',
+			body: 'Use the composer to request a representative sample, a revision, or a validation pass.',
 			tone: 'neutral'
 		});
 	}
@@ -253,14 +256,14 @@ export function buildBenchMessages(
 	pushMessage(messages, {
 		id: 'bench-response',
 		role: 'bench',
-		label: 'Bench',
+		label: 'Review assistant',
 		title:
 			pendingProposal?.request_disposition ??
 			calibration?.advice?.request_disposition ??
 			'Response',
 		body:
 			responseBody ||
-			'Waiting for a request. Bench responses will appear here with the resulting proposal context.',
+			'Waiting for a request. Review guidance will appear here with the resulting proposal context.',
 		meta: pendingProposal?.confidence ?? calibration?.advice?.confidence ?? undefined,
 		tone: responseBody ? 'active' : 'neutral'
 	});
@@ -270,7 +273,7 @@ export function buildBenchMessages(
 	pushMessage(messages, {
 		id: 'bench-diagnosis',
 		role: 'bench',
-		label: 'Bench',
+		label: 'Review assistant',
 		title: 'Diagnosis',
 		body: diagnosis,
 		tone: 'active'
@@ -282,7 +285,7 @@ export function buildBenchMessages(
 	pushMessage(messages, {
 		id: 'bench-follow-up',
 		role: 'bench',
-		label: 'Bench',
+		label: 'Review assistant',
 		title: 'Suggested next step',
 		body: followUp,
 		tone: 'active'
@@ -464,7 +467,7 @@ export function resolveWorkflow(
 			copy: String(
 				calibrationJob?.error ??
 					calibrationJob?.notes ??
-					'The latest representative sample did not complete. Retry when the host state is valid.'
+					'The latest representative sample did not complete. Retry when worker state is valid.'
 			),
 			primary: 'Retry sample',
 			primaryAction: 'retry-sample',
@@ -477,7 +480,7 @@ export function resolveWorkflow(
 			tone: 'active',
 			label: 'Sampling',
 			title: 'Representative sample is running',
-			copy: 'The operator is waiting for review evidence. Keep host, elapsed time, and queue state visible until the pack is ready.',
+			copy: 'The operator is waiting for review evidence. Keep worker, elapsed time, and queue state visible until the pack is ready.',
 			primary: 'Open Ops',
 			primaryAction: 'open-ops',
 			secondary: 'Stop sample',
@@ -502,10 +505,10 @@ export function resolveWorkflow(
 		return {
 			tone: 'ready',
 			label: 'Draft ready',
-			title: 'Bench draft is ready to sample',
+			title: 'Review draft is ready to sample',
 			copy:
 				pendingProposal.message ??
-				'Review the Bench draft, then queue the representative sample when it looks right.',
+				'Review the draft, then queue the representative sample when it looks right.',
 			primary: 'Start sample',
 			primaryAction: 'start-sample',
 			secondary: 'Revise',
@@ -531,8 +534,8 @@ export function resolveWorkflow(
 			tone: 'idle',
 			label: 'Not sampled',
 			title: 'No representative sample yet',
-			copy: 'Ask Bench for a sample draft before approving folder-wide settings. Host readiness and policy context stay visible while the sample is queued.',
-			primary: 'Ask Bench for draft',
+			copy: 'Ask the review assistant for a sample draft before approving folder-wide settings. Worker readiness and policy context stay visible while the sample is queued.',
+			primary: 'Ask for draft',
 			primaryAction: 'focus-bench',
 			secondary: 'Open Ops',
 			secondaryAction: 'open-ops'
@@ -543,7 +546,7 @@ export function resolveWorkflow(
 		label: 'Waiting',
 		title: 'Folder is waiting for review evidence',
 		copy: 'A representative item exists, but the current review state is incomplete. Refresh status or rerun the sample if the evidence is stale.',
-		primary: 'Ask Bench to refresh',
+		primary: 'Refresh draft',
 		primaryAction: 'focus-bench',
 		secondary: 'Open Ops',
 		secondaryAction: 'open-ops'
@@ -656,9 +659,9 @@ export function buildStatusTiles(
 						: 'idle'
 		},
 		{
-			label: 'Hosts',
+			label: 'Workers',
 			value: `${readyHosts} ready / ${totalHosts}`,
-			detail: totalHosts ? 'capacity check complete' : 'host status unavailable',
+			detail: totalHosts ? 'capacity check complete' : 'worker status unavailable',
 			tone: readyHosts > 0 ? 'ready' : totalHosts > 0 ? 'wait' : 'idle'
 		}
 	];
@@ -673,7 +676,7 @@ export function buildFooterSignals(
 		{ label: 'Review', value: status.calibration_status || 'unknown', tone: 'active' },
 		{ label: 'Metric', value: resolvedMetricCopy(folder), tone: 'ready' },
 		{
-			label: 'Hosts',
+			label: 'Workers',
 			value: `${hosts.hosts.filter((host) => host.available).length}/${hosts.hosts.length}`
 		},
 		{ label: 'API', value: status.polling_active ? 'polling' : 'idle' }

--- a/frontend/src/lib/components/workstation/ops-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.test.ts
@@ -206,14 +206,14 @@ describe('Ops workstation mapping', () => {
 		expect(blockers[2]).toMatchObject({ tone: 'wait' });
 	});
 
-	it('keeps scheduler, attention, sample, and host tones semantic', () => {
+	it('keeps scheduler, attention, sample, and worker tones semantic', () => {
 		const tiles = buildOpsStatusTiles(dashboardFixture(), hostsFixture(), null);
 
 		expect(tiles).toMatchObject([
 			{ label: 'Scheduler', tone: 'ready' },
 			{ label: 'Encode jobs', tone: 'wait' },
 			{ label: 'Sample checks', tone: 'active' },
-			{ label: 'Hosts', tone: 'ready' }
+			{ label: 'Workers', tone: 'ready' }
 		]);
 	});
 
@@ -271,9 +271,9 @@ describe('Ops workstation mapping', () => {
 
 		expect(hostPrepareDisabled(passwordHost, '')).toBe(true);
 		expect(hostPrepareDisabled(passwordHost, 'secret')).toBe(false);
-		expect(hostPrepareTitle(passwordHost)).toBe('Enter the prepare password for this host.');
+		expect(hostPrepareTitle(passwordHost)).toBe('Enter the prepare password for this worker.');
 		expect(hostPrepareDisabled(unsupportedHost, 'secret')).toBe(true);
-		expect(hostPrepareTitle(unsupportedHost)).toBe('Prepare is unavailable for this host.');
+		expect(hostPrepareTitle(unsupportedHost)).toBe('Prepare is unavailable for this worker.');
 	});
 
 	it('does not expose prefix retry for stale historical encode rows', () => {

--- a/frontend/src/lib/components/workstation/ops-workstation.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.ts
@@ -273,9 +273,9 @@ export function hostPrepareDisabled(host: HostRuntime, password: string): boolea
 }
 
 export function hostPrepareTitle(host: HostRuntime): string {
-	if (host.setup_supported === false) return 'Prepare is unavailable for this host.';
-	if (host.setup_requires_password) return 'Enter the prepare password for this host.';
-	return 'Prepare this host for Mediaforce work';
+	if (host.setup_supported === false) return 'Prepare is unavailable for this worker.';
+	if (host.setup_requires_password) return 'Enter the prepare password for this worker.';
+	return 'Prepare this worker for Mediaforce work';
 }
 
 export function buildCalibrationRows(
@@ -371,9 +371,9 @@ export function buildOpsBlockers(
 		blockers.push({
 			key: 'no-hosts-ready',
 			tone: 'fail',
-			title: 'No hosts can encode right now',
+			title: 'No workers can encode right now',
 			detail:
-				'Queued work exists, but every configured host is unavailable or outside its work window.'
+				'Queued work exists, but every configured worker is unavailable or outside its work window.'
 		});
 	} else if (scheduleWaiting > 0) {
 		blockers.push({
@@ -442,10 +442,10 @@ export function buildOpsReadinessSummary(
 	if (totalHosts > 0 && readyHosts === 0 && queuedWork > 0) {
 		return {
 			tone: 'fail',
-			title: 'No host can work right now',
+			title: 'No worker can work right now',
 			detail:
-				'Queued work exists, but every configured host is unavailable or outside its work window.',
-			metricLabel: 'Hosts ready',
+				'Queued work exists, but every configured worker is unavailable or outside its work window.',
+			metricLabel: 'Workers ready',
 			metricValue: '0'
 		};
 	}
@@ -474,15 +474,15 @@ export function buildOpsReadinessSummary(
 		return {
 			tone: 'ready',
 			title: 'Ready for work',
-			detail: 'Hosts are available and Mediaforce can start eligible encode work.',
-			metricLabel: 'Hosts ready',
+			detail: 'Workers are available and Mediaforce can start eligible encode work.',
+			metricLabel: 'Workers ready',
 			metricValue: String(readyHosts)
 		};
 	}
 	return {
 		tone: 'idle',
 		title: 'Standing by',
-		detail: totalHosts > 0 ? 'No current work is waiting on Ops.' : 'Host status is unavailable.',
+		detail: totalHosts > 0 ? 'No current work is waiting on Ops.' : 'Worker status is unavailable.',
 		metricLabel: 'Queued',
 		metricValue: String(queuedCount)
 	};
@@ -536,13 +536,13 @@ export function buildOpsStatusTiles(
 			tone: (calibration?.active_count ?? 0) > 0 ? 'active' : 'idle'
 		},
 		{
-			label: 'Hosts',
+			label: 'Workers',
 			value: `${readyHosts} ready / ${totalHosts}`,
 			detail: totalHosts
 				? readyHosts > 0
 					? 'capacity available'
-					: 'no host can start work'
-				: 'host status unavailable',
+					: 'no worker can start work'
+				: 'worker status unavailable',
 			tone: readyHosts > 0 ? 'ready' : totalHosts > 0 ? 'fail' : 'idle'
 		}
 	];
@@ -576,7 +576,7 @@ export function buildOpsFooterSignals(
 			tone: (calibration?.active_count ?? 0) > 0 ? 'active' : 'idle'
 		},
 		{
-			label: 'Hosts',
+			label: 'Workers',
 			value: `${hosts?.hosts.filter((host) => host.available).length ?? 0}/${hosts?.hosts.length ?? 0}`
 		}
 	];

--- a/frontend/src/lib/components/workstation/queue-workstation.ts
+++ b/frontend/src/lib/components/workstation/queue-workstation.ts
@@ -101,9 +101,9 @@ export function buildQueueStatusTiles(
 						: 'idle'
 		},
 		{
-			label: 'Hosts',
+			label: 'Workers',
 			value: `${readyHosts} ready / ${hosts.hosts.length}`,
-			detail: hosts.hosts.length ? 'capacity check complete' : 'host status unavailable',
+			detail: hosts.hosts.length ? 'capacity check complete' : 'worker status unavailable',
 			tone: readyHosts > 0 ? 'ready' : hosts.hosts.length > 0 ? 'wait' : 'idle'
 		}
 	];
@@ -127,7 +127,7 @@ export function buildQueueFooterSignals(
 			tone: dashboard.calibration_queue.active_count > 0 ? 'active' : 'idle'
 		},
 		{
-			label: 'Hosts',
+			label: 'Workers',
 			value: `${hosts.hosts.filter((host) => host.available).length}/${hosts.hosts.length}`
 		}
 	];

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -708,7 +708,7 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
             {
                 "label": "Ops unavailable host fixture",
                 "route": "/ops",
-                "marker": "No hosts can encode right now",
+                "marker": "No workers can encode right now",
             },
             {
                 "label": "Folder Studio review-ready fixture",


### PR DESCRIPTION
## Summary
- Replaces remaining first-glance Bench/host wording with review-assistant and worker language on operator-facing surfaces.
- Adds the final love-pass QA record and wires it into the design source lists.
- Updates the web smoke fixture marker so the blank-page/full-load gate follows the new Ops wording.

Refs #87

## Validation
- `bash scripts/pre-commit-check.sh`
- Live Playwright browser sweep against `http://127.0.0.1:8777` for `/`, `/folders`, `/ops`, `/completed`, `/settings`, and one redacted live Folder Studio route at desktop and narrow widths; screenshots stored locally under `scratch/ui-checks/final-love-pass/`.
