### PR TITLE
Fix completed cleanup progressive regressions

### DIFF
--- a/frontend/src/lib/components/workstation/CompletedWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/CompletedWorkstationView.svelte
@@ -2,6 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { postJson } from '$lib/api/client';
 	import type {
+		ArchiveCleanupSummary,
 		CompletedCleanupResult,
 		CompletedFolderRow,
 		CompletedHistoryEvent,
@@ -41,10 +42,14 @@
 
 	let {
 		completed: loadedCompleted,
-		loadError
+		loadError,
+		onArchiveRefresh = async () => null,
+		onCompletedUpdate = () => {}
 	}: {
 		completed: CompletedPayload | null;
 		loadError: string | null;
+		onArchiveRefresh?: () => Promise<ArchiveCleanupSummary | null>;
+		onCompletedUpdate?: (completed: CompletedPayload) => void;
 	} = $props();
 
 	let completed = $state<CompletedPayload | null>(null);
@@ -305,6 +310,18 @@
 		armedReview = armedReview === scope ? null : scope;
 	}
 
+	function applyCompleted(nextCompleted: CompletedPayload) {
+		completed = nextCompleted;
+		onCompletedUpdate(nextCompleted);
+	}
+
+	async function refreshArchiveSummary() {
+		if (!completed) return;
+		const archiveCleanup = await onArchiveRefresh();
+		if (!archiveCleanup) return;
+		applyCompleted({ ...completed, archive_cleanup: archiveCleanup });
+	}
+
 	async function confirmAlreadyRemoved() {
 		if (!completed || reviewFolders.length === 0 || reviewPending) return;
 		reviewPending = true;
@@ -318,7 +335,7 @@
 			);
 			actionMessage = result.message || 'Marked as already handled.';
 			if (result.completed) {
-				completed = result.completed;
+				applyCompleted(result.completed);
 			}
 			localHistory = [
 				{
@@ -361,7 +378,12 @@
 			lastCleanupResult = result;
 			actionMessage = result.message || 'Cleanup completed.';
 			if (result.completed) {
-				completed = result.completed;
+				applyCompleted(result.completed);
+			}
+			try {
+				await refreshArchiveSummary();
+			} catch {
+				// Cleanup already completed; keep that result visible if the follow-up scan fails.
 			}
 			localHistory = [
 				{

--- a/frontend/src/routes/completed/+page.svelte
+++ b/frontend/src/routes/completed/+page.svelte
@@ -1,18 +1,47 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { fetchJson } from '$lib/api/client';
-	import type { CompletedPayload } from '$lib/api/types';
+	import type { ArchiveCleanupSummary, CompletedPayload } from '$lib/api/types';
 	import CompletedWorkstationView from '$lib/components/workstation/CompletedWorkstationView.svelte';
 
 	let completed = $state<CompletedPayload | null>(null);
 	let loadError = $state('');
+	let archiveRefreshGeneration = 0;
 
-	onMount(async () => {
+	async function fetchArchiveCleanup(): Promise<ArchiveCleanupSummary> {
+		return fetchJson<ArchiveCleanupSummary>('/api/archive-cleanup');
+	}
+
+	function updateCompleted(nextCompleted: CompletedPayload) {
+		completed = nextCompleted;
+		archiveRefreshGeneration += 1;
+	}
+
+	async function refreshArchiveCleanup() {
+		const generation = ++archiveRefreshGeneration;
 		try {
-			completed = await fetchJson<CompletedPayload>('/api/completed');
+			const archiveCleanup = await fetchArchiveCleanup();
+			if (generation !== archiveRefreshGeneration || !completed) return;
+			completed = { ...completed, archive_cleanup: archiveCleanup };
+		} catch {
+			// Keep the cheap completed payload visible if the deeper archive scan fails.
+		}
+	}
+
+	async function hydrateCompleted() {
+		try {
+			updateCompleted(await fetchJson<CompletedPayload>('/api/completed'));
+			void refreshArchiveCleanup();
 		} catch (error) {
 			loadError = error instanceof Error ? error.message : 'Completed route failed to load.';
 		}
+	}
+
+	onMount(() => {
+		void hydrateCompleted();
+		return () => {
+			archiveRefreshGeneration += 1;
+		};
 	});
 </script>
 
@@ -20,4 +49,9 @@
 	<title>Mediaforce Completed</title>
 </svelte:head>
 
-<CompletedWorkstationView {completed} loadError={loadError || null} />
+<CompletedWorkstationView
+	{completed}
+	loadError={loadError || null}
+	onArchiveRefresh={fetchArchiveCleanup}
+	onCompletedUpdate={updateCompleted}
+/>

--- a/frontend/src/routes/folders/[...prefix]/+page.svelte
+++ b/frontend/src/routes/folders/[...prefix]/+page.svelte
@@ -76,11 +76,12 @@
 			folder = folderPayload;
 			status = statusPayload;
 			hosts = hostsPayload;
-			folderPending = false;
 		} catch (error) {
 			if (generation === hydrationGeneration) {
 				loadError = error instanceof Error ? error.message : 'Unable to load folder state.';
 			}
+		} finally {
+			if (generation === hydrationGeneration) folderPending = false;
 		}
 	}
 

--- a/mediaforce/web/runtime/completed_runtime.py
+++ b/mediaforce/web/runtime/completed_runtime.py
@@ -11,8 +11,6 @@ from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import item_events, library_items, staged_artifacts
 from mediaforce.encoding.staging import safe_unlink
-from mediaforce.web.runtime.archive_cleanup import archive_cleanup_summary
-
 FolderGroup = tuple[str, str, str, str]
 ORIGINALS_REMOVED_EVENT = "originals_removed_confirmed"
 HISTORY_DETAIL_MAX_CHARS = 320
@@ -68,11 +66,22 @@ def completed_page_payload(
         "folders": [asdict(folder) for folder in folders],
         "completed_count": len(folders),
         "folders_with_backups_count": folders_with_backups_count,
-        "archive_cleanup": archive_cleanup_summary(config),
+        "archive_cleanup": completed_archive_cleanup_summary(archive_root, folders),
         "history": [
             asdict(event)
             for event in list_completed_history_events(connection, folder_group=folder_group)
         ],
+    }
+
+
+def completed_archive_cleanup_summary(archive_root: Path | None, folders: list[CompletedFolder]) -> dict[str, Any]:
+    file_count = sum(folder.archived_backup_count for folder in folders)
+    total_size_bytes = sum(folder.archived_backup_size_bytes for folder in folders)
+    return {
+        "archive_root": str(archive_root) if archive_root is not None else "",
+        "file_count": file_count,
+        "total_size_bytes": total_size_bytes,
+        "has_cleanup": file_count > 0,
     }
 
 

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -1180,7 +1180,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(second_folder["cleanup_state"], "unknown")
         self.assertEqual(second_folder["missing_backup_count"], 1)
 
-    def test_completed_page_payload_counts_archive_files_for_cleanup_summary(self) -> None:
+    def test_completed_page_payload_uses_folder_backup_counts_for_archive_summary(self) -> None:
         from mediaforce.web import app as web_app
 
         self._insert_promoted_artifact(
@@ -1196,9 +1196,25 @@ class TuningRuntimeTests(unittest.TestCase):
         with open_db(self.config.paths.db_path) as connection:
             payload = completed_page_payload(self.config, connection, folder_group=web_app._folder_group)
 
-        self.assertEqual(payload["archive_cleanup"]["file_count"], 2)
-        self.assertEqual(payload["archive_cleanup"]["total_size_bytes"], 29)
+        self.assertEqual(payload["archive_cleanup"]["file_count"], 1)
+        self.assertEqual(payload["archive_cleanup"]["total_size_bytes"], 3)
         self.assertTrue(payload["archive_cleanup"]["has_cleanup"])
+
+    def test_completed_page_payload_does_not_scan_archive_cleanup(self) -> None:
+        from mediaforce.web import app as web_app
+
+        self._insert_promoted_artifact(
+            rel_path="tv/Example Show/Season 1/Episode 01.mkv",
+            promoted_at="2026-04-10T10:00:00+00:00",
+            archived_size_bytes=3,
+            bytes_saved=12,
+        )
+        with patch("mediaforce.web.runtime.archive_cleanup.Path.rglob") as rglob:
+            with open_db(self.config.paths.db_path) as connection:
+                payload = completed_page_payload(self.config, connection, folder_group=web_app._folder_group)
+
+        rglob.assert_not_called()
+        self.assertEqual(payload["archive_cleanup"]["file_count"], 1)
 
     def test_completed_page_payload_ignores_archived_paths_outside_active_archive_root(self) -> None:
         from mediaforce.web import app as web_app


### PR DESCRIPTION
## Summary
- clear Folder Studio pending state after failed progressive hydration
- keep /api/completed cheap by using DB-tracked completed backup counts instead of scanning the whole archive tree on page load
- refresh the full archive cleanup summary after Completed renders so orphan cleanup files still surface without blocking initial load
- keep Completed state parent-owned across action refreshes so slow archive scans cannot restore stale rows

## Validation
- `uv run --with pytest pytest tests/test_tuning_runtime.py -q -k "completed_page_payload_uses_folder_backup_counts_for_archive_summary or completed_page_payload_does_not_scan_archive_cleanup or completed_page_payload_ignores_archived_paths_outside_active_archive_root"`
- `npm --prefix frontend run check`
- `npm --prefix frontend run lint`
- `npm --prefix frontend run test:unit -- --run`
- `bash scripts/pre-commit-check.sh`