### PR TITLE
Prioritize workstation lists on narrow screens

### DIFF
--- a/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
+++ b/frontend/src/lib/components/workstation/HomeWorkbenchView.svelte
@@ -809,6 +809,14 @@
 		grid-template-columns: minmax(0, 1fr);
 	}
 
+	.queue-workspace .queue-lanes {
+		grid-row: 1;
+	}
+
+	.queue-workspace .queue-inspector {
+		grid-row: 2;
+	}
+
 	.queue-lanes,
 	.queue-inspector {
 		min-width: 0;
@@ -1426,7 +1434,7 @@
 		}
 	}
 
-	@media (min-width: 760px) {
+	@media (min-width: 1080px) {
 		.queue-workspace--work {
 			grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
 		}


### PR DESCRIPTION
## Summary
- keep the ranked Work/Folders list ahead of the selected-detail inspector on narrow and tablet-width workstation layouts
- delay the Work two-column split until there is enough width for the table to remain readable
- preserve the wide-screen inspector layout while making the first viewport list-first at common browser widths

## Validation
- `npm --prefix frontend run check`
- `npm --prefix frontend run test:unit -- --run`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run build`
- `bash scripts/pre-commit-check.sh`
- Browser reviewed Work and Folders at 1024x768: first viewport now leads with the ranked list/index instead of the selected detail card
- Playwright checked Work and Folders at 390x844: no horizontal overflow and list section precedes inspector in DOM position

## Notes
This is intentionally small: it improves scan speed without changing data contracts or adding another UI concept.