### PR TITLE
Fix operator queue filters and settings save affordance

### DIFF
--- a/frontend/src/lib/components/settings/SettingsEditor.svelte
+++ b/frontend/src/lib/components/settings/SettingsEditor.svelte
@@ -21,6 +21,8 @@
 		buildArchiveCleanupClearPayload,
 		buildSettingsSavePayload,
 		draftFromSettings,
+		hostLibraryAccessChecked,
+		hostLibraryAccessCopy,
 		hostDraftRuntimeKey,
 		removeAtIndex,
 		scheduleWindowSummaryCopy,
@@ -249,7 +251,12 @@
 	}
 
 	function toggleLibraryAccess(index: number, libraryKey: string) {
-		draft.remote_hosts = toggleHostAllowedLibrary(draft.remote_hosts, index, libraryKey);
+		draft.remote_hosts = toggleHostAllowedLibrary(
+			draft.remote_hosts,
+			index,
+			libraryKey,
+			activeLibraryKeys
+		);
 	}
 
 	function resetDraft() {
@@ -763,12 +770,13 @@
 										<div class="host-options host-options--primary">
 											<div>
 												<span class="option-label">Allowed libraries</span>
+												<small class="option-hint">{hostLibraryAccessCopy(host)}</small>
 												<div class="toggle-grid">
 													{#each activeLibraryKeys as libraryKey (libraryKey)}
 														<label class="toggle-chip">
 															<input
 																type="checkbox"
-																checked={host.allowed_libraries.includes(libraryKey)}
+																checked={hostLibraryAccessChecked(host, libraryKey)}
 																onchange={() => toggleLibraryAccess(index, libraryKey)}
 															/>
 															<span>{libraryKey}</span>
@@ -984,6 +992,33 @@
 			</section>
 
 			<aside class="settings-console__rail" aria-label="Settings navigation and files">
+				<WorkstationPanel eyebrow="Save state" title="Settings draft">
+					<div class="rail-save">
+						<StateBadge
+							tone={saveError ? 'fail' : dirty ? 'wait' : 'ready'}
+							label={saveError ? 'Error' : dirty ? 'Unsaved' : 'Saved'}
+						/>
+						<p>{saveError || saveMessage || 'Changes stay local until you save.'}</p>
+						<div class="rail-save__actions" aria-label="Settings save actions">
+							<button
+								type="button"
+								class="control control--compact"
+								disabled={!dirty || savePending}
+								onclick={resetDraft}
+							>
+								Reset
+							</button>
+							<button
+								type="button"
+								class="control control--compact control--ready"
+								disabled={!dirty || savePending}
+								onclick={saveSettings}
+							>
+								{savePending ? 'Saving' : 'Save'}
+							</button>
+						</div>
+					</div>
+				</WorkstationPanel>
 				<nav class="settings-rail-nav" aria-label="Settings sections">
 					<span class="mf-eyebrow">Sections</span>
 					<a href="#settings-libraries">Libraries</a>
@@ -1009,6 +1044,32 @@
 					</div>
 				</WorkstationPanel>
 			</aside>
+
+			{#if dirty || savePending || saveError}
+				<div class="settings-save-dock" role="status" aria-live="polite">
+					<StateBadge
+						tone={saveError ? 'fail' : dirty ? 'wait' : 'ready'}
+						label={saveError ? 'Error' : savePending ? 'Saving' : 'Unsaved'}
+					/>
+					<span>{saveError || 'Settings changes are not saved yet.'}</span>
+					<button
+						type="button"
+						class="control control--compact"
+						disabled={!dirty || savePending}
+						onclick={resetDraft}
+					>
+						Reset
+					</button>
+					<button
+						type="button"
+						class="control control--compact control--ready"
+						disabled={!dirty || savePending}
+						onclick={saveSettings}
+					>
+						{savePending ? 'Saving' : 'Save'}
+					</button>
+				</div>
+			{/if}
 		{/if}
 	</main>
 </OperatorShell>
@@ -1059,7 +1120,8 @@
 
 	.settings-header__actions,
 	.panel-actions,
-	.archive-actions {
+	.archive-actions,
+	.settings-save-dock {
 		align-items: center;
 		display: flex;
 		flex-wrap: wrap;
@@ -1184,6 +1246,27 @@
 		display: block;
 		min-height: var(--mf-control-sm);
 		padding: var(--mf-space-2) var(--mf-space-3);
+	}
+
+	.settings-save-dock {
+		background: var(--mf-bg-strip);
+		border: var(--mf-border-strong);
+		border-left: 2px solid var(--mf-wait-fg);
+		bottom: var(--mf-space-5);
+		box-shadow: var(--mf-shadow-2);
+		grid-column: 1 / -1;
+		justify-content: flex-end;
+		left: var(--mf-space-5);
+		padding: var(--mf-space-3);
+		position: fixed;
+		right: var(--mf-space-5);
+		z-index: 30;
+	}
+
+	.settings-save-dock span:not(:global(.state-badge span)) {
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-xs);
+		margin-right: auto;
 	}
 
 	.table-wrap {
@@ -1348,6 +1431,7 @@
 	.storage-readout small,
 	.danger-zone small,
 	.rail-row small,
+	.option-hint,
 	.muted-copy,
 	.schedule-summary,
 	.host-editor__head span {
@@ -1358,10 +1442,32 @@
 	.schedule-list,
 	.host-editor-list,
 	.host-runtime-board,
+	.rail-save,
 	.rail-list {
 		display: grid;
 		gap: var(--mf-space-4);
 		padding: var(--mf-space-5);
+	}
+
+	.rail-save {
+		gap: var(--mf-space-3);
+	}
+
+	.rail-save p {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-xs);
+		line-height: var(--mf-leading-snug);
+		margin: 0;
+	}
+
+	.rail-save__actions {
+		display: grid;
+		gap: var(--mf-space-3);
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.rail-save__actions .control {
+		width: 100%;
 	}
 
 	.host-runtime-board {
@@ -1672,13 +1778,24 @@
 
 		.settings-header__actions,
 		.panel-actions,
-		.archive-actions {
+		.archive-actions,
+		.settings-save-dock {
 			align-items: stretch;
+		}
+
+		.settings-save-dock {
+			left: var(--mf-space-3);
+			right: var(--mf-space-3);
+		}
+
+		.settings-save-dock span:not(:global(.state-badge span)) {
+			flex-basis: 100%;
 		}
 
 		.settings-header__actions .control,
 		.panel-actions .control,
-		.archive-actions .control {
+		.archive-actions .control,
+		.settings-save-dock .control {
 			flex: 1 1 auto;
 		}
 

--- a/frontend/src/lib/components/workstation/FolderStudioView.svelte
+++ b/frontend/src/lib/components/workstation/FolderStudioView.svelte
@@ -34,6 +34,8 @@
 		buildSampleFacts,
 		buildStatusTiles,
 		formatBytes,
+		buildSampleVerdict,
+		predictedFolderSizeBytes,
 		projectedReclaimBytes,
 		record,
 		resolveBenchRequestState,
@@ -63,6 +65,8 @@
 	let workflowPending = $state<WorkflowAction | null>(null);
 	let benchMessage = $state('');
 	let benchError = $state('');
+	let profileMessage = $state('');
+	let profileError = $state('');
 	let benchTextarea = $state<HTMLTextAreaElement | null>(null);
 	let localPendingProposal = $state<Record<string, unknown> | null | undefined>(undefined);
 	let localProposalPrefix = $state('');
@@ -119,6 +123,7 @@
 	const statusTiles = $derived(buildStatusTiles(studioFolder, status, hosts, workflow));
 	const footerSignals = $derived(buildFooterSignals(studioFolder, status, hosts));
 	const sampleFacts = $derived(buildSampleFacts(sampleItem, summary));
+	const sampleVerdict = $derived(buildSampleVerdict(studioFolder, calibration));
 	const benchMessages = $derived(
 		buildBenchMessages(calibration, pendingProposal, retryableSampleJob)
 	);
@@ -195,6 +200,31 @@
 			workflowPending = null;
 		}
 	}
+
+	async function saveProfileAndQueue(action: WorkflowAction) {
+		if (action !== 'queue-encode') return;
+		const actionState = workflowActionState(action);
+		if (actionState.disabled) return;
+		workflowPending = action;
+		profileMessage = '';
+		profileError = '';
+		try {
+			const response = await postJson<{ ok: boolean; message?: string }>(
+				`${resolve('/')}api/folders/${encodedPrefix}/save-profile`,
+				{
+					confirm_high_impact: true,
+					reviewed_draft_hash: calibration?.draft_hash ?? ''
+				}
+			);
+			profileMessage = response.message || 'Approved the draft and queued the folder encode.';
+			await invalidateAll();
+		} catch (error) {
+			profileError =
+				error instanceof Error ? error.message : 'Folder profile could not be approved.';
+		} finally {
+			workflowPending = null;
+		}
+	}
 </script>
 
 <OperatorShell
@@ -222,6 +252,10 @@
 					<div>
 						<span>Projected reclaim</span>
 						<strong>{formatBytes(projectedReclaimBytes(studioFolder))}</strong>
+					</div>
+					<div>
+						<span>Projected output</span>
+						<strong>{formatBytes(predictedFolderSizeBytes(studioFolder))}</strong>
 					</div>
 					<div>
 						<span>Metric</span>
@@ -257,18 +291,36 @@
 					<small>{primaryActionState.disabled ? primaryActionState.title : 'Ready now'}</small>
 				</div>
 				<div class="decision__metrics">
-					<div>
-						<span>Review pack</span>
-						<strong
-							>{reviewArtifacts.length
-								? `${reviewArtifacts.length} artifacts`
-								: reviewReadyCopy(calibration)}</strong
-						>
-					</div>
-					<div>
-						<span>Sample</span>
-						<strong>{sampleItem ? pathFilename(sampleItem.rel_path) : '—'}</strong>
-					</div>
+					{#if sampleVerdict}
+						<div>
+							<span>Per episode</span>
+							<strong>{sampleVerdict.predictedPerItem}</strong>
+							<small>{sampleVerdict.targetDelta || `Target ${sampleVerdict.target}`}</small>
+						</div>
+						<div>
+							<span>Folder output</span>
+							<strong>{sampleVerdict.predictedFolderTotal}</strong>
+							<small>Projected total</small>
+						</div>
+						<div>
+							<span>Reclaim</span>
+							<strong>{sampleVerdict.reclaim}</strong>
+							<small>{sampleVerdict.quality}</small>
+						</div>
+					{:else}
+						<div>
+							<span>Review pack</span>
+							<strong
+								>{reviewArtifacts.length
+									? `${reviewArtifacts.length} artifacts`
+									: reviewReadyCopy(calibration)}</strong
+							>
+						</div>
+						<div>
+							<span>Sample</span>
+							<strong>{sampleItem ? pathFilename(sampleItem.rel_path) : '—'}</strong>
+						</div>
+					{/if}
 				</div>
 				<div class="decision__actions">
 					{#if workflow.primaryAction === 'focus-bench'}
@@ -303,6 +355,17 @@
 							data-mf-action={workflow.primaryAction}
 							data-mf-wire="live"
 							>{workflowPending === workflow.primaryAction ? 'Queueing' : workflow.primary}</button
+						>
+					{:else if workflow.primaryAction === 'queue-encode'}
+						<button
+							class="control control--primary"
+							type="button"
+							disabled={workflowActionState(workflow.primaryAction).disabled}
+							title={workflowActionState(workflow.primaryAction).title}
+							onclick={() => saveProfileAndQueue(workflow.primaryAction)}
+							data-mf-action={workflow.primaryAction}
+							data-mf-wire="live"
+							>{workflowPending === workflow.primaryAction ? 'Approving' : workflow.primary}</button
 						>
 					{:else}
 						<button
@@ -347,6 +410,19 @@
 								? 'Queueing'
 								: workflow.secondary}</button
 						>
+					{:else if workflow.secondaryAction === 'queue-encode'}
+						<button
+							class="control"
+							type="button"
+							disabled={workflowActionState(workflow.secondaryAction).disabled}
+							title={workflowActionState(workflow.secondaryAction).title}
+							onclick={() => saveProfileAndQueue(workflow.secondaryAction)}
+							data-mf-action={workflow.secondaryAction}
+							data-mf-wire="live"
+							>{workflowPending === workflow.secondaryAction
+								? 'Approving'
+								: workflow.secondary}</button
+						>
 					{:else}
 						<button
 							class="control"
@@ -357,28 +433,43 @@
 							data-mf-wire="pending">{workflow.secondary}</button
 						>
 					{/if}
+					{#if profileError}
+						<p class="decision__status decision__status--fail">{profileError}</p>
+					{:else if profileMessage}
+						<p class="decision__status decision__status--ready">{profileMessage}</p>
+					{/if}
 				</div>
 			</section>
 
 			<WorkstationPanel title="Review assistant">
 				<div class="bench">
-					<div class="bench__thread" aria-label="Review assistant conversation">
-						{#each benchMessages as message (message.id)}
-							<div
-								class="bench-message bench-message--{message.role} bench-message--tone-{message.tone ??
-									'neutral'}"
-							>
-								<header>
-									<span>{message.label}</span>
-									{#if message.meta}
-										<small>{message.meta}</small>
-									{/if}
-								</header>
-								<strong>{message.title}</strong>
-								<p>{message.body}</p>
-							</div>
-						{/each}
-					</div>
+					<details
+						class="bench__thread"
+						open={!sampleVerdict}
+						aria-label="Review assistant conversation"
+					>
+						<summary>
+							<strong>Assistant transcript</strong>
+							<span>{benchMessages.length} notes</span>
+						</summary>
+						<div class="bench__messages">
+							{#each benchMessages as message (message.id)}
+								<div
+									class="bench-message bench-message--{message.role} bench-message--tone-{message.tone ??
+										'neutral'}"
+								>
+									<header>
+										<span>{message.label}</span>
+										{#if message.meta}
+											<small>{message.meta}</small>
+										{/if}
+									</header>
+									<strong>{message.title}</strong>
+									<p>{message.body}</p>
+								</div>
+							{/each}
+						</div>
+					</details>
 
 					<div class="bench__composer" aria-label="Review request composer">
 						<label>
@@ -820,7 +911,26 @@
 		align-items: center;
 		display: flex;
 		gap: var(--mf-space-4);
+		flex-wrap: wrap;
 		min-width: 0;
+	}
+
+	.decision__status {
+		border-left: 2px solid var(--mf-idle-fg);
+		flex-basis: 100%;
+		font-size: var(--mf-text-xs);
+		line-height: var(--mf-leading-normal);
+		padding-left: var(--mf-space-3);
+	}
+
+	.decision__status--ready {
+		border-left-color: var(--mf-ready-fg);
+		color: var(--mf-ready-fg);
+	}
+
+	.decision__status--fail {
+		border-left-color: var(--mf-fail-fg);
+		color: var(--mf-fail-fg);
 	}
 
 	.action-form {
@@ -871,9 +981,39 @@
 	}
 
 	.bench__thread {
+		background: var(--mf-bg-panel-2);
+		border: var(--mf-border-muted);
+		display: grid;
+		min-width: 0;
+	}
+
+	.bench__thread summary {
+		align-items: center;
+		cursor: pointer;
+		display: flex;
+		gap: var(--mf-space-4);
+		list-style-position: inside;
+		min-height: var(--mf-row-comfy);
+		padding: 0 var(--mf-space-5);
+	}
+
+	.bench__thread summary strong {
+		font-size: var(--mf-text-sm);
+		font-weight: var(--mf-weight-semibold);
+	}
+
+	.bench__thread summary span {
+		color: var(--mf-fg-tertiary);
+		font-family: var(--mf-font-mono), monospace;
+		font-size: var(--mf-text-xs);
+		margin-left: auto;
+	}
+
+	.bench__messages {
 		display: grid;
 		gap: var(--mf-space-4);
-		min-width: 0;
+		padding: var(--mf-space-5);
+		padding-top: 0;
 	}
 
 	.bench-message {

--- a/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
+++ b/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
@@ -21,7 +21,11 @@
 		totalPendingItems,
 		totalProjectedReclaim
 	} from './queue-workstation';
-	import { WORKBENCH_FILTER_STORAGE_KEY, parseStoredWorkbenchFilters } from './home-workbench';
+	import {
+		clearStoredWorkbenchFilters,
+		readStoredWorkbenchFilters,
+		writeStoredWorkbenchFilters
+	} from './home-workbench';
 	import { formatBytes } from './folder-studio-view';
 
 	let {
@@ -188,11 +192,9 @@
 	function restoreFilters() {
 		if (!browser || filtersLoaded) return;
 		filtersLoaded = true;
-		const filters = parseStoredWorkbenchFilters(
-			window.localStorage.getItem(WORKBENCH_FILTER_STORAGE_KEY)
-		);
+		const filters = readStoredWorkbenchFilters(mode);
 		if (!filters) {
-			window.localStorage.removeItem(WORKBENCH_FILTER_STORAGE_KEY);
+			clearStoredWorkbenchFilters(mode);
 			return;
 		}
 		searchQuery = filters.searchQuery;
@@ -202,10 +204,7 @@
 
 	function persistFilters() {
 		if (!browser || !filtersLoaded) return;
-		window.localStorage.setItem(
-			WORKBENCH_FILTER_STORAGE_KEY,
-			JSON.stringify({ searchQuery, libraryFilters, stateFilters })
-		);
+		writeStoredWorkbenchFilters(mode, { searchQuery, libraryFilters, stateFilters });
 	}
 
 	function libraryIncluded(key: string): boolean {

--- a/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
+++ b/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
+	import { browser } from '$app/environment';
 	import { folderRoutePath } from '$lib/folder-display';
 	import type {
 		DashboardFoldersPayload,
@@ -20,6 +21,7 @@
 		totalPendingItems,
 		totalProjectedReclaim
 	} from './queue-workstation';
+	import { WORKBENCH_FILTER_STORAGE_KEY, parseStoredWorkbenchFilters } from './home-workbench';
 	import { formatBytes } from './folder-studio-view';
 
 	let {
@@ -40,6 +42,7 @@
 	let searchQuery = $state('');
 	let libraryFilters = $state<Record<string, boolean>>({});
 	let stateFilters = $state<Record<string, boolean>>({});
+	let filtersLoaded = $state(false);
 	const libraryOptions = $derived(buildLibraryOptions(folders));
 	const stateOptions = $derived(buildStateOptions(folders));
 	const normalizedSearchQuery = $derived(searchQuery.trim().toLowerCase());
@@ -182,6 +185,29 @@
 		return Object.values(byState).sort((left, right) => right.pending - left.pending);
 	}
 
+	function restoreFilters() {
+		if (!browser || filtersLoaded) return;
+		filtersLoaded = true;
+		const filters = parseStoredWorkbenchFilters(
+			window.localStorage.getItem(WORKBENCH_FILTER_STORAGE_KEY)
+		);
+		if (!filters) {
+			window.localStorage.removeItem(WORKBENCH_FILTER_STORAGE_KEY);
+			return;
+		}
+		searchQuery = filters.searchQuery;
+		libraryFilters = filters.libraryFilters;
+		stateFilters = filters.stateFilters;
+	}
+
+	function persistFilters() {
+		if (!browser || !filtersLoaded) return;
+		window.localStorage.setItem(
+			WORKBENCH_FILTER_STORAGE_KEY,
+			JSON.stringify({ searchQuery, libraryFilters, stateFilters })
+		);
+	}
+
 	function libraryIncluded(key: string): boolean {
 		return libraryFilters[key] ?? true;
 	}
@@ -232,6 +258,9 @@
 		const rankCopy = index === 0 ? 'the first visible folder' : `#${index + 1} in the visible list`;
 		return `${folder.title} is ${rankCopy} with ${pending} pending items and about ${reclaim} of projected reclaim.`;
 	}
+
+	$effect(restoreFilters);
+	$effect(persistFilters);
 </script>
 
 <OperatorShell route={shellRoute} subject={shellSubject} {crumb} {statusTiles} {footerSignals}>

--- a/frontend/src/lib/components/workstation/OperatorShell.svelte
+++ b/frontend/src/lib/components/workstation/OperatorShell.svelte
@@ -20,10 +20,9 @@
 	const navItems: Array<{
 		id: ShellRouteId;
 		label: string;
-		href: '/' | '/folders' | '/ops' | '/completed' | '/settings';
+		href: '/' | '/ops' | '/completed' | '/settings';
 	}> = [
 		{ id: 'queue', label: 'Queue', href: '/' },
-		{ id: 'folders', label: 'Folders', href: '/folders' },
 		{ id: 'ops', label: 'Ops', href: '/ops' },
 		{ id: 'completed', label: 'Completed', href: '/completed' },
 		{ id: 'settings', label: 'Settings', href: '/settings' }

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -3,12 +3,15 @@ import type { FolderPayload, FolderStatusPayload } from '$lib/api/types';
 import type { FolderCalibrationJob } from '$lib/folders/studio';
 import {
 	buildBenchHostOptions,
+	buildSampleVerdict,
 	buildWorkflowSteps,
+	predictedFolderSizeBytes,
+	projectedReclaimBytes,
 	resolveBenchRequestState,
 	resolveWorkflow,
 	resolveWorkflowActionState
 } from './folder-studio-view';
-import type { PendingSampleProposal } from '$lib/folders/studio';
+import type { FolderCalibrationState, PendingSampleProposal } from '$lib/folders/studio';
 
 function folderPayload(overrides: Partial<FolderPayload> = {}): FolderPayload {
 	return {
@@ -38,6 +41,20 @@ function folderStatusPayload(overrides: Partial<FolderStatusPayload> = {}): Fold
 		folder_scan_status: 'idle',
 		calibration_job: null,
 		folder_scan_job: null,
+		...overrides
+	};
+}
+
+function folderSummary(overrides: Partial<NonNullable<FolderPayload['summary']>> = {}) {
+	return {
+		prefix: 'tv/Example/Season 1',
+		item_count: 1,
+		total_size_bytes: 1,
+		statuses: {},
+		video_codecs: {},
+		audio_codecs: {},
+		seasons: {},
+		resolved_policy: {},
 		...overrides
 	};
 }
@@ -107,6 +124,14 @@ describe('Folder Studio review request mapping', () => {
 		).toEqual({ disabled: false, title: '' });
 
 		expect(
+			resolveWorkflowActionState('queue-encode', {
+				reviewPackReady: true,
+				pendingProposal: null,
+				calibrationJob: null
+			})
+		).toEqual({ disabled: false, title: '' });
+
+		expect(
 			resolveWorkflowActionState('start-sample', {
 				reviewPackReady: false,
 				pendingProposal: null,
@@ -146,6 +171,110 @@ describe('Folder Studio review request mapping', () => {
 		).toMatchObject({
 			disabled: true,
 			title: 'A sample job is already active for this folder.'
+		});
+	});
+
+	it('projects sample output across the whole folder', () => {
+		const folder = folderPayload({
+			summary: folderSummary({
+				item_count: 22,
+				total_size_bytes: 80_158_807_611
+			}),
+			calibration: {
+				sample_result: {
+					predicted_total_size_bytes: 803_322_876,
+					quality_metric: 'VMAF',
+					quality_score: 95.0448
+				}
+			}
+		});
+
+		expect(predictedFolderSizeBytes(folder)).toBe(17_673_103_272);
+		expect(projectedReclaimBytes(folder)).toBe(62_485_704_339);
+	});
+
+	it('turns an over-budget sample into a revise-first verdict and workflow', () => {
+		const calibration = {
+			browser_review_ready: true,
+			review_media_ready: true,
+			sample_result: {
+				predicted_total_size_bytes: 803_322_876,
+				quality_metric: 'VMAF',
+				quality_score: 95.0448
+			},
+			advice: {
+				operator_request: {
+					budget_bytes: 314_572_800,
+					budget_label: '300 MB per episode',
+					request_text: 'Aim for 200-300 MB per episode.'
+				},
+				run_verdict: {
+					outcome: 'poor_fit',
+					next_step: 'Run another sample with a much lower video budget or a downscale.'
+				}
+			}
+		} as FolderCalibrationState;
+		const folder = folderPayload({
+			summary: folderSummary({
+				item_count: 22,
+				total_size_bytes: 80_158_807_611
+			}),
+			calibration
+		});
+
+		expect(buildSampleVerdict(folder, calibration)).toMatchObject({
+			label: 'Target missed',
+			title: '766 MiB per episode misses 300 MB per episode.',
+			predictedPerItem: '766 MiB',
+			predictedFolderTotal: '16.5 GiB',
+			reclaim: '58.2 GiB',
+			targetDelta: '2.6x target',
+			missesTarget: true
+		});
+
+		expect(
+			resolveWorkflow(folder, folderStatusPayload(), calibration, null, null, null, null)
+		).toMatchObject({
+			label: 'Target missed',
+			primary: 'Revise sample',
+			primaryAction: 'focus-bench',
+			secondary: 'Download review pack'
+		});
+	});
+
+	it('makes acceptable review evidence approve-first', () => {
+		const calibration = {
+			browser_review_ready: true,
+			review_media_ready: true,
+			sample_result: {
+				predicted_total_size_bytes: 250_000_000,
+				quality_metric: 'VMAF',
+				quality_score: 95.1
+			},
+			advice: {
+				operator_request: {
+					budget_bytes: 314_572_800,
+					budget_label: '300 MB per episode'
+				},
+				run_verdict: { outcome: 'good_fit' }
+			}
+		} as FolderCalibrationState;
+
+		expect(
+			resolveWorkflow(
+				folderPayload({ calibration }),
+				folderStatusPayload(),
+				calibration,
+				null,
+				null,
+				null,
+				null
+			)
+		).toMatchObject({
+			label: 'Review ready',
+			primary: 'Approve and queue',
+			primaryAction: 'queue-encode',
+			secondary: 'Download pack'
 		});
 	});
 

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -3,6 +3,7 @@ import type { FolderPayload, FolderStatusPayload } from '$lib/api/types';
 import type { FolderCalibrationJob } from '$lib/folders/studio';
 import {
 	buildBenchHostOptions,
+	buildBudgetEnforcementView,
 	buildSampleVerdict,
 	buildWorkflowSteps,
 	predictedFolderSizeBytes,
@@ -242,6 +243,57 @@ describe('Folder Studio review request mapping', () => {
 		});
 	});
 
+	it('keeps an over-budget sample revise-first when a stale warning draft exists', () => {
+		const calibration = {
+			browser_review_ready: true,
+			review_media_ready: true,
+			sample_result: {
+				predicted_total_size_bytes: 803_322_876,
+				quality_metric: 'VMAF',
+				quality_score: 95.0448
+			},
+			advice: {
+				operator_request: {
+					budget_bytes: 314_572_800,
+					budget_label: '300 MB per episode'
+				}
+			}
+		} as FolderCalibrationState;
+		const pendingProposal = {
+			proposal_id: 'stale-draft',
+			can_queue: true,
+			message: 'Download review pack.',
+			self_check: {
+				status: 'warning',
+				summary: 'Usable with caution.'
+			}
+		} as PendingSampleProposal;
+
+		expect(
+			resolveWorkflow(
+				folderPayload({
+					summary: folderSummary({
+						item_count: 22,
+						total_size_bytes: 80_158_807_611
+					}),
+					calibration,
+					pending_proposal: pendingProposal
+				}),
+				folderStatusPayload(),
+				calibration,
+				pendingProposal,
+				null,
+				null,
+				null
+			)
+		).toMatchObject({
+			label: 'Target missed',
+			primary: 'Revise sample',
+			primaryAction: 'focus-bench',
+			secondary: 'Download review pack'
+		});
+	});
+
 	it('makes acceptable review evidence approve-first', () => {
 		const calibration = {
 			browser_review_ready: true,
@@ -301,6 +353,44 @@ describe('Folder Studio review request mapping', () => {
 
 		expect(workflow).toMatchObject({
 			label: 'Draft ready',
+			primary: 'Start sample',
+			primaryAction: 'start-sample'
+		});
+	});
+
+	it('names measured budget enforcement as the next sample action', () => {
+		const pendingProposal = {
+			proposal_id: 'draft-3',
+			can_queue: true,
+			message: 'Queue this representative sample.',
+			operator_request: { budget_label: '300 MB per episode' },
+			budget_enforcement: {
+				status: 'enforced_after_miss',
+				size_target_analysis: { predicted_to_budget_ratio: 2.55 },
+				applied_policy: { video: { max_encoded_percent: 7 } }
+			}
+		} as PendingSampleProposal;
+
+		expect(buildBudgetEnforcementView(pendingProposal)).toEqual({
+			active: true,
+			cap: '7%',
+			reason: 'Applied after 2.6x target miss against 300 MB per episode.'
+		});
+
+		const workflow = resolveWorkflow(
+			folderPayload({ pending_proposal: pendingProposal }),
+			folderStatusPayload(),
+			null,
+			pendingProposal,
+			null,
+			null,
+			null
+		);
+
+		expect(workflow).toMatchObject({
+			label: 'Budget enforced',
+			title: 'Next sample has a 7% size ceiling',
+			copy: 'Applied after 2.6x target miss against 300 MB per episode.',
 			primary: 'Start sample',
 			primaryAction: 'start-sample'
 		});

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -70,6 +70,12 @@ export type ProposalRow = {
 	changed: boolean;
 };
 
+export type BudgetEnforcementView = {
+	active: boolean;
+	cap: string;
+	reason: string;
+};
+
 export type BenchMessage = {
 	id: string;
 	role: 'operator' | 'bench' | 'system';
@@ -129,6 +135,10 @@ function operatorRequest(
 
 function runVerdict(calibration: FolderCalibrationState | null): Record<string, unknown> | null {
 	return record<Record<string, unknown>>(calibrationAdvice(calibration)?.run_verdict);
+}
+
+function policyVideo(value: unknown): Record<string, unknown> | null {
+	return record<Record<string, unknown>>(record<Record<string, unknown>>(value)?.video);
 }
 
 export function record<T extends Record<string, unknown>>(value: unknown): T | null {
@@ -492,6 +502,25 @@ export function buildSampleVerdict(
 	};
 }
 
+export function buildBudgetEnforcementView(
+	pendingProposal: PendingSampleProposal | null
+): BudgetEnforcementView | null {
+	if (!pendingProposal) return null;
+	const enforcement = record<Record<string, unknown>>(pendingProposal.budget_enforcement);
+	const cap = numberValue(policyVideo(enforcement?.applied_policy)?.max_encoded_percent);
+	if (cap === null || cap <= 0) return null;
+	const analysis = record<Record<string, unknown>>(enforcement?.size_target_analysis);
+	const ratio = numberValue(analysis?.predicted_to_budget_ratio);
+	const target =
+		compactText(pendingProposal.operator_request?.budget_label) || 'requested size target';
+	const ratioCopy = ratio && ratio > 0 ? `${formatRatio(ratio)} miss` : 'measured miss';
+	return {
+		active: enforcement?.status === 'enforced_after_miss',
+		cap: `${cap.toLocaleString('en-US', { maximumFractionDigits: 1 })}%`,
+		reason: `Applied after ${ratioCopy} against ${target}.`
+	};
+}
+
 export function buildSampleFacts(
 	sampleItem: FolderSampleItem | null,
 	summary: FolderPayload['summary']
@@ -610,6 +639,36 @@ export function resolveWorkflow(
 			secondaryAction: 'stop-sample'
 		};
 	}
+	const verdict = buildSampleVerdict(folder, calibration);
+	if (verdict?.missesTarget) {
+		const budgetEnforcement = buildBudgetEnforcementView(pendingProposal);
+		if (
+			pendingProposal?.proposal_id &&
+			pendingProposal.can_queue !== false &&
+			budgetEnforcement?.active
+		) {
+			return {
+				tone: 'ready',
+				label: 'Budget enforced',
+				title: `Next sample has a ${budgetEnforcement.cap} size ceiling`,
+				copy: budgetEnforcement.reason,
+				primary: 'Start sample',
+				primaryAction: 'start-sample',
+				secondary: 'Revise',
+				secondaryAction: 'revise-proposal'
+			};
+		}
+		return {
+			tone: 'wait',
+			label: 'Target missed',
+			title: 'Sample is too large for the requested target',
+			copy: `${verdict.predictedPerItem} per episode against ${verdict.target}. ${verdict.recommendation}`,
+			primary: 'Revise sample',
+			primaryAction: 'focus-bench',
+			secondary: 'Download review pack',
+			secondaryAction: 'download-review-pack'
+		};
+	}
 	if (pendingProposal?.self_check?.status && pendingProposal.self_check.status !== 'passed') {
 		return {
 			tone: 'wait',
@@ -625,11 +684,15 @@ export function resolveWorkflow(
 		};
 	}
 	if (pendingProposal?.proposal_id && pendingProposal.can_queue !== false) {
+		const budgetEnforcement = buildBudgetEnforcementView(pendingProposal);
 		return {
 			tone: 'ready',
-			label: 'Draft ready',
-			title: 'Review draft is ready to sample',
+			label: budgetEnforcement?.active ? 'Budget enforced' : 'Draft ready',
+			title: budgetEnforcement?.active
+				? `Next sample has a ${budgetEnforcement.cap} size ceiling`
+				: 'Review draft is ready to sample',
 			copy:
+				budgetEnforcement?.reason ??
 				pendingProposal.message ??
 				'Review the draft, then queue the representative sample when it looks right.',
 			primary: 'Start sample',
@@ -639,19 +702,6 @@ export function resolveWorkflow(
 		};
 	}
 	if (pendingProposal || calibration?.browser_review_ready || calibration?.review_media_ready) {
-		const verdict = buildSampleVerdict(folder, calibration);
-		if (verdict?.missesTarget) {
-			return {
-				tone: 'wait',
-				label: 'Target missed',
-				title: 'Sample is too large for the requested target',
-				copy: `${verdict.predictedPerItem} per episode against ${verdict.target}. ${verdict.recommendation}`,
-				primary: 'Revise sample',
-				primaryAction: 'focus-bench',
-				secondary: 'Download review pack',
-				secondaryAction: 'download-review-pack'
-			};
-		}
 		return {
 			tone: 'ready',
 			label: 'Review ready',

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -35,6 +35,21 @@ export type WorkflowState = {
 	secondaryAction: WorkflowAction;
 };
 
+export type SampleVerdict = {
+	tone: ShellTone;
+	label: string;
+	title: string;
+	recommendation: string;
+	predictedPerItem: string;
+	predictedFolderTotal: string;
+	reclaim: string;
+	quality: string;
+	target: string;
+	targetDelta: string;
+	missRatio: number | null;
+	missesTarget: boolean;
+};
+
 export type WorkflowAction =
 	| 'download-review-pack'
 	| 'focus-bench'
@@ -90,6 +105,31 @@ export type WorkflowStep = {
 	tone: ShellTone;
 	current: boolean;
 };
+
+function numberValue(value: unknown): number | null {
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function sampleResult(calibration: FolderCalibrationState | null): Record<string, unknown> | null {
+	return record<Record<string, unknown>>(calibration?.sample_result);
+}
+
+function calibrationAdvice(
+	calibration: FolderCalibrationState | null
+): Record<string, unknown> | null {
+	return record<Record<string, unknown>>(calibration?.advice);
+}
+
+function operatorRequest(
+	calibration: FolderCalibrationState | null
+): Record<string, unknown> | null {
+	return record<Record<string, unknown>>(calibrationAdvice(calibration)?.operator_request);
+}
+
+function runVerdict(calibration: FolderCalibrationState | null): Record<string, unknown> | null {
+	return record<Record<string, unknown>>(calibrationAdvice(calibration)?.run_verdict);
+}
 
 export function record<T extends Record<string, unknown>>(value: unknown): T | null {
 	return value && typeof value === 'object' ? (value as T) : null;
@@ -170,6 +210,7 @@ export function resolveWorkflowActionState(
 	}
 	if (action === 'focus-bench') return { disabled: false, title: '' };
 	if (action === 'open-ops') return { disabled: false, title: '' };
+	if (action === 'queue-encode') return { disabled: false, title: '' };
 	if (action === 'download-review-pack') {
 		return reviewPackReady
 			? { disabled: false, title: '' }
@@ -336,9 +377,29 @@ export function resolveFolderTitle(prefix: string): string {
 export function formatBytes(value: number | null | undefined): string {
 	if (value == null) return '—';
 	if (!Number.isFinite(value)) return '—';
-	return `${(value / 1024 ** 3).toLocaleString('en-US', {
-		maximumFractionDigits: value >= 1024 ** 3 ? 1 : 2
-	})} GiB`;
+	const absValue = Math.abs(value);
+	if (absValue >= 1024 ** 3) {
+		return `${(value / 1024 ** 3).toLocaleString('en-US', {
+			maximumFractionDigits: 1
+		})} GiB`;
+	}
+	if (absValue >= 1024 ** 2) {
+		return `${(value / 1024 ** 2).toLocaleString('en-US', {
+			maximumFractionDigits: absValue >= 100 * 1024 ** 2 ? 0 : 1
+		})} MiB`;
+	}
+	if (absValue >= 1024) {
+		return `${(value / 1024).toLocaleString('en-US', { maximumFractionDigits: 0 })} KiB`;
+	}
+	return `${value.toLocaleString('en-US', { maximumFractionDigits: 0 })} B`;
+}
+
+function formatRatio(value: number | null): string {
+	if (value === null || !Number.isFinite(value) || value <= 0) return '';
+	return `${value.toLocaleString('en-US', {
+		maximumFractionDigits: value >= 10 ? 0 : 1,
+		minimumFractionDigits: value >= 10 ? 0 : 1
+	})}x target`;
 }
 
 export function summarizeStatuses(statuses: Record<string, number>): string {
@@ -359,14 +420,76 @@ export function resolvedMetricCopy(folder: FolderPayload): string {
 }
 
 export function projectedReclaimBytes(folder: FolderPayload): number | null {
-	const sampleResult = record<Record<string, unknown>>(folder.calibration)?.sample_result;
-	const predictedSize = Number(
-		record<Record<string, unknown>>(sampleResult)?.predicted_total_size_bytes
-	);
+	const calibration = record<FolderCalibrationState>(folder.calibration);
+	const result = sampleResult(calibration);
+	const predictedSize = Number(result?.predicted_total_size_bytes);
 	const sourceSize = Number(folder.summary?.total_size_bytes);
+	const itemCount = Number(folder.summary?.item_count);
 	if (!Number.isFinite(sourceSize) || sourceSize <= 0) return null;
 	if (!Number.isFinite(predictedSize) || predictedSize <= 0) return null;
-	return Math.max(sourceSize - predictedSize, 0);
+	const predictedFolderSize =
+		Number.isFinite(itemCount) && itemCount > 0 ? predictedSize * itemCount : predictedSize;
+	return Math.max(sourceSize - predictedFolderSize, 0);
+}
+
+export function predictedFolderSizeBytes(folder: FolderPayload): number | null {
+	const calibration = record<FolderCalibrationState>(folder.calibration);
+	const predictedSize = Number(sampleResult(calibration)?.predicted_total_size_bytes);
+	const itemCount = Number(folder.summary?.item_count);
+	if (!Number.isFinite(predictedSize) || predictedSize <= 0) return null;
+	return Number.isFinite(itemCount) && itemCount > 0 ? predictedSize * itemCount : predictedSize;
+}
+
+export function buildSampleVerdict(
+	folder: FolderPayload,
+	calibration: FolderCalibrationState | null
+): SampleVerdict | null {
+	const result = sampleResult(calibration);
+	if (!result) return null;
+	const predictedSize = numberValue(result.predicted_total_size_bytes);
+	if (predictedSize === null || predictedSize <= 0) return null;
+	const request = operatorRequest(calibration);
+	const verdict = runVerdict(calibration);
+	const itemCount = numberValue(folder.summary?.item_count);
+	const sourceSize = numberValue(folder.summary?.total_size_bytes);
+	const folderTotal =
+		itemCount !== null && itemCount > 0 ? predictedSize * itemCount : predictedSize;
+	const reclaim =
+		sourceSize !== null && sourceSize > 0 ? Math.max(sourceSize - folderTotal, 0) : null;
+	const budget = numberValue(request?.budget_bytes);
+	const target =
+		compactText(request?.budget_label) || (budget ? formatBytes(budget) : 'No size target');
+	const missRatio = budget && budget > 0 ? predictedSize / budget : null;
+	const outcome = compactText(verdict?.outcome).toLowerCase();
+	const missesTarget =
+		outcome === 'poor_fit' || outcome === 'over_target' || (missRatio !== null && missRatio > 1.15);
+	const qualityMetric =
+		compactText(result.quality_metric) || compactText(request?.metric).toUpperCase() || 'Quality';
+	const qualityScore = numberValue(result.quality_score);
+	const quality = qualityScore === null ? '—' : `${qualityMetric} ${qualityScore.toFixed(1)}`;
+	const predictedPerItem = formatBytes(predictedSize);
+	const recommendation =
+		compactText(verdict?.next_step) ||
+		(missesTarget
+			? 'Run another sample with a smaller-size target.'
+			: 'Review the sample clips, then approve or revise.');
+	return {
+		tone: missesTarget ? 'wait' : 'ready',
+		label: missesTarget ? 'Target missed' : 'Sample result',
+		title:
+			missesTarget && target !== 'No size target'
+				? `${predictedPerItem} per episode misses ${target}.`
+				: `${predictedPerItem} per episode sample is ready.`,
+		recommendation,
+		predictedPerItem,
+		predictedFolderTotal: formatBytes(folderTotal),
+		reclaim: reclaim === null ? '—' : formatBytes(reclaim),
+		quality,
+		target,
+		targetDelta: formatRatio(missRatio),
+		missRatio,
+		missesTarget
+	};
 }
 
 export function buildSampleFacts(
@@ -516,17 +639,32 @@ export function resolveWorkflow(
 		};
 	}
 	if (pendingProposal || calibration?.browser_review_ready || calibration?.review_media_ready) {
+		const verdict = buildSampleVerdict(folder, calibration);
+		if (verdict?.missesTarget) {
+			return {
+				tone: 'wait',
+				label: 'Target missed',
+				title: 'Sample is too large for the requested target',
+				copy: `${verdict.predictedPerItem} per episode against ${verdict.target}. ${verdict.recommendation}`,
+				primary: 'Revise sample',
+				primaryAction: 'focus-bench',
+				secondary: 'Download review pack',
+				secondaryAction: 'download-review-pack'
+			};
+		}
 		return {
 			tone: 'ready',
 			label: 'Review ready',
-			title: 'Review the sample pack, then approve or revise',
+			title: 'Approve this sample or revise it',
 			copy:
-				pendingProposal?.message ??
-				'Evidence is ready. Download the review pack, inspect the sample clips, then narrow the decision to approve or revise.',
-			primary: 'Download review pack',
-			primaryAction: 'download-review-pack',
-			secondary: 'Revise',
-			secondaryAction: 'revise-proposal'
+				verdict === null
+					? (pendingProposal?.message ??
+						'Evidence is ready. Review the sample clips, then approve the draft or revise it.')
+					: `${verdict.predictedPerItem} per episode, ${verdict.predictedFolderTotal} for the folder. Review the clips, then approve and queue if this is acceptable.`,
+			primary: 'Approve and queue',
+			primaryAction: 'queue-encode',
+			secondary: 'Download pack',
+			secondaryAction: 'download-review-pack'
 		};
 	}
 	if (!folder.sample_item) {

--- a/frontend/src/lib/components/workstation/home-workbench.test.ts
+++ b/frontend/src/lib/components/workstation/home-workbench.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseStoredWorkbenchFilters } from './home-workbench';
+
+describe('home workbench filter storage', () => {
+	it('restores only valid persisted filter values', () => {
+		expect(
+			parseStoredWorkbenchFilters(
+				JSON.stringify({
+					searchQuery: 'hevc',
+					libraryFilters: { tv: false, movies: true, stale: 'nope' },
+					stateFilters: { pending: false, ready: true, broken: null }
+				})
+			)
+		).toEqual({
+			searchQuery: 'hevc',
+			libraryFilters: { tv: false, movies: true },
+			stateFilters: { pending: false, ready: true }
+		});
+	});
+
+	it('ignores missing or invalid stored filters', () => {
+		expect(parseStoredWorkbenchFilters(null)).toBeNull();
+		expect(parseStoredWorkbenchFilters('{')).toBeNull();
+	});
+});

--- a/frontend/src/lib/components/workstation/home-workbench.test.ts
+++ b/frontend/src/lib/components/workstation/home-workbench.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseStoredWorkbenchFilters } from './home-workbench';
+import {
+	clearStoredWorkbenchFilters,
+	parseStoredWorkbenchFilters,
+	readStoredWorkbenchFilters,
+	workbenchFilterStorageKey,
+	writeStoredWorkbenchFilters
+} from './home-workbench';
 
 describe('home workbench filter storage', () => {
 	it('restores only valid persisted filter values', () => {
@@ -22,5 +28,45 @@ describe('home workbench filter storage', () => {
 	it('ignores missing or invalid stored filters', () => {
 		expect(parseStoredWorkbenchFilters(null)).toBeNull();
 		expect(parseStoredWorkbenchFilters('{')).toBeNull();
+	});
+
+	it('scopes persisted filter keys by route mode', () => {
+		expect(workbenchFilterStorageKey('queue')).toBe('mediaforce.workbench.filters.v1.queue');
+		expect(workbenchFilterStorageKey('folders')).toBe('mediaforce.workbench.filters.v1.folders');
+	});
+
+	it('skips storage errors when reading or writing persisted filters', () => {
+		const originalWindow = globalThis.window;
+		const storage = {
+			getItem() {
+				throw new Error('blocked');
+			},
+			setItem() {
+				throw new Error('blocked');
+			},
+			removeItem() {
+				throw new Error('blocked');
+			}
+		} as unknown as Storage;
+
+		Object.defineProperty(globalThis, 'window', {
+			configurable: true,
+			value: { localStorage: storage }
+		});
+
+		expect(readStoredWorkbenchFilters('queue')).toBeNull();
+		expect(() =>
+			writeStoredWorkbenchFilters('queue', {
+				searchQuery: 'hevc',
+				libraryFilters: { tv: true },
+				stateFilters: { ready: false }
+			})
+		).not.toThrow();
+		expect(() => clearStoredWorkbenchFilters('queue')).not.toThrow();
+
+		Object.defineProperty(globalThis, 'window', {
+			configurable: true,
+			value: originalWindow
+		});
 	});
 });

--- a/frontend/src/lib/components/workstation/home-workbench.ts
+++ b/frontend/src/lib/components/workstation/home-workbench.ts
@@ -1,10 +1,12 @@
-export const WORKBENCH_FILTER_STORAGE_KEY = 'mediaforce.queue.filters.v1';
+export const WORKBENCH_FILTER_STORAGE_KEY = 'mediaforce.workbench.filters.v1';
 
 export type WorkbenchFilterState = {
 	searchQuery: string;
 	libraryFilters: Record<string, boolean>;
 	stateFilters: Record<string, boolean>;
 };
+
+export type WorkbenchFilterMode = 'queue' | 'folders';
 
 type StoredFilters = {
 	searchQuery?: unknown;
@@ -34,5 +36,41 @@ export function parseStoredWorkbenchFilters(
 		};
 	} catch {
 		return null;
+	}
+}
+
+export function workbenchFilterStorageKey(mode: WorkbenchFilterMode): string {
+	return `${WORKBENCH_FILTER_STORAGE_KEY}.${mode}`;
+}
+
+export function readStoredWorkbenchFilters(mode: WorkbenchFilterMode): WorkbenchFilterState | null {
+	if (typeof window === 'undefined') return null;
+	try {
+		return parseStoredWorkbenchFilters(
+			window.localStorage.getItem(workbenchFilterStorageKey(mode))
+		);
+	} catch {
+		return null;
+	}
+}
+
+export function writeStoredWorkbenchFilters(
+	mode: WorkbenchFilterMode,
+	filters: WorkbenchFilterState
+): void {
+	if (typeof window === 'undefined') return;
+	try {
+		window.localStorage.setItem(workbenchFilterStorageKey(mode), JSON.stringify(filters));
+	} catch {
+		// Ignore unavailable or quota-limited storage so the view still works.
+	}
+}
+
+export function clearStoredWorkbenchFilters(mode: WorkbenchFilterMode): void {
+	if (typeof window === 'undefined') return;
+	try {
+		window.localStorage.removeItem(workbenchFilterStorageKey(mode));
+	} catch {
+		// Ignore unavailable storage.
 	}
 }

--- a/frontend/src/lib/components/workstation/home-workbench.ts
+++ b/frontend/src/lib/components/workstation/home-workbench.ts
@@ -1,0 +1,38 @@
+export const WORKBENCH_FILTER_STORAGE_KEY = 'mediaforce.queue.filters.v1';
+
+export type WorkbenchFilterState = {
+	searchQuery: string;
+	libraryFilters: Record<string, boolean>;
+	stateFilters: Record<string, boolean>;
+};
+
+type StoredFilters = {
+	searchQuery?: unknown;
+	libraryFilters?: unknown;
+	stateFilters?: unknown;
+};
+
+export function normalizeStoredFilterRecord(value: unknown): Record<string, boolean> {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+	return Object.fromEntries(
+		Object.entries(value).filter(
+			(entry): entry is [string, boolean] => typeof entry[1] === 'boolean'
+		)
+	);
+}
+
+export function parseStoredWorkbenchFilters(
+	rawFilters: string | null
+): WorkbenchFilterState | null {
+	if (!rawFilters) return null;
+	try {
+		const stored = JSON.parse(rawFilters) as StoredFilters;
+		return {
+			searchQuery: typeof stored.searchQuery === 'string' ? stored.searchQuery : '',
+			libraryFilters: normalizeStoredFilterRecord(stored.libraryFilters),
+			stateFilters: normalizeStoredFilterRecord(stored.stateFilters)
+		};
+	} catch {
+		return null;
+	}
+}

--- a/frontend/src/lib/folders/studio.ts
+++ b/frontend/src/lib/folders/studio.ts
@@ -265,6 +265,7 @@ export type FolderOperatorRequest = {
 	request_type?: string;
 	metric?: string;
 	target?: number;
+	budget_bytes?: number;
 	budget_label?: string;
 	scale_height?: number;
 	scale_label?: string;

--- a/frontend/src/lib/folders/studio.ts
+++ b/frontend/src/lib/folders/studio.ts
@@ -350,6 +350,11 @@ export type ProposalSelfCheck = {
 	summary?: string;
 	issues?: string[];
 };
+export type BudgetEnforcement = {
+	status?: string;
+	size_target_analysis?: Record<string, unknown>;
+	applied_policy?: FolderPolicy;
+};
 export type PendingSampleProposal = {
 	proposal_id?: string;
 	status?: string;
@@ -373,6 +378,7 @@ export type PendingSampleProposal = {
 	host?: { key?: string; label?: string };
 	latest_failed_sample_job?: Record<string, unknown> | null;
 	self_check?: ProposalSelfCheck;
+	budget_enforcement?: BudgetEnforcement | null;
 	operator_signal?: string | null;
 	evidence_checked?: string[];
 	multimodal_review_pack?: FolderMultimodalReviewPack | null;

--- a/frontend/src/lib/settings/editor.test.ts
+++ b/frontend/src/lib/settings/editor.test.ts
@@ -8,6 +8,8 @@ import {
 	buildSettingsSavePayload,
 	cloneScheduleProfile,
 	draftFromSettings,
+	hostLibraryAccessChecked,
+	hostLibraryAccessCopy,
 	scheduleDaysSummaryCopy,
 	scheduleWindowSummaryCopy,
 	settingsDraftIsDirty,
@@ -202,5 +204,19 @@ describe('settings draft helpers', () => {
 		expect(hosts[0]?.allowed_libraries).toEqual(['tv', 'movies']);
 		expect(toggleHostAllowedLibrary(hosts, 0, 'movies')[0]?.allowed_libraries).toEqual(['tv']);
 		expect(toggleHostAllowedLibrary(hosts, 0, '')).toBe(hosts);
+	});
+
+	it('treats an empty host library list as all libraries allowed in the editor', () => {
+		const allLibrariesHost = { ...payload.remote_hosts[0], allowed_libraries: [] };
+
+		expect(hostLibraryAccessChecked(allLibrariesHost, 'tv')).toBe(true);
+		expect(hostLibraryAccessCopy(allLibrariesHost)).toBe('All libraries allowed');
+
+		const hosts = toggleHostAllowedLibrary([{ ...allLibrariesHost }], 0, 'movies', [
+			'movies',
+			'tv'
+		]);
+
+		expect(hosts[0]?.allowed_libraries).toEqual(['tv']);
 	});
 });

--- a/frontend/src/lib/settings/editor.test.ts
+++ b/frontend/src/lib/settings/editor.test.ts
@@ -206,6 +206,29 @@ describe('settings draft helpers', () => {
 		expect(toggleHostAllowedLibrary(hosts, 0, '')).toBe(hosts);
 	});
 
+	it('collapses a fully selected allowlist back to the canonical empty state', () => {
+		const allLibrariesHost = { ...payload.remote_hosts[0], allowed_libraries: [] };
+		const libraryKeys = ['movies', 'tv'];
+
+		const hostsAfterOff = toggleHostAllowedLibrary(
+			[{ ...allLibrariesHost }],
+			0,
+			'movies',
+			libraryKeys
+		);
+		expect(hostsAfterOff[0]?.allowed_libraries).toEqual(['tv']);
+
+		const hostsAfterOn = toggleHostAllowedLibrary(hostsAfterOff, 0, 'movies', libraryKeys);
+		expect(hostsAfterOn[0]?.allowed_libraries).toEqual([]);
+	});
+
+	it('normalizes trimmed and duplicate library keys when toggling', () => {
+		const host = { ...payload.remote_hosts[0], allowed_libraries: [] };
+		const hosts = toggleHostAllowedLibrary([{ ...host }], 0, ' movies ', [' movies ', 'tv', 'tv']);
+
+		expect(hosts[0]?.allowed_libraries).toEqual(['tv']);
+	});
+
 	it('treats an empty host library list as all libraries allowed in the editor', () => {
 		const allLibrariesHost = { ...payload.remote_hosts[0], allowed_libraries: [] };
 

--- a/frontend/src/lib/settings/editor.ts
+++ b/frontend/src/lib/settings/editor.ts
@@ -259,17 +259,34 @@ export function toggleHostCapability(
 export function toggleHostAllowedLibrary(
 	remoteHosts: SettingsHost[],
 	index: number,
-	libraryKey: string
+	libraryKey: string,
+	libraryKeys: string[] = []
 ): SettingsHost[] {
 	const normalizedKey = libraryKey.trim();
 	if (!normalizedKey) return remoteHosts;
 	return remoteHosts.map((host, candidate) => {
 		if (candidate !== index) return host;
-		const allowed_libraries = host.allowed_libraries.includes(normalizedKey)
-			? host.allowed_libraries.filter((value) => value !== normalizedKey)
-			: [...host.allowed_libraries, normalizedKey];
+		const explicitAllowedLibraries =
+			host.allowed_libraries.length > 0
+				? host.allowed_libraries
+				: libraryKeys.map((key) => key.trim()).filter(Boolean);
+		const allowed_libraries = explicitAllowedLibraries.includes(normalizedKey)
+			? explicitAllowedLibraries.filter((value) => value !== normalizedKey)
+			: [...explicitAllowedLibraries, normalizedKey];
 		return { ...host, allowed_libraries };
 	});
+}
+
+export function hostLibraryAccessChecked(host: SettingsHost, libraryKey: string): boolean {
+	const normalizedKey = libraryKey.trim();
+	if (!normalizedKey) return false;
+	return host.allowed_libraries.length === 0 || host.allowed_libraries.includes(normalizedKey);
+}
+
+export function hostLibraryAccessCopy(host: SettingsHost): string {
+	return host.allowed_libraries.length === 0
+		? 'All libraries allowed'
+		: `${host.allowed_libraries.length.toLocaleString('en-US')} libraries allowed`;
 }
 
 export function hostActionKey(

--- a/frontend/src/lib/settings/editor.ts
+++ b/frontend/src/lib/settings/editor.ts
@@ -1,15 +1,9 @@
 import type {
-	HostRuntime,
 	ScheduleProfile,
 	SettingsHost,
 	SettingsLibrary,
 	SettingsPayload
 } from '$lib/api/types';
-
-export const AB_AV1_MISSING_ISSUE = 'ab-av1 is not installed on the remote PATH.';
-export const FFMPEG_MISSING_ISSUE = 'ffmpeg is not installed on the remote PATH.';
-export const FFMPEG_VIDEOTOOLBOX_MISSING_ISSUE =
-	'ffmpeg is missing VideoToolbox hardware decode required for H.264/H.265 sources.';
 export const SCHEDULE_DAY_OPTIONS = [
 	{ key: 'mon', shortLabel: 'Mon', label: 'Monday' },
 	{ key: 'tue', shortLabel: 'Tue', label: 'Tuesday' },
@@ -26,14 +20,6 @@ const scheduleDayIndex = new Map<ScheduleDayKey, number>(
 	SCHEDULE_DAY_OPTIONS.map((option, index) => [option.key, index])
 );
 
-export type HostActionState = {
-	preparing: boolean;
-	resettingTrust: boolean;
-	password: string;
-	showPassword: boolean;
-};
-
-export type HostPrimaryAction = 'prepare' | 'start' | null;
 export type SettingsDraft = ReturnType<typeof draftFromSettings>;
 export type SettingsSavePayload = {
 	libraries: SettingsLibrary[];
@@ -292,83 +278,4 @@ export function hostLibraryAccessCopy(host: SettingsHost): string {
 	return host.allowed_libraries.length === 0
 		? 'All libraries allowed'
 		: `${host.allowed_libraries.length.toLocaleString('en-US')} libraries allowed`;
-}
-
-export function hostActionKey(
-	host: SettingsHost,
-	runtimeHost: HostRuntime | null,
-	index: number
-): string {
-	return runtimeHost?.key || host.host || `${host.label || 'host'}-${index}`;
-}
-
-export function defaultHostActionState(): HostActionState {
-	return {
-		preparing: false,
-		resettingTrust: false,
-		password: '',
-		showPassword: false
-	};
-}
-
-export function primaryHostAction(runtimeHost: HostRuntime, host: SettingsHost): HostPrimaryAction {
-	if (
-		!runtimeHost.available &&
-		Boolean(host.start_command.trim()) &&
-		runtimeHost.message === 'SSH unavailable'
-	) {
-		return 'start';
-	}
-	if (!runtimeHost.setup_supported) return null;
-	if (runtimeHost.missing_paths.length > 0 && runtimeHost.issues.length === 0) return null;
-	return 'prepare';
-}
-
-export function primaryHostActionLabel(runtimeHost: HostRuntime, host: SettingsHost): string {
-	if (primaryHostAction(runtimeHost, host) === 'start') {
-		return 'Start host';
-	}
-	if (runtimeHost.issues.includes(AB_AV1_MISSING_ISSUE)) {
-		return 'Install ab-av1';
-	}
-	if (runtimeHost.issues.includes(FFMPEG_MISSING_ISSUE)) {
-		return 'Install ffmpeg';
-	}
-	if (runtimeHost.issues.includes(FFMPEG_VIDEOTOOLBOX_MISSING_ISSUE)) {
-		return 'Reinstall ffmpeg';
-	}
-	if (runtimeHost.message === 'SSH access setup required') {
-		return 'Install SSH key';
-	}
-	return 'Prepare host';
-}
-
-export function primaryHostActionHelp(runtimeHost: HostRuntime, host: SettingsHost): string {
-	if (primaryHostAction(runtimeHost, host) === 'start') {
-		return 'Runs the configured host start command, then waits for SSH status to come back before refreshing this card.';
-	}
-	if (runtimeHost.issues.includes(AB_AV1_MISSING_ISSUE)) {
-		return 'Runs remote setup so sampled calibration can find ab-av1 on the host PATH.';
-	}
-	if (runtimeHost.issues.includes(FFMPEG_MISSING_ISSUE)) {
-		return 'Installs the missing ffmpeg toolchain on the remote Mac through the normal setup path.';
-	}
-	if (runtimeHost.issues.includes(FFMPEG_VIDEOTOOLBOX_MISSING_ISSUE)) {
-		return 'Refreshes the ffmpeg toolchain on the remote Mac so VideoToolbox decode is available for H.264/H.265 sources.';
-	}
-	if (runtimeHost.message === 'SSH access setup required') {
-		return "Installs this Mac's SSH key so Mediaforce can reconnect without prompting in the future.";
-	}
-	return 'Runs the built-in remote setup flow for this worker.';
-}
-
-export function hasPrimaryHostAction(runtimeHost: HostRuntime, host: SettingsHost): boolean {
-	return primaryHostAction(runtimeHost, host) !== null;
-}
-
-export function shouldShowHostActions(runtimeHost: HostRuntime, host: SettingsHost): boolean {
-	return (
-		Boolean(runtimeHost.trust_reset_supported) ||
-		(!runtimeHost.available && hasPrimaryHostAction(runtimeHost, host))
-	);
 }

--- a/frontend/src/lib/settings/editor.ts
+++ b/frontend/src/lib/settings/editor.ts
@@ -264,16 +264,21 @@ export function toggleHostAllowedLibrary(
 ): SettingsHost[] {
 	const normalizedKey = libraryKey.trim();
 	if (!normalizedKey) return remoteHosts;
+	const normalizedLibraryKeys = [...new Set(libraryKeys.map((key) => key.trim()).filter(Boolean))];
 	return remoteHosts.map((host, candidate) => {
 		if (candidate !== index) return host;
 		const explicitAllowedLibraries =
-			host.allowed_libraries.length > 0
-				? host.allowed_libraries
-				: libraryKeys.map((key) => key.trim()).filter(Boolean);
+			host.allowed_libraries.length > 0 ? host.allowed_libraries : normalizedLibraryKeys;
 		const allowed_libraries = explicitAllowedLibraries.includes(normalizedKey)
 			? explicitAllowedLibraries.filter((value) => value !== normalizedKey)
 			: [...explicitAllowedLibraries, normalizedKey];
-		return { ...host, allowed_libraries };
+		const canonicalAllowedLibraries =
+			normalizedLibraryKeys.length > 0 &&
+			allowed_libraries.length === normalizedLibraryKeys.length &&
+			normalizedLibraryKeys.every((key) => allowed_libraries.includes(key))
+				? []
+				: allowed_libraries;
+		return { ...host, allowed_libraries: canonicalAllowedLibraries };
 	});
 }
 

--- a/mediaforce/web/runtime/folder_ai_tuning.py
+++ b/mediaforce/web/runtime/folder_ai_tuning.py
@@ -5,9 +5,11 @@ from typing import Any
 from fastapi import HTTPException
 
 from mediaforce.advisor import apply_seed_policy, request_note_tuning, request_review_artifact_critique
+from mediaforce.advising.policy import merge_policy_fragments
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient, open_db
 from mediaforce.core.type_defs import object_dict, object_list
+from mediaforce.web.runtime.folder_tuning_helpers import measured_size_budget_policy_fragment
 from mediaforce.library.folder_profiles import inspect_prefix
 from mediaforce.tuning.tuning_memory import promote_learning_artifact, retrieve_learning_context
 
@@ -705,6 +707,30 @@ def _tuned_preview_action(
         "under_target",
         "over_target",
     }
+    measured_budget_fragment = measured_size_budget_policy_fragment(
+        operator_request=operator_request,
+        size_target_analysis=size_target_analysis,
+    )
+    if measured_budget_fragment:
+        combined_fragment = merge_policy_fragments(combined_fragment, measured_budget_fragment)
+        tuned_policy = deps.apply_policy_fragment(current_policy, combined_fragment)
+        advice_payload["applied_policy"] = combined_fragment
+        advice_payload["budget_enforcement"] = {
+            "status": "enforced_after_miss",
+            "size_target_analysis": size_target_analysis,
+            "applied_policy": measured_budget_fragment,
+        }
+        if operator_request:
+            operator_request = {
+                **operator_request,
+                "applied_max_encoded_percent": object_dict(measured_budget_fragment.get("video")).get(
+                    "max_encoded_percent"
+                ),
+                "applied_policy": merge_policy_fragments(
+                    object_dict(operator_request.get("applied_policy")), measured_budget_fragment
+                ),
+            }
+            advice_payload["operator_request"] = operator_request
     alignment_issue = deps.proposal_alignment_issue(
         operator_request=operator_request,
         request_disposition=tuning.request_disposition,
@@ -766,6 +792,7 @@ def _tuned_preview_action(
         "self_check": tuning.self_check,
         "evidence_checked": tuning.evidence_checked,
         "advice_payload": advice_payload,
+        "budget_enforcement": object_dict(advice_payload.get("budget_enforcement")) or None,
         "latest_failed_sample_job": latest_failed_sample_job,
         "trace": {
             "prompt_version": tuning.prompt_version,

--- a/mediaforce/web/runtime/folder_state.py
+++ b/mediaforce/web/runtime/folder_state.py
@@ -277,6 +277,7 @@ def pending_proposal_public_view(deps: FolderStateDeps, payload: dict[str, Any] 
             "summary": self_check.get("summary"),
             "issues": object_list(self_check.get("issues")),
         },
+        "budget_enforcement": object_dict(payload.get("budget_enforcement")) or None,
         "operator_signal": payload.get("operator_signal"),
         "evidence_checked": object_list(payload.get("evidence_checked")),
         "multimodal_review_pack": object_dict(payload.get("multimodal_review_pack")) or None,

--- a/mediaforce/web/runtime/folder_tuning_helpers.py
+++ b/mediaforce/web/runtime/folder_tuning_helpers.py
@@ -106,6 +106,29 @@ def _number_or_none(value: JSONValue) -> float | None:
     return parsed
 
 
+def measured_size_budget_policy_fragment(
+        *,
+        operator_request: dict[str, Any] | None,
+        size_target_analysis: dict[str, Any] | None,
+) -> dict[str, Any]:
+    request = object_dict(operator_request)
+    analysis = object_dict(size_target_analysis)
+    if str(request.get("request_type") or "").strip().lower() not in {"size_budget", "combined_experiment"}:
+        return {}
+    if str(analysis.get("status") or "").strip().lower() != "over_target":
+        return {}
+    requested_cap = _number_or_none(request.get("requested_max_encoded_percent"))
+    if requested_cap is None:
+        requested_cap = _number_or_none(request.get("target_encoded_percent"))
+    if requested_cap is None:
+        size_budget_request = object_dict(request.get("size_budget_request"))
+        requested_cap = _number_or_none(size_budget_request.get("requested_max_encoded_percent"))
+    if requested_cap is None or requested_cap <= 0:
+        return {}
+    cap = max(1, min(100, int(round(requested_cap))))
+    return {"video": {"max_encoded_percent": cap}}
+
+
 def proposal_alignment_issue(
         *,
         operator_request: dict[str, Any] | None,
@@ -329,6 +352,10 @@ def proposal_alignment_issue(
         return None
 
     if request_type == "size_budget":
+        if _float_or_none(operator_request.get("applied_max_encoded_percent")) is not None:
+            return _size_budget_cap_alignment_issue()
+        if object_dict(operator_request.get("applied_policy")):
+            return _size_budget_cap_alignment_issue()
         return _size_budget_alignment_issue()
     if request_type == "metric_target":
         return _metric_alignment_issue()

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -713,7 +713,7 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
             {
                 "label": "Folder Studio review-ready fixture",
                 "route": "/folders/tv/Review%20Ready/Season%201",
-                "marker": "Review the sample pack",
+                "marker": "Approve and queue",
             },
             {
                 "label": "Folder Studio active processing fixture",

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -100,7 +100,11 @@ from mediaforce.web.runtime.folder_ai_tuning import (
     folder_ai_tune_preview_action,
 )
 from mediaforce.web.runtime.folder_tuning_advice import audio_tradeoff_hint, operator_request_signature, size_budget_feasibility
-from mediaforce.web.runtime.folder_tuning_helpers import proposal_alignment_issue, size_budget_sample_issue
+from mediaforce.web.runtime.folder_tuning_helpers import (
+    measured_size_budget_policy_fragment,
+    proposal_alignment_issue,
+    size_budget_sample_issue,
+)
 from mediaforce.web.runtime.folder_state import _merge_review_pairs
 
 
@@ -3720,6 +3724,143 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIsNone(proposal["job_fields"]["seed_applied_policy"])
         self.assertEqual(proposal["request_disposition"], "honored")
 
+    def test_folder_ai_tune_preview_enforces_size_cap_after_measured_miss(self) -> None:
+        saved_proposals: list[dict[str, Any]] = []
+        base_policy = {"video": {"target_vmaf": 95.0, "max_encoded_percent": 80}}
+        host = HostStatus(
+            key="host-1",
+            label="M4 Studio",
+            mode="ssh",
+            priority=10,
+            capabilities=["sample_calibration"],
+            available=True,
+            message="Mounted and ready",
+            missing_paths=[],
+        )
+        operator_request = {
+            "request_type": "size_budget",
+            "operator_confirmed": True,
+            "budget_label": "300 MB per episode",
+            "budget_bytes": 314_572_800,
+            "requested_max_encoded_percent": 7.23,
+            "target_encoded_percent": 7.23,
+            "applied_policy": None,
+        }
+        size_target_analysis = {
+            "status": "over_target",
+            "predicted_total_size_bytes": 803_322_876,
+            "budget_bytes": 314_572_800,
+            "predicted_to_budget_ratio": 2.55,
+        }
+
+        def apply_fragment(current: dict[str, Any], fragment: dict[str, Any]) -> dict[str, Any]:
+            merged = dict(current)
+            for section, values in fragment.items():
+                if isinstance(values, dict) and isinstance(merged.get(section), dict):
+                    merged[section] = {**merged[section], **values}
+                else:
+                    merged[section] = values
+            return merged
+
+        def fake_request_note_tuning(*, project_root: Path, payload: dict[str, object]) -> TuningPolicyResponse:
+            self.assertEqual(project_root, self.config.paths.project_root)
+            self.assertEqual(payload["requested_experiment"], operator_request)
+            return TuningPolicyResponse(
+                ok=True,
+                summary="Lower quality slightly for the next measured sample.",
+                raw="{}",
+                prompt_version="test",
+                diagnosis="The last sample missed the requested size target.",
+                confidence="high",
+                evidence_checked=["runtime_toolbelt.size_target_analysis"],
+                suggested_follow_up=None,
+                request_disposition="honored",
+                request_response="I tightened the next sample against the measured miss.",
+                feasibility_note=None,
+                proposed_policy={"video": {"target_vmaf": 88.0}},
+                toolbelt_used=["size_target_analysis"],
+                self_check={"status": "pass", "summary": "ok", "issues": []},
+            )
+
+        deps = FolderAiTuneDeps(
+            resolve_sample_host=lambda _config, _host_key: host,
+            load_job_state=lambda *_args, **_kwargs: None,
+            load_retryable_sample_job_state=lambda *_args, **_kwargs: None,
+            sample_item=lambda *_args, **_kwargs: {
+                "rel_path": "tv/show/episode.mkv",
+                "source_path": str(self.root / "source" / "tv" / "show" / "episode.mkv"),
+                "source_size_bytes": 4_000_000_000,
+                "video_codec": "h264",
+                "duration_seconds": 2500.0,
+                "audio_summary": [],
+                "subtitle_summary": [],
+                "resolved_policy": dict(base_policy),
+            },
+            operator_requested_experiment=lambda *_args, **_kwargs: dict(operator_request),
+            load_calibration_state=lambda *_args, **_kwargs: {
+                "policy": dict(base_policy),
+                "sample_result": {
+                    "predicted_total_size_bytes": 803_322_876,
+                    "predicted_encode_percent": 18.47,
+                    "quality_metric": "VMAF",
+                    "quality_score": 95.04,
+                },
+            },
+            recent_tuning_sessions=lambda *_args, **_kwargs: [],
+            matching_request_history=lambda *_args, **_kwargs: None,
+            metric_support=lambda: {"vmaf": True},
+            maybe_seed_baseline_policy=lambda *_args, **_kwargs: None,
+            seed_advice_payload=lambda *_args, **_kwargs: None,
+            proposal_alignment_issue=proposal_alignment_issue,
+            now_iso=lambda: "2026-04-25T18:30:00+00:00",
+            proposal_signal_copy=lambda *_args, **_kwargs: "signal",
+            proposal_context_snapshot=lambda **kwargs: dict(kwargs),
+            save_pending_proposal=lambda _config, _prefix, payload: saved_proposals.append(dict(payload)),
+            pending_proposal_public_view=lambda payload: payload,
+            build_tuning_runtime_toolbelt=lambda *_args, **_kwargs: {
+                "size_target_analysis": dict(size_target_analysis),
+                "recent_sample_result": {"quality_score": 95.04},
+            },
+            review_pack_dir=lambda *_args, **_kwargs: self.root / "review-pack",
+            remove_path_if_exists=lambda *_args, **_kwargs: None,
+            build_multimodal_review_pack=lambda *_args, **_kwargs: None,
+            multimodal_review_pack_public_view=lambda *_args, **_kwargs: None,
+            tuning_advice_payload=lambda **kwargs: {"summary": kwargs["tuning"].summary},
+            load_pending_proposal=lambda *_args, **_kwargs: None,
+            apply_policy_fragment=apply_fragment,
+            save_advice_state=lambda *_args, **_kwargs: None,
+            save_job_state=lambda *_args, **_kwargs: None,
+            clear_pending_proposal=lambda *_args, **_kwargs: None,
+            record_tuning_session=lambda *_args, **_kwargs: "session-1",
+        )
+
+        with patch("mediaforce.web.runtime.folder_ai_tuning.inspect_prefix", return_value={"item_count": 1}), patch(
+                "mediaforce.web.runtime.folder_ai_tuning.request_note_tuning",
+                side_effect=fake_request_note_tuning,
+        ):
+            result = folder_ai_tune_preview_action(
+                self.config,
+                deps,
+                "tv/show",
+                "Aim for 200-300 MB per episode.",
+                "host-1",
+            )
+
+        self.assertTrue(result["ok"])
+        proposal = saved_proposals[0]
+        self.assertTrue(proposal["can_queue"])
+        self.assertEqual(proposal["preview_policy"]["video"]["max_encoded_percent"], 7)
+        self.assertEqual(proposal["preview_policy"]["video"]["target_vmaf"], 88.0)
+        self.assertEqual(proposal["applied_policy"]["video"]["max_encoded_percent"], 7)
+        self.assertEqual(proposal["operator_request"]["applied_max_encoded_percent"], 7)
+        self.assertEqual(proposal["operator_request"]["applied_policy"]["video"]["max_encoded_percent"], 7)
+        self.assertEqual(proposal["budget_enforcement"]["status"], "enforced_after_miss")
+        self.assertEqual(proposal["advice_payload"]["budget_enforcement"]["status"], "enforced_after_miss")
+        self.assertEqual(
+            proposal["advice_payload"]["budget_enforcement"]["applied_policy"],
+            {"video": {"max_encoded_percent": 7}},
+        )
+
     def test_folder_ai_tune_preview_exposes_latest_failed_sample_job_to_bench(self) -> None:
         captured_payloads: list[dict[str, Any]] = []
         saved_proposals: list[dict[str, Any]] = []
@@ -3932,6 +4073,28 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(request["budget_label"], "200 MB per episode")
         self.assertEqual(request["applied_policy"]["video"]["target_vmaf"], 85.0)
         self.assertNotIn("max_encoded_percent", request["applied_policy"]["video"])
+
+    def test_measured_size_budget_policy_fragment_enforces_cap_after_miss(self) -> None:
+        fragment = measured_size_budget_policy_fragment(
+            operator_request={
+                "request_type": "size_budget",
+                "requested_max_encoded_percent": 7.23,
+            },
+            size_target_analysis={"status": "over_target"},
+        )
+
+        self.assertEqual(fragment, {"video": {"max_encoded_percent": 7}})
+
+    def test_measured_size_budget_policy_fragment_waits_for_measured_miss(self) -> None:
+        fragment = measured_size_budget_policy_fragment(
+            operator_request={
+                "request_type": "size_budget",
+                "requested_max_encoded_percent": 7.23,
+            },
+            size_target_analysis={"status": "under_target"},
+        )
+
+        self.assertEqual(fragment, {})
 
     def test_operator_requested_experiment_returns_none_when_structured_parse_fails(self) -> None:
         with patch("mediaforce.web.runtime.folder_tuning_advice.request_operator_note_parse", return_value=None):
@@ -5287,13 +5450,14 @@ class TuningRuntimeTests(unittest.TestCase):
 
         self.assertIsNone(issue)
 
-    def test_proposal_alignment_issue_still_rejects_measured_size_budget_cap_change(self) -> None:
+    def test_proposal_alignment_issue_allows_enforced_measured_size_budget_cap(self) -> None:
         issue = proposal_alignment_issue(
             operator_request={
                 "request_type": "size_budget",
                 "budget_label": "300 MB per episode",
                 "budget_bytes": 300 * 1024 * 1024,
-                "applied_policy": None,
+                "applied_max_encoded_percent": 8,
+                "applied_policy": {"video": {"max_encoded_percent": 8}},
             },
             request_disposition="honored",
             current_policy={"video": {"target_vmaf": 95.0, "max_encoded_percent": 80}},
@@ -5301,10 +5465,26 @@ class TuningRuntimeTests(unittest.TestCase):
             allow_measured_size_quality_tradeoff=True,
         )
 
+        self.assertIsNone(issue)
+
+    def test_proposal_alignment_issue_rejects_measured_size_budget_weaker_cap(self) -> None:
+        issue = proposal_alignment_issue(
+            operator_request={
+                "request_type": "size_budget",
+                "budget_label": "300 MB per episode",
+                "budget_bytes": 300 * 1024 * 1024,
+                "applied_max_encoded_percent": 8,
+                "applied_policy": {"video": {"max_encoded_percent": 8}},
+            },
+            request_disposition="honored",
+            current_policy={"video": {"target_vmaf": 95.0, "max_encoded_percent": 80}},
+            preview_policy={"video": {"target_vmaf": 92.0, "max_encoded_percent": 12}},
+            allow_measured_size_quality_tradeoff=True,
+        )
+
         self.assertEqual(
             issue,
-            "The draft turns the size budget into a max_encoded_percent change. Size budgets are planning "
-            "targets for measured comparison unless the operator explicitly asks for a hard cap.",
+            "The draft uses a 12% size ceiling instead of the requested 8% ceiling.",
         )
 
     def test_proposal_alignment_issue_rejects_combined_metric_size_budget_cap_change(self) -> None:


### PR DESCRIPTION
## Summary

- remove the duplicate top-level Folders nav item while keeping folder routes available
- persist queue workbench search/library/state filters in local storage
- fix worker allowed-library UI semantics so an empty saved list displays as all libraries allowed
- add visible settings save affordances, including a dirty-state save dock while editing lower settings sections

## Validation

- pre-commit acceptance hook passed:
  - backend tests: 546 passed
  - CLI smoke: `uv run mediaforce --help`
  - frontend check: `npm --prefix frontend run check`
  - frontend lint: `npm --prefix frontend run lint`
  - frontend unit tests: 60 passed
  - frontend build: `npm --prefix frontend run build`
  - managed web route smoke including narrow routes and empty fixtures: passed
- manual browser QA verified:
  - primary nav shows Queue, Ops, Completed, Settings
  - queue library exclusions persist across refresh
  - worker library access starts as all checked when saved config has implicit all-libraries access
  - unsaved worker changes show the fixed save dock

## Notes

- PyCharm changed-files inspection was attempted and reported existing CSS font-resolution findings in `frontend/src/lib/design/tokens.css`; no findings were reported in the files changed for this PR.
- During validation, ignored smoke fixture state under `state/web-smoke` and `scratch/web-smoke` had stale local runtime/catalog data and was cleared so the managed smoke gate could run against deterministic fixtures.
