### PR TITLE
Guide the single-folder encode workflow

### DIFF
--- a/frontend/src/lib/components/workstation/CompletedWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/CompletedWorkstationView.svelte
@@ -772,7 +772,7 @@
 											class="control control--primary armed"
 											disabled={reviewPending}
 											onclick={confirmAlreadyRemoved}
-											>{reviewPending ? 'Working' : 'Confirm reviewed'}</button
+											>{reviewPending ? 'Working' : 'Mark handled'}</button
 										>
 										<button
 											type="button"

--- a/frontend/src/lib/components/workstation/FolderStudioView.svelte
+++ b/frontend/src/lib/components/workstation/FolderStudioView.svelte
@@ -31,6 +31,7 @@
 		buildProposalRows,
 		buildReviewWorkspaceView,
 		buildDecisionFacts,
+		buildBasicEncodeGuide,
 		buildRuntimeFacts,
 		buildSampleFacts,
 		buildSampleVerdict,
@@ -146,6 +147,7 @@
 		)
 	);
 	const workflowSteps = $derived(buildWorkflowSteps(workflow));
+	const basicEncodeGuide = $derived(buildBasicEncodeGuide(workflow));
 	const proposalRows = $derived(buildProposalRows(studioFolder, pendingProposal));
 	const statusTiles = $derived(buildStatusTiles(studioFolder, status, hosts, workflow));
 	const footerSignals = $derived(buildFooterSignals(studioFolder, status, hosts, workflow));
@@ -169,9 +171,13 @@
 	);
 	const draftReviewRow = $derived(
 		outputReviewRows.find(
-			(row) => row.label === 'Next sample draft' || row.label === 'Video output'
+			(row) =>
+				row.label === 'Next sample plan' ||
+				row.label === 'Next sample draft' ||
+				row.label === 'Video output'
 		) ?? null
 	);
+	const guideActionState = $derived(workflowActionState(basicEncodeGuide.action));
 	const visualReviewArtifacts = $derived(
 		[...reviewArtifacts.filter((artifact) => artifact.category === 'visual')]
 			.sort((left, right) => reviewArtifactPriority(left.kind) - reviewArtifactPriority(right.kind))
@@ -251,7 +257,8 @@
 			);
 			localPendingProposal = response.proposal ?? studioFolder.pending_proposal ?? null;
 			localProposalPrefix = prefix;
-			benchMessage = response.message || 'Draft ready. Nothing is queued until you confirm it.';
+			benchMessage =
+				response.message || 'Sample plan ready. Nothing is queued until you confirm it.';
 			benchNote = '';
 		} catch (error) {
 			benchError = error instanceof Error ? error.message : 'Review request failed.';
@@ -274,7 +281,7 @@
 			);
 			localPendingProposal = null;
 			localProposalPrefix = prefix;
-			benchMessage = response.message || 'Queued the sample run from the draft.';
+			benchMessage = response.message || 'Queued the sample run from the plan.';
 			await onMutate();
 		} catch (error) {
 			benchError = error instanceof Error ? error.message : 'Sample could not be queued.';
@@ -307,7 +314,8 @@
 								reviewed_draft_hash: calibration?.draft_hash ?? ''
 							}
 						);
-			profileMessage = response.message || 'Approved the draft and queued the folder encode.';
+			profileMessage =
+				response.message || 'Approved the sample plan and queued the folder process.';
 			await onMutate();
 		} catch (error) {
 			profileError =
@@ -440,6 +448,123 @@
 				{/each}
 			</nav>
 
+			<section class="basic-run" aria-labelledby="basic-run-title">
+				<header class="basic-run__header">
+					<div>
+						<span>{basicEncodeGuide.label}</span>
+						<h2 id="basic-run-title">{basicEncodeGuide.title}</h2>
+						<p>{basicEncodeGuide.detail}</p>
+					</div>
+					{#if basicEncodeGuide.action === 'focus-bench'}
+						<button
+							class="basic-run__action"
+							type="button"
+							onclick={focusBenchComposer}
+							data-mf-action={`guide-${basicEncodeGuide.action}`}>{basicEncodeGuide.primary}</button
+						>
+					{:else if basicEncodeGuide.action === 'open-series' || basicEncodeGuide.action === 'open-folders'}
+						<a
+							class="basic-run__action"
+							href={resolve(seriesRoute)}
+							data-mf-action={`guide-${basicEncodeGuide.action}`}>{basicEncodeGuide.primary}</a
+						>
+					{:else if basicEncodeGuide.action === 'open-completed'}
+						<a
+							class="basic-run__action"
+							href={resolve('/completed')}
+							data-mf-action={`guide-${basicEncodeGuide.action}`}>{basicEncodeGuide.primary}</a
+						>
+					{:else if basicEncodeGuide.action === 'open-ops' || basicEncodeGuide.action.startsWith('monitor-')}
+						<a
+							class="basic-run__action"
+							href={resolve('/ops')}
+							data-mf-action={`guide-${basicEncodeGuide.action}`}>{basicEncodeGuide.primary}</a
+						>
+					{:else if basicEncodeGuide.action === 'download-review-pack' && !guideActionState.disabled}
+						<form
+							class="action-form"
+							method="get"
+							action={`${resolve('/')}api/folders/${encodedPrefix}/review-compare/download`}
+							data-mf-action={`guide-${basicEncodeGuide.action}`}
+						>
+							<button class="basic-run__action" type="submit">{basicEncodeGuide.primary}</button>
+						</form>
+					{:else if basicEncodeGuide.action === 'start-sample' || basicEncodeGuide.action === 'retry-sample'}
+						<button
+							class="basic-run__action"
+							type="button"
+							disabled={guideActionState.disabled}
+							title={guideActionState.title}
+							onclick={() => confirmBenchProposal(basicEncodeGuide.action)}
+							data-mf-action={`guide-${basicEncodeGuide.action}`}
+							data-mf-wire="live"
+							>{workflowPending === basicEncodeGuide.action
+								? 'Queueing'
+								: basicEncodeGuide.primary}</button
+						>
+					{:else if basicEncodeGuide.action === 'queue-encode' || basicEncodeGuide.action === 'approve-size-tradeoff'}
+						<button
+							class="basic-run__action"
+							type="button"
+							disabled={guideActionState.disabled}
+							title={guideActionState.title}
+							onclick={() => saveProfileAndQueue(basicEncodeGuide.action)}
+							data-mf-action={`guide-${basicEncodeGuide.action}`}
+							data-mf-wire="live"
+							>{workflowPending === basicEncodeGuide.action
+								? 'Approving'
+								: basicEncodeGuide.primary}</button
+						>
+					{:else if basicEncodeGuide.action === 'retry-encode'}
+						<button
+							class="basic-run__action"
+							type="button"
+							disabled={guideActionState.disabled}
+							title={guideActionState.title}
+							onclick={retryEncode}
+							data-mf-action={`guide-${basicEncodeGuide.action}`}
+							data-mf-wire="live"
+							>{workflowPending === basicEncodeGuide.action
+								? 'Retrying'
+								: basicEncodeGuide.primary}</button
+						>
+					{:else if basicEncodeGuide.action === 'validate-outputs' || basicEncodeGuide.action === 'promote-outputs'}
+						<button
+							class="basic-run__action"
+							type="button"
+							disabled={guideActionState.disabled}
+							title={guideActionState.title}
+							onclick={() => runFolderWorkflowAction(basicEncodeGuide.action)}
+							data-mf-action={`guide-${basicEncodeGuide.action}`}
+							data-mf-wire="live"
+							>{workflowPending === basicEncodeGuide.action
+								? 'Running'
+								: basicEncodeGuide.primary}</button
+						>
+					{:else}
+						<button
+							class="basic-run__action"
+							type="button"
+							disabled={guideActionState.disabled}
+							title={guideActionState.title}
+							data-mf-action={`guide-${basicEncodeGuide.action}`}
+							data-mf-wire="pending">{basicEncodeGuide.primary}</button
+						>
+					{/if}
+				</header>
+				<ol class="basic-run__steps" aria-label="Single folder encode steps">
+					{#each basicEncodeGuide.steps as step, index (step.label)}
+						<li class="basic-run__step basic-run__step--{step.state}">
+							<span>{index + 1}</span>
+							<div>
+								<strong>{step.label}</strong>
+								<small>{step.detail}</small>
+							</div>
+						</li>
+					{/each}
+				</ol>
+			</section>
+
 			<section class="decision decision--{workflow.tone}" aria-labelledby="decision-title">
 				{#if loadError}
 					<div class="route-error" role="status">
@@ -473,6 +598,12 @@
 						<a
 							class="control control--primary"
 							href={resolve(seriesRoute)}
+							data-mf-action={workflow.primaryAction}>{workflow.primary}</a
+						>
+					{:else if workflow.primaryAction === 'open-completed'}
+						<a
+							class="control control--primary"
+							href={resolve('/completed')}
 							data-mf-action={workflow.primaryAction}>{workflow.primary}</a
 						>
 					{:else if workflow.primaryAction === 'open-ops' || workflow.primaryAction.startsWith('monitor-')}
@@ -561,6 +692,12 @@
 					{:else if workflow.secondaryAction === 'open-series' || workflow.secondaryAction === 'open-folders'}
 						<a class="control" href={resolve(seriesRoute)} data-mf-action={workflow.secondaryAction}
 							>{workflow.secondary}</a
+						>
+					{:else if workflow.secondaryAction === 'open-completed'}
+						<a
+							class="control"
+							href={resolve('/completed')}
+							data-mf-action={workflow.secondaryAction}>{workflow.secondary}</a
 						>
 					{:else if workflow.secondaryAction === 'open-ops'}
 						<a class="control" href={resolve('/ops')} data-mf-action={workflow.secondaryAction}
@@ -678,7 +815,7 @@
 							<small>{approvedSeasonShortcut?.count ?? 1} approved season policy available</small>
 						</div>
 						<button class="control" type="button" onclick={fillDraftFromApprovedPolicy}
-							>Fill draft from policy</button
+							>Use policy as sample plan</button
 						>
 					</div>
 				{/if}
@@ -716,7 +853,7 @@
 						<div class="output-review-table__head">
 							<span>Area</span>
 							<span>Source</span>
-							<span>Output / draft</span>
+							<span>Planned output</span>
 							<span>Why it matters</span>
 						</div>
 						{#each outputReviewRows as row (row.label)}
@@ -741,7 +878,7 @@
 							</button>
 						{:else}
 							<div class="empty-note">
-								Run a sample to generate source-versus-draft review images.
+								Run a sample to generate source-versus-output review images.
 							</div>
 						{/each}
 						{#each audioReviewArtifacts as artifact (artifact.imageUrl || artifact.label)}
@@ -794,7 +931,7 @@
 								<span>Request</span>
 								<textarea
 									rows="5"
-									placeholder="Ask what to sample, revise, or validate for this folder."
+									placeholder="Describe the content and your quality or size goal, or ask for a standard sample to get started."
 									bind:this={benchTextarea}
 									bind:value={benchNote}
 								></textarea>
@@ -847,9 +984,11 @@
 				</WorkstationPanel>
 
 				{#if !workflow.isOutputWorkflow}
-					<WorkstationPanel title={pendingProposal?.proposal_id ? 'Active draft' : 'Sample target'}>
+					<WorkstationPanel
+						title={pendingProposal?.proposal_id ? 'Active sample plan' : 'Sample target'}
+					>
 						<dl class="kv kv--compact">
-							<dt>{pendingProposal?.proposal_id ? 'Draft' : 'Source'}</dt>
+							<dt>{pendingProposal?.proposal_id ? 'Plan' : 'Source'}</dt>
 							<dd>{draftReviewRow?.output ?? '—'}</dd>
 							<dt>Reason</dt>
 							<dd>{draftReviewRow?.detail ?? '—'}</dd>
@@ -909,12 +1048,12 @@
 					<summary>
 						<strong>Proposed settings details</strong>
 						<span
-							>{proposalRows.length ? `${proposalRows.length} draft differences` : 'No draft'}</span
+							>{proposalRows.length ? `${proposalRows.length} plan differences` : 'No plan'}</span
 						>
 					</summary>
 					<WorkstationPanel
 						title="Current settings vs. proposal"
-						meta={proposalRows.length ? `${proposalRows.length} rows` : 'No draft'}
+						meta={proposalRows.length ? `${proposalRows.length} rows` : 'No plan'}
 					>
 						<div class="table-wrap">
 							<table class="policy-table">
@@ -923,7 +1062,7 @@
 										<th>Area</th>
 										<th>Setting</th>
 										<th>Current</th>
-										<th>Draft</th>
+										<th>Plan</th>
 									</tr>
 								</thead>
 								<tbody>
@@ -1238,7 +1377,7 @@
 		border: var(--mf-border);
 		display: grid;
 		grid-template-columns: repeat(4, minmax(0, 1fr));
-		order: 3;
+		order: 4;
 	}
 
 	.workflow-strip__step {
@@ -1246,10 +1385,10 @@
 		border-right: var(--mf-border-muted);
 		border-top: 2px solid var(--mf-line-strong);
 		display: grid;
-		gap: var(--mf-space-3);
+		gap: var(--mf-space-2);
 		grid-template-columns: auto minmax(0, 1fr);
 		min-width: 0;
-		padding: var(--mf-space-4);
+		padding: var(--mf-space-3);
 	}
 
 	.workflow-strip__step:last-child {
@@ -1263,10 +1402,10 @@
 		color: var(--mf-fg-tertiary);
 		display: inline-flex;
 		font-family: var(--mf-font-mono), monospace;
-		font-size: var(--mf-text-xs);
-		height: 24px;
+		font-size: var(--mf-text-2xs);
+		height: 20px;
 		justify-content: center;
-		width: 24px;
+		width: 20px;
 	}
 
 	.workflow-strip__step div {
@@ -1276,13 +1415,13 @@
 	}
 
 	.workflow-strip__step strong {
-		font-size: var(--mf-text-sm);
+		font-size: var(--mf-text-xs);
 		font-weight: var(--mf-weight-semibold);
 	}
 
 	.workflow-strip__step small {
 		color: var(--mf-fg-tertiary);
-		font-size: var(--mf-text-xs);
+		font-size: var(--mf-text-2xs);
 		line-height: var(--mf-leading-snug);
 		overflow-wrap: anywhere;
 	}
@@ -1307,6 +1446,132 @@
 		border-top-color: var(--mf-fail-fg);
 	}
 
+	.basic-run {
+		background: var(--mf-bg-panel);
+		border: var(--mf-border);
+		display: grid;
+		gap: var(--mf-space-3);
+		order: 3;
+		padding: var(--mf-space-4);
+	}
+
+	.basic-run__header {
+		align-items: center;
+		display: grid;
+		gap: var(--mf-space-4);
+		grid-template-columns: minmax(0, 1fr) auto;
+	}
+
+	.basic-run__header div {
+		display: grid;
+		gap: var(--mf-space-1);
+		min-width: 0;
+	}
+
+	.basic-run__header span {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0;
+		text-transform: uppercase;
+	}
+
+	.basic-run__header h2 {
+		font-size: var(--mf-text-base);
+		font-weight: var(--mf-weight-semibold);
+		margin: 0;
+	}
+
+	.basic-run__header p {
+		color: var(--mf-fg-muted);
+		font-size: var(--mf-text-xs);
+		line-height: var(--mf-leading-snug);
+		margin: 0;
+	}
+
+	.basic-run__action,
+	.basic-run__next {
+		background: var(--mf-ready-bg);
+		border: 1px solid var(--mf-ready-line);
+		color: var(--mf-ready-fg);
+		display: inline-flex;
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-semibold);
+		justify-content: center;
+		min-width: 140px;
+		padding: var(--mf-space-2) var(--mf-space-3);
+		text-decoration: none;
+		white-space: nowrap;
+	}
+
+	.basic-run__action {
+		cursor: pointer;
+	}
+
+	button.basic-run__action {
+		font: inherit;
+	}
+
+	.basic-run__steps {
+		display: grid;
+		gap: var(--mf-space-2);
+		grid-template-columns: repeat(7, minmax(0, 1fr));
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	.basic-run__step {
+		background: var(--mf-bg-strip);
+		border: var(--mf-border-muted);
+		border-top: 2px solid var(--mf-line-strong);
+		display: grid;
+		gap: var(--mf-space-1);
+		grid-template-columns: minmax(0, 1fr);
+		min-width: 0;
+		padding: var(--mf-space-2);
+	}
+
+	.basic-run__step > span {
+		align-items: center;
+		background: var(--mf-bg-input);
+		border: var(--mf-border-muted);
+		color: var(--mf-fg-tertiary);
+		display: inline-flex;
+		font-family: var(--mf-font-mono), monospace;
+		font-size: var(--mf-text-2xs);
+		height: 18px;
+		justify-content: center;
+		width: 18px;
+	}
+
+	.basic-run__step div {
+		display: grid;
+		gap: var(--mf-space-1);
+		min-width: 0;
+	}
+
+	.basic-run__step strong {
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+	}
+
+	.basic-run__step small {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		line-height: var(--mf-leading-snug);
+		overflow-wrap: anywhere;
+	}
+
+	.basic-run__step--done {
+		border-top-color: var(--mf-ready-fg);
+	}
+
+	.basic-run__step--current {
+		background: var(--mf-active-bg);
+		border-top-color: var(--mf-active-fg);
+	}
+
 	.decision {
 		--decision-line: var(--mf-idle-line);
 		background: var(--mf-bg-panel);
@@ -1315,7 +1580,7 @@
 		display: grid;
 		gap: var(--mf-space-6);
 		grid-template-columns: minmax(0, 1fr);
-		order: 1;
+		order: 5;
 		padding: var(--mf-space-6);
 	}
 
@@ -2032,7 +2297,7 @@
 		color: var(--mf-fg-tertiary);
 		font-size: var(--mf-text-2xs);
 		font-weight: var(--mf-weight-semibold);
-		letter-spacing: 0.08em;
+		letter-spacing: 0;
 		text-transform: uppercase;
 	}
 
@@ -2044,9 +2309,14 @@
 	}
 
 	.kv--compact {
-		grid-template-columns: minmax(74px, auto) minmax(0, 1fr);
+		grid-template-columns: minmax(64px, auto) minmax(0, 1fr);
 		padding: var(--mf-space-5);
 		row-gap: var(--mf-space-3);
+	}
+
+	.kv--compact dd {
+		min-width: 0;
+		white-space: normal;
 	}
 
 	.history-list--compact {
@@ -2091,6 +2361,14 @@
 			grid-template-columns: minmax(190px, 240px) minmax(0, 1fr);
 		}
 
+		.basic-run__steps {
+			grid-template-columns: repeat(7, minmax(0, 1fr));
+		}
+
+		.basic-run__step small {
+			display: none;
+		}
+
 		.decision__facts {
 			display: grid;
 			grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -2115,12 +2393,18 @@
 
 		.folder-header,
 		.workflow-strip,
+		.basic-run__header,
 		.decision,
 		.bench,
 		.review-workspace__header,
 		.support-grid,
 		.evidence-grid {
 			grid-template-columns: 1fr;
+		}
+
+		.basic-run__steps {
+			grid-template-columns: repeat(7, minmax(84px, 1fr));
+			overflow-x: auto;
 		}
 
 		.output-review-table__head {
@@ -2211,7 +2495,7 @@
 		}
 
 		.policy-table td:nth-child(4)::before {
-			content: 'Draft';
+			content: 'Plan';
 		}
 	}
 </style>

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -8,6 +8,7 @@ import type {
 import type { FolderCalibrationJob } from '$lib/folders/studio';
 import {
 	buildBenchHostOptions,
+	buildBasicEncodeGuide,
 	buildBudgetEnforcementView,
 	buildDecisionFacts,
 	buildFooterSignals,
@@ -15,6 +16,7 @@ import {
 	buildProcessingHostOptions,
 	buildReviewWorkspaceView,
 	buildRuntimeFacts,
+	approvalStatusCopy,
 	buildSampleFacts,
 	buildSeasonScopeRows,
 	buildSampleVerdict,
@@ -27,6 +29,7 @@ import {
 	resolveQueueSubmissionMode,
 	resolveWorkflow,
 	resolveWorkflowActionState,
+	sampleStatusCopy,
 	summarizeOutputWorkflowPending
 } from './folder-studio-view';
 import type { FolderCalibrationState, PendingSampleProposal } from '$lib/folders/studio';
@@ -378,7 +381,7 @@ describe('Folder Studio review request mapping', () => {
 			})
 		).toMatchObject({
 			disabled: true,
-			title: 'Ask the review assistant for a draft before starting the sample.'
+			title: 'Ask the review assistant for a sample plan before starting the sample.'
 		});
 
 		expect(
@@ -410,6 +413,116 @@ describe('Folder Studio review request mapping', () => {
 		).toMatchObject({
 			disabled: true,
 			title: 'A sample job is already active for this folder.'
+		});
+	});
+
+	it('maps sample status into basic user copy', () => {
+		expect(sampleStatusCopy('queued')).toBe('Sample waiting');
+		expect(sampleStatusCopy('running')).toBe('Sampling');
+		expect(sampleStatusCopy('pending_review')).toBe('Ready to review');
+		expect(sampleStatusCopy('failed')).toBe('Sample needs retry');
+		expect(sampleStatusCopy('idle')).toBe('Needs sample');
+	});
+
+	it('maps approval status into basic user copy', () => {
+		expect(approvalStatusCopy('missing_sample')).toBe('Needs sample');
+		expect(approvalStatusCopy('accepted')).toBe('Approved');
+		expect(approvalStatusCopy('blocked')).toBe('Blocked');
+		expect(approvalStatusCopy('needs_review')).toBe('Needs review');
+		expect(approvalStatusCopy('pending_review')).toBe('Ready to review');
+		expect(approvalStatusCopy(null)).toBe('Not reviewed');
+	});
+
+	it('builds a single-folder guide around the current next step', () => {
+		const sampleWorkflow = resolveWorkflow(
+			folderPayload(),
+			folderStatusPayload(),
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+		expect(buildBasicEncodeGuide(sampleWorkflow)).toMatchObject({
+			label: 'Single folder run',
+			title: 'Run sample',
+			primary: 'Ask review assistant',
+			action: 'focus-bench'
+		});
+		expect(buildBasicEncodeGuide(sampleWorkflow).steps.map((step) => step.state)).toEqual([
+			'done',
+			'current',
+			'upcoming',
+			'upcoming',
+			'upcoming',
+			'upcoming',
+			'upcoming'
+		]);
+
+		const validateWorkflow = resolveWorkflow(
+			folderPayload({ workflow_state: workflowState() }),
+			folderStatusPayload(),
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+		expect(buildBasicEncodeGuide(validateWorkflow)).toMatchObject({
+			title: 'Validate output',
+			primary: 'Validate outputs',
+			action: 'validate-outputs'
+		});
+		expect(buildBasicEncodeGuide(validateWorkflow).steps[4]).toMatchObject({
+			label: 'Validate output',
+			state: 'current'
+		});
+
+		const reviewWorkflow = {
+			tone: 'ready',
+			label: 'Review ready',
+			title: 'Approve this sample or revise it',
+			copy: 'Review the clips, then approve and queue if this is acceptable.',
+			primary: 'Approve and queue',
+			primaryAction: 'queue-encode',
+			secondary: 'Download pack',
+			secondaryAction: 'download-review-pack'
+		} as const;
+		expect(buildBasicEncodeGuide(reviewWorkflow)).toMatchObject({
+			title: 'Review sample',
+			primary: 'Approve and queue',
+			action: 'queue-encode'
+		});
+		expect(buildBasicEncodeGuide(reviewWorkflow).steps[2]).toMatchObject({
+			label: 'Review sample',
+			state: 'current'
+		});
+
+		const completeWorkflow = resolveWorkflow(
+			folderPayload({
+				workflow_state: workflowState({
+					state: 'complete',
+					label: 'Complete',
+					detail: 'All folder outputs are promoted.',
+					next_action: {
+						kind: 'review_scope',
+						label: 'Review scope',
+						enabled: true,
+						target_prefix: 'tv/Example/Season 1'
+					}
+				})
+			}),
+			folderStatusPayload(),
+			null,
+			null,
+			null,
+			null,
+			null
+		);
+		expect(buildBasicEncodeGuide(completeWorkflow)).toMatchObject({
+			title: 'Clean up',
+			primary: 'Review cleanup',
+			action: 'open-completed'
 		});
 	});
 
@@ -541,7 +654,7 @@ describe('Folder Studio review request mapping', () => {
 					tone: 'wait'
 				}),
 				expect.objectContaining({
-					label: 'Next sample draft',
+					label: 'Next sample plan',
 					output: 'AV1 · max 720p',
 					detail: 'VMAF target 89 · floor 87 · downscale allowed by the size request · grain off'
 				}),
@@ -838,9 +951,9 @@ describe('Folder Studio review request mapping', () => {
 				workflow
 			)
 		).toEqual([
-			{ label: 'Calibration', value: 'idle' },
+			{ label: 'Sample', value: 'Needs sample' },
 			{ label: 'Scan', value: 'idle' },
-			{ label: 'Approval', value: 'missing_sample' },
+			{ label: 'Approval', value: 'Needs sample' },
 			{ label: 'Processing', value: 'No folder job queued' }
 		]);
 		expect(
@@ -852,7 +965,7 @@ describe('Folder Studio review request mapping', () => {
 			)[1]
 		).toEqual({
 			label: 'Sample',
-			value: 'idle',
+			value: 'Needs sample',
 			detail: 'polling idle',
 			tone: 'idle'
 		});
@@ -864,9 +977,9 @@ describe('Folder Studio review request mapping', () => {
 				workflow
 			)[0]
 		).toEqual({
-			label: 'Review',
-			value: 'idle',
-			tone: 'active'
+			label: 'Sample',
+			value: 'Needs sample',
+			tone: 'idle'
 		});
 	});
 
@@ -1392,7 +1505,7 @@ describe('Folder Studio review request mapping', () => {
 				null
 			)
 		).toMatchObject({
-			label: 'Check draft',
+			label: 'Check sample plan',
 			primary: 'Download review pack',
 			primaryAction: 'download-review-pack',
 			secondary: 'Revise'
@@ -1542,7 +1655,7 @@ describe('Folder Studio review request mapping', () => {
 				null
 			)
 		).toMatchObject({
-			label: 'Capped draft ready',
+			label: 'Capped sample plan ready',
 			title: 'Run a sample with a 7% size ceiling',
 			copy: 'Applied after 2.6x target miss against 300 MB per episode.',
 			primary: 'Start sample',
@@ -1581,10 +1694,10 @@ describe('Folder Studio review request mapping', () => {
 				null
 			)
 		).toMatchObject({
-			label: 'Draft blocked',
-			title: 'The draft does not match your request yet',
+			label: 'Sample plan blocked',
+			title: 'The sample plan does not match your request yet',
 			copy: 'The draft lowers VMAF based only on a soft size target.',
-			primary: 'Revise draft',
+			primary: 'Revise sample plan',
 			primaryAction: 'revise-proposal'
 		});
 	});
@@ -1693,7 +1806,7 @@ describe('Folder Studio review request mapping', () => {
 
 		expect(workflow).toMatchObject({
 			label: 'Not sampled',
-			primary: 'Ask for draft',
+			primary: 'Ask review assistant',
 			primaryAction: 'focus-bench'
 		});
 	});
@@ -1720,7 +1833,7 @@ describe('Folder Studio review request mapping', () => {
 		);
 
 		expect(workflow).toMatchObject({
-			label: 'Draft ready',
+			label: 'Sample plan ready',
 			primary: 'Start sample',
 			primaryAction: 'start-sample'
 		});
@@ -1793,7 +1906,7 @@ describe('Folder Studio review request mapping', () => {
 		);
 
 		expect(workflow).toMatchObject({
-			label: 'Capped draft ready',
+			label: 'Capped sample plan ready',
 			title: 'Run a sample with a 7% size ceiling',
 			copy: 'Applied after 2.6x target miss against 300 MB per episode.',
 			primary: 'Start sample',
@@ -1903,7 +2016,7 @@ describe('Folder Studio review request mapping', () => {
 
 		expect(workflow).toMatchObject({
 			label: 'Not sampled',
-			primary: 'Ask for draft',
+			primary: 'Ask review assistant',
 			primaryAction: 'focus-bench'
 		});
 	});

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -74,6 +74,7 @@ export type WorkflowAction =
 	| 'approve-size-tradeoff'
 	| 'download-review-pack'
 	| 'focus-bench'
+	| 'open-completed'
 	| 'monitor-processing'
 	| 'monitor-review'
 	| 'monitor-sample'
@@ -188,6 +189,21 @@ export type WorkflowStep = {
 	detail: string;
 	tone: ShellTone;
 	current: boolean;
+};
+
+export type BasicEncodeGuideStep = {
+	label: string;
+	detail: string;
+	state: 'done' | 'current' | 'upcoming';
+};
+
+export type BasicEncodeGuide = {
+	label: string;
+	title: string;
+	detail: string;
+	primary: string;
+	action: WorkflowAction;
+	steps: BasicEncodeGuideStep[];
 };
 
 function numberValue(value: unknown): number | null {
@@ -438,6 +454,7 @@ export function resolveWorkflowActionState(
 		};
 	}
 	if (action === 'focus-bench') return { disabled: false, title: '' };
+	if (action === 'open-completed') return { disabled: false, title: '' };
 	if (action === 'approve-size-tradeoff') {
 		return approvalReviewReady
 			? { disabled: false, title: '' }
@@ -461,7 +478,7 @@ export function resolveWorkflowActionState(
 		if (pendingProposal?.proposal_id && pendingProposal.can_queue === false) {
 			return {
 				disabled: true,
-				title: pendingProposal.message || 'The current draft is not ready to queue.'
+				title: pendingProposal.message || 'The current sample plan is not ready to queue.'
 			};
 		}
 		return { disabled: false, title: '' };
@@ -479,13 +496,13 @@ export function resolveWorkflowActionState(
 		if (!pendingProposal?.proposal_id) {
 			return {
 				disabled: true,
-				title: 'Ask the review assistant for a draft before starting the sample.'
+				title: 'Ask the review assistant for a sample plan before starting the sample.'
 			};
 		}
 		if (pendingProposal.can_queue === false) {
 			return {
 				disabled: true,
-				title: pendingProposal.message || 'The current draft is not ready to queue.'
+				title: pendingProposal.message || 'The current sample plan is not ready to queue.'
 			};
 		}
 		return { disabled: false, title: '' };
@@ -548,7 +565,7 @@ export function buildBenchMessages(
 			role: 'operator',
 			label: 'Operator',
 			title: 'No request sent',
-			body: 'Use the composer to request a representative sample, a revision, or a validation pass.',
+			body: 'Use the composer to request a sample. Describe your quality or size goal, then click Send request.',
 			tone: 'neutral'
 		});
 	}
@@ -1035,8 +1052,12 @@ function buildOutputScopeFact(folder: FolderPayload): {
 }
 
 function workflowActionDetail(workflow: WorkflowState | undefined): string {
-	if (!workflow) return 'Draft, sample, review, or approve from here';
-	if (workflow.secondaryAction !== 'open-ops' && workflow.secondary !== workflow.primary) {
+	if (!workflow) return 'Plan, sample, review, or approve from here';
+	if (
+		workflow.secondaryAction !== 'open-ops' &&
+		workflow.secondaryAction !== 'open-completed' &&
+		workflow.secondary !== workflow.primary
+	) {
 		return `${workflow.secondary} also available`;
 	}
 	return workflow.copy;
@@ -1209,7 +1230,7 @@ export function buildOutputReviewRows(
 			tone: verdict?.missesTarget ? 'wait' : verdict ? 'ready' : 'idle'
 		},
 		{
-			label: pendingProposal?.proposal_id ? 'Next sample draft' : 'Video output',
+			label: pendingProposal?.proposal_id ? 'Next sample plan' : 'Video output',
 			source: compactParts([
 				codecLabel(sampleItem?.video_codec),
 				formatResolutionCopy(sampleItem?.width, sampleItem?.height)
@@ -1399,6 +1420,31 @@ export function reviewReadyCopy(calibration: FolderCalibrationState | null): str
 	return '—';
 }
 
+export function sampleStatusCopy(value: string | null | undefined): string {
+	const status = String(value ?? '')
+		.trim()
+		.toLowerCase();
+	if (status === 'queued') return 'Sample waiting';
+	if (status === 'running') return 'Sampling';
+	if (status === 'pending_review') return 'Ready to review';
+	if (status === 'failed' || status === 'stopped') return 'Sample needs retry';
+	if (status === 'idle' || !status) return 'Needs sample';
+	return status.replaceAll('_', ' ');
+}
+
+export function approvalStatusCopy(value: string | null | undefined): string {
+	const status = String(value ?? '')
+		.trim()
+		.toLowerCase();
+	if (!status) return 'Not reviewed';
+	if (status === 'missing_sample') return 'Needs sample';
+	if (status === 'accepted') return 'Approved';
+	if (status === 'blocked') return 'Blocked';
+	if (status === 'needs_review') return 'Needs review';
+	if (status === 'pending_review') return 'Ready to review';
+	return status.replaceAll('_', ' ');
+}
+
 function workflowToneToShellTone(tone: FolderWorkflowState['tone']): ShellTone {
 	if (tone === 'active') return 'active';
 	if (tone === 'ready' || tone === 'success') return 'ready';
@@ -1444,8 +1490,8 @@ function resolveBackendWorkflow(
 			copy: workflow.detail,
 			primary: folder.series_context ? 'Open whole show' : 'Open Folders',
 			primaryAction: folder.series_context ? 'open-series' : 'open-folders',
-			secondary: 'Open Ops',
-			secondaryAction: 'open-ops',
+			secondary: 'Review cleanup',
+			secondaryAction: 'open-completed',
 			isOutputWorkflow: true
 		};
 	}
@@ -1604,7 +1650,7 @@ export function resolveWorkflow(
 	) {
 		return {
 			tone: 'fail',
-			label: 'Retryable',
+			label: 'Sample needs retry',
 			title: 'Sample run needs recovery',
 			copy: String(
 				calibrationJob?.error ??
@@ -1645,11 +1691,11 @@ export function resolveWorkflow(
 	if (pendingProposal?.self_check?.status && pendingProposal.self_check.status !== 'passed') {
 		return {
 			tone: 'wait',
-			label: 'Check draft',
+			label: 'Check sample plan',
 			title: 'Proposal needs review before approval',
 			copy:
 				pendingProposal.self_check.summary ??
-				'The proposal self-check returned a warning. Inspect the draft and revise before approving.',
+				'The proposal self-check returned a warning. Inspect the sample plan and revise before approving.',
 			primary: 'Download review pack',
 			primaryAction: 'download-review-pack',
 			secondary: 'Revise',
@@ -1661,14 +1707,14 @@ export function resolveWorkflow(
 		if (budgetEnforcement?.active || !calibration?.browser_review_ready) {
 			return {
 				tone: 'ready',
-				label: budgetEnforcement?.active ? 'Capped draft ready' : 'Draft ready',
+				label: budgetEnforcement?.active ? 'Capped sample plan ready' : 'Sample plan ready',
 				title: budgetEnforcement?.active
 					? `Run a sample with a ${budgetEnforcement.cap} size ceiling`
-					: 'Review draft is ready to sample',
+					: 'Sample plan is ready to run',
 				copy:
 					budgetEnforcement?.reason ??
 					pendingProposal.message ??
-					'Review the draft, then queue the representative sample when it looks right.',
+					'Review the sample plan, then queue the representative sample when it looks right.',
 				primary: 'Start sample',
 				primaryAction: 'start-sample',
 				secondary: 'Revise',
@@ -1683,12 +1729,12 @@ export function resolveWorkflow(
 	) {
 		return {
 			tone: 'wait',
-			label: 'Draft blocked',
-			title: 'The draft does not match your request yet',
+			label: 'Sample plan blocked',
+			title: 'The sample plan does not match your request yet',
 			copy:
 				pendingProposal.message ??
-				'The bench draft changed something outside your request. Revise it before starting another sample.',
-			primary: 'Revise draft',
+				'The sample plan changed something outside your request. Revise it before starting another sample.',
+			primary: 'Revise sample plan',
 			primaryAction: 'revise-proposal',
 			secondary: 'Download pack',
 			secondaryAction: 'download-review-pack'
@@ -1729,7 +1775,7 @@ export function resolveWorkflow(
 			copy:
 				verdict === null
 					? (pendingProposal?.message ??
-						'Evidence is ready. Review the sample clips, then approve the draft or revise it.')
+						'Evidence is ready. Review the sample clips, then approve the sample plan or revise it.')
 					: `${verdict.predictedPerItem} per episode, ${verdict.predictedFolderTotal} for the folder. Review the clips, then approve and queue if this is acceptable.`,
 			primary: 'Approve and queue',
 			primaryAction: 'queue-encode',
@@ -1755,7 +1801,7 @@ export function resolveWorkflow(
 			label: 'Not sampled',
 			title: 'No representative sample yet',
 			copy: 'Ask the review assistant for a sample proposal before approving folder-wide settings. Worker readiness and settings context stay visible while the sample is queued.',
-			primary: 'Ask for draft',
+			primary: 'Ask review assistant',
 			primaryAction: 'focus-bench',
 			secondary: 'Open Ops',
 			secondaryAction: 'open-ops'
@@ -1765,8 +1811,8 @@ export function resolveWorkflow(
 		tone: 'wait',
 		label: 'Waiting',
 		title: 'Folder is waiting for review evidence',
-		copy: 'A representative item exists, but the current review state is incomplete. Refresh status or rerun the sample if the evidence is stale.',
-		primary: 'Refresh draft',
+		copy: 'A representative item exists, but the current review state is incomplete. Ask the review assistant for the next sample plan.',
+		primary: 'Ask review assistant',
 		primaryAction: 'focus-bench',
 		secondary: 'Open Ops',
 		secondaryAction: 'open-ops'
@@ -1826,10 +1872,11 @@ export function buildWorkflowSteps(workflow: WorkflowState): WorkflowStep[] {
 	const sampleCurrent =
 		['focus-bench', 'monitor-sample', 'start-sample', 'retry-sample', 'stop-sample'].includes(
 			activeAction
-		) || ['not sampled', 'sampling', 'retryable', 'draft ready'].includes(activeLabel);
+		) ||
+		['not sampled', 'sampling', 'sample needs retry', 'sample plan ready'].includes(activeLabel);
 	const reviewCurrent =
 		['download-review-pack', 'monitor-review', 'revise-proposal'].includes(activeAction) ||
-		['review ready', 'check draft'].includes(activeLabel);
+		['review ready', 'check sample plan'].includes(activeLabel);
 	const approveCurrent =
 		['queue-encode', 'approve-size-tradeoff'].includes(activeAction) || activeLabel === 'approved';
 	const encodeCurrent =
@@ -1867,6 +1914,123 @@ export function buildWorkflowSteps(workflow: WorkflowState): WorkflowStep[] {
 			current: encodeCurrent
 		}
 	];
+}
+
+const BASIC_ENCODE_STEPS = [
+	{
+		label: 'Pick folder',
+		detail: 'Choose one folder from Work or Folders.'
+	},
+	{
+		label: 'Run sample',
+		detail: 'Create review evidence from one representative item.'
+	},
+	{
+		label: 'Review sample',
+		detail: 'Compare quality and size before approving.'
+	},
+	{
+		label: 'Process folder',
+		detail: 'Queue the approved settings and let workers run.'
+	},
+	{
+		label: 'Validate output',
+		detail: 'Check finished files before publishing.'
+	},
+	{
+		label: 'Promote',
+		detail: 'Move validated files into the library.'
+	},
+	{
+		label: 'Clean up',
+		detail: 'Delete archived originals from Completed.'
+	}
+] as const;
+
+function basicEncodeStepIndex(workflow: WorkflowState): number {
+	const action = workflow.primaryAction;
+	const label = workflow.label.toLowerCase();
+	if (label === 'complete') return 6;
+	if (action === 'promote-outputs' || label === 'ready to promote') return 5;
+	if (action === 'validate-outputs' || label === 'ready to validate') return 4;
+	if (
+		workflow.isOutputWorkflow ||
+		['monitor-processing', 'retry-encode'].includes(action) ||
+		['approved', 'processing', 'processing failed', 'processing stopped'].includes(label)
+	) {
+		return 3;
+	}
+	if (
+		['download-review-pack', 'monitor-review', 'queue-encode', 'approve-size-tradeoff'].includes(
+			action
+		) ||
+		['review ready', 'review pending', 'target missed', 'check sample plan'].includes(label)
+	) {
+		return 2;
+	}
+	if (
+		['start-sample', 'retry-sample', 'monitor-sample', 'stop-sample'].includes(action) ||
+		['sample plan ready', 'capped sample plan ready', 'sampling', 'sample needs retry'].includes(
+			label
+		)
+	) {
+		return 1;
+	}
+	return 1;
+}
+
+function basicEncodeDetail(workflow: WorkflowState, currentStep: number): string {
+	if (currentStep === 1) {
+		return 'Start by making one representative sample. Do not approve the full folder until review evidence is ready.';
+	}
+	if (currentStep === 2) {
+		return 'Look at the review evidence. If it looks good, approve and queue the folder; if not, revise and sample again.';
+	}
+	if (currentStep === 3) {
+		if (workflow.primaryAction === 'queue-encode') {
+			return 'The sample is accepted. Queue folder processing when you are ready to run the real work.';
+		}
+		return 'Folder processing is underway or needs attention. Ops shows worker and queue details.';
+	}
+	if (currentStep === 4) return 'Processing finished. Validate the outputs before publishing them.';
+	if (currentStep === 5) return 'Outputs are validated. Promote them into the library.';
+	if (currentStep === 6) {
+		return 'This folder is processed. Go to Completed when you are ready to delete archived originals.';
+	}
+	return 'Choose one folder, then follow the highlighted step until the folder is complete.';
+}
+
+export function buildBasicEncodeGuide(workflow: WorkflowState): BasicEncodeGuide {
+	const currentStep = basicEncodeStepIndex(workflow);
+	const primary =
+		currentStep === 6 && workflow.secondaryAction === 'open-completed'
+			? workflow.secondary
+			: workflow.primary;
+	const action =
+		currentStep === 6 && workflow.secondaryAction === 'open-completed'
+			? workflow.secondaryAction
+			: workflow.primaryAction;
+	return {
+		label: 'Single folder run',
+		title: BASIC_ENCODE_STEPS[currentStep]?.label ?? 'Follow the next step',
+		detail: basicEncodeDetail(workflow, currentStep),
+		primary,
+		action,
+		steps: BASIC_ENCODE_STEPS.map((step, index) => ({
+			...step,
+			state: index < currentStep ? 'done' : index === currentStep ? 'current' : 'upcoming'
+		}))
+	};
+}
+
+function sampleFooterTone(status: string | null | undefined): FooterSignal['tone'] {
+	const normalized = String(status ?? '')
+		.trim()
+		.toLowerCase();
+	if (normalized === 'failed' || normalized === 'stopped') return 'fail';
+	if (normalized === 'queued' || normalized === 'running') return 'active';
+	if (normalized === 'pending_review') return 'ready';
+	return 'idle';
 }
 
 export function buildProposalRows(
@@ -1929,7 +2093,7 @@ export function buildStatusTiles(
 			}
 		: {
 				label: 'Sample',
-				value: status.calibration_status || 'Unknown',
+				value: sampleStatusCopy(status.calibration_status),
 				detail: status.polling_active ? 'polling active' : 'polling idle',
 				tone:
 					status.calibration_status === 'failed'
@@ -2000,9 +2164,9 @@ export function buildRuntimeFacts(
 		];
 	}
 	return [
-		{ label: 'Calibration', value: status.calibration_status || '—' },
+		{ label: 'Sample', value: sampleStatusCopy(status.calibration_status) },
 		{ label: 'Scan', value: status.folder_scan_status || '—' },
-		{ label: 'Approval', value: reviewGate?.status ?? '—' },
+		{ label: 'Approval', value: approvalStatusCopy(reviewGate?.status) },
 		{ label: 'Processing', value: queueSummary }
 	];
 }
@@ -2015,7 +2179,11 @@ export function buildFooterSignals(
 ): FooterSignal[] {
 	const firstSignal: FooterSignal = workflow.isOutputWorkflow
 		? { label: 'Pipeline', value: workflow.label.toLowerCase(), tone: workflow.tone }
-		: { label: 'Review', value: status.calibration_status || 'unknown', tone: 'active' };
+		: {
+				label: 'Sample',
+				value: sampleStatusCopy(status.calibration_status),
+				tone: sampleFooterTone(status.calibration_status)
+			};
 	return [
 		firstSignal,
 		{ label: 'Metric', value: resolvedMetricCopy(folder), tone: 'ready' },


### PR DESCRIPTION
## Summary
- add a compact single-folder run guide to Folder Studio with a live next-action control
- map sample and approval status copy away from backend terms like calibration/missing_sample/draft
- point completed folder workflows toward cleanup review and update Completed copy to Mark handled
- cover guide step/action mapping and user-facing status copy in unit tests

## Validation
- browser checked Folder Studio desktop and mobile, including the guide CTA focusing the review assistant and no horizontal overflow
- npm --prefix frontend run smoke:web
- bash scripts/pre-commit-check.sh
