### PR TITLE
Refine operator UI copy and readiness states

### DIFF
--- a/docs/development/browser-qa-matrix.md
+++ b/docs/development/browser-qa-matrix.md
@@ -35,10 +35,10 @@ The managed smoke seeds a compact but non-empty workflow dataset:
   job that exposes retry copy.
 - Review-ready state: `/folders/tv/Review%20Ready/Season%201`, with retained
   review media and visible review-pack artifacts.
-- Active encode state: `/folders/tv/Encoding%20Show/Season%201`, with a running
-  folder encode row.
-- Retryable encode state: `/folders/tv/Failed%20Encode/Season%201`, with a
-  needs-attention encode row that exposes recovery copy.
+- Active processing state: `/folders/tv/Encoding%20Show/Season%201`, with a
+  running folder processing row.
+- Retryable processing state: `/folders/tv/Failed%20Encode/Season%201`, with a
+  needs-attention processing row that exposes recovery copy.
 - Unavailable worker state: `config/web-smoke.toml` includes a smoke-only remote
   host that is unavailable, so `/ops` can expose the no-ready-host blocker while
   queued encode work exists.
@@ -64,8 +64,8 @@ Every browser QA pass should cover these routes:
 - `/folders/tv/Sampling%20Show/Season%201`: active sample queue state.
 - `/folders/tv/Retry%20Show/Season%201`: retryable sample state.
 - `/folders/tv/Review%20Ready/Season%201`: review-pack-ready sample state.
-- `/folders/tv/Encoding%20Show/Season%201`: running encode state.
-- `/folders/tv/Failed%20Encode/Season%201`: retryable encode state.
+- `/folders/tv/Encoding%20Show/Season%201`: running processing state.
+- `/folders/tv/Failed%20Encode/Season%201`: retryable processing state.
 - `/ops`: blockers, worker readiness, queues, and collapsed history.
 - `/completed`: no-action history and cleanup-ready work.
 - `/settings`: basic, advanced, and danger-zone settings sections.
@@ -88,6 +88,6 @@ state, and narrow layout.
 
 The current fixture covers non-empty queue, empty queue, waiting Folder Studio,
 queued sample, retryable sample, review-pack-ready sample, active encode,
-retryable encode, cleanup-ready Completed, blocked Completed, unavailable host
+retryable processing, cleanup-ready Completed, blocked Completed, unavailable host
 Ops, idle Ops, and narrow layout. Future UI work should extend this fixture or
 add dedicated fixture modes when it introduces new workflow states.

--- a/frontend/src/lib/components/settings/SettingsEditor.svelte
+++ b/frontend/src/lib/components/settings/SettingsEditor.svelte
@@ -34,6 +34,7 @@
 	import OperatorShell from '../workstation/OperatorShell.svelte';
 	import StateBadge from '../workstation/StateBadge.svelte';
 	import WorkstationPanel from '../workstation/WorkstationPanel.svelte';
+	import { workerCapabilityLabel } from '../workstation/ops-workstation';
 
 	type SaveResponse = {
 		ok: boolean;
@@ -115,7 +116,7 @@
 	);
 	const draftScheduleOptions = $derived([
 		{ key: 'always', label: 'Always', summary: 'Runs anytime.' },
-		{ key: 'never', label: 'Never', summary: 'Never accepts queued encodes.' },
+		{ key: 'never', label: 'Never', summary: 'Never starts queued processing.' },
 		...configuredProfiles.map((profile) => ({
 			key: profile.key.trim(),
 			label: profile.label.trim() || profile.key.trim(),
@@ -132,7 +133,7 @@
 		{
 			label: 'Libraries',
 			value: configuredLibraries.length.toLocaleString('en-US'),
-			detail: draft.transcode_root.trim() || 'Transcode root missing',
+			detail: draft.transcode_root.trim() || 'Working folder missing',
 			tone: (draft.transcode_root.trim() && configuredLibraries.length
 				? 'ready'
 				: 'wait') as BadgeTone,
@@ -146,7 +147,7 @@
 			mono: true
 		},
 		{
-			label: 'Schedules',
+			label: 'Work windows',
 			value: (configuredProfiles.length + 2).toLocaleString('en-US'),
 			detail: 'Includes Always and Never',
 			tone: 'idle' as BadgeTone,
@@ -390,7 +391,7 @@
 						<strong>{draft.transcode_root.trim() ? 'Set' : 'Missing'}</strong>
 					</a>
 					<a href="#settings-schedules">
-						<span>Schedules</span>
+						<span>Work windows</span>
 						<strong>{(configuredProfiles.length + 2).toLocaleString('en-US')}</strong>
 					</a>
 					<a href="#settings-workers">
@@ -510,7 +511,7 @@
 									<span>Originals waiting folder</span>
 									<strong class="mf-path">{savedArchiveRootCopy}</strong>
 									{#if cleanupTargetDirty}
-										<small>Save settings before clearing a changed archive target.</small>
+										<small>Save settings before deleting from a changed cleanup folder.</small>
 									{/if}
 								</div>
 								<div class="storage-readout">
@@ -537,13 +538,13 @@
 							<span class="mf-eyebrow">Advanced setup</span>
 							<h2 id="settings-advanced-title">Workers and run windows</h2>
 						</div>
-						<p>Use these when adding machines or changing when encode work may run.</p>
+						<p>Use these when adding machines or changing when processing work may run.</p>
 					</header>
 
 					<div id="settings-schedules" class="settings-anchor">
 						<WorkstationPanel
-							eyebrow="Schedules"
-							title="Queue profiles"
+							eyebrow="Work windows"
+							title="Work windows"
 							meta={`${configuredProfiles.length.toLocaleString('en-US')} custom`}
 						>
 							<div class="schedule-list">
@@ -555,13 +556,13 @@
 								<div class="schedule-row schedule-row--builtin">
 									<StateBadge compact tone="idle" label="Built in" />
 									<strong>Never</strong>
-									<span>Never accepts queued encodes</span>
+									<span>Never starts queued processing</span>
 								</div>
 								{#each draft.schedule_profiles as profile, index (`schedule-${profile.index}-${index}`)}
 									<div class="schedule-row">
 										<div class="schedule-row__fields">
 											<label>
-												<span>Key</span>
+												<span>Window key</span>
 												<input
 													class="field"
 													value={profile.key}
@@ -570,7 +571,7 @@
 												/>
 											</label>
 											<label>
-												<span>Label</span>
+												<span>Name</span>
 												<input
 													class="field"
 													value={profile.label}
@@ -608,14 +609,14 @@
 												onclick={() =>
 													(draft.schedule_profiles = removeAtIndex(draft.schedule_profiles, index))}
 											>
-												Remove schedule
+												Remove window
 											</button>
 										</div>
 										<div
 											class="day-grid"
 											aria-label={`${profile.label || profile.key || 'Schedule'} days`}
 										>
-											<span>Window</span>
+											<span>Runs</span>
 											{#each SCHEDULE_DAY_OPTIONS as day (day.key)}
 												<button
 													type="button"
@@ -659,7 +660,7 @@
 									onclick={() =>
 										(draft.schedule_profiles = addScheduleDraft(draft.schedule_profiles))}
 								>
-									Add schedule
+									Add work window
 								</button>
 							</div>
 						</WorkstationPanel>
@@ -725,30 +726,12 @@
 										</header>
 										<div class="host-grid">
 											<label>
-												<span>Label</span>
+												<span>Worker name</span>
 												<input
 													class="field"
 													value={host.label}
 													placeholder="Studio Mac"
 													oninput={(event) => updateHost(index, { label: inputValue(event) })}
-												/>
-											</label>
-											<label>
-												<span>SSH address</span>
-												<input
-													class="field"
-													value={host.host}
-													placeholder="studio.local"
-													oninput={(event) => updateHost(index, { host: inputValue(event) })}
-												/>
-											</label>
-											<label>
-												<span>Repo path</span>
-												<input
-													class="field field--path"
-													value={host.repo_path}
-													placeholder="/Users/operator/mediaforce"
-													oninput={(event) => updateHost(index, { repo_path: inputValue(event) })}
 												/>
 											</label>
 											<label>
@@ -764,27 +747,7 @@
 												</select>
 											</label>
 											<label>
-												<span>Priority</span>
-												<input
-													class="field field--number"
-													type="number"
-													value={host.priority}
-													oninput={(event) => updateHost(index, { priority: inputValue(event) })}
-												/>
-											</label>
-											<label>
-												<span>Parallel encodes</span>
-												<input
-													class="field field--number"
-													type="number"
-													min="1"
-													value={host.max_parallel_encodes}
-													oninput={(event) =>
-														updateHost(index, { max_parallel_encodes: inputValue(event) })}
-												/>
-											</label>
-											<label>
-												<span>Schedule</span>
+												<span>Work window</span>
 												<select
 													class="field"
 													bind:value={draft.remote_hosts[index].schedule_profile}
@@ -796,25 +759,85 @@
 													{/each}
 												</select>
 											</label>
-											<label>
-												<span>Staging root</span>
-												<input
-													class="field field--path"
-													value={host.staging_root}
-													placeholder="Uses transcode root"
-													oninput={(event) =>
-														updateHost(index, { staging_root: inputValue(event) })}
-												/>
-											</label>
+										</div>
+										<div class="host-options host-options--primary">
+											<div>
+												<span class="option-label">Allowed libraries</span>
+												<div class="toggle-grid">
+													{#each activeLibraryKeys as libraryKey (libraryKey)}
+														<label class="toggle-chip">
+															<input
+																type="checkbox"
+																checked={host.allowed_libraries.includes(libraryKey)}
+																onchange={() => toggleLibraryAccess(index, libraryKey)}
+															/>
+															<span>{libraryKey}</span>
+														</label>
+													{:else}
+														<span class="muted-copy"
+															>Add library keys before assigning workers.</span
+														>
+													{/each}
+												</div>
+											</div>
 										</div>
 										<details class="host-advanced">
 											<summary>
-												<strong>Advanced worker internals</strong>
+												<strong>Connection and advanced settings</strong>
 												<span
-													>Start/stop commands, wake settings, timeout, and source overrides.</span
+													>SSH address, repo path, staging folder, command hooks, and source
+													overrides.</span
 												>
 											</summary>
 											<div class="host-grid host-grid--advanced">
+												<label>
+													<span>SSH address</span>
+													<input
+														class="field"
+														value={host.host}
+														placeholder="studio.local"
+														oninput={(event) => updateHost(index, { host: inputValue(event) })}
+													/>
+												</label>
+												<label>
+													<span>Repo path</span>
+													<input
+														class="field field--path"
+														value={host.repo_path}
+														placeholder="/Users/operator/mediaforce"
+														oninput={(event) => updateHost(index, { repo_path: inputValue(event) })}
+													/>
+												</label>
+												<label>
+													<span>Priority</span>
+													<input
+														class="field field--number"
+														type="number"
+														value={host.priority}
+														oninput={(event) => updateHost(index, { priority: inputValue(event) })}
+													/>
+												</label>
+												<label>
+													<span>Parallel processing</span>
+													<input
+														class="field field--number"
+														type="number"
+														min="1"
+														value={host.max_parallel_encodes}
+														oninput={(event) =>
+															updateHost(index, { max_parallel_encodes: inputValue(event) })}
+													/>
+												</label>
+												<label>
+													<span>Worker staging folder</span>
+													<input
+														class="field field--path"
+														value={host.staging_root}
+														placeholder="Uses working folder"
+														oninput={(event) =>
+															updateHost(index, { staging_root: inputValue(event) })}
+													/>
+												</label>
 												<label>
 													<span>Start command</span>
 													<input
@@ -856,6 +879,23 @@
 													/>
 												</label>
 											</div>
+											<div class="host-options">
+												<div>
+													<span class="option-label">Worker abilities</span>
+													<div class="toggle-grid">
+														{#each savedSettings.host_capability_options as option (option.key)}
+															<label class="toggle-chip">
+																<input
+																	type="checkbox"
+																	checked={host.capabilities.includes(option.key)}
+																	onchange={() => toggleCapability(index, option.key)}
+																/>
+																<span>{workerCapabilityLabel(option.key)}</span>
+															</label>
+														{/each}
+													</div>
+												</div>
+											</div>
 											<label class="stacked-field">
 												<span>Source root overrides JSON</span>
 												<textarea
@@ -867,40 +907,6 @@
 												></textarea>
 											</label>
 										</details>
-										<div class="host-options">
-											<div>
-												<span class="option-label">Capabilities</span>
-												<div class="toggle-grid">
-													{#each savedSettings.host_capability_options as option (option.key)}
-														<label class="toggle-chip">
-															<input
-																type="checkbox"
-																checked={host.capabilities.includes(option.key)}
-																onchange={() => toggleCapability(index, option.key)}
-															/>
-															<span>{option.label}</span>
-														</label>
-													{/each}
-												</div>
-											</div>
-											<div>
-												<span class="option-label">Allowed libraries</span>
-												<div class="toggle-grid">
-													{#each activeLibraryKeys as libraryKey (libraryKey)}
-														<label class="toggle-chip">
-															<input
-																type="checkbox"
-																checked={host.allowed_libraries.includes(libraryKey)}
-																onchange={() => toggleLibraryAccess(index, libraryKey)}
-															/>
-															<span>{libraryKey}</span>
-														</label>
-													{:else}
-														<span class="muted-copy">Add library keys before assigning hosts.</span>
-													{/each}
-												</div>
-											</div>
-										</div>
 									</section>
 								{/each}
 							</div>
@@ -931,10 +937,10 @@
 					</header>
 
 					<div id="settings-danger" class="settings-anchor">
-						<WorkstationPanel eyebrow="Danger zone" title="Clear originals waiting folder">
+						<WorkstationPanel eyebrow="Danger zone" title="Delete archived originals">
 							<div class="danger-zone">
 								<div>
-									<span>Target</span>
+									<span>Cleanup folder</span>
 									<strong class="mf-path">{savedArchiveRootCopy}</strong>
 									<small
 										>{archiveCleanup?.file_count.toLocaleString('en-US') ?? '0'} files · {formatGiB(
@@ -956,7 +962,7 @@
 											cleanupTargetDirty}
 										onclick={clearArchiveCleanup}
 										title={cleanupTargetDirty
-											? 'Save the changed transcode root before clearing archived originals.'
+											? 'Save the changed cleanup folder before deleting archived originals.'
 											: undefined}
 									>
 										{clearArchivePending
@@ -982,7 +988,7 @@
 					<span class="mf-eyebrow">Sections</span>
 					<a href="#settings-libraries">Libraries</a>
 					<a href="#settings-storage">Storage</a>
-					<a href="#settings-schedules">Schedules</a>
+					<a href="#settings-schedules">Work windows</a>
 					<a href="#settings-workers">Workers</a>
 					<a href="#settings-danger">Cleanup</a>
 				</nav>
@@ -1486,12 +1492,7 @@
 	.host-grid {
 		display: grid;
 		gap: var(--mf-space-4);
-		grid-template-columns: repeat(4, minmax(130px, 1fr));
-	}
-
-	.host-grid label:nth-child(3),
-	.host-grid label:nth-child(8) {
-		grid-column: span 2;
+		grid-template-columns: repeat(3, minmax(150px, 1fr));
 	}
 
 	.host-advanced {
@@ -1524,7 +1525,10 @@
 	}
 
 	.host-grid--advanced label:nth-child(1),
-	.host-grid--advanced label:nth-child(2) {
+	.host-grid--advanced label:nth-child(2),
+	.host-grid--advanced label:nth-child(5),
+	.host-grid--advanced label:nth-child(6),
+	.host-grid--advanced label:nth-child(7) {
 		grid-column: span 2;
 	}
 

--- a/frontend/src/lib/components/workstation/CompletedWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/CompletedWorkstationView.svelte
@@ -156,6 +156,7 @@
 		...localHistory.map((event) => ({ ...event, source: 'api' as const })),
 		...(completed ? buildCompletedHistoryRows(completed) : [])
 	]);
+	const showMainHistorySummary = $derived(!cleanupNeedsAction && historyRows.length > 0);
 	const normalizedHistoryQuery = $derived(historyQuery.trim().toLowerCase());
 	const visibleHistory = $derived(
 		historyRows.filter((event) => {
@@ -477,7 +478,7 @@
 					</div>
 				</WorkstationPanel>
 
-				{#if !cleanupNeedsAction && historyRows.length > 0}
+				{#if showMainHistorySummary}
 					<WorkstationPanel
 						eyebrow="History"
 						title="Recent handled work"
@@ -505,7 +506,7 @@
 				>
 					<div class="completed-filter" aria-label="Completed cleanup filters">
 						<div class="completed-filter__summary">
-							<span>Visible cleanup</span>
+							<span>{cleanupNeedsAction ? 'Visible cleanup' : 'Visible completed work'}</span>
 							<strong
 								>{filteredFolders.length.toLocaleString('en-US')} / {folders.length.toLocaleString(
 									'en-US'
@@ -655,7 +656,7 @@
 										onclick={() => armCleanup('selected')}
 										>{armedScope === 'selected'
 											? 'Selected armed'
-											: 'Remove selected originals'}</button
+											: 'Delete selected originals'}</button
 									>
 									<button
 										type="button"
@@ -663,7 +664,9 @@
 										class:armed={armedScope === 'global'}
 										disabled={cleanupDisabled('global')}
 										onclick={() => armCleanup('global')}
-										>{armedScope === 'global' ? 'Global armed' : 'Clear entire archive'}</button
+										>{armedScope === 'global'
+											? 'Global armed'
+											: 'Delete all archived originals'}</button
 									>
 									<button
 										type="button"
@@ -707,8 +710,8 @@
 												: globalRemovalSummary}</span
 										>
 										<small>
-											This deletes originals from the cleanup waiting folder. It does not remove the
-											promoted encoded files.
+											This deletes originals from the cleanup folder. It does not remove the new
+											processed files.
 										</small>
 									</div>
 									<div class="confirm-panel__actions">
@@ -887,9 +890,9 @@
 		</section>
 
 		<aside class="completed__rail" aria-label="Completed cleanup context">
-			<WorkstationPanel eyebrow="Cleanup" title="Originals waiting folder">
+			<WorkstationPanel eyebrow="Cleanup" title="Cleanup folder">
 				<dl class="kv">
-					<dt>Root</dt>
+					<dt>Folder</dt>
 					<dd>{archive.archive_root || 'not configured'}</dd>
 					<dt>Files</dt>
 					<dd>{archive.file_count.toLocaleString('en-US')}</dd>
@@ -900,7 +903,7 @@
 				</dl>
 			</WorkstationPanel>
 
-			<WorkstationPanel eyebrow="State" title="Originals review">
+			<WorkstationPanel eyebrow="State" title="Cleanup state">
 				<div class="scope-list">
 					<div class="scope-row scope-row--ready">
 						<span>Waiting originals</span>
@@ -913,7 +916,7 @@
 						<small>Mediaforce cannot check these originals</small>
 					</div>
 					<div class="scope-row" class:scope-row--wait={counts.unknown > 0}>
-						<span>Needs review</span>
+						<span>Already removed</span>
 						<strong>{counts.unknown.toLocaleString('en-US')} folders</strong>
 						<small>originals already gone; confirm after review</small>
 					</div>
@@ -925,26 +928,35 @@
 				</div>
 			</WorkstationPanel>
 
-			<WorkstationPanel
-				eyebrow="History"
-				title="Recent handled work"
-				meta={`${historyRows.length.toLocaleString('en-US')} events`}
-			>
-				<div class="history-list">
-					{#each historyRows.slice(0, 8) as event (`rail:${event.source}:${event.id}:${event.created_at}`)}
-						<div class="history-row history-row--rail">
-							<StateBadge compact tone={eventTone(event.tone)} label={event.label} />
-							<div>
-								<strong>{event.title}</strong>
-								<span>{event.prefix}</span>
+			{#if cleanupNeedsAction || mode === 'history'}
+				<WorkstationPanel
+					eyebrow="History"
+					title="Recent handled work"
+					meta={`${historyRows.length.toLocaleString('en-US')} events`}
+				>
+					<div class="history-list">
+						{#each historyRows.slice(0, 8) as event (`rail:${event.source}:${event.id}:${event.created_at}`)}
+							<div class="history-row history-row--rail">
+								<StateBadge compact tone={eventTone(event.tone)} label={event.label} />
+								<div>
+									<strong>{event.title}</strong>
+									<span>{event.prefix}</span>
+								</div>
+								<time>{formatTimestamp(event.created_at)}</time>
 							</div>
-							<time>{formatTimestamp(event.created_at)}</time>
-						</div>
-					{:else}
-						<div class="empty-note">No completed-history events are available yet.</div>
-					{/each}
-				</div>
-			</WorkstationPanel>
+						{:else}
+							<div class="empty-note">No completed-history events are available yet.</div>
+						{/each}
+					</div>
+				</WorkstationPanel>
+			{:else}
+				<WorkstationPanel eyebrow="History" title="Audit trail">
+					<div class="audit-note">
+						<strong>Handled history is available in the History tab.</strong>
+						<span>No cleanup action is waiting.</span>
+					</div>
+				</WorkstationPanel>
+			{/if}
 		</aside>
 	</main>
 </OperatorShell>
@@ -1060,7 +1072,8 @@
 	.cleanup-command,
 	.scope-list,
 	.history-workspace,
-	.history-list {
+	.history-list,
+	.audit-note {
 		display: grid;
 		gap: var(--mf-space-4);
 		padding: var(--mf-space-5);
@@ -1096,7 +1109,8 @@
 	.folder-link + small,
 	.state-detail,
 	.history-row span,
-	.history-row p {
+	.history-row p,
+	.audit-note span {
 		color: var(--mf-fg-tertiary);
 		font-size: var(--mf-text-xs);
 	}
@@ -1218,10 +1232,17 @@
 	.cleanup-status strong,
 	.cleanup-command__state strong,
 	.scope-row strong,
-	.history-row strong {
+	.history-row strong,
+	.audit-note strong {
 		font-size: var(--mf-text-sm);
 		font-weight: var(--mf-weight-semibold);
 		overflow-wrap: anywhere;
+	}
+
+	.audit-note {
+		background: var(--mf-bg-strip);
+		border-left: 2px solid var(--mf-line-strong);
+		gap: var(--mf-space-1);
 	}
 
 	.cleanup-command__actions,

--- a/frontend/src/lib/components/workstation/FolderStudioView.svelte
+++ b/frontend/src/lib/components/workstation/FolderStudioView.svelte
@@ -431,7 +431,7 @@
 						<dd>{status.folder_scan_status || '—'}</dd>
 						<dt>Approval</dt>
 						<dd>{reviewGate?.status ?? '—'}</dd>
-						<dt>Encode</dt>
+						<dt>Processing</dt>
 						<dd>{encodeJob?.status ?? studioFolder.encode_queue_summary ?? '—'}</dd>
 					</dl>
 				</WorkstationPanel>
@@ -508,13 +508,13 @@
 
 			<details class="technical-details">
 				<summary>
-					<strong>Policy details</strong>
+					<strong>Proposed settings details</strong>
 					<span
 						>{proposalRows.length ? `${proposalRows.length} draft differences` : 'No draft'}</span
 					>
 				</summary>
 				<WorkstationPanel
-					title="Current policy vs. draft"
+					title="Current settings vs. proposal"
 					meta={proposalRows.length ? `${proposalRows.length} rows` : 'No draft'}
 				>
 					<div class="table-wrap">

--- a/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
+++ b/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
@@ -95,7 +95,7 @@
 	const headerCopy = $derived(
 		isFolderIndex
 			? 'Search or filter discovered folders, then open Folder Studio when you know which folder needs attention.'
-			: 'Use the ranked list to pick the next folder worth reviewing, then open Folder Studio when the action looks right.'
+			: 'Use the worklist to pick the next folder that needs review, then open Folder Studio when the action looks right.'
 	);
 	const workspaceLabel = $derived(
 		isFolderIndex ? 'Folder index and selected folder' : 'Queue worklist and selected folder'
@@ -229,7 +229,7 @@
 		if (isFolderIndex) {
 			return `${folder.title} has ${pending} pending items and about ${reclaim} of projected reclaim.`;
 		}
-		const rankCopy = index === 0 ? 'the highest-ranked visible folder' : `ranked #${index + 1}`;
+		const rankCopy = index === 0 ? 'the first visible folder' : `#${index + 1} in the visible list`;
 		return `${folder.title} is ${rankCopy} with ${pending} pending items and about ${reclaim} of projected reclaim.`;
 	}
 </script>
@@ -351,7 +351,7 @@
 						<small>{pendingReviews} waiting for review</small>
 					</div>
 					<div class="scope-row">
-						<span>Encode</span>
+						<span>Processing</span>
 						<strong
 							>{dashboard.encode_queue.running_count} running · {dashboard.encode_queue
 								.queued_count}
@@ -359,7 +359,7 @@
 						>
 						<small
 							>{dashboard.encode_queue.state.scheduler_summary ??
-								'scheduler state unavailable'}</small
+								'work schedule unavailable'}</small
 						>
 					</div>
 				</div>
@@ -450,7 +450,7 @@
 				</WorkstationPanel>
 
 				<WorkstationPanel
-					eyebrow={tableEyebrow}
+					eyebrow={isFolderIndex ? tableEyebrow : 'Worklist'}
 					title={tableTitle}
 					meta={`${visibleFolders.length.toLocaleString('en-US')} visible`}
 				>

--- a/frontend/src/lib/components/workstation/OperatorShell.svelte
+++ b/frontend/src/lib/components/workstation/OperatorShell.svelte
@@ -111,7 +111,6 @@
 		color: var(--mf-fg-primary);
 		display: grid;
 		min-height: 100vh;
-		padding-bottom: 28px;
 	}
 
 	.masthead {
@@ -350,7 +349,7 @@
 		min-height: 28px;
 		overflow: hidden;
 		padding: 0 var(--mf-space-6);
-		position: fixed;
+		position: sticky;
 		right: 0;
 		white-space: nowrap;
 		z-index: 20;

--- a/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
@@ -21,6 +21,7 @@
 		hostTone,
 		rowRecoveryLabel,
 		rowRecoveryTitle,
+		workerCapabilitiesSummary,
 		type OpsActionId,
 		type OpsQueueRow
 	} from './ops-workstation';
@@ -74,7 +75,7 @@
 				!encodeQueue?.state.stop_requested &&
 				encodeWorkCount > 0 &&
 				actionPending === null,
-			unavailable: 'No encode work is running or queued.'
+			unavailable: 'No processing work is running or queued.'
 		},
 		{
 			id: 'resume-encode' as const,
@@ -83,13 +84,13 @@
 				Boolean(encodeQueue) &&
 				Boolean(encodeQueue?.state.is_paused || encodeQueue?.state.stop_requested) &&
 				actionPending === null,
-			unavailable: 'Queue is already accepting eligible work.'
+			unavailable: 'Work is already accepting eligible folders.'
 		},
 		{
 			id: 'retry-failed-encode' as const,
 			tone: 'warn',
 			enabled: Boolean(encodeQueue) && needsAttentionCount > 0 && actionPending === null,
-			unavailable: 'No approved encode retries are waiting.'
+			unavailable: 'No approved processing retries are waiting.'
 		},
 		{
 			id: 'stop-encode' as const,
@@ -102,7 +103,7 @@
 					encodeQueue?.state.is_paused
 				) &&
 				actionPending === null,
-			unavailable: 'No encode work is running, queued, or paused.'
+			unavailable: 'No processing work is running, queued, or paused.'
 		},
 		{
 			id: 'stop-calibration' as const,
@@ -111,7 +112,7 @@
 				Boolean(calibrationQueue) &&
 				(calibrationQueue?.active_count ?? 0) > 0 &&
 				actionPending === null,
-			unavailable: 'No sample or proof jobs are running.'
+			unavailable: 'No sample or review jobs are running.'
 		}
 	]);
 	const availableGlobalCommands = $derived(globalCommands.filter((command) => command.enabled));
@@ -136,13 +137,13 @@
 	}
 
 	function actionTitle(action: OpsActionId): string {
-		if (action === 'stop-encode') return 'Stop running encode workers and pause the queue';
-		if (action === 'stop-calibration') return 'Stop running and queued sample/proof jobs';
+		if (action === 'stop-encode') return 'Stop running processing workers and pause the queue';
+		if (action === 'stop-calibration') return 'Stop running and queued sample/review jobs';
 		if (action === 'retry-failed-encode')
-			return 'Retry approved folder encodes that are ready to try again';
-		if (action === 'retry-encode-prefix') return 'Retry this folder encode';
-		if (action === 'pause-encode') return 'Pause the encode scheduler';
-		if (action === 'resume-encode') return 'Resume the encode scheduler and clear stop request';
+			return 'Retry approved folders that are ready to process again';
+		if (action === 'retry-encode-prefix') return 'Retry processing for this folder';
+		if (action === 'pause-encode') return 'Pause processing';
+		if (action === 'resume-encode') return 'Resume processing and clear stop request';
 		if (action === 'start-host') return 'Start or wake this worker';
 		if (action === 'prepare-host') return 'Prepare this worker for Mediaforce work';
 		return 'Reset stored trust for this worker';
@@ -248,10 +249,10 @@
 
 	function hostReadinessReason(host: HostRuntime): string {
 		if (host.available && host.schedule_open === false) {
-			return host.schedule_detail || 'Scheduled off; this is a normal wait, not a failure.';
+			return host.schedule_detail || 'Off schedule; this is a normal wait, not a failure.';
 		}
 		if (host.available && host.queue_active === false) {
-			return host.message || 'Host is reachable but not accepting Mediaforce work.';
+			return host.message || 'Worker is reachable but not accepting Mediaforce work.';
 		}
 		if (host.available) {
 			return host.message || host.active_reason || 'Ready for assigned work.';
@@ -276,7 +277,7 @@
 		if (action === 'resume-encode') return 'Resume';
 		if (action === 'retry-failed-encode') return 'Retry available';
 		if (action === 'retry-encode-prefix') return 'Retry folder';
-		if (action === 'stop-encode') return 'Stop encode';
+		if (action === 'stop-encode') return 'Stop processing';
 		if (action === 'stop-calibration') return 'Stop samples';
 		if (action === 'start-host') return 'Start';
 		if (action === 'prepare-host') return 'Prepare';
@@ -286,6 +287,12 @@
 
 	function canOpenFolder(row: OpsQueueRow): boolean {
 		return row.prefix !== 'system scope';
+	}
+
+	function queueKindLabel(row: OpsQueueRow): string {
+		if (row.kind === 'encode') return 'Processing';
+		if (row.kind === 'proof') return 'Review';
+		return 'Sample';
 	}
 
 	onMount(() => {
@@ -358,7 +365,7 @@
 				</div>
 			</WorkstationPanel>
 
-			<WorkstationPanel eyebrow="Global controls" title="Encode and sample queues">
+			<WorkstationPanel eyebrow="Global controls" title="Processing and sample queues">
 				<div class="scheduler-console">
 					<div class="scheduler-console__state">
 						<StateBadge
@@ -374,8 +381,7 @@
 									: 'Ready'}
 						/>
 						<div>
-							<strong>{encodeQueue?.state.scheduler_summary ?? 'Scheduler data unavailable'}</strong
-							>
+							<strong>{encodeQueue?.state.scheduler_summary ?? 'Work schedule unavailable'}</strong>
 							<span
 								>{queuedWaitingCount.toLocaleString('en-US')} waiting · {needsAttentionCount.toLocaleString(
 									'en-US'
@@ -385,14 +391,14 @@
 						</div>
 					</div>
 					<div class="scheduler-console__scope">
-						<strong>Global queue controls</strong>
+						<strong>Global work controls</strong>
 						<span
 							>{availableGlobalCommands.length > 0
 								? 'Only actions that can run now are shown in the command lane.'
 								: 'No global queue command is needed in the current state.'}</span
 						>
 					</div>
-					<div class="scheduler-console__actions" aria-label="Scheduler controls">
+					<div class="scheduler-console__actions" aria-label="Work controls">
 						{#each availableGlobalCommands as command (command.id)}
 							<button
 								type="button"
@@ -448,9 +454,9 @@
 								<tr>
 									<th>State</th>
 									<th>Work</th>
-									<th>Host</th>
+									<th>Worker</th>
 									<th>Progress</th>
-									<th>Scheduler</th>
+									<th>Work window</th>
 									<th>Recovery</th>
 								</tr>
 							</thead>
@@ -464,21 +470,21 @@
 											{#if canOpenFolder(row)}
 												<a class="work-link" href={resolve(folderRoutePath(row.prefix))}>
 													<strong>{row.prefix}</strong>
-													<span>{row.kind} · {row.phase}</span>
+													<span>{queueKindLabel(row)} · {row.phase}</span>
 												</a>
 											{:else}
 												<div class="work-link">
 													<strong>{row.prefix}</strong>
-													<span>{row.kind} · {row.phase}</span>
+													<span>{queueKindLabel(row)} · {row.phase}</span>
 												</div>
 											{/if}
 										</td>
-										<td data-label="Host">{row.host}</td>
+										<td data-label="Worker">{row.host}</td>
 										<td data-label="Progress">
 											<strong>{row.progress}</strong>
 											<span>{row.detail}</span>
 										</td>
-										<td data-label="Scheduler">{row.scheduler}</td>
+										<td data-label="Work window">{row.scheduler}</td>
 										<td data-label="Recovery">
 											{#if row.action}
 												{@const action = row.action}
@@ -503,8 +509,8 @@
 					<div class="current-standby">
 						<StateBadge tone="ready" label="No current work" />
 						<div>
-							<strong>Encoding is idle and ready.</strong>
-							<span>Queued folders, active samples, and retry-ready encodes will appear here.</span>
+							<strong>Processing is idle and ready.</strong>
+							<span>Queued folders, active samples, and retry-ready folders will appear here.</span>
 						</div>
 					</div>
 				{/if}
@@ -513,13 +519,13 @@
 			{#if historyRows.length > 0}
 				<WorkstationPanel
 					eyebrow="History"
-					title="Recent sample and proof history"
+					title="Recent sample and review history"
 					meta={`${historyRows.length.toLocaleString('en-US')} visible`}
 				>
 					<details class="history-disclosure">
 						<summary>
 							<StateBadge compact tone="idle" label="History" />
-							<span>Past sample/proof issues are not blocking current encoding.</span>
+							<span>Past sample/review issues are not blocking current processing.</span>
 						</summary>
 						<div class="table-wrap table-wrap--history">
 							<table class="ops-table ops-table--history">
@@ -527,7 +533,7 @@
 									<tr>
 										<th>State</th>
 										<th>Work</th>
-										<th>Host</th>
+										<th>Worker</th>
 										<th>Last note</th>
 										<th>When</th>
 									</tr>
@@ -542,16 +548,16 @@
 												{#if canOpenFolder(row)}
 													<a class="work-link" href={resolve(folderRoutePath(row.prefix))}>
 														<strong>{row.prefix}</strong>
-														<span>{row.kind} · {row.phase}</span>
+														<span>{queueKindLabel(row)} · {row.phase}</span>
 													</a>
 												{:else}
 													<div class="work-link">
 														<strong>{row.prefix}</strong>
-														<span>{row.kind} · {row.phase}</span>
+														<span>{queueKindLabel(row)} · {row.phase}</span>
 													</div>
 												{/if}
 											</td>
-											<td data-label="Host">{row.host}</td>
+											<td data-label="Worker">{row.host}</td>
 											<td data-label="Last note">
 												<strong>{row.progress}</strong>
 												<span>{row.detail}</span>
@@ -575,7 +581,7 @@
 			>
 				<div class="host-list">
 					{#each hosts?.hosts ?? [] as host (host.key)}
-						<div class="host-row">
+						<div class="host-row host-row--{hostTone(host, fleetHasReadyCapacity)}">
 							<div class="host-row__head">
 								<StateBadge
 									compact
@@ -588,9 +594,9 @@
 								<dt>Window</dt>
 								<dd>{host.schedule_detail || host.schedule_profile_label}</dd>
 								<dt>Work</dt>
-								<dd>{host.active_encode_count.toLocaleString('en-US')} encodes</dd>
+								<dd>{host.active_encode_count.toLocaleString('en-US')} processing</dd>
 								<dt>Can run</dt>
-								<dd>{host.capabilities.join(' · ') || 'none'}</dd>
+								<dd>{workerCapabilitiesSummary(host.capabilities)}</dd>
 							</dl>
 							{#if host.setup_requires_password && host.setup_supported}
 								<label class="host-password">
@@ -641,20 +647,20 @@
 				</div>
 			</WorkstationPanel>
 
-			<WorkstationPanel eyebrow="Schedule" title="Encode windows">
+			<WorkstationPanel eyebrow="Work schedule" title="Work windows">
 				<div class="schedule-list">
 					<div class="scope-row scope-row--active">
-						<span>Policy</span>
+						<span>Work window</span>
 						<strong>{encodeQueue?.state.scheduler_summary ?? 'unknown'}</strong>
 						<small
-							>{queuedWaitingCount.toLocaleString('en-US')} encode jobs waiting on schedule</small
+							>{queuedWaitingCount.toLocaleString('en-US')} folders waiting for a work window</small
 						>
-						<a class="inline-link" href={resolve('/settings')}>Edit schedule</a>
+						<a class="inline-link" href={resolve('/settings')}>Edit work windows</a>
 					</div>
 					{#each closedHosts as host (host.key)}
 						<div class="scope-row scope-row--wait">
 							<span>{host.label}</span>
-							<strong>Scheduled off</strong>
+							<strong>Off schedule</strong>
 							<small>{host.schedule_detail}</small>
 						</div>
 					{:else}
@@ -762,11 +768,17 @@
 		text-transform: uppercase;
 	}
 
-	.ops-header__status strong,
-	.host-row dd {
+	.ops-header__status strong {
 		font-family: var(--mf-font-mono), monospace;
 		font-size: var(--mf-text-lg);
 		font-weight: var(--mf-weight-medium);
+	}
+
+	.host-row dd {
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-medium);
+		line-height: var(--mf-leading-snug);
 	}
 
 	.scheduler-console,
@@ -1113,9 +1125,35 @@
 	.host-row {
 		background: var(--mf-bg-panel-2);
 		border: var(--mf-border-muted);
+		border-left: 2px solid var(--mf-line-strong);
 		display: grid;
 		gap: var(--mf-space-4);
 		padding: var(--mf-space-4);
+	}
+
+	.host-row--active {
+		background: var(--mf-active-bg);
+		border-left-color: var(--mf-active-fg);
+	}
+
+	.host-row--ready {
+		background: var(--mf-ready-bg);
+		border-left-color: var(--mf-ready-fg);
+	}
+
+	.host-row--fail {
+		background: var(--mf-fail-bg);
+		border-left-color: var(--mf-fail-fg);
+	}
+
+	.host-row--wait {
+		background: var(--mf-bg-strip);
+		border-left-color: var(--mf-wait-fg);
+	}
+
+	.host-row--idle {
+		background: var(--mf-bg-strip);
+		opacity: 0.86;
 	}
 
 	.host-row__head {

--- a/frontend/src/lib/components/workstation/completed-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/completed-workstation.test.ts
@@ -67,9 +67,9 @@ describe('Completed workstation mapping', () => {
 
 		expect(tiles).toMatchObject([
 			{ label: 'Completed folders', tone: 'ready' },
-			{ label: 'Originals waiting', tone: 'wait' },
-			{ label: 'Reclaimable', tone: 'ready' },
-			{ label: 'Waiting / review', value: '1 / 1', tone: 'fail' },
+			{ label: 'Delete queue', tone: 'wait' },
+			{ label: 'Space ready', tone: 'ready' },
+			{ label: 'Review needed', value: '1 / 1', tone: 'fail' },
 			{ label: 'Cleanup folder', tone: 'ready' }
 		]);
 	});

--- a/frontend/src/lib/components/workstation/completed-workstation.ts
+++ b/frontend/src/lib/components/workstation/completed-workstation.ts
@@ -145,9 +145,15 @@ export function buildCompletedReadinessSummary(
 	if (reviewCount > 0) {
 		return {
 			tone: counts.blocked > 0 ? 'fail' : 'wait',
-			title: 'Cleanup review is needed',
-			detail: `${reviewCount.toLocaleString('en-US')} completed ${reviewCount === 1 ? 'folder needs' : 'folders need'} review before leaving cleanup.`,
-			metricLabel: 'Review',
+			title:
+				counts.blocked > 0
+					? 'Check before deleting'
+					: 'Already removed originals need confirmation',
+			detail:
+				counts.blocked > 0
+					? `${counts.blocked.toLocaleString('en-US')} completed ${counts.blocked === 1 ? 'folder needs' : 'folders need'} settings checked before deleting originals.`
+					: `${counts.unknown.toLocaleString('en-US')} completed ${counts.unknown === 1 ? 'folder has' : 'folders have'} originals already gone; confirm after checking the new files.`,
+			metricLabel: counts.blocked > 0 ? 'Check' : 'Confirm',
 			metricValue: String(reviewCount)
 		};
 	}
@@ -185,22 +191,22 @@ export function buildCompletedStatusTiles(
 			tone: payload.completed_count > 0 ? 'ready' : 'idle'
 		},
 		{
-			label: 'Originals waiting',
+			label: 'Delete queue',
 			value: payload.folders_with_backups_count.toLocaleString('en-US'),
 			detail: `${archive.file_count.toLocaleString('en-US')} files ready to remove`,
 			tone: payload.folders_with_backups_count > 0 ? 'wait' : 'idle'
 		},
 		{
-			label: 'Reclaimable',
+			label: 'Space ready',
 			value: formatBytes(archive.total_size_bytes),
 			detail: archive.has_cleanup ? 'cleanup available' : 'no cleanup files',
 			tone: archive.has_cleanup ? 'ready' : 'idle',
 			mono: true
 		},
 		{
-			label: 'Waiting / review',
+			label: 'Review needed',
 			value: `${counts.ready} / ${counts.blocked + counts.unknown}`,
-			detail: 'folders with originals waiting versus folders needing review',
+			detail: 'ready to delete versus needing review',
 			tone:
 				counts.blocked > 0
 					? 'fail'

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -211,7 +211,7 @@ describe('Folder Studio review request mapping', () => {
 			['Sample', true],
 			['Review', false],
 			['Approve', false],
-			['Encode', false]
+			['Process', false]
 		]);
 	});
 });

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -416,11 +416,11 @@ export function resolveWorkflow(
 		return {
 			tone: 'wait',
 			label: 'Retry available',
-			title: 'Encode needs recovery',
+			title: 'Processing needs recovery',
 			copy:
 				encodeJob?.error ??
 				encodeJob?.attempt_summary ??
-				'The approved encode needs review before it runs again. Retry from Ops when the folder is still safe to process.',
+				'The approved folder needs review before it runs again. Retry from Ops when the folder is still safe to process.',
 			primary: 'Open Ops',
 			primaryAction: 'open-ops',
 			secondary: 'Retry',
@@ -431,11 +431,11 @@ export function resolveWorkflow(
 		return {
 			tone: 'active',
 			label: 'Processing',
-			title: 'Approved encode is in the queue',
+			title: 'Approved folder is processing',
 			copy:
 				encodeJob?.telemetry_summary ??
 				folder.encode_queue_summary ??
-				'Folder policy is approved. Monitor progress here or open Ops for deeper fleet state.',
+				'Folder settings are approved. Monitor progress here or open Ops for deeper worker state.',
 			primary: 'Download review pack',
 			primaryAction: 'download-review-pack',
 			secondary: 'Open Ops',
@@ -534,7 +534,7 @@ export function resolveWorkflow(
 			tone: 'idle',
 			label: 'Not sampled',
 			title: 'No representative sample yet',
-			copy: 'Ask the review assistant for a sample draft before approving folder-wide settings. Worker readiness and policy context stay visible while the sample is queued.',
+			copy: 'Ask the review assistant for a sample proposal before approving folder-wide settings. Worker readiness and settings context stay visible while the sample is queued.',
 			primary: 'Ask for draft',
 			primaryAction: 'focus-bench',
 			secondary: 'Open Ops',
@@ -581,12 +581,12 @@ export function buildWorkflowSteps(workflow: WorkflowState): WorkflowStep[] {
 		},
 		{
 			label: 'Approve',
-			detail: approveCurrent ? workflow.title : 'Accept or revise policy',
+			detail: approveCurrent ? workflow.title : 'Accept or revise settings',
 			tone: approveCurrent ? workflow.tone : 'idle',
 			current: approveCurrent
 		},
 		{
-			label: 'Encode',
+			label: 'Process',
 			detail: encodeCurrent ? workflow.title : 'Run approved folder work',
 			tone: encodeCurrent ? workflow.tone : 'idle',
 			current: encodeCurrent
@@ -645,7 +645,7 @@ export function buildStatusTiles(
 				status.calibration_status === 'failed' ? 'fail' : status.polling_active ? 'active' : 'idle'
 		},
 		{
-			label: 'Encode queue',
+			label: 'Processing',
 			value: encodeQueue
 				? `${encodeQueue.running_count} running · ${encodeQueue.queued_count} queued`
 				: '—',

--- a/frontend/src/lib/components/workstation/ops-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.test.ts
@@ -12,7 +12,8 @@ import {
 	hostTone,
 	rowRecoveryLabel,
 	rowRecoveryTitle,
-	retryableEncodeJobIds
+	retryableEncodeJobIds,
+	workerCapabilitiesSummary
 } from './ops-workstation';
 
 function dashboardFixture(): DashboardSummaryPayload {
@@ -206,12 +207,12 @@ describe('Ops workstation mapping', () => {
 		expect(blockers[2]).toMatchObject({ tone: 'wait' });
 	});
 
-	it('keeps scheduler, attention, sample, and worker tones semantic', () => {
+	it('keeps work schedule, attention, sample, and worker tones semantic', () => {
 		const tiles = buildOpsStatusTiles(dashboardFixture(), hostsFixture(), null);
 
 		expect(tiles).toMatchObject([
-			{ label: 'Scheduler', tone: 'ready' },
-			{ label: 'Encode jobs', tone: 'wait' },
+			{ label: 'Work schedule', tone: 'ready' },
+			{ label: 'Processing', tone: 'wait' },
 			{ label: 'Sample checks', tone: 'active' },
 			{ label: 'Workers', tone: 'ready' }
 		]);
@@ -248,12 +249,19 @@ describe('Ops workstation mapping', () => {
 		const unavailable = { ...ready, available: false, active_encode_count: 0 };
 
 		expect(hostTone(ready)).toBe('active');
-		expect(hostStateCopy(ready)).toBe('Encoding');
+		expect(hostStateCopy(ready)).toBe('Processing');
 		expect(hostTone(scheduledOff)).toBe('idle');
-		expect(hostStateCopy(scheduledOff)).toBe('Scheduled off');
+		expect(hostStateCopy(scheduledOff)).toBe('Off schedule');
 		expect(hostTone(unavailable)).toBe('fail');
 		expect(hostTone(unavailable, true)).toBe('wait');
 		expect(hostStateCopy(unavailable)).toBe('Unavailable');
+	});
+
+	it('maps worker capabilities to user-facing labels', () => {
+		expect(workerCapabilitiesSummary(['encode_queue', 'sample_calibration', 'proof_encode'])).toBe(
+			'Process folders · Run samples · Run review evidence'
+		);
+		expect(workerCapabilitiesSummary([])).toBe('No work assigned');
 	});
 
 	it('keeps password-gated host prepare disabled until a password is present', () => {

--- a/frontend/src/lib/components/workstation/ops-workstation.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.ts
@@ -128,6 +128,19 @@ function statusCopy(status: string): string {
 	return normalized.replaceAll('_', ' ');
 }
 
+export function workerCapabilityLabel(capability: string): string {
+	const normalized = capability.trim().toLowerCase();
+	if (normalized === 'encode_queue') return 'Process folders';
+	if (normalized === 'sample_calibration') return 'Run samples';
+	if (normalized === 'proof_encode') return 'Run review evidence';
+	return capability.trim().replaceAll('_', ' ') || 'Mediaforce work';
+}
+
+export function workerCapabilitiesSummary(capabilities: string[]): string {
+	const labels = capabilities.map(workerCapabilityLabel).filter(Boolean);
+	return labels.length ? labels.join(' · ') : 'No work assigned';
+}
+
 export function encodeJobTone(job: EncodeQueueJob): ShellTone {
 	const status = String(job.status ?? '').toLowerCase();
 	if (['failed', 'needs_attention', 'stopped', 'retry_backoff'].includes(status)) return 'wait';
@@ -208,9 +221,12 @@ export function buildEncodeRows(
 			status: statusCopy(job.status || 'unknown'),
 			prefix: job.prefix || 'system scope',
 			host: job.active_hosts?.map(hostCopy).filter(Boolean).join(', ') || hostCopy(job.host),
-			phase: job.running_shard_count ? `${job.running_shard_count} active shards` : 'encode queue',
+			phase: job.running_shard_count
+				? `${job.running_shard_count} active parts`
+				: 'processing queue',
 			progress: encodeJobProgress(job),
-			scheduler: job.scheduler_status_copy || (job.schedule_waiting ? 'schedule waiting' : 'ready'),
+			scheduler:
+				job.scheduler_status_copy || (job.schedule_waiting ? 'waiting for window' : 'ready'),
 			detail: encodeJobDetail(job),
 			action: canRetryPrefix ? 'retry-encode-prefix' : undefined,
 			actionScope: canRetryPrefix ? 'row' : undefined
@@ -234,10 +250,10 @@ function buildCalibrationLaneRows(
 		phase: options.historical
 			? laneName === 'sample'
 				? 'sample check history'
-				: 'proof encode history'
+				: 'review evidence history'
 			: laneName === 'sample'
 				? 'sample check'
-				: 'proof encode',
+				: 'review evidence',
 		progress: compactText(job.progress) || compactText(job.stage) || '—',
 		scheduler:
 			compactText(job.scheduler_status_copy) || compactText(job.created_at) || 'queued order',
@@ -256,7 +272,7 @@ export function rowRecoveryLabel(row: OpsQueueRow): string {
 export function rowRecoveryTitle(row: OpsQueueRow): string {
 	if (!row.action) return 'No action is available for this row.';
 	if (row.action === 'retry-encode-prefix') {
-		return 'Retry the encode for this folder only.';
+		return 'Retry processing for this folder only.';
 	}
 	if (row.action === 'retry-failed-encode') {
 		return 'Retry every approved folder that has retry available.';
@@ -344,7 +360,7 @@ export function buildOpsBlockers(
 		blockers.push({
 			key: 'stop-requested',
 			tone: 'fail',
-			title: 'Encoding is stopping',
+			title: 'Processing is stopping',
 			detail: 'Workers are finishing current items before the queue can start more work.',
 			action: 'resume-encode'
 		});
@@ -353,8 +369,8 @@ export function buildOpsBlockers(
 		blockers.push({
 			key: 'paused',
 			tone: 'wait',
-			title: 'Encoding is paused',
-			detail: queue.state.scheduler_summary ?? 'No new encode jobs will start until resumed.',
+			title: 'Processing is paused',
+			detail: queue.state.scheduler_summary ?? 'No new processing will start until resumed.',
 			action: 'resume-encode'
 		});
 	}
@@ -362,7 +378,7 @@ export function buildOpsBlockers(
 		blockers.push({
 			key: 'needs-attention',
 			tone: 'wait',
-			title: `${attentionCount} encode ${attentionCount === 1 ? 'job has' : 'jobs have'} retry available`,
+			title: `${attentionCount} ${attentionCount === 1 ? 'folder has' : 'folders have'} retry available`,
 			detail: 'Review the row, then retry approved folders from this page.',
 			action: 'retry-failed-encode'
 		});
@@ -371,7 +387,7 @@ export function buildOpsBlockers(
 		blockers.push({
 			key: 'no-hosts-ready',
 			tone: 'fail',
-			title: 'No workers can encode right now',
+			title: 'No workers can process right now',
 			detail:
 				'Queued work exists, but every configured worker is unavailable or outside its work window.'
 		});
@@ -379,9 +395,8 @@ export function buildOpsBlockers(
 		blockers.push({
 			key: 'schedule-waiting',
 			tone: 'wait',
-			title: `${scheduleWaiting} queued ${scheduleWaiting === 1 ? 'folder is' : 'folders are'} waiting for schedule`,
-			detail:
-				queue?.state.scheduler_summary ?? 'Work will start when an allowed encode window opens.'
+			title: `${scheduleWaiting} queued ${scheduleWaiting === 1 ? 'folder is' : 'folders are'} waiting for a work window`,
+			detail: queue?.state.scheduler_summary ?? 'Work will start when an allowed window opens.'
 		});
 	}
 	return blockers;
@@ -415,7 +430,7 @@ export function buildOpsReadinessSummary(
 	if (queue?.state.stop_requested) {
 		return {
 			tone: 'fail',
-			title: 'Encoding is stopping',
+			title: 'Processing is stopping',
 			detail: 'Workers are finishing current items before Mediaforce can start more work.',
 			metricLabel: 'Active work',
 			metricValue: String(runningCount)
@@ -424,8 +439,8 @@ export function buildOpsReadinessSummary(
 	if (queue?.state.is_paused) {
 		return {
 			tone: 'wait',
-			title: 'Encoding is paused',
-			detail: queue.state.scheduler_summary ?? 'Resume the queue when encoding should continue.',
+			title: 'Processing is paused',
+			detail: queue.state.scheduler_summary ?? 'Resume the queue when processing should continue.',
 			metricLabel: 'Queued',
 			metricValue: String(queuedCount)
 		};
@@ -434,7 +449,7 @@ export function buildOpsReadinessSummary(
 		return {
 			tone: 'wait',
 			title: 'Retry is available',
-			detail: `${needsAttention} approved encode ${needsAttention === 1 ? 'job needs' : 'jobs need'} operator review before retry.`,
+			detail: `${needsAttention} approved ${needsAttention === 1 ? 'folder needs' : 'folders need'} operator review before retry.`,
 			metricLabel: 'Retry',
 			metricValue: String(needsAttention)
 		};
@@ -455,7 +470,7 @@ export function buildOpsReadinessSummary(
 			title: 'Mediaforce is working',
 			detail:
 				queue?.telemetry?.eta_copy ??
-				`${runningCount} encode ${runningCount === 1 ? 'job' : 'jobs'} and ${activeChecks} sample/proof ${activeChecks === 1 ? 'job' : 'jobs'} active.`,
+				`${runningCount} processing ${runningCount === 1 ? 'job' : 'jobs'} and ${activeChecks} sample/review ${activeChecks === 1 ? 'job' : 'jobs'} active.`,
 			metricLabel: 'Running',
 			metricValue: String(runningCount + activeChecks)
 		};
@@ -463,7 +478,7 @@ export function buildOpsReadinessSummary(
 	if (queuedWaiting > 0) {
 		return {
 			tone: 'wait',
-			title: 'Waiting for the encode window',
+			title: 'Waiting for the work window',
 			detail:
 				queue?.state.scheduler_summary ?? 'Queued work will start when an allowed window opens.',
 			metricLabel: 'Waiting',
@@ -474,7 +489,7 @@ export function buildOpsReadinessSummary(
 		return {
 			tone: 'ready',
 			title: 'Ready for work',
-			detail: 'Workers are available and Mediaforce can start eligible encode work.',
+			detail: 'Workers are available and Mediaforce can start eligible processing work.',
 			metricLabel: 'Workers ready',
 			metricValue: String(readyHosts)
 		};
@@ -499,7 +514,7 @@ export function buildOpsStatusTiles(
 	const totalHosts = hosts?.hosts.length ?? 0;
 	return [
 		{
-			label: 'Scheduler',
+			label: 'Work schedule',
 			value: encode?.state.is_paused
 				? 'paused'
 				: encode?.state.stop_requested
@@ -516,7 +531,7 @@ export function buildOpsStatusTiles(
 						: 'ready'
 		},
 		{
-			label: 'Encode jobs',
+			label: 'Processing',
 			value: `${encode?.running_count ?? 0} running · ${encode?.queued_count ?? 0} queued`,
 			detail:
 				encode?.telemetry?.eta_copy ?? `${encode?.needs_attention_count ?? 0} retry available`,
@@ -556,7 +571,7 @@ export function buildOpsFooterSignals(
 	const calibration = dashboard?.calibration_queue;
 	return [
 		{
-			label: 'Encode',
+			label: 'Processing',
 			value: `${encode?.running_count ?? 0}/${encode?.queued_count ?? 0}`,
 			tone:
 				(encode?.running_count ?? 0) > 0
@@ -591,8 +606,8 @@ export function hostTone(host: HostRuntime, fleetHasReadyCapacity = false): Shel
 
 export function hostStateCopy(host: HostRuntime): string {
 	if (!host.available) return 'Unavailable';
-	if (host.schedule_open === false) return 'Scheduled off';
+	if (host.schedule_open === false) return 'Off schedule';
 	if (host.queue_active === false) return 'Not accepting';
-	if (host.active_encode_count > 0) return 'Encoding';
+	if (host.active_encode_count > 0) return 'Processing';
 	return 'Ready';
 }

--- a/frontend/src/lib/components/workstation/queue-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/queue-workstation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { FolderCard } from '$lib/api/types';
+import { queueFolderState, queueStateLabel } from './queue-workstation';
+
+function folder(overrides: Partial<FolderCard>): FolderCard {
+	return {
+		prefix: 'tv/show',
+		title: 'Show',
+		subtitle: 'TV',
+		scope_label: 'tv',
+		item_count: 4,
+		pending_count: 0,
+		total_size_bytes: 1024,
+		estimated_savings_bytes: 0,
+		known_saved_bytes: 0,
+		projected_reclaim_bytes: 512,
+		average_age_days: 12,
+		sort_score: 1,
+		statuses: {},
+		video_codecs: {},
+		details_loading: false,
+		...overrides
+	};
+}
+
+describe('Queue workstation labels', () => {
+	it('normalizes workflow state labels into basic-user actions', () => {
+		expect(queueStateLabel('Ready to start')).toBe('Needs sample');
+		expect(queueStateLabel('Sample queued')).toBe('Sample waiting');
+		expect(queueStateLabel('Review media')).toBe('Ready to review');
+		expect(queueStateLabel('Encode failed')).toBe('Processing needs attention');
+	});
+
+	it('uses action-ready fallback labels when backend state is absent', () => {
+		expect(queueFolderState(folder({ pending_count: 3 }))).toBe('Needs sample');
+		expect(queueFolderState(folder({ known_saved_bytes: 2048 }))).toBe('Completed');
+		expect(queueFolderState(folder({}))).toBe('Cataloged');
+	});
+});

--- a/frontend/src/lib/components/workstation/queue-workstation.ts
+++ b/frontend/src/lib/components/workstation/queue-workstation.ts
@@ -19,10 +19,28 @@ export function queueFolderTone(folder: FolderCard): ShellTone {
 }
 
 export function queueFolderState(folder: FolderCard): string {
-	if (folder.review_badge_label) return folder.review_badge_label;
-	if (folder.pending_count > 0) return 'Ready to start';
+	const label = folder.review_badge_label?.trim();
+	if (label) return queueStateLabel(label);
+	if (folder.pending_count > 0) return 'Needs sample';
 	if (folder.known_saved_bytes > 0) return 'Completed';
 	return 'Cataloged';
+}
+
+export function queueStateLabel(label: string): string {
+	const normalized = label.trim().toLowerCase();
+	if (normalized === 'ready to start') return 'Needs sample';
+	if (normalized === 'no sample' || normalized === 'missing sample') return 'Needs sample';
+	if (normalized === 'sample queued') return 'Sample waiting';
+	if (normalized === 'sample running') return 'Sampling';
+	if (normalized === 'sample failed retry') return 'Sample needs retry';
+	if (normalized === 'review media') return 'Ready to review';
+	if (normalized === 'proposal warning') return 'Review warning';
+	if (normalized === 'proposal accepted') return 'Approved';
+	if (normalized === 'encode queued' || normalized === 'encode running') return 'Processing';
+	if (normalized === 'encode failed' || normalized === 'encode stopped') {
+		return 'Processing needs attention';
+	}
+	return label.trim();
 }
 
 export function codecSummary(codecs: Record<string, number>): string {
@@ -64,7 +82,7 @@ export function buildQueueStatusTiles(
 		{
 			label: 'Projected reclaim',
 			value: formatBytes(totalProjectedReclaim(folders)),
-			detail: 'ranked by current scoring',
+			detail: 'estimated from visible folders',
 			tone: totalProjectedReclaim(folders) > 0 ? 'ready' : 'idle',
 			mono: true
 		},
@@ -86,7 +104,7 @@ export function buildQueueStatusTiles(
 					: 'idle'
 		},
 		{
-			label: 'Encode queue',
+			label: 'Processing',
 			value: `${encodeQueue.running_count} running · ${encodeQueue.queued_count} queued`,
 			detail:
 				encodeQueue.telemetry?.eta_copy ??

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -708,7 +708,7 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
             {
                 "label": "Ops unavailable host fixture",
                 "route": "/ops",
-                "marker": "No workers can encode right now",
+                "marker": "No workers can process right now",
             },
             {
                 "label": "Folder Studio review-ready fixture",
@@ -716,14 +716,14 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 "marker": "Review the sample pack",
             },
             {
-                "label": "Folder Studio active encode fixture",
+                "label": "Folder Studio active processing fixture",
                 "route": "/folders/tv/Encoding%20Show/Season%201",
-                "marker": "Approved encode is in the queue",
+                "marker": "Approved folder is processing",
             },
             {
-                "label": "Folder Studio retryable encode fixture",
+                "label": "Folder Studio retryable processing fixture",
                 "route": "/folders/tv/Failed%20Encode/Season%201",
-                "marker": "Encode needs recovery",
+                "marker": "Processing needs recovery",
             },
         ],
         "completedPrefix": COMPLETED_PREFIX,

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -1,419 +1,494 @@
 #!/usr/bin/env node
 
-import { execFile as execFileCallback, spawn } from 'node:child_process';
-import { createRequire } from 'node:module';
-import net from 'node:net';
-import { mkdir, stat } from 'node:fs/promises';
-import path from 'node:path';
-import process from 'node:process';
-import { promisify } from 'node:util';
-import { fileURLToPath } from 'node:url';
+import { execFile as execFileCallback, spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import net from "node:net";
+import { mkdir, stat } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
 
-const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const require = createRequire(path.join(rootDir, 'frontend', 'package.json'));
-const { chromium } = require('@playwright/test');
-const execFile = promisify(execFileCallback);
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const require = createRequire(path.join(rootDir, "frontend", "package.json"));
+const { chromium } = require("@playwright/test");
 
 const DEFAULT_ENDPOINT_TIMEOUT_MS = 2000;
 const DEFAULT_ROUTE_TIMEOUT_MS = 3500;
 const SERVER_START_TIMEOUT_MS = 12000;
 const NARROW_VIEWPORT = { width: 390, height: 844 };
 
+/**
+ * @typedef {object} SmokeFixtureRoute
+ * @property {string} label
+ * @property {string} route
+ * @property {string} marker
+ */
+
+/**
+ * @typedef {object} SmokeFixtureResult
+ * @property {string=} profile
+ * @property {number} libraryItems
+ * @property {number=} encodeJobs
+ * @property {SmokeFixtureRoute[]=} folderRoutes
+ */
+
 const endpointChecks = [
-	['Dashboard summary', '/api/dashboard'],
-	['Dashboard folders', '/api/dashboard/folders'],
-	['Host status', '/api/hosts?compact=1'],
-	['Settings initial payload', '/api/settings?include_archive_cleanup=0'],
-	['Completed payload', '/api/completed']
+  ["Dashboard summary", "/api/dashboard"],
+  ["Dashboard folders", "/api/dashboard/folders"],
+  ["Host status", "/api/hosts?compact=1"],
+  ["Settings initial payload", "/api/settings?include_archive_cleanup=0"],
+  ["Completed payload", "/api/completed"],
 ];
 
 const routeChecks = [
-	['Queue', '/', 'Queue'],
-	['Folders', '/folders', 'Folders'],
-	['Ops', '/ops', 'Ops'],
-	['Settings', '/settings', 'Settings'],
-	['Completed', '/completed', 'Completed']
+  ["Queue", "/", "Queue"],
+  ["Folders", "/folders", "Folders"],
+  ["Ops", "/ops", "Ops"],
+  ["Settings", "/settings", "Settings"],
+  ["Completed", "/completed", "Completed"],
 ];
 
 function parseArgs(argv) {
-	const parsed = {
-		baseUrl: '',
-		config: path.join(rootDir, 'config', 'web-smoke.toml'),
-		endpointTimeoutMs: DEFAULT_ENDPOINT_TIMEOUT_MS,
-		routeTimeoutMs: DEFAULT_ROUTE_TIMEOUT_MS,
-		seedFixtures: null,
-		narrow: true
-	};
-	for (let index = 0; index < argv.length; index += 1) {
-		const arg = argv[index];
-		if (arg === '--base-url') {
-			parsed.baseUrl = argv[++index] ?? '';
-		} else if (arg === '--config') {
-			parsed.config = path.resolve(argv[++index] ?? parsed.config);
-		} else if (arg === '--endpoint-timeout-ms') {
-			parsed.endpointTimeoutMs = Number(argv[++index] ?? parsed.endpointTimeoutMs);
-		} else if (arg === '--route-timeout-ms') {
-			parsed.routeTimeoutMs = Number(argv[++index] ?? parsed.routeTimeoutMs);
-		} else if (arg === '--seed-fixtures') {
-			parsed.seedFixtures = true;
-		} else if (arg === '--skip-fixture-seed') {
-			parsed.seedFixtures = false;
-		} else if (arg === '--skip-narrow') {
-			parsed.narrow = false;
-		} else {
-			throw new Error(`Unknown argument: ${arg}`);
-		}
-	}
-	return parsed;
+  const parsed = {
+    baseUrl: "",
+    config: path.join(rootDir, "config", "web-smoke.toml"),
+    endpointTimeoutMs: DEFAULT_ENDPOINT_TIMEOUT_MS,
+    routeTimeoutMs: DEFAULT_ROUTE_TIMEOUT_MS,
+    seedFixtures: null,
+    narrow: true,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--base-url") {
+      parsed.baseUrl = argv[++index] ?? "";
+    } else if (arg === "--config") {
+      parsed.config = path.resolve(argv[++index] ?? parsed.config);
+    } else if (arg === "--endpoint-timeout-ms") {
+      parsed.endpointTimeoutMs = Number(
+        argv[++index] ?? parsed.endpointTimeoutMs,
+      );
+    } else if (arg === "--route-timeout-ms") {
+      parsed.routeTimeoutMs = Number(argv[++index] ?? parsed.routeTimeoutMs);
+    } else if (arg === "--seed-fixtures") {
+      parsed.seedFixtures = true;
+    } else if (arg === "--skip-fixture-seed") {
+      parsed.seedFixtures = false;
+    } else if (arg === "--skip-narrow") {
+      parsed.narrow = false;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
 }
 
 function normalizeBaseUrl(value) {
-	return value.replace(/\/+$/, '');
+  return value.replace(/\/+$/, "");
 }
 
 async function pathExists(filePath) {
-	try {
-		await stat(filePath);
-		return true;
-	} catch {
-		return false;
-	}
+  try {
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function freePort() {
-	return new Promise((resolve, reject) => {
-		const server = net.createServer();
-		server.once('error', reject);
-		server.listen(0, '127.0.0.1', () => {
-			const address = server.address();
-			server.close(() => {
-				if (address && typeof address === 'object') {
-					resolve(address.port);
-				} else {
-					reject(new Error('Could not allocate a local port.'));
-				}
-			});
-		});
-	});
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close(() => {
+        if (address && typeof address === "object") {
+          resolve(address.port);
+        } else {
+          reject(new Error("Could not allocate a local port."));
+        }
+      });
+    });
+  });
 }
 
 async function prepareSmokeState() {
-	const paths = [
-		['scratch', 'web-smoke', 'source', 'movies'],
-		['scratch', 'web-smoke', 'source', 'tv'],
-		['scratch', 'web-smoke', 'transcode', '_replaced'],
-		['state', 'web-smoke', 'runs'],
-		['state', 'web-smoke', 'web'],
-		['state', 'web-smoke', 'review']
-	];
-	await Promise.all(paths.map((parts) => mkdir(path.join(rootDir, ...parts), { recursive: true })));
+  const paths = [
+    ["scratch", "web-smoke", "source", "movies"],
+    ["scratch", "web-smoke", "source", "tv"],
+    ["scratch", "web-smoke", "transcode", "_replaced"],
+    ["state", "web-smoke", "runs"],
+    ["state", "web-smoke", "web"],
+    ["state", "web-smoke", "review"],
+  ];
+  await Promise.all(
+    paths.map((parts) =>
+      mkdir(path.join(rootDir, ...parts), { recursive: true }),
+    ),
+  );
 }
 
-async function seedSmokeFixtures(configPath, profile = 'default') {
-	const { stdout, stderr } = await execFile(
-		'uv',
-		[
-			'run',
-			'python',
-			'scripts/seed-web-smoke-fixtures.py',
-			'--config',
-			configPath,
-			'--profile',
-			profile
-		],
-		{
-			cwd: rootDir,
-			timeout: 15000,
-			maxBuffer: 1024 * 1024
-		}
-	);
-	if (stderr.trim()) {
-		console.error(stderr.trim());
-	}
-	const result = JSON.parse(stdout.trim());
-	console.log(
-		`fixture ok: ${result.profile ?? profile} ${result.libraryItems} items seeded, ${result.encodeJobs ?? 0} encode jobs seeded`
-	);
-	return result;
+function execFile(command, args, options) {
+  return new Promise((resolve, reject) => {
+    execFileCallback(command, args, options, (error, stdout, stderr) => {
+      if (error) {
+        error.stdout = stdout;
+        error.stderr = stderr;
+        reject(error);
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+async function seedSmokeFixtures(configPath, profile = "default") {
+  const { stdout, stderr } = await execFile(
+    "uv",
+    [
+      "run",
+      "python",
+      "scripts/seed-web-smoke-fixtures.py",
+      "--config",
+      configPath,
+      "--profile",
+      profile,
+    ],
+    {
+      cwd: rootDir,
+      timeout: 15000,
+      maxBuffer: 1024 * 1024,
+    },
+  );
+  if (stderr.trim()) {
+    console.error(stderr.trim());
+  }
+  /** @type {SmokeFixtureResult} */
+  const result = JSON.parse(stdout.trim());
+  console.log(
+    `fixture ok: ${result.profile ?? profile} ${result.libraryItems} items seeded, ${result.encodeJobs ?? 0} encode jobs seeded`,
+  );
+  return result;
 }
 
 async function fetchWithTimeout(url, timeoutMs) {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), timeoutMs);
-	const started = performance.now();
-	let response;
-	try {
-		response = await fetch(url, { signal: controller.signal });
-	} catch (error) {
-		if (error instanceof Error && error.name === 'AbortError') {
-			throw new Error(`timed out after ${timeoutMs}ms`);
-		}
-		throw error;
-	} finally {
-		clearTimeout(timeout);
-	}
-	const elapsedMs = Math.round(performance.now() - started);
-	if (!response.ok) {
-		throw new Error(`${response.status} ${response.statusText}`);
-	}
-	await response.arrayBuffer();
-	return elapsedMs;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const started = performance.now();
+  let response;
+  try {
+    response = await fetch(url, { signal: controller.signal });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+  const elapsedMs = Math.round(performance.now() - started);
+  if (!response.ok) {
+    throw new Error(`${response.status} ${response.statusText}`);
+  }
+  await response.arrayBuffer();
+  return elapsedMs;
 }
 
 async function waitForServer(baseUrl, child) {
-	const deadline = Date.now() + SERVER_START_TIMEOUT_MS;
-	let lastError = null;
-	while (Date.now() < deadline) {
-		if (child.exitCode !== null) {
-			throw new Error(`mediaforce-web exited before serving routes with code ${child.exitCode}`);
-		}
-		try {
-			await fetchWithTimeout(`${baseUrl}/`, 1000);
-			return;
-		} catch (error) {
-			lastError = error;
-			await new Promise((resolve) => setTimeout(resolve, 200));
-		}
-	}
-	throw new Error(`mediaforce-web did not start within ${SERVER_START_TIMEOUT_MS}ms: ${lastError}`);
+  const deadline = Date.now() + SERVER_START_TIMEOUT_MS;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(
+        `mediaforce-web exited before serving routes with code ${child.exitCode}`,
+      );
+    }
+    try {
+      await fetchWithTimeout(`${baseUrl}/`, 1000);
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+  }
+  throw new Error(
+    `mediaforce-web did not start within ${SERVER_START_TIMEOUT_MS}ms: ${lastError}`,
+  );
 }
 
 async function startServer(configPath) {
-	const indexPath = path.join(rootDir, 'frontend', 'build', 'index.html');
-	if (!(await pathExists(indexPath))) {
-		throw new Error(
-			'frontend/build/index.html is missing. Run npm --prefix frontend run build first.'
-		);
-	}
-	await prepareSmokeState();
-	const port = await freePort();
-	const child = spawn(
-		'uv',
-		[
-			'run',
-			'mediaforce-web',
-			'--config',
-			configPath,
-			'--host',
-			'127.0.0.1',
-			'--port',
-			String(port),
-			'--no-reload'
-		],
-		{
-			cwd: rootDir,
-			env: {
-				...process.env,
-				MEDIAFORCE_WEB_RELOAD: '0'
-			},
-			stdio: ['ignore', 'pipe', 'pipe']
-		}
-	);
-	const logs = [];
-	for (const stream of [child.stdout, child.stderr]) {
-		stream.setEncoding('utf8');
-		stream.on('data', (chunk) => {
-			logs.push(chunk);
-			if (logs.join('').length > 8000) logs.splice(0, logs.length - 20);
-		});
-	}
-	const baseUrl = `http://127.0.0.1:${port}`;
-	await waitForServer(baseUrl, child);
-	return {
-		baseUrl,
-		stop: async () => {
-			if (child.exitCode !== null) return;
-			child.kill('SIGTERM');
-			let exited = false;
-			await new Promise((resolve) => {
-				const timeout = setTimeout(resolve, 3000);
-				child.once('exit', () => {
-					exited = true;
-					clearTimeout(timeout);
-					resolve();
-				});
-			});
-			if (!exited) child.kill('SIGKILL');
-		},
-		logs: () => logs.join('')
-	};
+  const indexPath = path.join(rootDir, "frontend", "build", "index.html");
+  if (!(await pathExists(indexPath))) {
+    throw new Error(
+      "frontend/build/index.html is missing. Run npm --prefix frontend run build first.",
+    );
+  }
+  await prepareSmokeState();
+  const port = await freePort();
+  const child = spawn(
+    "uv",
+    [
+      "run",
+      "mediaforce-web",
+      "--config",
+      configPath,
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--no-reload",
+    ],
+    {
+      cwd: rootDir,
+      env: {
+        ...process.env,
+        MEDIAFORCE_WEB_RELOAD: "0",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const logs = [];
+  for (const stream of [child.stdout, child.stderr]) {
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => {
+      logs.push(chunk);
+      if (logs.join("").length > 8000) logs.splice(0, logs.length - 20);
+    });
+  }
+  const baseUrl = `http://127.0.0.1:${port}`;
+  await waitForServer(baseUrl, child);
+  return {
+    baseUrl,
+    stop: async () => {
+      if (child.exitCode !== null) return;
+      child.kill("SIGTERM");
+      let exited = false;
+      await new Promise((resolve) => {
+        const timeout = setTimeout(resolve, 3000);
+        child.once("exit", () => {
+          exited = true;
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+      if (!exited) child.kill("SIGKILL");
+    },
+    logs: () => logs.join(""),
+  };
 }
 
 async function checkEndpoints(baseUrl, timeoutMs) {
-	for (const [label, route] of endpointChecks) {
-		const elapsedMs = await fetchWithTimeout(`${baseUrl}${route}`, timeoutMs);
-		console.log(`endpoint ok: ${label} ${elapsedMs}ms`);
-	}
+  for (const [label, route] of endpointChecks) {
+    const elapsedMs = await fetchWithTimeout(`${baseUrl}${route}`, timeoutMs);
+    console.log(`endpoint ok: ${label} ${elapsedMs}ms`);
+  }
 }
 
 async function checkRoutes(baseUrl, routeChecksForBrowser, timeoutMs) {
-	const browser = await chromium.launch();
-	try {
-		const page = await browser.newPage({
-			viewport: { width: 1440, height: 1000 }
-		});
-		const pageErrors = [];
-		page.on('pageerror', (error) => pageErrors.push(error.message));
-		for (const [label, route, marker] of routeChecksForBrowser) {
-			pageErrors.length = 0;
-			const started = performance.now();
-			await page.goto(`${baseUrl}${route}`, {
-				waitUntil: 'domcontentloaded',
-				timeout: timeoutMs
-			});
-			await page.waitForSelector('.operator-shell', {
-				state: 'visible',
-				timeout: timeoutMs
-			});
-			await page.waitForSelector('main', {
-				state: 'visible',
-				timeout: timeoutMs
-			});
-			const state = await page.evaluate((expectedMarker) => {
-				const bodyText = document.body.innerText.trim();
-				return {
-					bodyLength: bodyText.length,
-					hasMain: document.querySelector('main') !== null,
-					hasShell: document.querySelector('.operator-shell') !== null,
-					hasMarker: bodyText.includes(expectedMarker)
-				};
-			}, marker);
-			if (!state.hasShell || !state.hasMain || !state.hasMarker || state.bodyLength < 80) {
-				throw new Error(`${label} rendered an incomplete app shell: ${JSON.stringify(state)}`);
-			}
-			if (pageErrors.length > 0) {
-				throw new Error(`${label} raised browser errors: ${pageErrors.join(' | ')}`);
-			}
-			const elapsedMs = Math.round(performance.now() - started);
-			console.log(`route ok: ${label} ${elapsedMs}ms`);
-		}
-	} finally {
-		await browser.close();
-	}
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage({
+      viewport: { width: 1440, height: 1000 },
+    });
+    const pageErrors = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+    for (const [label, route, marker] of routeChecksForBrowser) {
+      pageErrors.length = 0;
+      const started = performance.now();
+      await page.goto(`${baseUrl}${route}`, {
+        waitUntil: "domcontentloaded",
+        timeout: timeoutMs,
+      });
+      await page.waitForSelector(".operator-shell", {
+        state: "visible",
+        timeout: timeoutMs,
+      });
+      await page.waitForSelector("main", {
+        state: "visible",
+        timeout: timeoutMs,
+      });
+      const state = await page.evaluate((expectedMarker) => {
+        const bodyText = document.body.innerText.trim();
+        return {
+          bodyLength: bodyText.length,
+          hasMain: document.querySelector("main") !== null,
+          hasShell: document.querySelector(".operator-shell") !== null,
+          hasMarker: bodyText.includes(expectedMarker),
+        };
+      }, marker);
+      if (
+        !state.hasShell ||
+        !state.hasMain ||
+        !state.hasMarker ||
+        state.bodyLength < 80
+      ) {
+        throw new Error(
+          `${label} rendered an incomplete app shell: ${JSON.stringify(state)}`,
+        );
+      }
+      if (pageErrors.length > 0) {
+        throw new Error(
+          `${label} raised browser errors: ${pageErrors.join(" | ")}`,
+        );
+      }
+      const elapsedMs = Math.round(performance.now() - started);
+      console.log(`route ok: ${label} ${elapsedMs}ms`);
+    }
+  } finally {
+    await browser.close();
+  }
 }
 
 async function checkNarrowRoutes(baseUrl, routeChecksForNarrow, timeoutMs) {
-	const browser = await chromium.launch();
-	try {
-		const page = await browser.newPage({
-			viewport: NARROW_VIEWPORT,
-			deviceScaleFactor: 2,
-			isMobile: true
-		});
-		const pageErrors = [];
-		page.on('pageerror', (error) => pageErrors.push(error.message));
-		for (const [label, route, marker] of routeChecksForNarrow) {
-			pageErrors.length = 0;
-			const started = performance.now();
-			await page.goto(`${baseUrl}${route}`, {
-				waitUntil: 'domcontentloaded',
-				timeout: timeoutMs
-			});
-			await page.waitForSelector('.operator-shell', {
-				state: 'visible',
-				timeout: timeoutMs
-			});
-			await page.waitForSelector('main', {
-				state: 'visible',
-				timeout: timeoutMs
-			});
-			const state = await page.evaluate((expectedMarker) => {
-				const bodyText = document.body.innerText.trim();
-				const visibleWideTables = [...document.querySelectorAll('table')]
-					.map((el) => {
-						const rect = el.getBoundingClientRect();
-						return {
-							text: el.textContent?.trim().replace(/\s+/g, ' ').slice(0, 80) ?? '',
-							width: Math.round(rect.width),
-							height: Math.round(rect.height),
-							display: getComputedStyle(el).display
-						};
-					})
-					.filter((item) => item.width > window.innerWidth + 2 && item.height > 0);
-				return {
-					bodyLength: bodyText.length,
-					hasMarker: bodyText.includes(expectedMarker),
-					pageOverflow: document.documentElement.scrollWidth > window.innerWidth + 2,
-					scrollWidth: document.documentElement.scrollWidth,
-					visibleWideTables
-				};
-			}, marker);
-			if (
-				state.bodyLength < 80 ||
-				!state.hasMarker ||
-				state.pageOverflow ||
-				state.visibleWideTables.length
-			) {
-				throw new Error(`${label} narrow layout failed: ${JSON.stringify(state)}`);
-			}
-			if (pageErrors.length > 0) {
-				throw new Error(
-					`${label} raised browser errors in narrow layout: ${pageErrors.join(' | ')}`
-				);
-			}
-			const elapsedMs = Math.round(performance.now() - started);
-			console.log(`narrow route ok: ${label} ${elapsedMs}ms`);
-		}
-	} finally {
-		await browser.close();
-	}
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage({
+      viewport: NARROW_VIEWPORT,
+      deviceScaleFactor: 2,
+      isMobile: true,
+    });
+    const pageErrors = [];
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+    for (const [label, route, marker] of routeChecksForNarrow) {
+      pageErrors.length = 0;
+      const started = performance.now();
+      await page.goto(`${baseUrl}${route}`, {
+        waitUntil: "domcontentloaded",
+        timeout: timeoutMs,
+      });
+      await page.waitForSelector(".operator-shell", {
+        state: "visible",
+        timeout: timeoutMs,
+      });
+      await page.waitForSelector("main", {
+        state: "visible",
+        timeout: timeoutMs,
+      });
+      const state = await page.evaluate((expectedMarker) => {
+        const bodyText = document.body.innerText.trim();
+        const visibleWideTables = Array.from(document.querySelectorAll("table"))
+          .map((el) => {
+            const rect = el.getBoundingClientRect();
+            return {
+              text: String(el.textContent ?? "")
+                .trim()
+                .replace(/\s+/g, " ")
+                .slice(0, 80),
+              width: Math.round(rect.width),
+              height: Math.round(rect.height),
+              display: getComputedStyle(el).display,
+            };
+          })
+          .filter(
+            (item) => item.width > window.innerWidth + 2 && item.height > 0,
+          );
+        return {
+          bodyLength: bodyText.length,
+          hasMarker: bodyText.includes(expectedMarker),
+          pageOverflow:
+            document.documentElement.scrollWidth > window.innerWidth + 2,
+          scrollWidth: document.documentElement.scrollWidth,
+          visibleWideTables,
+        };
+      }, marker);
+      if (
+        state.bodyLength < 80 ||
+        !state.hasMarker ||
+        state.pageOverflow ||
+        state.visibleWideTables.length
+      ) {
+        throw new Error(
+          `${label} narrow layout failed: ${JSON.stringify(state)}`,
+        );
+      }
+      if (pageErrors.length > 0) {
+        throw new Error(
+          `${label} raised browser errors in narrow layout: ${pageErrors.join(" | ")}`,
+        );
+      }
+      const elapsedMs = Math.round(performance.now() - started);
+      console.log(`narrow route ok: ${label} ${elapsedMs}ms`);
+    }
+  } finally {
+    await browser.close();
+  }
 }
 
 async function checkEmptyFixtureRoutes(baseUrl, configPath, timeoutMs, narrow) {
-	await seedSmokeFixtures(configPath, 'empty');
-	const emptyRouteChecks = [
-		['Empty Queue', '/', 'No folders match the current filters'],
-		['Empty Folders', '/folders', 'No folders match the current filters'],
-		['Empty Ops', '/ops', 'Encoding is idle and ready'],
-		['Empty Completed', '/completed', 'No completed folders match the active filters']
-	];
-	await checkRoutes(baseUrl, emptyRouteChecks, timeoutMs);
-	if (narrow) {
-		await checkNarrowRoutes(baseUrl, emptyRouteChecks, timeoutMs);
-	}
+  await seedSmokeFixtures(configPath, "empty");
+  const emptyRouteChecks = [
+    ["Empty Queue", "/", "No folders match the current filters"],
+    ["Empty Folders", "/folders", "No folders match the current filters"],
+    ["Empty Ops", "/ops", "Processing is idle and ready"],
+    [
+      "Empty Completed",
+      "/completed",
+      "No completed folders match the active filters",
+    ],
+  ];
+  await checkRoutes(baseUrl, emptyRouteChecks, timeoutMs);
+  if (narrow) {
+    await checkNarrowRoutes(baseUrl, emptyRouteChecks, timeoutMs);
+  }
 }
 
 async function main() {
-	const args = parseArgs(process.argv.slice(2));
-	let managedServer = null;
-	let targetUrl = args.baseUrl ? normalizeBaseUrl(args.baseUrl) : null;
-	let fixtures = null;
-	const shouldSeedFixtures = args.seedFixtures ?? !targetUrl;
-	try {
-		if (shouldSeedFixtures) {
-			await prepareSmokeState();
-			fixtures = await seedSmokeFixtures(args.config);
-		}
-		if (!targetUrl) {
-			managedServer = await startServer(args.config);
-			targetUrl = managedServer.baseUrl;
-		}
-		const browserRouteChecks = [...routeChecks];
-		for (const fixtureRoute of fixtures?.folderRoutes ?? []) {
-			browserRouteChecks.push([fixtureRoute.label, fixtureRoute.route, fixtureRoute.marker]);
-		}
-		await checkEndpoints(targetUrl, args.endpointTimeoutMs);
-		await checkRoutes(targetUrl, browserRouteChecks, args.routeTimeoutMs);
-		if (args.narrow) {
-			await checkNarrowRoutes(targetUrl, browserRouteChecks, args.routeTimeoutMs);
-		}
-		if (managedServer && shouldSeedFixtures) {
-			await checkEmptyFixtureRoutes(targetUrl, args.config, args.routeTimeoutMs, args.narrow);
-		}
-		console.log(`web route smoke passed: ${targetUrl}`);
-	} catch (error) {
-		if (managedServer) {
-			const logs = managedServer.logs();
-			if (logs.trim()) {
-				console.error('\nmediaforce-web output:\n');
-				console.error(logs.trim());
-			}
-		}
-		console.error(error instanceof Error ? error.message : String(error));
-		process.exitCode = 1;
-	} finally {
-		if (managedServer) await managedServer.stop();
-	}
+  const args = parseArgs(process.argv.slice(2));
+  let managedServer = null;
+  let targetUrl = args.baseUrl ? normalizeBaseUrl(args.baseUrl) : null;
+  let fixtures = null;
+  const shouldSeedFixtures = args.seedFixtures ?? !targetUrl;
+  try {
+    if (shouldSeedFixtures) {
+      await prepareSmokeState();
+      fixtures = await seedSmokeFixtures(args.config);
+    }
+    if (!targetUrl) {
+      managedServer = await startServer(args.config);
+      targetUrl = managedServer.baseUrl;
+    }
+    const browserRouteChecks = [...routeChecks];
+    for (const fixtureRoute of fixtures?.folderRoutes ?? []) {
+      browserRouteChecks.push([
+        fixtureRoute.label,
+        fixtureRoute.route,
+        fixtureRoute.marker,
+      ]);
+    }
+    await checkEndpoints(targetUrl, args.endpointTimeoutMs);
+    await checkRoutes(targetUrl, browserRouteChecks, args.routeTimeoutMs);
+    if (args.narrow) {
+      await checkNarrowRoutes(
+        targetUrl,
+        browserRouteChecks,
+        args.routeTimeoutMs,
+      );
+    }
+    if (managedServer && shouldSeedFixtures) {
+      await checkEmptyFixtureRoutes(
+        targetUrl,
+        args.config,
+        args.routeTimeoutMs,
+        args.narrow,
+      );
+    }
+    console.log(`web route smoke passed: ${targetUrl}`);
+  } catch (error) {
+    if (managedServer) {
+      const logs = managedServer.logs();
+      if (logs.trim()) {
+        console.error("\nmediaforce-web output:\n");
+        console.error(logs.trim());
+      }
+    }
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  } finally {
+    if (managedServer) await managedServer.stop();
+  }
 }
 
 await main();


### PR DESCRIPTION
## Summary

- Replaces remaining first-glance internal vocabulary with operator-facing language across Queue, Folder Studio, Ops, Completed, and Settings.
- Demotes advanced worker internals in Settings, calms Completed history/cleanup wording, and makes Ops readiness/capabilities read in terms of user impact.
- Tightens route smoke fixtures and UI smoke coverage for renamed processing/review states, including active/retry folder fixtures and narrow layout checks.
- Changes the shell telemetry strip from a fixed overlay to a sticky footer so it no longer covers long tables or settings controls.

## Validation

- `bash scripts/pre-commit-check.sh`
- `uv build`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py run --repo "$PWD" --scope changed_files` (JS findings fixed; remaining PyCharm warning is stale interpreter metadata expecting `uvicorn==0.46.0` while `uv.lock` and `uv run` resolve `uvicorn 0.47.0`)
- Live browser QA at `http://127.0.0.1:5555` for Queue, Ops, Completed, and Settings with desktop screenshots under `scratch/ui-checks/post-design-ui-refinements/final-live-sticky-footer/`

Closes #89
Closes #90
Closes #91
Closes #92
Closes #93
Closes #94
