### PR TITLE
Fix follow-up workflow and filter migrations

### DIFF
--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -131,6 +131,17 @@ describe('Folder Studio review request mapping', () => {
 				calibrationJob: null
 			})
 		).toEqual({ disabled: false, title: '' });
+		expect(
+			resolveWorkflowActionState('queue-encode', {
+				reviewPackReady: true,
+				pendingProposal: {
+					proposal_id: 'draft-blocked',
+					can_queue: false,
+					message: 'The draft needs revision before queueing.'
+				} as PendingSampleProposal,
+				calibrationJob: null
+			})
+		).toEqual({ disabled: true, title: 'The draft needs revision before queueing.' });
 
 		expect(
 			resolveWorkflowActionState('start-sample', {
@@ -327,6 +338,34 @@ describe('Folder Studio review request mapping', () => {
 			primary: 'Approve and queue',
 			primaryAction: 'queue-encode',
 			secondary: 'Download pack'
+		});
+	});
+
+	it('does not approve stale non-queueable drafts without review evidence', () => {
+		const workflow = resolveWorkflow(
+			folderPayload({
+				pending_proposal: {
+					proposal_id: 'blocked-draft',
+					can_queue: false,
+					message: 'The draft needs revision before queueing.'
+				}
+			}),
+			folderStatusPayload(),
+			null,
+			{
+				proposal_id: 'blocked-draft',
+				can_queue: false,
+				message: 'The draft needs revision before queueing.'
+			} as PendingSampleProposal,
+			null,
+			null,
+			null
+		);
+
+		expect(workflow).toMatchObject({
+			label: 'Not sampled',
+			primary: 'Ask for draft',
+			primaryAction: 'focus-bench'
 		});
 	});
 

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -220,7 +220,15 @@ export function resolveWorkflowActionState(
 	}
 	if (action === 'focus-bench') return { disabled: false, title: '' };
 	if (action === 'open-ops') return { disabled: false, title: '' };
-	if (action === 'queue-encode') return { disabled: false, title: '' };
+	if (action === 'queue-encode') {
+		if (pendingProposal?.proposal_id && pendingProposal.can_queue === false) {
+			return {
+				disabled: true,
+				title: pendingProposal.message || 'The current draft is not ready to queue.'
+			};
+		}
+		return { disabled: false, title: '' };
+	}
 	if (action === 'download-review-pack') {
 		return reviewPackReady
 			? { disabled: false, title: '' }
@@ -701,7 +709,7 @@ export function resolveWorkflow(
 			secondaryAction: 'revise-proposal'
 		};
 	}
-	if (pendingProposal || calibration?.browser_review_ready || calibration?.review_media_ready) {
+	if (calibration?.browser_review_ready || calibration?.review_media_ready) {
 		return {
 			tone: 'ready',
 			label: 'Review ready',

--- a/frontend/src/lib/components/workstation/home-workbench.test.ts
+++ b/frontend/src/lib/components/workstation/home-workbench.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	clearStoredWorkbenchFilters,
+	LEGACY_WORKBENCH_FILTER_STORAGE_KEY,
 	parseStoredWorkbenchFilters,
 	readStoredWorkbenchFilters,
 	workbenchFilterStorageKey,
@@ -33,6 +34,54 @@ describe('home workbench filter storage', () => {
 	it('scopes persisted filter keys by route mode', () => {
 		expect(workbenchFilterStorageKey('queue')).toBe('mediaforce.workbench.filters.v1.queue');
 		expect(workbenchFilterStorageKey('folders')).toBe('mediaforce.workbench.filters.v1.folders');
+	});
+
+	it('migrates legacy queue filters to the scoped queue key', () => {
+		const originalWindow = globalThis.window;
+		const values = new Map<string, string>();
+		values.set(
+			LEGACY_WORKBENCH_FILTER_STORAGE_KEY,
+			JSON.stringify({
+				searchQuery: 'terminator',
+				libraryFilters: { tv: false },
+				stateFilters: { ready: true }
+			})
+		);
+		const storage = {
+			getItem(key: string) {
+				return values.get(key) ?? null;
+			},
+			setItem(key: string, value: string) {
+				values.set(key, value);
+			},
+			removeItem(key: string) {
+				values.delete(key);
+			}
+		} as unknown as Storage;
+
+		Object.defineProperty(globalThis, 'window', {
+			configurable: true,
+			value: { localStorage: storage }
+		});
+
+		expect(readStoredWorkbenchFilters('queue')).toEqual({
+			searchQuery: 'terminator',
+			libraryFilters: { tv: false },
+			stateFilters: { ready: true }
+		});
+		expect(values.has(LEGACY_WORKBENCH_FILTER_STORAGE_KEY)).toBe(false);
+		expect(
+			parseStoredWorkbenchFilters(values.get(workbenchFilterStorageKey('queue')) ?? null)
+		).toEqual({
+			searchQuery: 'terminator',
+			libraryFilters: { tv: false },
+			stateFilters: { ready: true }
+		});
+
+		Object.defineProperty(globalThis, 'window', {
+			configurable: true,
+			value: originalWindow
+		});
 	});
 
 	it('skips storage errors when reading or writing persisted filters', () => {

--- a/frontend/src/lib/components/workstation/home-workbench.ts
+++ b/frontend/src/lib/components/workstation/home-workbench.ts
@@ -1,4 +1,5 @@
 export const WORKBENCH_FILTER_STORAGE_KEY = 'mediaforce.workbench.filters.v1';
+export const LEGACY_WORKBENCH_FILTER_STORAGE_KEY = 'mediaforce.queue.filters.v1';
 
 export type WorkbenchFilterState = {
 	searchQuery: string;
@@ -46,9 +47,18 @@ export function workbenchFilterStorageKey(mode: WorkbenchFilterMode): string {
 export function readStoredWorkbenchFilters(mode: WorkbenchFilterMode): WorkbenchFilterState | null {
 	if (typeof window === 'undefined') return null;
 	try {
-		return parseStoredWorkbenchFilters(
+		const storedFilters = parseStoredWorkbenchFilters(
 			window.localStorage.getItem(workbenchFilterStorageKey(mode))
 		);
+		if (storedFilters || mode !== 'queue') return storedFilters;
+		const legacyFilters = parseStoredWorkbenchFilters(
+			window.localStorage.getItem(LEGACY_WORKBENCH_FILTER_STORAGE_KEY)
+		);
+		if (legacyFilters) {
+			writeStoredWorkbenchFilters(mode, legacyFilters);
+			window.localStorage.removeItem(LEGACY_WORKBENCH_FILTER_STORAGE_KEY);
+		}
+		return legacyFilters;
 	} catch {
 		return null;
 	}


### PR DESCRIPTION
Fixes two post-merge review findings from PR #98.\n\n- Disable approval/queue actions when a pending draft is explicitly non-queueable.\n- Avoid treating a non-queueable pending draft without review evidence as review-ready.\n- Migrate legacy queue filter localStorage from mediaforce.queue.filters.v1 to the new scoped queue key.\n\nValidation:\n- bash scripts/pre-commit-check.sh\n- Focused Vitest coverage for workflow gating and legacy filter migration\n\nNote: PyCharm changed-file inspection reported existing CSS font resolution noise in frontend/src/lib/design/tokens.css, unrelated to this patch.