### PR TITLE
Fix progressive refresh regressions

### DIFF
--- a/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { invalidateAll } from '$app/navigation';
 	import { onDestroy, onMount } from 'svelte';
 	import { resolve } from '$app/paths';
 	import { postJson } from '$lib/api/client';
@@ -31,11 +30,13 @@
 	let {
 		dashboard,
 		hosts,
-		loadError
+		loadError,
+		onRefresh = async () => {}
 	}: {
 		dashboard: DashboardSummaryPayload | null;
 		hosts: HostsPayload | null;
 		loadError: string | null;
+		onRefresh?: () => Promise<void>;
 	} = $props();
 
 	const queueRows = $derived(buildOpsQueueRows(dashboard));
@@ -186,7 +187,7 @@
 			if (action === 'prepare-host' && host) {
 				hostPasswords = { ...hostPasswords, [host.key]: '' };
 			}
-			await invalidateAll();
+			await onRefresh();
 		} catch (error) {
 			actionError = error instanceof Error ? error.message : 'Action failed.';
 		} finally {
@@ -203,7 +204,7 @@
 		}
 		refreshError = '';
 		try {
-			await invalidateAll();
+			await onRefresh();
 			lastRefreshAt = new Date();
 			if (!quiet) actionMessage = 'Ops state refreshed.';
 		} catch (error) {

--- a/frontend/src/routes/ops/+page.svelte
+++ b/frontend/src/routes/ops/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+
 	import { fetchJson } from '$lib/api/client';
 	import { initialDashboard, initialHosts } from '$lib/api/placeholders';
 	import type { DashboardSummaryPayload, HostsPayload } from '$lib/api/types';
@@ -8,18 +9,31 @@
 	let dashboard = $state<DashboardSummaryPayload | null>(initialDashboard);
 	let hosts = $state<HostsPayload | null>(initialHosts);
 	let loadError = $state('');
+	let refreshGeneration = 0;
 
-	onMount(async () => {
+	async function refreshOpsData() {
+		const generation = ++refreshGeneration;
 		try {
 			const [dashboardPayload, hostsPayload] = await Promise.all([
 				fetchJson<DashboardSummaryPayload>('/api/dashboard?preview_limit=0'),
 				fetchJson<HostsPayload>('/api/hosts?compact=1')
 			]);
+			if (generation !== refreshGeneration) return;
 			dashboard = dashboardPayload;
 			hosts = hostsPayload;
+			loadError = '';
 		} catch (error) {
+			if (generation !== refreshGeneration) return;
 			loadError = error instanceof Error ? error.message : 'Ops route failed to load.';
+			throw error instanceof Error ? error : new Error(loadError);
 		}
+	}
+
+	onMount(() => {
+		void refreshOpsData().catch(() => undefined);
+		return () => {
+			refreshGeneration += 1;
+		};
 	});
 </script>
 
@@ -27,4 +41,4 @@
 	<title>Mediaforce Ops</title>
 </svelte:head>
 
-<OpsWorkstationView {dashboard} {hosts} loadError={loadError || null} />
+<OpsWorkstationView {dashboard} {hosts} loadError={loadError || null} onRefresh={refreshOpsData} />

--- a/mediaforce/web/runtime/completed_runtime.py
+++ b/mediaforce/web/runtime/completed_runtime.py
@@ -11,6 +11,7 @@ from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import item_events, library_items, staged_artifacts
 from mediaforce.encoding.staging import safe_unlink
+from mediaforce.web.runtime.archive_cleanup import archive_cleanup_summary
 
 FolderGroup = tuple[str, str, str, str]
 ORIGINALS_REMOVED_EVENT = "originals_removed_confirmed"
@@ -67,22 +68,11 @@ def completed_page_payload(
         "folders": [asdict(folder) for folder in folders],
         "completed_count": len(folders),
         "folders_with_backups_count": folders_with_backups_count,
-        "archive_cleanup": completed_archive_cleanup_summary(archive_root, folders),
+        "archive_cleanup": archive_cleanup_summary(config),
         "history": [
             asdict(event)
             for event in list_completed_history_events(connection, folder_group=folder_group)
         ],
-    }
-
-
-def completed_archive_cleanup_summary(archive_root: Path | None, folders: list[CompletedFolder]) -> dict[str, Any]:
-    file_count = sum(folder.archived_backup_count for folder in folders)
-    total_size_bytes = sum(folder.archived_backup_size_bytes for folder in folders)
-    return {
-        "archive_root": str(archive_root) if archive_root is not None else "",
-        "file_count": file_count,
-        "total_size_bytes": total_size_bytes,
-        "has_cleanup": file_count > 0,
     }
 
 

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -1180,7 +1180,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(second_folder["cleanup_state"], "unknown")
         self.assertEqual(second_folder["missing_backup_count"], 1)
 
-    def test_completed_page_payload_uses_folder_backup_counts_for_archive_summary(self) -> None:
+    def test_completed_page_payload_counts_archive_files_for_cleanup_summary(self) -> None:
         from mediaforce.web import app as web_app
 
         self._insert_promoted_artifact(
@@ -1196,8 +1196,8 @@ class TuningRuntimeTests(unittest.TestCase):
         with open_db(self.config.paths.db_path) as connection:
             payload = completed_page_payload(self.config, connection, folder_group=web_app._folder_group)
 
-        self.assertEqual(payload["archive_cleanup"]["file_count"], 1)
-        self.assertEqual(payload["archive_cleanup"]["total_size_bytes"], 3)
+        self.assertEqual(payload["archive_cleanup"]["file_count"], 2)
+        self.assertEqual(payload["archive_cleanup"]["total_size_bytes"], 29)
         self.assertTrue(payload["archive_cleanup"]["has_cleanup"])
 
     def test_completed_page_payload_ignores_archived_paths_outside_active_archive_root(self) -> None:
@@ -1208,6 +1208,7 @@ class TuningRuntimeTests(unittest.TestCase):
             promoted_at="2026-04-10T10:00:00+00:00",
             archived_size_bytes=3,
             bytes_saved=12,
+            archive_exists=False,
         )
         outside_archive = self.root / "outside-archive" / "tv" / "Example Show" / "Season 1" / "Episode 02.mkv"
         outside_archive.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- pass an explicit Ops refresh callback from the progressive route to the workstation component so actions and auto-refresh reload dashboard and host data again
- propagate Ops refresh failures so the UI does not report success on failed API reloads
- count completed-page archive cleanup from the configured archive root so orphaned cleanup files keep the global cleanup action visible
- update completed cleanup tests for archive-scanned global counts while preserving row-level outside-root state

## Validation
- `uv run --with pytest pytest tests/test_tuning_runtime.py -q -k "completed_page_payload_counts_archive_files_for_cleanup_summary or completed_page_payload_ignores_archived_paths_outside_active_archive_root or completed_page_payload_groups_promoted_folders_and_active_backups"`
- `npm --prefix frontend run check`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:unit -- --run`
- `bash scripts/pre-commit-check.sh`