### PR TITLE
Honor operator-approved AV1 evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Once the current sampled draft has been explicitly saved to the folder profile,
 `Queue Folder Encode` is unlocked so the real folder job can enter the encode
 queue without letting a stale unsaved preview slip into production work.
 
+For this personal workflow, source-resolution 1080p AV1 around 200–300 MB per
+40 minutes is an established operator-approved baseline, including conventional
+and dark or stylized TV material. Direct operator instructions and accepted
+visual samples outrank generic bitrate guidance; real sample evidence decides
+whether a particular folder needs adjustment.
+
 For scene-aware engine research, generate a repeatable bakeoff plan from an
 existing manifest instead of replacing the production engine path directly:
 

--- a/docs/design/basic-user-vocabulary.md
+++ b/docs/design/basic-user-vocabulary.md
@@ -65,7 +65,8 @@ debugging a worker, or comparing logs against backend output.
   approving.
 - Proposal warning exists: `Review warning`. The user must inspect the warning
   before approving.
-- Proposal accepted: `Approved`. The folder settings are accepted.
+- Proposal accepted: `Approved`. The folder settings are accepted, and that
+  visual approval remains authoritative evidence for future tuning.
 - Encode queued or running: `Processing`. Folder-wide work is underway.
 - Encode failed or stopped: `Processing needs attention`. The user must inspect
   or retry from the route that owns recovery.

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -1614,7 +1614,7 @@ describe('Folder Studio review request mapping', () => {
 			{
 				label: 'Current target',
 				value: 'source resolution',
-				detail: 'VMAF low-bitrate target 85 · floor 80'
+				detail: 'VMAF target 85 · floor 80'
 			},
 			{
 				label: 'Next action',

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -1167,8 +1167,7 @@ function videoPolicySummary(
 	const metric = compactText(video.quality_metric).toUpperCase();
 	const target = numberValue(metric === 'XPSNR' ? video.target_xpsnr : video.target_vmaf);
 	const floor = numberValue(metric === 'XPSNR' ? video.min_target_xpsnr : video.min_target_vmaf);
-	const metricCopy =
-		metric === 'VMAF' && target !== null && target <= 88 ? 'VMAF low-bitrate' : metric;
+	const metricCopy = metric;
 	const output = compactParts([
 		encoder.includes('av1') ? 'AV1' : encoder || null,
 		maxHeight !== null && maxHeight > 0 ? `max ${maxHeight}p` : 'source resolution',
@@ -1787,7 +1786,7 @@ export function resolveWorkflow(
 			tone: 'wait',
 			label: 'New sample needed',
 			title: 'Previous sample used older settings',
-			copy: `${verdict.predictedPerItem} per episode was measured against older quality targets. Run a fresh sample using the current source-resolution, low-bitrate defaults before approving this folder.`,
+			copy: `${verdict.predictedPerItem} per episode was measured against older quality targets. Run a fresh sample using the current source-resolution, size-first AV1 defaults before approving this folder.`,
 			primary: 'Ask for sample',
 			primaryAction: 'focus-bench',
 			secondary: 'Download old pack',

--- a/mediaforce/advising/policy.py
+++ b/mediaforce/advising/policy.py
@@ -131,6 +131,7 @@ def operator_note_parse_schema() -> dict[str, Any]:
             "request_type",
             "operator_confirmed",
             "measured_size_followup",
+            "evidence_authority",
             "metric",
             "metric_target",
             "size_budget_value",
@@ -152,6 +153,10 @@ def operator_note_parse_schema() -> dict[str, Any]:
             },
             "operator_confirmed": {"type": "boolean"},
             "measured_size_followup": {"type": "boolean"},
+            "evidence_authority": {
+                "type": "string",
+                "enum": ["none", "operator_observed", "approved_visual_result", "rejected_visual_result"],
+            },
             "metric": {"type": ["string", "null"], "enum": ["vmaf", "xpsnr", None]},
             "metric_target": {"type": ["number", "null"]},
             "size_budget_value": {"type": ["number", "null"]},
@@ -162,6 +167,29 @@ def operator_note_parse_schema() -> dict[str, Any]:
             "reasoning_note": {"type": "string"},
         },
     }
+
+
+def has_nonpositive_video_budget(requested_experiment: dict[str, Any] | None) -> bool:
+    request = object_dict(requested_experiment)
+    for candidate in (request, object_dict(request.get("size_budget_request"))):
+        estimated_video_bitrate = candidate.get("estimated_video_bitrate_kbps")
+        if (
+                isinstance(estimated_video_bitrate, int | float)
+                and not isinstance(estimated_video_bitrate, bool)
+                and float(estimated_video_bitrate) <= 0
+        ):
+            return True
+        budget_bytes = candidate.get("budget_bytes")
+        estimated_audio_bytes = candidate.get("estimated_audio_bytes")
+        if (
+                isinstance(budget_bytes, int | float)
+                and not isinstance(budget_bytes, bool)
+                and isinstance(estimated_audio_bytes, int | float)
+                and not isinstance(estimated_audio_bytes, bool)
+                and float(budget_bytes) <= float(estimated_audio_bytes)
+        ):
+            return True
+    return False
 
 
 def extract_seed_payload(raw: str) -> JSONObject:

--- a/mediaforce/advising/prompts.py
+++ b/mediaforce/advising/prompts.py
@@ -4,6 +4,20 @@ from typing import Any, Callable
 from mediaforce.core.type_defs import object_dict, object_list
 
 
+AV1_EVIDENCE_PRECEDENCE = (
+    "For this operator, source-resolution 1080p SVT-AV1 at a normalized total size of 200-300 MiB per "
+    "40 minutes is an established, visually approved product baseline across conventional and dark or "
+    "stylized TV material. Do not describe that baseline as low-bitrate, aggressive, high-risk, unrealistic, "
+    "or suitable only for clean or forgiving material based on bitrate or source-size percentage alone. "
+    "Evidence precedence is strict: follow the current explicit operator instruction first; then operator-approved "
+    "visual results and saved accepted policies; then measured sample and validation results; and use generic "
+    "codec heuristics only when stronger evidence is absent. Generic intuition may suggest what to inspect in a "
+    "sample, but it may never veto a safe sample or override accepted visual evidence. A non-positive video budget, "
+    "a measured encode failure, stale evidence, or an explicit visual rejection remains a concrete stop or redirect "
+    "signal; current rejection outranks older approval. "
+)
+
+
 def _summarize_multimodal_review_pack(review_pack: dict[str, Any]) -> dict[str, Any]:
     summarized_pack = {key: value for key, value in review_pack.items() if key != "images"}
     if "images" in review_pack:
@@ -21,6 +35,7 @@ def build_prompt(payload: dict[str, Any]) -> str:
     return (
         "You are advising a personal media re-encoding calibration workflow. "
         "Bias slightly toward smaller files, but do not recommend obvious quality damage. "
+        f"{AV1_EVIDENCE_PRECEDENCE}"
         "Return short markdown with these sections exactly: "
         "Recommendation, Why, Setting changes, Audio/Subtitles notes. "
         "Use plain language for a human reviewing TV encodes. Here is the calibration context:\n\n"
@@ -44,24 +59,24 @@ def build_seed_prompt(
         "This is a cold-start guess for one folder, not a measured calibration result. "
         "Your job is to draft the best first-pass attempt at the operator's request using the available policy keys, not to negotiate the operator back to the base policy. "
         "When runtime_toolbelt.decision_defaults or the video policy includes decision_model=size_first_review, treat the configured target_size_mb per target_runtime_minutes as the product's default goal and treat VMAF/XPSNR as guardrails for review rather than the primary objective. "
+        f"{AV1_EVIDENCE_PRECEDENCE}"
         "Treat the operator note as an instruction to satisfy when it is clear and specific. "
         "Use the base policy as a starting surface, not as something that overrules a direct operator request. "
         "If the operator asks for materially smaller files, you are allowed to make material policy changes that pursue that goal, including changing quality targets, encoded-percent caps, CRF bounds, grain, preset, or sample methodology when those knobs exist in the allowed policy keys. "
         "Bias toward accomplishing the operator's ask while still describing the risk honestly. "
         f"When audio_tradeoff_hint.recommended_seed_action is 'hold', strongly prefer leaving {hinted_audio_key} at the base policy value in this first-pass seed. A tight size budget alone is not sufficient to override a hold, especially when audio_tradeoff_hint.review_confidence is low because these audio changes may be harder for the operator to judge casually. If you still lower that hinted audio bitrate despite a hold, explain why the savings are materially necessary and worth the review risk. "
-        "When the note is a direct request or explicit experiment, default to honoring it. Use honored_with_risk when the request is aggressive or fragile, not softened. "
+        "When the note is a direct request or explicit experiment, default to honoring it. Use honored_with_risk only when supplied measurements show a concrete failed or impossible constraint, never because a bitrate merely looks small. "
         "Use softened only when the operator note is exploratory, ambiguous, self-contradictory, or cannot be expressed with the available policy keys. "
-        "When operator_repeat_signal shows the same explicit experiment was asked for again after earlier softening, treat that as deliberate confirmation and keep the risky draft unless the request cannot be expressed with the available policy keys. "
-        "If the request looks unrealistic, still try to draft the closest faithful experiment you can and mark it honored_with_risk instead of fighting the request. "
+        "When operator_repeat_signal shows the same explicit experiment was asked for again after earlier softening, treat that as deliberate confirmation and keep the requested draft unless supplied measurements show it cannot run safely or the request cannot be expressed with the available policy keys. "
+        "When supplied measurements show a concrete caveat while a safe sample remains queueable, draft the closest faithful experiment and use honored_with_risk. Reject or redirect a non-positive video budget, repeated measured failure, stale evidence, or explicit visual rejection. "
         "When latest_failed_sample_job is present, treat it as the most recent failed or stopped sample attempt; use its error, policy, and result fields to avoid repeating the same failure. "
         "If the operator asks for a smaller encode, do not silently move to a higher quality target or otherwise preserve the old behavior behind reassuring wording. "
         "When the available policy keys include video.black_bar_handling, consider setting it to smart for letterboxed, matted, widescreen, or black-bar-heavy sources when the operator note, folder class, or sample metadata makes that likely; prefer smart detection over manual crop unless the operator supplied an exact crop. "
         "Treat video.max_height as an explicit downsample/cap-height request knob. Do not infer 1080p or 720p scaling from a size budget alone; use max_height only when the operator request or requested_experiment clearly asks for a scale target. When the operator asks to preserve source resolution, avoid downscaling, or keep max_height unset/0, preserve video.max_height as 0 rather than replacing it with the source height. "
-        "Do not anchor on legacy H.264 or HEVC bitrate intuition when the policy is using AV1. For AV1, a projected bitrate that looks surprisingly low by older codec standards can still be a plausible high-quality outcome for clean or forgiving material, so do not soften a size-first request just because the bitrate number looks small on its own. "
-        "Teach media-class taste, not a single-title compression floor, but do that in service of the operator's ask rather than as a reason to refuse it. "
+        "Do not anchor on legacy H.264 or HEVC bitrate intuition when the policy is using AV1. "
+        "Teach media-class taste by choosing representative sample moments, not by inventing a compression floor before measurement. "
         "If you soften or reject a request, say so explicitly and only do it for the narrow reasons above. "
-        "When the operator explicitly wants heavy compression with very little perceptible loss, high-80s VMAF can still be a legitimate AV1 experiment on clean or forgiving material, but treat that as class-dependent and risk-aware rather than a universal default. "
-        "If the class signals clearly look like clean 1080p catalog TV, a mild lean can look like VMAF around 94-95, XPSNR around 39-40, max encoded percent in the low-to-mid 70s, grain around 4-6, and 5.1 Opus around 224k, but treat those as gentle reference points rather than mandatory targets. "
+        "High-80s VMAF can be a strong visually approved AV1 result; report the measured score without turning it into a quality verdict. "
         "Use metric_support and the current base policy to decide whether VMAF or XPSNR guidance is more relevant. "
         "Return valid JSON only with this exact shape: "
         f'{{"request_response":"short conversational reply","request_disposition":"honored|honored_with_risk|softened|rejected|unclear","summary":"short sentence","diagnosis":"short diagnosis","confidence":"high|medium|low","evidence_checked":["..."],"suggested_follow_up":"optional short suggestion","feasibility_note":"optional short feasibility note","policy":{json.dumps(policy_shape, sort_keys=True)}}}. '
@@ -94,6 +109,7 @@ def build_tune_prompt(
         "You are GPT-5.4 acting as a fast media encode tuning worker. "
         "Your job is to use the operator's note plus the current calibration context to draft the next sampled calibration run for operator review before anything queues. "
         "When runtime_toolbelt.decision_defaults says decision_model=size_first_review, center the next run around the configured target_size_mb per target_runtime_minutes and the operator's visual review, using VMAF/XPSNR as guardrails instead of overriding the requested size-first intent. "
+        f"{AV1_EVIDENCE_PRECEDENCE}"
         "The runtime has already gathered the only allowed quick toolbelt evidence for this turn and will run a separate self-check after your proposal. "
         "Do not assume any other probing, frame grabs, or external tools are available. "
         "When review_media_context is present, treat it as part of the active review conversation: the operator may be asking about the sampled source-versus-draft clips, the compare clip, or the current audio tradeoff before approving a folder encode. "
@@ -112,10 +128,10 @@ def build_tune_prompt(
         "If the operator asks for a smaller encode, do not silently move to a higher quality target or preserve the old behavior behind reassuring language. "
         "When the available policy keys include video.black_bar_handling, consider setting it to smart for letterboxed, matted, widescreen, or black-bar-heavy sources when the operator note, review evidence, or sample metadata makes that likely; prefer smart detection over manual crop unless the operator supplied an exact crop. "
         "Treat video.max_height as an explicit downsample/cap-height request knob. Do not infer 1080p or 720p scaling from a size budget alone; use max_height only when operator_note_parse.scale_height, requested_experiment, or the operator note clearly asks for a scale target. When the operator asks to preserve source resolution, avoid downscaling, or keep max_height unset/0, preserve video.max_height as 0 rather than replacing it with the source height. "
-        "Do not anchor on legacy H.264 or HEVC bitrate intuition when the policy is using AV1. For AV1, a projected bitrate that looks surprisingly low by older codec standards can still be a plausible high-quality outcome for clean or forgiving material, so do not redirect a size-first request just because the bitrate number looks small on its own. "
-        "When the operator explicitly wants heavy compression with very little perceptible loss, high-80s VMAF can still be a legitimate AV1 experiment on clean or forgiving material, but treat that as class-dependent and risk-aware rather than a universal default. "
-        "When requested_experiment or retrieved_memory shows the operator repeated the same explicit risky request, treat that as deliberate confirmation and keep the risky draft unless the request cannot be expressed with the available policy keys. "
-        "If the request looks unrealistic, still draft the closest faithful experiment you can, mark it honored_with_risk, and explain the risk plainly instead of fighting the request. "
+        "Do not anchor on legacy H.264 or HEVC bitrate intuition when the policy is using AV1. "
+        "Treat high-80s VMAF as a measured score for review, not as evidence that an AV1 draft is inherently deficient. "
+        "When requested_experiment or retrieved_memory shows the operator repeated the same explicit request, treat that as deliberate confirmation and keep the requested draft unless supplied measurements show it cannot run safely or the request cannot be expressed with the available policy keys. "
+        "When supplied measurements show a concrete caveat while a safe sample remains queueable, draft the closest faithful experiment and use honored_with_risk. Reject or redirect a non-positive video budget, repeated measured failure, stale evidence, or explicit visual rejection. "
         "When latest_failed_sample_job is present, treat it as the most recent failed or stopped sample attempt; use its error, policy, and result fields to diagnose what to change instead of repeating that run. "
         "Return JSON only with no markdown fences or extra commentary. "
         "Return valid JSON only with this exact shape: "
@@ -137,6 +153,7 @@ def build_review_artifact_critique_prompt(payload: dict[str, Any]) -> str:
     return (
         "You are reviewing source-versus-draft media artifacts extracted from actual sampled review clips. "
         "Use the attached images as visual evidence from the real clips, but never claim to watch motion or hear audio beyond what those artifacts can support. "
+        "Do not infer visible damage from bitrate, source-size percentage, or metric target when the supplied artifacts do not show it. "
         "Focus on what looks preserved, what looks fragile, and which moments deserve extra caution before another draft is approved. "
         "Return JSON only with no markdown fences or extra commentary. "
         "Return valid JSON only with this exact shape: "
@@ -151,8 +168,9 @@ def build_run_verdict_prompt(payload: dict[str, Any]) -> str:
     return (
         "You are GPT-5.4 summarizing a completed media encode calibration run for a human operator. "
         "The run is already measured by deterministic tools; do not invent metrics. "
+        f"{AV1_EVIDENCE_PRECEDENCE}"
         "If the operator requested an explicit experiment, judge the outcome against that request instead of generic conservative defaults. "
-        "When size_target_analysis is present, use its status and target band directly: inside_target_band means the size request is satisfied, under_target means the run saved more than requested and may have spent too little on quality, and over_target means another measured sample may be needed if the operator still wants that size. "
+        "When size_target_analysis is present, use its status and target band directly: inside_target_band means the size request is satisfied, under_target means the run is smaller than requested without implying quality damage, and over_target means another measured sample may be needed if the operator still wants that size. "
         "Keep the answer short, practical, and honest about risk. "
         "Return valid JSON only with this exact shape: "
         '{"summary":"short verdict","outcome":"strong_match|acceptable_experiment|needs_review|poor_fit","confidence":"high|medium|low","next_step":"optional short suggestion","evidence_checked":["..."]}. '
@@ -169,6 +187,7 @@ def build_operator_note_parse_prompt(payload: dict[str, Any]) -> str:
         "Extract only explicit tuning requests that are actually present in the note. "
         "Mark operator_confirmed true only when the note is a clear instruction the system should act on now. "
         "Mark measured_size_followup true only when the note is explicitly a follow-up to a previous measured sample missing or exceeding a size target, such as revising smaller after a larger-than-target sample. "
+        "Set evidence_authority to operator_observed when the operator reports a positive observation about what they actually saw or heard in a real sample. Set it to approved_visual_result only when the operator clearly says they reviewed and accepted or approved the real result. Set it to rejected_visual_result when the operator explicitly rejects the real result or reports visible or audible damage. Otherwise set it to none. "
         "Directive questions still count as direct requests when they clearly ask for action, such as 'Target 300MB per episode?' or 'Can you target 300MB per episode?'. "
         "Exploratory wording stays unconfirmed when the operator is asking whether a change would help or is realistic, such as 'Can we try to target 85 VMAF instead? Will that help?' or 'I want to understand if 300MB per episode is realistic.' "
         "Extract explicit downsample or output-height cap requests into scale_height, such as 'downsample to 1080p', 'cap at 720p', or 'make the 4K files 1080p'. This is only for requested scaling; do not infer a scale target from source resolution, a size budget, or general smaller-file language. If the operator asks to preserve source resolution, avoid downscaling, or keep max_height unset/0, set scale_height to 0 to represent source resolution/no height cap. "
@@ -176,7 +195,7 @@ def build_operator_note_parse_prompt(payload: dict[str, Any]) -> str:
         "If any scale, black-bar, or crop target appears with a size budget or metric target, use combined_experiment. If only scale, black-bar, or crop targets are requested, use scale_target. If both a size budget and a metric target are explicitly requested, use combined_experiment. "
         "Return JSON only with no markdown fences or extra commentary. "
         "Return valid JSON only with this exact shape: "
-        '{"summary":"short summary","intent_type":"direct_request|exploratory_question|approval_feedback|other|unclear","request_type":"none|metric_target|size_budget|scale_target|combined_experiment","operator_confirmed":true,"measured_size_followup":false,"metric":"vmaf|xpsnr|null","metric_target":85,"size_budget_value":300,"size_budget_unit":"mb|gb|kb|tb|null","scale_height":1080,"black_bar_handling":"smart|null","crop":"1920:800:0:140|null","reasoning_note":"short explanation"}. '
+        '{"summary":"short summary","intent_type":"direct_request|exploratory_question|approval_feedback|other|unclear","request_type":"none|metric_target|size_budget|scale_target|combined_experiment","operator_confirmed":true,"measured_size_followup":false,"evidence_authority":"none|operator_observed|approved_visual_result|rejected_visual_result","metric":"vmaf|xpsnr|null","metric_target":85,"size_budget_value":300,"size_budget_unit":"mb|gb|kb|tb|null","scale_height":1080,"black_bar_handling":"smart|null","crop":"1920:800:0:140|null","reasoning_note":"short explanation"}. '
         "Do not invent requests that are not explicitly in the note. Here is the note context:\n\n"
         f"{serialized}"
     )

--- a/mediaforce/advisor.py
+++ b/mediaforce/advisor.py
@@ -20,6 +20,7 @@ from mediaforce.advising.policy import compact_policy_payload as _compact_policy
     normalize_like_base as _normalize_like_base_impl, finalize_video_policy_updates as _finalize_video_policy_updates_impl, \
     normalize_duration_like as _normalize_duration_like_impl, normalize_string_list as _normalize_string_list_impl, \
     coerce_bool as _coerce_bool_impl, merge_policy_fragments as _merge_policy_fragments_impl, \
+    has_nonpositive_video_budget, \
     parse_bitrate_kbps as _parse_bitrate_kbps_impl, \
     clamp_float as _clamp_float_impl, clamp_int as _clamp_int_impl, \
     operator_note_parse_schema as _operator_note_parse_schema_impl
@@ -31,10 +32,10 @@ from mediaforce.advising.runtime import StructuredLLMFailure, run_code_prompt as
     run_structured_llm_request as _run_structured_llm_request_impl
 
 ADVISOR_MODEL = "gpt-5.4"
-SEED_PROMPT_VERSION = "seed-v8"
-TUNE_PROMPT_VERSION = "tune-v9"
+SEED_PROMPT_VERSION = "seed-v9"
+TUNE_PROMPT_VERSION = "tune-v10"
 TUNE_SELF_CHECK_VERSION = "tune-self-check-v1"
-RUN_VERDICT_PROMPT_VERSION = "run-verdict-v1"
+RUN_VERDICT_PROMPT_VERSION = "run-verdict-v2"
 REVIEW_ARTIFACT_CRITIQUE_PROMPT_VERSION = "review-artifact-critique-v1"
 OPERATOR_NOTE_PARSE_PROMPT_VERSION = "operator-note-parse-v2"
 REQUEST_DISPOSITIONS = ("honored", "honored_with_risk", "softened", "rejected", "unclear")
@@ -95,8 +96,48 @@ def _should_force_repeated_experiment(repeat_signal: dict[str, Any] | None) -> b
     return int_value(object_dict(repeat_signal).get("repeat_count")) >= 2
 
 
-def _should_force_operator_confirmed_experiment(requested_experiment: dict[str, Any] | None) -> bool:
-    return bool(object_dict(requested_experiment).get("operator_confirmed"))
+def _has_blocking_request_evidence(
+        requested_experiment: dict[str, Any] | None,
+        latest_failed_sample_job: dict[str, Any] | None = None,
+) -> bool:
+    request = object_dict(requested_experiment)
+    return (
+        bool(object_dict(latest_failed_sample_job))
+        or str(request.get("evidence_authority") or "none").strip().lower() == "rejected_visual_result"
+        or has_nonpositive_video_budget(request)
+    )
+
+
+def _should_force_operator_confirmed_experiment(
+        requested_experiment: dict[str, Any] | None,
+        latest_failed_sample_job: dict[str, Any] | None = None,
+) -> bool:
+    request = object_dict(requested_experiment)
+    return (
+        bool(request.get("operator_confirmed"))
+        and not _has_blocking_request_evidence(request, latest_failed_sample_job)
+    )
+
+
+def _reject_nonpositive_video_budget(
+        parsed: dict[str, Any],
+        requested_experiment: dict[str, Any] | None,
+) -> bool:
+    if not has_nonpositive_video_budget(requested_experiment):
+        return False
+    parsed["request_disposition"] = "rejected"
+    parsed["summary"] = "The requested total size leaves no positive video budget."
+    parsed["diagnosis"] = (
+        "The estimated audio allocation consumes the requested total size, so there is no positive video budget "
+        "for a safe measured sample."
+    )
+    parsed["request_response"] = (
+        "That total size cannot queue as written because it leaves no positive video budget. "
+        "Increase the total target or explicitly reduce the audio allocation first."
+    )
+    parsed["suggested_follow_up"] = "Increase the total size target or choose an explicit lower audio bitrate."
+    parsed["feasibility_note"] = "The estimated video budget is non-positive."
+    return True
 
 
 def _raw_failure_payload(parsed: Any) -> str:
@@ -110,37 +151,31 @@ def _force_operator_confirmed_experiment(
         current_policy: dict[str, Any],
         parsed: dict[str, Any],
         requested_experiment: dict[str, Any] | None,
+        latest_failed_sample_job: dict[str, Any] | None,
         mode: str,
 ) -> dict[str, Any] | None:
-    if not _should_force_operator_confirmed_experiment(requested_experiment):
+    if not _should_force_operator_confirmed_experiment(requested_experiment, latest_failed_sample_job):
         return None
     request_disposition = str(parsed.get("request_disposition") or "").strip().lower()
     if request_disposition not in {"softened", "rejected"}:
         return None
     requested_policy = object_dict(object_dict(requested_experiment).get("applied_policy"))
-    if not requested_policy:
-        return None
-    _, applied_fragment = apply_seed_policy(current_policy, requested_policy, mode=mode)
-    if not applied_fragment:
-        return None
     draft_label = "first sample" if mode == "seed" else "next sample"
-    parsed["request_disposition"] = "honored_with_risk"
-    parsed["summary"] = f"Kept the explicit requested experiment as a high-risk {draft_label} draft."
+    parsed["request_disposition"] = "honored"
+    parsed["summary"] = f"Kept the explicit operator request as the {draft_label} draft."
     parsed["diagnosis"] = (
-        "The operator gave a direct explicit experiment request, "
-        f"so this {draft_label} keeps the risky target for measurement instead of softening it away."
+        "The operator gave a direct request, so this draft preserves it for measurement instead of replacing it "
+        "with generic bitrate assumptions."
     )
     parsed["request_response"] = (
-        "You asked for this aggressive experiment directly, so I kept it as an honored high-risk draft "
-        "instead of softening it again."
+        f"You asked for this directly, so I kept it as the {draft_label}. The real sample and your review will decide."
     )
-    parsed["suggested_follow_up"] = (
-        f"Measure this risky {draft_label} and decide from the clips whether to pull it back."
-    )
+    parsed["suggested_follow_up"] = f"Measure this {draft_label} and decide from the clips."
     if not parsed.get("feasibility_note"):
-        parsed["feasibility_note"] = (
-            f"This draft is operator-confirmed and intentionally riskier than the usual {draft_label}."
-        )
+        parsed["feasibility_note"] = "The operator-confirmed target is queueable for a safe measured sample."
+    if not requested_policy:
+        return {}
+    _, applied_fragment = apply_seed_policy(current_policy, requested_policy, mode=mode)
     return applied_fragment
 
 
@@ -150,33 +185,33 @@ def _force_repeated_tune_experiment(
         parsed: dict[str, Any],
         requested_experiment: dict[str, Any] | None,
         repeat_signal: dict[str, Any] | None,
+        latest_failed_sample_job: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
     if not _should_force_repeated_experiment(repeat_signal):
+        return None
+    if _has_blocking_request_evidence(requested_experiment, latest_failed_sample_job):
         return None
     request_disposition = str(parsed.get("request_disposition") or "").strip().lower()
     if request_disposition not in {"softened", "rejected"}:
         return None
     requested_policy = object_dict(object_dict(requested_experiment).get("applied_policy"))
-    if not requested_policy:
-        return None
-    _, applied_fragment = apply_seed_policy(current_policy, requested_policy, mode="tune")
-    if not applied_fragment:
-        return None
     previous_softened = int_value(object_dict(repeat_signal).get("previous_softened_count"))
-    parsed["request_disposition"] = "honored_with_risk"
-    parsed["summary"] = "Kept the repeated requested experiment as a high-risk next sample draft."
+    parsed["request_disposition"] = "honored"
+    parsed["summary"] = "Kept the repeated operator request as the next sample draft."
     parsed["diagnosis"] = (
         "The operator repeated the same explicit experiment after earlier softening, "
-        "so this draft keeps the risky target for a measured retry instead of overriding it again."
+        "so this draft preserves the target for measurement instead of overriding it again."
     )
     parsed["request_response"] = (
-        "You asked for the same aggressive experiment again, so I kept it as an honored high-risk draft "
-        "instead of softening it again."
+        "You repeated the same request, so I kept it as the next sample. The measured result and your review decide."
     )
     if previous_softened:
-        parsed["suggested_follow_up"] = "Measure this risky retry and decide from the clips whether to pull it back."
+        parsed["suggested_follow_up"] = "Measure this retry and decide from the clips."
     if not parsed.get("feasibility_note"):
-        parsed["feasibility_note"] = "This draft is operator-confirmed and intentionally riskier than the usual next sample."
+        parsed["feasibility_note"] = "The repeated operator-confirmed target is queueable for a measured sample."
+    if not requested_policy:
+        return {}
+    _, applied_fragment = apply_seed_policy(current_policy, requested_policy, mode="tune")
     return applied_fragment
 
 
@@ -295,25 +330,33 @@ def request_seed_policy(*, project_root: Path, payload: dict[str, Any]) -> SeedP
     proposed_policy = _compact_policy_payload(proposed_policy)
     evidence_checked_raw = parsed.get("evidence_checked")
     evidence_checked = evidence_checked_raw if isinstance(evidence_checked_raw, list) else []
-    summary = str(parsed.get("summary") or "No summary returned.")
     request_disposition = str(parsed.get("request_disposition") or "unclear")
     if request_disposition not in REQUEST_DISPOSITIONS:
         request_disposition = "unclear"
-    forced_confirmed_policy = _force_operator_confirmed_experiment(
-        current_policy=base_policy,
-        parsed=parsed,
-        requested_experiment=object_dict(payload.get("requested_experiment")),
-        mode="seed",
-    )
-    if forced_confirmed_policy:
-        proposed_policy = _merge_policy_fragments(proposed_policy, forced_confirmed_policy) or proposed_policy
-        request_disposition = "honored_with_risk"
+    requested_experiment = object_dict(payload.get("requested_experiment"))
+    latest_failed_sample_job = object_dict(payload.get("latest_failed_sample_job"))
+    if _reject_nonpositive_video_budget(parsed, requested_experiment):
+        proposed_policy = None
+        request_disposition = "rejected"
+    else:
+        forced_confirmed_policy = _force_operator_confirmed_experiment(
+            current_policy=base_policy,
+            parsed=parsed,
+            requested_experiment=requested_experiment,
+            latest_failed_sample_job=latest_failed_sample_job,
+            mode="seed",
+        )
+        if forced_confirmed_policy is not None:
+            if forced_confirmed_policy:
+                proposed_policy = _merge_policy_fragments(proposed_policy, forced_confirmed_policy) or proposed_policy
+            request_disposition = "honored"
     if _should_carry_requested_experiment(request_disposition):
         requested_policy = _requested_experiment_policy(payload)
         if requested_policy:
             proposed_policy = _merge_policy_fragments(proposed_policy, requested_policy) or proposed_policy
     if proposed_policy is not None and base_policy:
         _, proposed_policy = apply_seed_policy(base_policy, proposed_policy)
+    summary = str(parsed.get("summary") or "No summary returned.")
     request_response = str(parsed.get("request_response") or summary)
     if proposed_policy is None:
         return SeedPolicyResponse(
@@ -403,24 +446,34 @@ def request_note_tuning(*, project_root: Path, payload: dict[str, Any]) -> Tunin
     request_disposition = str(parsed.get("request_disposition") or "unclear")
     if request_disposition not in REQUEST_DISPOSITIONS:
         request_disposition = "unclear"
-    forced_repeated_policy = _force_repeated_tune_experiment(
-        current_policy=current_policy,
-        parsed=parsed,
-        requested_experiment=object_dict(payload.get("requested_experiment")),
-        repeat_signal=object_dict(payload.get("operator_repeat_signal")),
-    )
-    if forced_repeated_policy:
-        proposed_policy = _merge_policy_fragments(proposed_policy, forced_repeated_policy) or proposed_policy
-        request_disposition = "honored_with_risk"
-    forced_confirmed_policy = _force_operator_confirmed_experiment(
-        current_policy=current_policy,
-        parsed=parsed,
-        requested_experiment=object_dict(payload.get("requested_experiment")),
-        mode="tune",
-    )
-    if forced_confirmed_policy:
-        proposed_policy = _merge_policy_fragments(proposed_policy, forced_confirmed_policy) or proposed_policy
-        request_disposition = "honored_with_risk"
+    requested_experiment = object_dict(payload.get("requested_experiment"))
+    latest_failed_sample_job = object_dict(payload.get("latest_failed_sample_job"))
+    if _reject_nonpositive_video_budget(parsed, requested_experiment):
+        proposed_policy = None
+        request_disposition = "rejected"
+    else:
+        forced_repeated_policy = _force_repeated_tune_experiment(
+            current_policy=current_policy,
+            parsed=parsed,
+            requested_experiment=requested_experiment,
+            repeat_signal=object_dict(payload.get("operator_repeat_signal")),
+            latest_failed_sample_job=latest_failed_sample_job,
+        )
+        if forced_repeated_policy is not None:
+            if forced_repeated_policy:
+                proposed_policy = _merge_policy_fragments(proposed_policy, forced_repeated_policy) or proposed_policy
+            request_disposition = "honored"
+        forced_confirmed_policy = _force_operator_confirmed_experiment(
+            current_policy=current_policy,
+            parsed=parsed,
+            requested_experiment=requested_experiment,
+            latest_failed_sample_job=latest_failed_sample_job,
+            mode="tune",
+        )
+        if forced_confirmed_policy is not None:
+            if forced_confirmed_policy:
+                proposed_policy = _merge_policy_fragments(proposed_policy, forced_confirmed_policy) or proposed_policy
+            request_disposition = "honored"
     requested_policy = _requested_experiment_policy(payload)
     if _should_carry_requested_experiment(request_disposition) and requested_policy:
         proposed_policy = _merge_policy_fragments(proposed_policy, requested_policy) or proposed_policy

--- a/mediaforce/library/folder_profiles.py
+++ b/mediaforce/library/folder_profiles.py
@@ -97,7 +97,7 @@ def recommend_folder_profile(prefix: str, rows: list[dict[str, Any]], resolved_p
 
     if avg_size_gib >= 2.5:
         suggestion["video"]["max_encoded_percent"] = 55
-        suggestion["reason"].append("Episodes are large enough that an aggressive size target is worthwhile.")
+        suggestion["reason"].append("Episodes are large enough that a size-first AV1 target is worthwhile.")
 
     if _looks_clean_catalog_tv(prefix):
         suggestion["video"]["default_grain"] = 0

--- a/mediaforce/tuning/tuning_memory.py
+++ b/mediaforce/tuning/tuning_memory.py
@@ -128,38 +128,82 @@ def retrieve_learning_context(
 ) -> list[dict[str, Any]]:
     candidate_rows = connection.execute(
         select(
+            learning_artifacts.c.prefix,
             learning_artifacts.c.title,
             learning_artifacts.c.artifact_path,
             learning_artifacts.c.summary,
             learning_artifacts.c.tags_json,
             learning_artifacts.c.updated_at,
-        ).order_by(learning_artifacts.c.updated_at.desc())
+            tuning_sessions.c.applied_policy_json,
+            tuning_sessions.c.toolbelt_json,
+        )
+        .select_from(
+            learning_artifacts.join(
+                tuning_sessions,
+                learning_artifacts.c.session_id == tuning_sessions.c.session_id,
+                isouter=True,
+            )
+        )
+        .order_by(learning_artifacts.c.updated_at.desc())
     ).mappings().fetchall()
     desired_tags = set(_artifact_tags(prefix=prefix, sample_item=sample_item, note=note, response={}))
-    ranked: list[tuple[int, dict[str, Any]]] = []
+    normalized_prefix = str(prefix).strip().strip("/")
+    requested_series_root = _season_root_prefix(normalized_prefix) or _series_root_prefix(normalized_prefix)
+    ranked: list[tuple[int, str, dict[str, Any]]] = []
     for row in candidate_rows:
-        tags = [str(value) for value in json.loads(str(row["tags_json"] or "[]"))]
+        try:
+            tags = [str(value) for value in json.loads(str(row["tags_json"] or "[]"))]
+        except json.JSONDecodeError:
+            tags = []
+        tag_set = set(tags)
         overlap = len(desired_tags.intersection(tags))
-        same_prefix = 1 if str(row["artifact_path"]).find(_slug(prefix)) != -1 else 0
-        score = overlap + same_prefix
+        artifact_prefix = str(row["prefix"] or "").strip().strip("/")
+        same_prefix = int(artifact_prefix == normalized_prefix)
+        artifact_series_root = _season_root_prefix(artifact_prefix) or _series_root_prefix(artifact_prefix)
+        same_series = int(bool(requested_series_root and artifact_series_root == requested_series_root))
+        approved_visual = "approval:visual" in tag_set and "decision:accepted" in tag_set
+        approval_authoritative = approved_visual and bool(same_prefix or same_series)
+        if approved_visual and not approval_authoritative:
+            continue
+        score = overlap + (same_prefix * 10) + (same_series * 6) + (20 if approval_authoritative else 0)
         if score <= 0:
             continue
         artifact_path = Path(str(row["artifact_path"]))
         excerpt = _artifact_excerpt(artifact_path)
+        applied_policy = _json_object(row.get("applied_policy_json"))
+        toolbelt = _json_object(row.get("toolbelt_json"))
+        sample_result = object_dict(toolbelt.get("sample_result"))
+        run_verdict = object_dict(toolbelt.get("run_verdict"))
         ranked.append(
             (
                 score,
+                str(row["updated_at"] or ""),
                 {
+                    "prefix": artifact_prefix,
                     "title": str(row["title"]),
                     "summary": str(row["summary"] or ""),
                     "tags": tags,
                     "updated_at": str(row["updated_at"]),
                     "excerpt": excerpt,
+                    "evidence_authority": "approved_visual_result" if approval_authoritative else "none",
+                    "approved_policy": applied_policy if approval_authoritative else {},
+                    "sample_result": sample_result if approval_authoritative else {},
+                    "run_verdict": run_verdict if approval_authoritative else {},
                 },
             )
         )
-    ranked.sort(key=lambda item: (-item[0], item[1]["updated_at"]))
-    return [payload for _, payload in ranked[:limit]]
+    ranked.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return [payload for _, _, payload in ranked[:limit]]
+
+
+def _json_object(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(str(raw or "{}"))
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def sibling_approved_season_memory(

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -2025,6 +2025,7 @@ def _build_seed_policy_payload(
         recent_sessions_payload: list[dict[str, Any]] | None = None,
         requested_experiment: dict[str, Any] | None = None,
         latest_failed_sample_job: dict[str, Any] | None = None,
+        learning_context_payload: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     return runtime_build_seed_policy_payload(
         prefix=prefix,
@@ -2036,6 +2037,7 @@ def _build_seed_policy_payload(
         recent_sessions_payload=recent_sessions_payload,
         requested_experiment=requested_experiment,
         latest_failed_sample_job=latest_failed_sample_job,
+        learning_context_payload=learning_context_payload,
     )
 
 

--- a/mediaforce/web/runtime/folder_ai_tuning.py
+++ b/mediaforce/web/runtime/folder_ai_tuning.py
@@ -5,7 +5,7 @@ from typing import Any
 from fastapi import HTTPException
 
 from mediaforce.advisor import apply_seed_policy, request_note_tuning, request_review_artifact_critique
-from mediaforce.advising.policy import merge_policy_fragments
+from mediaforce.advising.policy import has_nonpositive_video_budget, merge_policy_fragments
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient, open_db
 from mediaforce.core.type_defs import object_dict, object_list
@@ -19,7 +19,7 @@ from mediaforce.tuning.tuning_memory import promote_learning_artifact, retrieve_
 
 
 QUEUEABLE_NO_CHANGE_DISPOSITIONS = {"honored", "honored_with_risk"}
-SEED_REQUEST_REFUSAL_DISPOSITIONS = {"softened", "rejected"}
+NONQUEUEABLE_DISPOSITIONS = {"softened", "rejected", "unclear"}
 
 
 @dataclass(slots=True)
@@ -182,9 +182,11 @@ def _proposal_can_queue(
 ) -> bool:
     if alignment_issue is not None:
         return False
+    disposition = str(request_disposition or "").strip().lower()
+    if disposition in NONQUEUEABLE_DISPOSITIONS:
+        return False
     if applied_fragment:
         return True
-    disposition = str(request_disposition or "").strip().lower()
     return bool(preview_policy) and disposition in QUEUEABLE_NO_CHANGE_DISPOSITIONS
 
 
@@ -214,13 +216,59 @@ def _size_budget_measurement_fragment(operator_request: dict[str, Any] | None) -
     return None
 
 
-def _can_keep_first_size_budget_sample(operator_request: dict[str, Any] | None) -> bool:
+def _can_keep_first_size_budget_sample(
+        operator_request: dict[str, Any] | None,
+        *,
+        latest_failed_sample_job: dict[str, Any] | None = None,
+) -> bool:
     request = object_dict(operator_request)
     if str(request.get("request_type") or "").strip().lower() != "size_budget":
+        return False
+    if str(request.get("feasibility") or "").strip().lower() != "plausible":
+        return False
+    if str(request.get("evidence_authority") or "none").strip().lower() == "rejected_visual_result":
+        return False
+    if object_dict(latest_failed_sample_job):
         return False
     if request.get("measured_size_followup") or request.get("hard_size_cap"):
         return False
     return bool(request.get("operator_confirmed")) and not object_dict(request.get("applied_policy"))
+
+
+def _operator_request_with_retrieved_memory_authority(
+        operator_request: dict[str, Any] | None,
+        learning_context: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    request = object_dict(operator_request)
+    if not request:
+        return operator_request
+    authority = str(request.get("evidence_authority") or "none").strip().lower()
+    if authority != "none":
+        return request
+    if not any(
+            str(object_dict(memory).get("evidence_authority") or "none").strip().lower()
+            == "approved_visual_result"
+            for memory in learning_context
+    ):
+        return request
+    return {**request, "evidence_authority": "approved_visual_result"}
+
+
+def _blocking_sample_evidence_issue(
+        *,
+        operator_request: dict[str, Any] | None,
+        latest_failed_sample_job: dict[str, Any] | None,
+        current_policy: dict[str, Any],
+        preview_policy: dict[str, Any],
+) -> str | None:
+    if preview_policy != current_policy:
+        return None
+    authority = str(object_dict(operator_request).get("evidence_authority") or "none").strip().lower()
+    if authority == "rejected_visual_result":
+        return "The operator rejected the current sample. Change the draft before queueing another run."
+    if object_dict(latest_failed_sample_job):
+        return "The previous sample failed. Change the draft before queueing another run."
+    return None
 
 
 def _keep_first_size_budget_sample(
@@ -228,24 +276,49 @@ def _keep_first_size_budget_sample(
         advice_payload: dict[str, Any] | None,
         seed_job_fields: dict[str, Any],
         trimmed_note: str,
-        operator_request: dict[str, Any],
+    operator_request: dict[str, Any],
 ) -> dict[str, Any]:
     request = object_dict(operator_request)
-    existing_disposition = str(
-        seed_job_fields.get("seed_request_disposition")
-        or object_dict(advice_payload).get("request_disposition")
-        or ""
-    ).strip().lower()
-    if existing_disposition in SEED_REQUEST_REFUSAL_DISPOSITIONS:
-        return advice_payload if advice_payload is not None else {}
+    if has_nonpositive_video_budget(request):
+        summary = "The requested total size leaves no positive video budget."
+        diagnosis = (
+            "The estimated audio allocation consumes the requested total size, so this sample cannot queue "
+            "until the total target or audio allocation changes."
+        )
+        request_response = (
+            "That total size cannot queue as written because it leaves no positive video budget. "
+            "Increase the total target or explicitly reduce the audio allocation first."
+        )
+        seed_job_fields["seed_source"] = "operator_request"
+        seed_job_fields["seed_summary"] = summary
+        seed_job_fields["seed_diagnosis"] = diagnosis
+        seed_job_fields["seed_request_disposition"] = "rejected"
+        seed_job_fields["seed_request_response"] = request_response
+        seed_job_fields["seed_feasibility_note"] = "infeasible"
+        seed_job_fields["seed_applied_policy"] = None
+        payload = advice_payload if advice_payload is not None else {}
+        payload.update(
+            {
+                "ok": False,
+                "summary": summary,
+                "kind": "seed_baseline",
+                "operator_note": trimmed_note or None,
+                "request_disposition": "rejected",
+                "request_response": request_response,
+                "feasibility_note": "infeasible",
+                "diagnosis": diagnosis,
+                "applied_policy": None,
+            }
+        )
+        return payload
     summary = "Kept the first sample at the current policy so the size target can be measured."
     diagnosis = (
-        "A first size-budget request is a planning target, so the bench can measure the current policy "
-        "before trading quality, audio, or hard caps for size."
+        "A direct AV1 size target is queueable for a safe first measurement, so the bench keeps the current policy "
+        "and lets the real sample plus operator review decide the next change."
     )
     request_response = (
         "I kept this first sample at the current policy so we can compare the measured result to "
-        f"{request.get('budget_label') or 'your size target'} before making riskier changes."
+        f"{request.get('budget_label') or 'your size target'} before changing the policy."
     )
     seed_job_fields["seed_source"] = "operator_request"
     seed_job_fields["seed_summary"] = summary
@@ -549,6 +622,8 @@ def _seed_preview_action(
     )
     seed_metadata = object_dict(seed_metadata_raw)
     seed_job_fields = object_dict(seed_metadata.get("job_fields"))
+    seed_context_payload = object_dict(seed_job_fields.get("seed_context_payload"))
+    learning_context = [object_dict(item) for item in object_list(seed_context_payload.get("retrieved_memory"))]
     seeded_policy = object_dict(seed_metadata.get("policy")) if seed_metadata_raw is not None else base_policy
     seed_fragment = object_dict(seed_job_fields.get("seed_applied_policy"))
     combined_fragment = seed_fragment
@@ -567,7 +642,10 @@ def _seed_preview_action(
     if advice_payload is not None and combined_fragment:
         advice_payload["applied_policy"] = combined_fragment
     advice_details = object_dict(advice_payload)
-    if not combined_fragment and _can_keep_first_size_budget_sample(operator_request):
+    if not combined_fragment and _can_keep_first_size_budget_sample(
+            operator_request,
+            latest_failed_sample_job=latest_failed_sample_job,
+    ):
         advice_payload = _keep_first_size_budget_sample(
             advice_payload=advice_payload,
             seed_job_fields=seed_job_fields,
@@ -575,14 +653,26 @@ def _seed_preview_action(
             operator_request=object_dict(operator_request),
         )
         advice_details = object_dict(advice_payload)
+    alignment_operator_request = _operator_request_with_retrieved_memory_authority(
+        operator_request,
+        learning_context,
+    )
     alignment_issue = deps.proposal_alignment_issue(
-        operator_request=operator_request,
+        operator_request=alignment_operator_request,
         request_disposition=advice_details.get("request_disposition"),
         current_policy=base_policy,
         preview_policy=seeded_policy,
     )
+    blocking_evidence_issue = _blocking_sample_evidence_issue(
+        operator_request=operator_request,
+        latest_failed_sample_job=latest_failed_sample_job,
+        current_policy=base_policy,
+        preview_policy=seeded_policy,
+    )
+    if alignment_issue is None:
+        alignment_issue = blocking_evidence_issue
     measurement_fragment = _size_budget_measurement_fragment(operator_request)
-    if alignment_issue is not None and measurement_fragment is not None:
+    if blocking_evidence_issue is None and alignment_issue is not None and measurement_fragment is not None:
         seeded_policy = deps.apply_policy_fragment(base_policy, measurement_fragment) if measurement_fragment else base_policy
         seed_fragment = measurement_fragment
         combined_fragment = measurement_fragment
@@ -895,14 +985,25 @@ def _tuned_preview_action(
             if size_budget_request:
                 operator_request["size_budget_request"] = size_budget_request
             advice_payload["operator_request"] = operator_request
+    alignment_operator_request = _operator_request_with_retrieved_memory_authority(
+        operator_request,
+        learning_context,
+    )
     alignment_issue = deps.proposal_alignment_issue(
-        operator_request=operator_request,
+        operator_request=alignment_operator_request,
         request_disposition=tuning.request_disposition,
         current_policy=current_policy,
         preview_policy=tuned_policy,
         allow_measured_size_quality_tradeoff=allow_measured_size_quality_tradeoff,
         allow_measured_size_quality_increase=allow_measured_size_quality_increase,
     )
+    if alignment_issue is None:
+        alignment_issue = _blocking_sample_evidence_issue(
+            operator_request=operator_request,
+            latest_failed_sample_job=latest_failed_sample_job,
+            current_policy=current_policy,
+            preview_policy=tuned_policy,
+        )
     can_queue = _proposal_can_queue(
         applied_fragment=combined_fragment,
         preview_policy=tuned_policy,

--- a/mediaforce/web/runtime/folder_tuning_advice.py
+++ b/mediaforce/web/runtime/folder_tuning_advice.py
@@ -6,13 +6,14 @@ from pathlib import Path
 from typing import Any
 
 from mediaforce.advisor import apply_seed_policy, request_operator_note_parse, request_run_verdict, request_seed_policy
-from mediaforce.advising.policy import merge_policy_fragments, policy_key_paths
+from mediaforce.advising.policy import has_nonpositive_video_budget, merge_policy_fragments, policy_key_paths
 from mediaforce.core.binaries import ffmpeg_binary
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.type_defs import JSONValue, float_value, int_value, object_dict, object_list
 from mediaforce.library.folder_profiles import inspect_prefix
 from mediaforce.reviewing.helpers import planned_audio_action, select_primary_audio_track
+from mediaforce.tuning.tuning_memory import retrieve_learning_context
 from mediaforce.web.runtime.folder_tuning_helpers import (
     load_json_object,
     recent_tuning_sessions,
@@ -43,8 +44,12 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[3]
 _NOTE_PARSE_INTENT_TYPES = {"direct_request", "exploratory_question", "approval_feedback", "other", "unclear"}
 _NOTE_PARSE_REQUEST_TYPES = {"none", "metric_target", "size_budget", "scale_target", "combined_experiment"}
 _NOTE_PARSE_METRICS = {"vmaf", "xpsnr"}
+_EVIDENCE_AUTHORITY_VALUES = {"none", "operator_observed", "approved_visual_result", "rejected_visual_result"}
 _CROP_VALUE_RE = re.compile(r"\d+:\d+:\d+:\d+")
-_SIZE_BUDGET_RE = re.compile(r"(?P<amount>\d+(?:\.\d+)?)\s*(?P<unit>kb|mb|gb|tb)\b", re.IGNORECASE)
+_SIZE_BUDGET_RE = re.compile(
+    r"(?<![\w.])(?P<sign>[+-]?)\s*(?P<amount>\d+(?:\.\d+)?)\s*(?P<unit>kb|mb|gb|tb)\b",
+    re.IGNORECASE,
+)
 _SCALE_HEIGHT_RE = re.compile(r"(?<!\d)(?P<height>240|360|480|540|720|1080|1440|2160|4320)p\b", re.IGNORECASE)
 _SOURCE_RESOLUTION_RE = re.compile(
     r"\b(?:source|original|native)\s+resolution\b|\b(?:do\s+not|don't|dont|no)\s+(?:downsample|downscale|scale\s+down)\b|\bkeep\s+max_height\s+(?:unset|at\s+0|0)\b|\bmax_height\s+(?:unset|0)\b",
@@ -67,6 +72,38 @@ _METRIC_DIRECTIVE_RE = re.compile(
     r"(?P<metric>vmaf|xpsnr)\b",
     re.IGNORECASE,
 )
+_OPERATOR_OBSERVED_RE = re.compile(
+    r"\b(?:look(?:s|ed)?|sound(?:s|ed)?|is|was|are|were)\s+"
+    r"(?:good|great|excellent|fine|clean|identical|indistinguishable|acceptable)\b|"
+    r"\b(?:cannot|can't|could not|couldn't)\s+(?:see|hear|tell|notice)\b.*\b(?:difference|damage|artifact)\b",
+    re.IGNORECASE,
+)
+_VISUAL_APPROVAL_RE = re.compile(
+    r"\b(?:i\s+)?(?:approve|approved|accept|accepted)\b.*\b(?:sample|clip|encode|result|draft|quality)\b|"
+    r"\b(?:sample|clip|encode|result|draft|quality)\b.*\b(?:is\s+)?(?:approved|accepted)\b",
+    re.IGNORECASE,
+)
+_VISUAL_REJECTION_RE = re.compile(
+    r"\b(?:i\s+)?(?:reject|rejected|decline|declined)\b.*\b(?:sample|clip|encode|result|draft|quality)\b|"
+    r"\b(?:do\s+not|don't|dont|did\s+not|didn't|didnt)\s+(?:approve|accept)\b.*"
+    r"\b(?:sample|clip|encode|result|draft|quality)\b|"
+    r"\b(?:sample|clip|encode|result|draft|quality)\b.*\b"
+    r"(?:look(?:s|ed)?|sound(?:s|ed)?|is|was)\s+(?:bad|worse|unacceptable|blocky|banded|damaged)\b",
+    re.IGNORECASE,
+)
+_NEGATIVE_VISUAL_OBSERVATION_RE = re.compile(
+    r"\b(?:saw|noticed|showed|shows|had|has|with)\b.{0,48}\b"
+    r"(?:artifact(?:s|ing)?|banding|blocking|blockiness|smearing|damage|ringing|mosquito noise|"
+    r"color banding|macroblocking|blurring|blur)\b",
+    re.IGNORECASE,
+)
+
+
+def _positive_size_budget_match(note: str) -> re.Match[str] | None:
+    for match in _SIZE_BUDGET_RE.finditer(note):
+        if match.group("sign") != "-":
+            return match
+    return None
 
 
 def _normalize_operator_note_parse(parsed: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -79,6 +116,9 @@ def _normalize_operator_note_parse(parsed: dict[str, Any] | None) -> dict[str, A
     intent_type = str(parsed_object.get("intent_type") or "").strip().lower()
     if intent_type not in _NOTE_PARSE_INTENT_TYPES:
         intent_type = "unclear"
+    evidence_authority = str(parsed_object.get("evidence_authority") or "none").strip().lower()
+    if evidence_authority not in _EVIDENCE_AUTHORITY_VALUES:
+        evidence_authority = "none"
     metric = str(parsed_object.get("metric") or "").strip().lower() or None
     metric_target = None
     size_budget_value = None
@@ -139,6 +179,7 @@ def _normalize_operator_note_parse(parsed: dict[str, Any] | None) -> dict[str, A
         "intent_type": intent_type,
         "request_type": request_type,
         "operator_confirmed": operator_confirmed,
+        "evidence_authority": evidence_authority,
         "metric": metric if metric_target is not None else None,
         "metric_target": metric_target,
         "size_budget_value": size_budget_value,
@@ -157,8 +198,17 @@ def _heuristic_operator_note_parse(note: str) -> dict[str, Any] | None:
     if not trimmed:
         return None
     lowered = trimmed.lower()
+    evidence_authority = "none"
+    if _VISUAL_REJECTION_RE.search(trimmed):
+        evidence_authority = "rejected_visual_result"
+    elif _VISUAL_APPROVAL_RE.search(trimmed):
+        evidence_authority = "approved_visual_result"
+    elif _NEGATIVE_VISUAL_OBSERVATION_RE.search(trimmed):
+        evidence_authority = "rejected_visual_result"
+    elif _OPERATOR_OBSERVED_RE.search(trimmed):
+        evidence_authority = "operator_observed"
 
-    size_budget_match = _SIZE_BUDGET_RE.search(trimmed)
+    size_budget_match = _positive_size_budget_match(trimmed)
     metric_match = _METRIC_TARGET_RE.search(trimmed)
     metric_directive_match = _METRIC_DIRECTIVE_RE.search(trimmed)
     scale_match = _SCALE_HEIGHT_RE.search(trimmed)
@@ -188,7 +238,7 @@ def _heuristic_operator_note_parse(note: str) -> dict[str, Any] | None:
     explicit_parts = sum(
         part is not None for part in (metric, size_budget_value, scale_height, black_bar_handling, crop)
     )
-    if explicit_parts == 0:
+    if explicit_parts == 0 and evidence_authority == "none":
         return None
 
     if explicit_parts >= 2:
@@ -197,6 +247,8 @@ def _heuristic_operator_note_parse(note: str) -> dict[str, Any] | None:
         request_type = "metric_target"
     elif size_budget_value is not None:
         request_type = "size_budget"
+    elif explicit_parts == 0:
+        request_type = "none"
     else:
         request_type = "scale_target"
 
@@ -208,8 +260,8 @@ def _heuristic_operator_note_parse(note: str) -> dict[str, Any] | None:
         "do you think",
         "what do you think",
     )
-    operator_confirmed = True
-    intent_type = "direct_request"
+    operator_confirmed = request_type != "none"
+    intent_type = "approval_feedback" if request_type == "none" and evidence_authority != "none" else "direct_request"
     if any(marker in lowered for marker in exploratory_markers):
         operator_confirmed = False
         intent_type = "exploratory_question"
@@ -234,6 +286,7 @@ def _heuristic_operator_note_parse(note: str) -> dict[str, Any] | None:
         "intent_type": intent_type,
         "request_type": request_type,
         "operator_confirmed": operator_confirmed,
+        "evidence_authority": evidence_authority,
         "metric": metric,
         "metric_target": metric_target,
         "size_budget_value": size_budget_value,
@@ -284,6 +337,7 @@ def _merge_operator_note_parse(
             "scale_height",
             "black_bar_handling",
             "crop",
+            "evidence_authority",
     ):
         if merged.get(key) in {None, ""} and heuristic.get(key) is not None and heuristic.get(key) != "":
             merged[key] = heuristic.get(key)
@@ -293,6 +347,12 @@ def _merge_operator_note_parse(
             merged["intent_type"] = "direct_request"
     if heuristic.get("measured_size_followup"):
         merged["measured_size_followup"] = True
+    structured_authority = str(merged.get("evidence_authority") or "none")
+    heuristic_authority = str(heuristic.get("evidence_authority") or "none")
+    if heuristic_authority == "rejected_visual_result":
+        merged["evidence_authority"] = heuristic_authority
+    elif structured_authority == "none" and heuristic_authority != "none":
+        merged["evidence_authority"] = heuristic_authority
     merged = _normalize_operator_note_parse(merged)
     if merged is None:
         return heuristic
@@ -453,13 +513,9 @@ def size_budget_feasibility(
     if source_percent is None or video_bitrate_kbps is None:
         return "unknown", False
     if _is_av1_encoder(video_encoder):
-        # AV1 can stay visually strong at bitrates that look "too low" through an older-codec lens,
-        # so keep the hard stop for only the smallest AV1 budgets and treat the next band as aggressive.
-        if source_percent <= 4.0 or video_bitrate_kbps <= 325.0:
-            return "unreasonable", True
-        if source_percent <= 15.0 or video_bitrate_kbps <= 650.0:
-            return "aggressive", False
-        return "reasonable", False
+        if video_bitrate_kbps <= 0:
+            return "infeasible", True
+        return "plausible", False
     if source_percent <= 10.0 or video_bitrate_kbps <= 500.0:
         return "unreasonable", True
     if source_percent <= 20.0 or video_bitrate_kbps <= 900.0:
@@ -561,6 +617,7 @@ def size_budget_request(
         "target_tolerance_percent": SIZE_BUDGET_TARGET_TOLERANCE,
         "hard_size_cap": hard_size_cap,
         "measured_size_followup": measured_size_followup,
+        "evidence_authority": str(parsed_note.get("evidence_authority") or "none"),
         "feasibility": feasibility,
         "requires_confirmation": requires_confirmation,
         "requested_max_encoded_percent": requested_max_encoded_percent,
@@ -657,7 +714,19 @@ def operator_requested_experiment(
     note_parse = object_dict(parsed_note) or object_dict(_parsed_operator_note(trimmed))
     request_type = str(note_parse.get("request_type") or "").strip().lower()
     if request_type == "none":
-        return None
+        evidence_authority = str(note_parse.get("evidence_authority") or "none").strip().lower()
+        if evidence_authority == "none":
+            return None
+        return {
+            "source": "operator_note",
+            "operator_note_parse": note_parse,
+            "honor_mode": "evidence_feedback",
+            "request_type": "none",
+            "request_text": trimmed,
+            "operator_confirmed": False,
+            "evidence_authority": evidence_authority,
+            "applied_policy": None,
+        }
     operator_confirmed = bool(note_parse.get("operator_confirmed"))
 
     requested_size_budget = size_budget_request(
@@ -694,6 +763,7 @@ def operator_requested_experiment(
             "requested_max_encoded_percent": object_dict(requested_size_budget).get("requested_max_encoded_percent"),
             "applied_max_encoded_percent": object_dict(requested_size_budget).get("applied_max_encoded_percent"),
             "operator_confirmed": operator_confirmed,
+            "evidence_authority": str(note_parse.get("evidence_authority") or "none"),
             "metric_request": requested_metric_target,
             "size_budget_request": requested_size_budget,
             "scale_request": requested_scale_target,
@@ -705,12 +775,15 @@ def operator_requested_experiment(
         }
     if requested_metric_target:
         requested_metric_target["operator_confirmed"] = operator_confirmed
+        requested_metric_target["evidence_authority"] = str(note_parse.get("evidence_authority") or "none")
         return requested_metric_target
     if requested_size_budget:
         requested_size_budget["operator_confirmed"] = operator_confirmed
+        requested_size_budget["evidence_authority"] = str(note_parse.get("evidence_authority") or "none")
         return requested_size_budget
     if requested_scale_target:
         requested_scale_target["operator_confirmed"] = operator_confirmed
+        requested_scale_target["evidence_authority"] = str(note_parse.get("evidence_authority") or "none")
         return requested_scale_target
     return None
 
@@ -821,35 +894,42 @@ def maybe_force_repeated_seed_experiment(
         seed_response: Any,
         requested_experiment: dict[str, Any] | None,
         repeat_signal: dict[str, Any] | None,
+        latest_failed_sample_job: dict[str, Any] | None = None,
 ) -> None:
     repeat_payload = object_dict(repeat_signal)
     if int_value(repeat_payload.get("repeat_count")) < 2:
         return
+    request = object_dict(requested_experiment)
+    if (
+            has_nonpositive_video_budget(request)
+            or str(request.get("evidence_authority") or "none").strip().lower() == "rejected_visual_result"
+            or bool(object_dict(latest_failed_sample_job))
+    ):
+        return
     if str(seed_response.request_disposition or "").strip().lower() not in {"softened", "rejected"}:
         return
-    requested_policy = object_dict(object_dict(requested_experiment).get("applied_policy"))
+    requested_policy = object_dict(request.get("applied_policy"))
+    previous_softened = int_value(repeat_payload.get("previous_softened_count"))
+    seed_response.request_disposition = "honored"
+    seed_response.summary = "Kept the repeated operator request as the first sample draft."
+    seed_response.diagnosis = (
+        "The operator repeated the same explicit experiment after an earlier softening, "
+        "so the seed preserves the target for measurement instead of overriding it again."
+    )
+    seed_response.request_response = (
+        "You repeated the same request, so I kept it as the first sample. The measured result and your review decide."
+    )
+    if previous_softened:
+        seed_response.suggested_follow_up = "Measure this first sample and decide from the clips."
+    if not seed_response.feasibility_note:
+        seed_response.feasibility_note = "The repeated operator-confirmed target is queueable for a measured sample."
     if not requested_policy:
         return
     _, applied_fragment = apply_seed_policy(base_policy, requested_policy)
     if not applied_fragment:
         return
-    previous_softened = int_value(repeat_payload.get("previous_softened_count"))
     seed_response.ok = True
     seed_response.proposed_policy = applied_fragment
-    seed_response.request_disposition = "honored_with_risk"
-    seed_response.summary = "Kept the repeated requested experiment as a high-risk first sample draft."
-    seed_response.diagnosis = (
-        "The operator repeated the same explicit experiment after an earlier softening, "
-        "so the seed keeps the risky target for measurement instead of overriding it again."
-    )
-    seed_response.request_response = (
-        "You asked for the same aggressive experiment again, so I kept it as an honored high-risk draft "
-        "instead of softening it again."
-    )
-    if previous_softened:
-        seed_response.suggested_follow_up = "Measure this risky first sample and decide from the clips whether to pull it back."
-    if not seed_response.feasibility_note:
-        seed_response.feasibility_note = "This draft is operator-confirmed and intentionally riskier than the usual cold-start seed."
 
 
 def build_run_verdict_payload(
@@ -1044,12 +1124,12 @@ def seed_class_signals(prefix: str, sample_item: dict[str, Any], summary: dict[s
     elif collection_shape == "movie_folder":
         positive_signals.append("Folder is movie-shaped rather than episodic TV.")
     else:
-        caution_flags.append("Folder shape is broad enough that the seed should stay close to the base policy.")
+        caution_flags.append("Folder shape is broad; choose representative samples before applying one policy broadly.")
 
     if sample_resolution_tier is not None:
         positive_signals.append(f"Sample item resolves to {sample_resolution_tier}.")
     else:
-        caution_flags.append("Sample resolution is unknown, so avoid overfitting the first-pass guess.")
+        caution_flags.append("Sample resolution is unknown; measure it rather than inferring a resolution or bitrate floor.")
 
     sample_codec = str(sample_item.get("video_codec") or "").strip().lower()
     if dominant_video_codec and sample_codec and dominant_video_codec == sample_codec:
@@ -1061,14 +1141,14 @@ def seed_class_signals(prefix: str, sample_item: dict[str, Any], summary: dict[s
 
     item_count = int_value(summary.get("item_count"))
     if item_count and item_count < 6:
-        caution_flags.append("Small folder sample size means the seed should remain conservative.")
+        caution_flags.append("Small folder size makes representative sample selection especially important.")
 
     for reason in object_list(suggested_override.get("reason"))[:2]:
         if reason:
             positive_signals.append(str(reason))
 
     caution_flags.append(
-        "This first-pass seed is only a bounded starting point; measured calibration should confirm any lean move."
+        "This first-pass seed is only a bounded starting point; measured calibration and operator review decide."
     )
     return {
         "collection_shape": collection_shape,
@@ -1090,6 +1170,7 @@ def build_seed_policy_payload(
         recent_sessions_payload: list[dict[str, Any]] | None = None,
         requested_experiment: dict[str, Any] | None = None,
         latest_failed_sample_job: dict[str, Any] | None = None,
+        learning_context_payload: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     suggested_override = object_dict(summary.get("suggested_override"))
     resolved_requested_experiment = object_dict(requested_experiment) or operator_requested_experiment(user_note, sample_item)
@@ -1103,12 +1184,12 @@ def build_seed_policy_payload(
     )
     return {
         "folder": prefix,
-        "goal": "Prefer slightly smaller files when the visual difference is hard to spot, but keep first-pass drafts conservative when the class is uncertain.",
+        "goal": "Target source-resolution 1080p AV1 around 200-300 MiB per 40 minutes and let measured samples plus operator visual review decide quality.",
         "seed_principles": [
-            "Teach media-class taste instead of optimizing one easy title in isolation.",
-            "Prefer small, reversible moves away from the base policy.",
-            "Clean, forgiving TV can lean a little smaller than default.",
-            "Dark, grainy, fast-motion, or uncertain material should stay near the base policy until measured calibration says otherwise.",
+            "The operator has already observed strong 1080p AV1 results in this size range across conventional and dark or stylized TV.",
+            "Do not infer a minimum acceptable bitrate from source size, resolution, or content-class folklore.",
+            "Use representative sample moments to discover actual weaknesses instead of preemptively enlarging the encode.",
+            "Preserve source resolution unless the operator explicitly asks to downsample.",
         ],
         "sample_item": {
             "rel_path": sample_item["rel_path"],
@@ -1148,6 +1229,7 @@ def build_seed_policy_payload(
         "operator_note": user_note or None,
         "requested_experiment": resolved_requested_experiment,
         "operator_repeat_signal": repeat_signal,
+        "retrieved_memory": list(learning_context_payload or []),
         "latest_failed_sample_job": object_dict(latest_failed_sample_job) or None,
         "metric_support": metric_support_payload,
         "preferred_metric": "vmaf" if metric_support_payload.get("vmaf") else (
@@ -1255,6 +1337,12 @@ def maybe_seed_baseline_policy(
         load_json_object_fn=load_json_object,
         limit=4,
     )
+    learning_context = retrieve_learning_context(
+        connection,
+        prefix=prefix,
+        sample_item=sample_item,
+        note=user_note,
+    )
     payload = build_seed_policy_payload(
         prefix=prefix,
         user_note=user_note,
@@ -1265,6 +1353,7 @@ def maybe_seed_baseline_policy(
         recent_sessions_payload=recent_sessions_payload,
         requested_experiment=requested_experiment,
         latest_failed_sample_job=latest_failed_sample_job,
+        learning_context_payload=learning_context,
     )
     seed_response = request_seed_policy(project_root=project_root, payload=payload)
     maybe_force_repeated_seed_experiment(
@@ -1272,6 +1361,7 @@ def maybe_seed_baseline_policy(
         seed_response=seed_response,
         requested_experiment=object_dict(payload.get("requested_experiment")),
         repeat_signal=object_dict(payload.get("operator_repeat_signal")),
+        latest_failed_sample_job=latest_failed_sample_job,
     )
     if not seed_response.ok or not seed_response.proposed_policy:
         return {

--- a/mediaforce/web/runtime/folder_tuning_helpers.py
+++ b/mediaforce/web/runtime/folder_tuning_helpers.py
@@ -89,7 +89,7 @@ def proposal_signal_copy(
 ) -> str:
     disposition = str(request_disposition or "").strip().lower()
     if disposition == "honored_with_risk":
-        return "The bench kept your requested experiment, but called out the risk before anything queues."
+        return "The bench kept your requested experiment and called out the measured caveat before anything queues."
     if disposition == "softened":
         return "The bench softened part of your request and explained why in the reply below."
     if disposition == "rejected":
@@ -211,6 +211,11 @@ def proposal_alignment_issue(
     preview_audio = object_dict(preview_policy.get("audio"))
     requested_video = object_dict(object_dict(operator_request.get("applied_policy")).get("video"))
     requested_audio = object_dict(object_dict(operator_request.get("applied_policy")).get("audio"))
+    evidence_authority = str(operator_request.get("evidence_authority") or "none").strip().lower()
+    allow_evidence_backed_video_tradeoff = evidence_authority in {
+        "operator_observed",
+        "approved_visual_result",
+    }
 
     def _float_or_none(value: JSONValue) -> float | None:
         if not isinstance(value, str | int | float):
@@ -270,6 +275,7 @@ def proposal_alignment_issue(
             return "The draft raises the VMAF target even though your note asked for a smaller encode."
         if (
                 not allow_measured_size_quality_tradeoff
+                and not allow_evidence_backed_video_tradeoff
                 and current_vmaf is not None
                 and preview_vmaf is not None
                 and preview_vmaf < current_vmaf - 0.01
@@ -287,6 +293,7 @@ def proposal_alignment_issue(
             return "The draft raises the XPSNR target even though your note asked for a smaller encode."
         if (
                 not allow_measured_size_quality_tradeoff
+                and not allow_evidence_backed_video_tradeoff
                 and current_xpsnr is not None
                 and preview_xpsnr is not None
                 and preview_xpsnr < current_xpsnr - 0.01
@@ -305,7 +312,7 @@ def proposal_alignment_issue(
         tradeoff_issue = _unrequested_size_tradeoff_issue()
         if tradeoff_issue is not None:
             return tradeoff_issue
-        if not allow_measured_size_quality_tradeoff:
+        if not allow_measured_size_quality_tradeoff and not allow_evidence_backed_video_tradeoff:
             for key in ("default_grain", "grain_denoise", "min_crf", "max_crf", "preset"):
                 if key in requested_video:
                     continue
@@ -340,7 +347,7 @@ def proposal_alignment_issue(
             tradeoff_issue = _unrequested_size_tradeoff_issue()
             if tradeoff_issue is not None:
                 return tradeoff_issue
-            if not allow_measured_size_quality_tradeoff:
+            if not allow_measured_size_quality_tradeoff and not allow_evidence_backed_video_tradeoff:
                 for key in ("default_grain", "grain_denoise", "min_crf", "max_crf", "preset"):
                     if key in requested_video:
                         continue

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -28,6 +28,7 @@ from mediaforce.advisor import (
     _build_operator_note_parse_prompt,
     _extract_seed_payload,
     _filter_audio_specific_guardrail_issues,
+    _force_repeated_tune_experiment,
     _memory_disabled_code_args,
     _policy_response_schema,
     _run_tune_self_check,
@@ -95,6 +96,10 @@ from mediaforce.web.runtime.completed_runtime import (
 from mediaforce.web.runtime.dashboard_payloads import dashboard_summary_payload
 from mediaforce.web.runtime.folder_ai_tuning import (
     FolderAiTuneDeps,
+    _blocking_sample_evidence_issue,
+    _can_keep_first_size_budget_sample,
+    _keep_first_size_budget_sample,
+    _operator_request_with_retrieved_memory_authority,
     _proposal_can_queue,
     _proposal_ready_message,
     folder_ai_tune_confirm_action,
@@ -136,7 +141,12 @@ def _fake_operator_note_parse(*, project_root: Path, payload: dict[str, object])
     if not note:
         return None
     lower = note.lower()
-    budget_match = re.search(r"(?P<amount>\d+(?:\.\d+)?)\s*(?P<unit>kb|mb|gb|tb)", lower)
+    budget_match = re.search(
+        r"(?<![\w.])(?P<sign>[+-]?)\s*(?P<amount>\d+(?:\.\d+)?)\s*(?P<unit>kb|mb|gb|tb)",
+        lower,
+    )
+    if budget_match is not None and budget_match.group("sign") == "-":
+        budget_match = None
     metric_match = re.search(
         r"\b(?P<metric>vmaf|xpsnr)\b(?:\s+(?:target|around|about|roughly|approximately|approx|at|to|of)|\s*=){0,3}\s*(?P<target>\d{2}(?:\.\d+)?)\b",
         lower,
@@ -171,6 +181,23 @@ def _fake_operator_note_parse(*, project_root: Path, payload: dict[str, object])
     ) else None
     crop_match = re.search(r"\b(?P<crop>\d{3,5}:\d{3,5}:\d{1,5}:\d{1,5})\b", lower)
     crop = crop_match.group("crop") if crop_match else None
+    evidence_authority = "none"
+    if re.search(
+            r"\b(?:reject|rejected|decline|declined)\b.*\b(?:sample|clip|encode|result|draft|quality)\b|"
+            r"\b(?:sample|clip|encode|result|draft|quality)\b.*\b(?:look(?:s|ed)?|sound(?:s|ed)?|is|was)\s+"
+            r"(?:bad|worse|unacceptable|blocky|banded|damaged)\b|"
+            r"\b(?:saw|noticed|showed|shows|had|has|with)\b.{0,48}\b"
+            r"(?:artifact(?:s|ing)?|banding|blocking|blockiness|smearing|damage|ringing|macroblocking|blur)\b",
+            lower,
+    ):
+        evidence_authority = "rejected_visual_result"
+    elif re.search(r"\b(?:approve|approved|accept|accepted)\b.*\b(?:sample|clip|encode|result|draft|quality)\b", lower):
+        evidence_authority = "approved_visual_result"
+    elif re.search(
+            r"\b(?:look(?:s|ed)?|sound(?:s|ed)?)\s+(?:good|great|excellent|fine|clean|identical|indistinguishable)\b",
+            lower,
+    ):
+        evidence_authority = "operator_observed"
     explicit_request_count = sum(
         value is not None for value in (size_budget_value, metric_target, scale_height, black_bar_handling, crop)
     )
@@ -194,13 +221,16 @@ def _fake_operator_note_parse(*, project_root: Path, payload: dict[str, object])
         )
     )
     operator_confirmed = request_type != "none" and not exploratory
-    intent_type = "exploratory_question" if exploratory else ("direct_request" if request_type != "none" else "other")
+    intent_type = "exploratory_question" if exploratory else (
+        "direct_request" if request_type != "none" else "approval_feedback" if evidence_authority != "none" else "other"
+    )
     return {
         "summary": "parsed note",
         "intent_type": intent_type,
         "request_type": request_type,
         "operator_confirmed": operator_confirmed,
         "measured_size_followup": "revise" in lower and "sample" in lower and "target" in lower,
+        "evidence_authority": evidence_authority,
         "metric": metric,
         "metric_target": metric_target,
         "size_budget_value": size_budget_value,
@@ -349,6 +379,8 @@ class TuningRuntimeTests(unittest.TestCase):
                     "intent_type": "direct_request",
                     "request_type": "size_budget",
                     "operator_confirmed": True,
+                    "measured_size_followup": False,
+                    "evidence_authority": "none",
                     "metric": None,
                     "metric_target": None,
                     "size_budget_value": 300,
@@ -369,6 +401,7 @@ class TuningRuntimeTests(unittest.TestCase):
 
         assert parsed is not None
         self.assertTrue(parsed["operator_confirmed"])
+        self.assertEqual(parsed["evidence_authority"], "none")
         self._assert_structured_subprocess_call(commands)
         self.assertIn("llm", commands[0])
         self.assertIn(_build_operator_note_parse_prompt({"operator_note": "Can you target 300MB per episode?"}), commands[0])
@@ -3507,7 +3540,7 @@ class TuningRuntimeTests(unittest.TestCase):
             )
 
         self.assertTrue(response.ok)
-        self.assertEqual(response.request_disposition, "honored_with_risk")
+        self.assertEqual(response.request_disposition, "honored")
         assert response.proposed_policy is not None
         self.assertEqual(response.proposed_policy["video"]["target_vmaf"], 88.5)
         self.assertEqual(response.proposed_policy["video"]["min_target_vmaf"], 87.0)
@@ -3608,11 +3641,112 @@ class TuningRuntimeTests(unittest.TestCase):
             )
 
         self.assertTrue(response.ok)
-        self.assertEqual(response.request_disposition, "honored_with_risk")
+        self.assertEqual(response.request_disposition, "honored")
         assert response.proposed_policy is not None
         self.assertEqual(response.proposed_policy["video"]["max_encoded_percent"], 8)
-        self.assertIn("aggressive experiment directly", response.request_response)
+        self.assertIn("real sample and your review will decide", response.request_response)
         self._assert_structured_subprocess_call(commands)
+
+    def test_request_seed_policy_rejects_nonpositive_video_budget(self) -> None:
+        response_body = json.dumps(
+            {
+                "request_response": "I kept the requested target.",
+                "request_disposition": "honored",
+                "summary": "Queue the requested sample.",
+                "diagnosis": "The request was explicit.",
+                "confidence": "medium",
+                "evidence_checked": ["requested_experiment"],
+                "suggested_follow_up": None,
+                "feasibility_note": None,
+                "policy": {"video": {"target_vmaf": 85.0}},
+            }
+        )
+        commands, fake_run = self._capture_subprocess_commands(response_body)
+
+        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+            response = request_seed_policy(
+                project_root=self.root,
+                payload={
+                    "folder": "tv/suits/season-3",
+                    "base_policy": {"video": {"target_vmaf": 95.0}},
+                    "requested_experiment": {
+                        "request_type": "size_budget",
+                        "operator_confirmed": True,
+                        "budget_bytes": 20 * 1024 * 1024,
+                        "estimated_audio_bytes": 24 * 1024 * 1024,
+                        "estimated_video_bitrate_kbps": 0.0,
+                        "applied_policy": None,
+                    },
+                },
+            )
+
+        self.assertFalse(response.ok)
+        self.assertEqual(response.request_disposition, "rejected")
+        self.assertIsNone(response.proposed_policy)
+        self.assertIn("no positive video budget", response.request_response)
+        self._assert_structured_subprocess_call(commands)
+
+    def test_request_seed_policy_does_not_override_failed_sample_refusal(self) -> None:
+        response_body = json.dumps(
+            {
+                "request_response": "The failed sample needs a different plan.",
+                "request_disposition": "rejected",
+                "summary": "Do not repeat the failed draft.",
+                "diagnosis": "The previous sample failed with the same constraints.",
+                "confidence": "high",
+                "evidence_checked": ["latest_failed_sample_job.error"],
+                "suggested_follow_up": "Change the draft before retrying.",
+                "feasibility_note": None,
+                "policy": {"video": {"target_vmaf": 94.0}},
+            }
+        )
+        commands, fake_run = self._capture_subprocess_commands(response_body)
+
+        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+            response = request_seed_policy(
+                project_root=self.root,
+                payload={
+                    "folder": "tv/suits/season-3",
+                    "base_policy": {"video": {"target_vmaf": 95.0}},
+                    "requested_experiment": {
+                        "request_type": "size_budget",
+                        "operator_confirmed": True,
+                        "feasibility": "plausible",
+                        "applied_policy": None,
+                    },
+                    "latest_failed_sample_job": {
+                        "status": "failed",
+                        "error": "Failed to find a suitable CRF",
+                    },
+                },
+            )
+
+        self.assertTrue(response.ok)
+        self.assertEqual(response.request_disposition, "rejected")
+        assert response.proposed_policy is not None
+        self.assertEqual(response.proposed_policy["video"]["target_vmaf"], 94.0)
+        self._assert_structured_subprocess_call(commands)
+
+    def test_repeated_tune_backstop_preserves_visual_rejection(self) -> None:
+        parsed = {
+            "request_disposition": "rejected",
+            "summary": "The current sample was rejected.",
+        }
+
+        forced = _force_repeated_tune_experiment(
+            current_policy={"video": {"target_vmaf": 95.0}},
+            parsed=parsed,
+            requested_experiment={
+                "operator_confirmed": True,
+                "evidence_authority": "rejected_visual_result",
+                "applied_policy": {"video": {"target_vmaf": 85.0}},
+            },
+            repeat_signal={"repeat_count": 2, "previous_softened_count": 1},
+            latest_failed_sample_job=None,
+        )
+
+        self.assertIsNone(forced)
+        self.assertEqual(parsed["request_disposition"], "rejected")
 
     def test_request_seed_policy_keeps_structured_worker_failure_diagnostics(self) -> None:
         def fake_run(cmd: list[str], **kwargs: object) -> object:
@@ -3684,7 +3818,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(request["request_type"], "size_budget")
         self.assertTrue(request["operator_confirmed"])
         self.assertEqual(request["budget_label"], "200 MB per episode")
-        self.assertEqual(request["feasibility"], "aggressive")
+        self.assertEqual(request["feasibility"], "plausible")
         self.assertFalse(request["requires_confirmation"])
         self.assertFalse(request["hard_size_cap"])
         self.assertFalse(request["measured_size_followup"])
@@ -3693,6 +3827,109 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIsNone(request["requested_max_encoded_percent"])
         self.assertIsNone(request["applied_max_encoded_percent"])
         self.assertIsNone(request["applied_policy"])
+
+    def test_operator_requested_experiment_ignores_negative_size_budget(self) -> None:
+        with patch("mediaforce.web.runtime.folder_tuning_advice.request_operator_note_parse", return_value=None):
+            request = _operator_requested_experiment("Target -10MB per episode.")
+
+        self.assertIsNone(request)
+
+    def test_operator_requested_experiment_preserves_observed_av1_quality_authority(self) -> None:
+        request = _operator_requested_experiment(
+            "The 1080p AV1 sample looked excellent. Keep source resolution and target 250MB per episode.",
+            {
+                "source_size_bytes": 4_815_446_620,
+                "duration_seconds": 2660.352,
+                "audio_summary": [{"codec_name": "eac3", "channels": 6}],
+                "resolved_policy": {
+                    "video": {"encoder": "libsvtav1"},
+                    "audio": {
+                        "convert_to_opus_codecs": ["eac3"],
+                        "surround_5_1_opus_bitrate": "256k",
+                    },
+                },
+            },
+        )
+
+        assert request is not None
+        self.assertEqual(request["request_type"], "combined_experiment")
+        self.assertEqual(request["evidence_authority"], "operator_observed")
+        self.assertEqual(request["feasibility"], "plausible")
+        self.assertEqual(request["scale_height"], 0)
+
+    def test_operator_requested_experiment_preserves_visual_rejection(self) -> None:
+        request = _operator_requested_experiment(
+            "I reject this sample because it looked blocky. Keep source resolution and target 250MB per episode.",
+            {
+                "source_size_bytes": 4_815_446_620,
+                "duration_seconds": 2660.352,
+                "audio_summary": [{"codec_name": "eac3", "channels": 6}],
+                "resolved_policy": {
+                    "video": {"encoder": "libsvtav1"},
+                    "audio": {
+                        "convert_to_opus_codecs": ["eac3"],
+                        "surround_5_1_opus_bitrate": "256k",
+                    },
+                },
+            },
+        )
+
+        assert request is not None
+        self.assertEqual(request["evidence_authority"], "rejected_visual_result")
+        issue = proposal_alignment_issue(
+            operator_request=request,
+            request_disposition="honored",
+            current_policy={"video": {"target_vmaf": 95.0, "max_height": 0}},
+            preview_policy={"video": {"target_vmaf": 85.0, "max_height": 0}},
+        )
+        self.assertIsNotNone(issue)
+
+    def test_operator_requested_experiment_preserves_standalone_visual_rejection(self) -> None:
+        request = _operator_requested_experiment("I reject this sample because it looked blocky.")
+
+        assert request is not None
+        self.assertEqual(request["request_type"], "none")
+        self.assertEqual(request["evidence_authority"], "rejected_visual_result")
+        self.assertIsNone(request["applied_policy"])
+
+    def test_operator_requested_experiment_mixed_review_is_not_positive_authority(self) -> None:
+        with patch(
+                "mediaforce.web.runtime.folder_tuning_advice.request_operator_note_parse",
+                return_value={
+                    "summary": "Approved-looking structured parse.",
+                    "intent_type": "direct_request",
+                    "request_type": "size_budget",
+                    "operator_confirmed": True,
+                    "measured_size_followup": False,
+                    "evidence_authority": "approved_visual_result",
+                    "metric": None,
+                    "metric_target": None,
+                    "size_budget_value": 250,
+                    "size_budget_unit": "mb",
+                    "scale_height": None,
+                    "black_bar_handling": None,
+                    "crop": None,
+                    "reasoning_note": "Incorrectly treated the mixed review as approval.",
+                },
+        ):
+            request = _operator_requested_experiment(
+                "The sample looked good overall, but dark scenes showed banding. Target 250MB per episode.",
+                {
+                    "source_size_bytes": 4_815_446_620,
+                    "duration_seconds": 2660.352,
+                    "audio_summary": [{"codec_name": "eac3", "channels": 6}],
+                    "resolved_policy": {
+                        "video": {"encoder": "libsvtav1"},
+                        "audio": {
+                            "convert_to_opus_codecs": ["eac3"],
+                            "surround_5_1_opus_bitrate": "256k",
+                        },
+                    },
+                },
+            )
+
+        assert request is not None
+        self.assertEqual(request["evidence_authority"], "rejected_visual_result")
 
     def test_operator_requested_experiment_detects_explicit_hard_size_cap(self) -> None:
         request = _operator_requested_experiment(
@@ -3881,25 +4118,25 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(request["applied_policy"]["video"]["max_height"], 0)
         self.assertAlmostEqual(request["estimated_video_bitrate_kbps"], 540.0, places=1)
 
-    def test_size_budget_feasibility_treats_old_codec_style_low_bitrates_as_aggressive_first(self) -> None:
+    def test_size_budget_feasibility_treats_positive_av1_budget_as_plausible(self) -> None:
         feasibility, requires_confirmation = size_budget_feasibility(
             source_percent=4.36,
             video_bitrate_kbps=379.7,
             video_encoder="libsvtav1",
         )
 
-        self.assertEqual(feasibility, "aggressive")
+        self.assertEqual(feasibility, "plausible")
         self.assertFalse(requires_confirmation)
 
-    def test_size_budget_feasibility_keeps_hard_stop_for_tiny_av1_budgets(self) -> None:
+    def test_size_budget_feasibility_leaves_tiny_positive_av1_budget_to_sampling(self) -> None:
         feasibility, requires_confirmation = size_budget_feasibility(
             source_percent=2.8,
             video_bitrate_kbps=240.0,
             video_encoder="libsvtav1",
         )
 
-        self.assertEqual(feasibility, "unreasonable")
-        self.assertTrue(requires_confirmation)
+        self.assertEqual(feasibility, "plausible")
+        self.assertFalse(requires_confirmation)
 
     def test_size_budget_feasibility_keeps_legacy_encoders_on_stricter_thresholds(self) -> None:
         feasibility, requires_confirmation = size_budget_feasibility(
@@ -3936,7 +4173,7 @@ class TuningRuntimeTests(unittest.TestCase):
         )
 
         assert request is not None
-        self.assertEqual(request["feasibility"], "aggressive")
+        self.assertEqual(request["feasibility"], "plausible")
         self.assertFalse(request["requires_confirmation"])
 
     def test_folder_ai_tune_preview_uses_calibration_policy_for_operator_budget_request(self) -> None:
@@ -4117,7 +4354,7 @@ class TuningRuntimeTests(unittest.TestCase):
             "operator_confirmed": True,
             "budget_label": "300 MB per episode",
             "budget_bytes": 300 * 1024 * 1024,
-            "feasibility": "aggressive",
+            "feasibility": "plausible",
             "applied_policy": None,
         }
         failed_seed = {
@@ -4132,7 +4369,7 @@ class TuningRuntimeTests(unittest.TestCase):
                 "seed_request_disposition": "unclear",
                 "seed_request_response": "I could not turn that note into a trustworthy first draft.",
                 "seed_feasibility_note": None,
-                "seed_prompt_version": "seed-v8",
+                "seed_prompt_version": "seed-v9",
                 "seed_raw_response": "attempt 1: timed out after 90s",
                 "seed_proposed_policy": None,
                 "seed_applied_policy": None,
@@ -4213,7 +4450,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIn("current policy", proposal["request_response"])
         self.assertEqual(proposal["trace"]["raw_response"], "attempt 1: timed out after 90s")
 
-    def test_folder_ai_tune_preview_preserves_seed_refusal_for_first_size_budget(self) -> None:
+    def test_folder_ai_tune_preview_overrides_seed_refusal_for_first_av1_size_budget(self) -> None:
         saved_proposals: list[dict[str, Any]] = []
         base_policy = {"video": {"target_size_mb": 300.0, "target_vmaf": 85.0, "max_encoded_percent": 80}}
         host = HostStatus(
@@ -4231,7 +4468,7 @@ class TuningRuntimeTests(unittest.TestCase):
             "operator_confirmed": True,
             "budget_label": "300 MB per episode",
             "budget_bytes": 300 * 1024 * 1024,
-            "feasibility": "infeasible",
+            "feasibility": "plausible",
             "applied_policy": None,
         }
         refused_seed = {
@@ -4246,7 +4483,7 @@ class TuningRuntimeTests(unittest.TestCase):
                 "seed_request_disposition": "rejected",
                 "seed_request_response": "I cannot make this first sample queueable as written.",
                 "seed_feasibility_note": "infeasible",
-                "seed_prompt_version": "seed-v8",
+                "seed_prompt_version": "seed-v9",
                 "seed_raw_response": "{\"request_disposition\":\"rejected\"}",
                 "seed_proposed_policy": None,
                 "seed_applied_policy": None,
@@ -4320,10 +4557,82 @@ class TuningRuntimeTests(unittest.TestCase):
 
         self.assertTrue(result["ok"])
         proposal = saved_proposals[0]
-        self.assertFalse(proposal["can_queue"])
-        self.assertEqual(proposal["request_disposition"], "rejected")
-        self.assertEqual(proposal["request_response"], "I cannot make this first sample queueable as written.")
+        self.assertTrue(proposal["can_queue"])
+        self.assertEqual(proposal["request_disposition"], "honored")
+        self.assertIn("current policy", proposal["request_response"])
 
+    def test_first_size_budget_sample_rejects_nonpositive_video_budget(self) -> None:
+        seed_job_fields = {
+            "seed_request_disposition": "honored",
+            "seed_applied_policy": None,
+        }
+        advice = _keep_first_size_budget_sample(
+            advice_payload={"ok": True, "request_disposition": "honored"},
+            seed_job_fields=seed_job_fields,
+            trimmed_note="Target 20MB per episode",
+            operator_request={
+                "request_type": "size_budget",
+                "operator_confirmed": True,
+                "budget_bytes": 20 * 1024 * 1024,
+                "estimated_audio_bytes": 24 * 1024 * 1024,
+                "estimated_video_bitrate_kbps": 0.0,
+                "applied_policy": None,
+            },
+        )
+
+        self.assertFalse(advice["ok"])
+        self.assertEqual(advice["request_disposition"], "rejected")
+        self.assertEqual(seed_job_fields["seed_request_disposition"], "rejected")
+        self.assertFalse(
+            _proposal_can_queue(
+                applied_fragment={},
+                preview_policy={"video": {"target_vmaf": 85.0}},
+                request_disposition=advice["request_disposition"],
+                alignment_issue=None,
+            )
+        )
+
+    def test_first_size_budget_fallback_requires_unblocked_plausible_request(self) -> None:
+        plausible_request = {
+            "request_type": "size_budget",
+            "operator_confirmed": True,
+            "feasibility": "plausible",
+            "applied_policy": None,
+        }
+
+        self.assertTrue(_can_keep_first_size_budget_sample(plausible_request))
+        self.assertFalse(
+            _can_keep_first_size_budget_sample(
+                {**plausible_request, "evidence_authority": "rejected_visual_result"}
+            )
+        )
+        self.assertFalse(
+            _can_keep_first_size_budget_sample(
+                plausible_request,
+                latest_failed_sample_job={"status": "failed", "error": "encode failed"},
+            )
+        )
+
+    def test_blocking_sample_evidence_uses_semantic_policy_change(self) -> None:
+        current_policy = {"video": {"target_vmaf": 95.0, "min_target_vmaf": 93.0}}
+        rejected_request = {"evidence_authority": "rejected_visual_result"}
+
+        self.assertIsNotNone(
+            _blocking_sample_evidence_issue(
+                operator_request=rejected_request,
+                latest_failed_sample_job=None,
+                current_policy=current_policy,
+                preview_policy=dict(current_policy),
+            )
+        )
+        self.assertIsNone(
+            _blocking_sample_evidence_issue(
+                operator_request=rejected_request,
+                latest_failed_sample_job=None,
+                current_policy=current_policy,
+                preview_policy={"video": {"target_vmaf": 94.0, "min_target_vmaf": 92.0}},
+            )
+        )
     def test_folder_ai_tune_preview_enforces_followup_size_target_after_measured_miss(self) -> None:
         saved_proposals: list[dict[str, Any]] = []
         base_policy = {"video": {"target_vmaf": 95.0, "max_encoded_percent": 80}}
@@ -5188,12 +5497,19 @@ class TuningRuntimeTests(unittest.TestCase):
                     "created_at": "2026-04-04T01:29:02+00:00",
                 }
             ],
+            learning_context_payload=[
+                {
+                    "evidence_authority": "approved_visual_result",
+                    "summary": "A prior 1080p AV1 result was visually approved near 250 MiB.",
+                }
+            ],
         )
 
         repeat_signal = payload["operator_repeat_signal"]
         assert repeat_signal is not None
         self.assertEqual(repeat_signal["repeat_count"], 2)
         self.assertEqual(repeat_signal["previous_softened_count"], 1)
+        self.assertEqual(payload["retrieved_memory"][0]["evidence_authority"], "approved_visual_result")
 
     def test_build_seed_policy_payload_reuses_stored_operator_note_parse(self) -> None:
         sample_item = {
@@ -5308,9 +5624,14 @@ class TuningRuntimeTests(unittest.TestCase):
                         "width": 1920,
                         "height": 1080,
                         "duration_seconds": 2645.248,
-                        "audio_summary": [{"channels": 6}],
+                        "audio_summary": [{"codec_name": "eac3", "channels": 6}],
                         "subtitle_summary": [],
-                        "resolved_policy": {"audio": {"surround_5_1_opus_bitrate": "224k"}},
+                        "resolved_policy": {
+                            "audio": {
+                                "convert_to_opus_codecs": ["eac3"],
+                                "surround_5_1_opus_bitrate": "224k",
+                            }
+                        },
                     },
                     existing_calibration=None,
                     connection=connection,
@@ -5318,7 +5639,7 @@ class TuningRuntimeTests(unittest.TestCase):
 
         assert metadata is not None
         job_fields = metadata["job_fields"]
-        self.assertEqual(job_fields["seed_request_disposition"], "honored_with_risk")
+        self.assertEqual(job_fields["seed_request_disposition"], "honored")
         self.assertEqual(job_fields["seed_applied_policy"]["video"]["target_vmaf"], 85.0)
         self.assertNotIn("max_encoded_percent", job_fields["seed_applied_policy"]["video"])
 
@@ -5812,6 +6133,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertTrue(Path(artifact["artifact_path"]).exists())
         self.assertTrue(context)
         self.assertIn("Lower XPSNR slightly", context[0]["summary"])
+        self.assertEqual(context[0]["evidence_authority"], "none")
 
     def test_record_visual_approval_artifact_creates_retrievable_memory(self) -> None:
         sample_item = {
@@ -5849,6 +6171,47 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertTrue(Path(artifact["artifact_path"]).exists())
         self.assertTrue(context)
         self.assertIn("Aggressive but acceptable", context[0]["summary"])
+        self.assertEqual(context[0]["evidence_authority"], "approved_visual_result")
+        self.assertEqual(context[0]["approved_policy"], calibration["policy"])
+        self.assertEqual(context[0]["sample_result"], calibration["sample_result"])
+        self.assertEqual(context[0]["run_verdict"]["summary"], "Aggressive but acceptable for this show.")
+
+    def test_retrieve_learning_context_ignores_unrelated_visual_approval(self) -> None:
+        approved_sample_item = {
+            "rel_path": "tv/House/Season 2/Episode.mkv",
+            "video_codec": "h264",
+            "recommendation": "priority_encode",
+            "resolved_policy": {"video": {"quality_metric": "vmaf"}},
+        }
+        with open_db(self.config.paths.db_path) as connection:
+            artifact = record_visual_approval_artifact(
+                connection,
+                self.config,
+                prefix="tv/House/Season 2",
+                note="Looks good after review.",
+                sample_item=approved_sample_item,
+                calibration={
+                    "job_id": "job-house",
+                    "policy": {"video": {"target_vmaf": 88.0}},
+                    "sample_result": {"quality_metric": "VMAF", "quality_score": 89.0},
+                },
+                run_verdict={"summary": "Approved for House."},
+                created_at="2026-03-29T23:45:00+00:00",
+            )
+            context = retrieve_learning_context(
+                connection,
+                prefix="tv/Suits/Season 5",
+                sample_item={
+                    "rel_path": "tv/Suits/Season 5/Episode.mkv",
+                    "video_codec": "h264",
+                    "recommendation": "priority_encode",
+                    "resolved_policy": {"video": {"quality_metric": "vmaf"}},
+                },
+                note="Need a smaller approved draft.",
+            )
+
+        self.assertIsNotNone(artifact)
+        self.assertEqual(context, [])
 
     def test_sibling_approved_season_memory_lists_other_approved_seasons(self) -> None:
         with open_db(self.config.paths.db_path) as connection:
@@ -6137,6 +6500,14 @@ class TuningRuntimeTests(unittest.TestCase):
                 alignment_issue=None,
             )
         )
+        self.assertFalse(
+            _proposal_can_queue(
+                applied_fragment={"video": {"target_vmaf": 87.0}},
+                preview_policy={"video": {"target_vmaf": 87.0}},
+                request_disposition="rejected",
+                alignment_issue=None,
+            )
+        )
 
     def test_proposal_alignment_issue_still_blocks_queue(self) -> None:
         self.assertFalse(
@@ -6312,6 +6683,52 @@ class TuningRuntimeTests(unittest.TestCase):
             "The draft lowers the VMAF target based only on a size budget. Run a measured sample or ask for "
             "a specific quality tradeoff before changing quality targets.",
         )
+
+    def test_proposal_alignment_issue_allows_evidence_backed_av1_video_tradeoff(self) -> None:
+        issue = proposal_alignment_issue(
+            operator_request={
+                "request_type": "size_budget",
+                "budget_label": "250 MB per episode",
+                "budget_bytes": 250 * 1024 * 1024,
+                "evidence_authority": "operator_observed",
+                "applied_policy": None,
+            },
+            request_disposition="honored",
+            current_policy={"video": {"target_vmaf": 95.0, "max_crf": 38, "max_height": 0}},
+            preview_policy={"video": {"target_vmaf": 85.0, "max_crf": 46, "max_height": 0}},
+        )
+
+        self.assertIsNone(issue)
+
+    def test_retrieved_visual_approval_authorizes_alignment_without_overriding_current_rejection(self) -> None:
+        request = {
+            "request_type": "size_budget",
+            "budget_label": "250 MB per episode",
+            "budget_bytes": 250 * 1024 * 1024,
+            "evidence_authority": "none",
+            "applied_policy": None,
+        }
+        effective_request = _operator_request_with_retrieved_memory_authority(
+            request,
+            [{"evidence_authority": "approved_visual_result", "prefix": "tv/House/Season 2"}],
+        )
+
+        assert effective_request is not None
+        self.assertEqual(effective_request["evidence_authority"], "approved_visual_result")
+        self.assertIsNone(
+            proposal_alignment_issue(
+                operator_request=effective_request,
+                request_disposition="honored",
+                current_policy={"video": {"target_vmaf": 95.0, "max_crf": 38}},
+                preview_policy={"video": {"target_vmaf": 85.0, "max_crf": 46}},
+            )
+        )
+        rejected_request = _operator_request_with_retrieved_memory_authority(
+            {**request, "evidence_authority": "rejected_visual_result"},
+            [{"evidence_authority": "approved_visual_result", "prefix": "tv/House/Season 2"}],
+        )
+        assert rejected_request is not None
+        self.assertEqual(rejected_request["evidence_authority"], "rejected_visual_result")
 
     def test_proposal_alignment_issue_rejects_size_budget_resolution_drop(self) -> None:
         issue = proposal_alignment_issue(
@@ -6991,7 +7408,7 @@ class TuningRuntimeTests(unittest.TestCase):
     def test_seed_prompt_adds_class_guardrails(self) -> None:
         prompt = _build_seed_prompt({"folder": "tv/House/Season 5"})
 
-        self.assertEqual(SEED_PROMPT_VERSION, "seed-v8")
+        self.assertEqual(SEED_PROMPT_VERSION, "seed-v9")
         self.assertIn("cold-start guess", prompt)
         self.assertIn("best first-pass attempt", prompt)
         self.assertIn("instruction to satisfy", prompt)
@@ -7002,9 +7419,13 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIn("Use softened only when the operator note is exploratory", prompt)
         self.assertIn("closest faithful experiment", prompt)
         self.assertIn("operator_repeat_signal", prompt)
-        self.assertIn("clean 1080p catalog TV", prompt)
+        self.assertIn("established, visually approved product baseline", prompt)
+        self.assertIn("Evidence precedence is strict", prompt)
         self.assertIn("legacy H.264 or HEVC bitrate intuition", prompt)
-        self.assertIn("high-80s VMAF", prompt)
+        self.assertIn("High-80s VMAF", prompt)
+        self.assertIn("non-positive video budget", prompt)
+        self.assertNotIn("risky draft", prompt)
+        self.assertNotIn("request looks unrealistic", prompt)
         self.assertIn("video.black_bar_handling", prompt)
         self.assertIn("Do not infer 1080p or 720p scaling from a size budget alone", prompt)
         self.assertIn("request_response", prompt)
@@ -7102,6 +7523,8 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIn("tv/House/Season 2", generic_prompt)
         self.assertIn("acceptable_experiment", verdict_prompt)
         self.assertIn("sample_result", verdict_prompt)
+        self.assertIn("Evidence precedence is strict", verdict_prompt)
+        self.assertIn("without implying quality damage", verdict_prompt)
 
     def test_tune_prompt_mentions_review_media_conversation(self) -> None:
         prompt = _build_tune_prompt(
@@ -7126,6 +7549,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIn("closest faithful experiment", prompt)
         self.assertIn("video.black_bar_handling", prompt)
         self.assertIn("operator_note_parse.scale_height", prompt)
+        self.assertIn("Evidence precedence is strict", prompt)
 
     def test_tune_prompt_summarizes_multimodal_review_pack_without_paths(self) -> None:
         prompt = _build_tune_prompt(
@@ -7181,6 +7605,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIn("crop", prompt)
         self.assertIn("scale_target", prompt)
         self.assertIn("do not infer a scale target", prompt)
+        self.assertIn("evidence_authority", prompt)
 
     def test_build_tuning_runtime_toolbelt_summarizes_review_media(self) -> None:
         toolbelt = _build_tuning_runtime_toolbelt(
@@ -7455,7 +7880,7 @@ class TuningRuntimeTests(unittest.TestCase):
             payload["class_signals"]["positive_signals"],
         )
         self.assertIn(
-            "This first-pass seed is only a bounded starting point; measured calibration should confirm any lean move.",
+            "This first-pass seed is only a bounded starting point; measured calibration and operator review decide.",
             payload["class_signals"]["caution_flags"],
         )
 


### PR DESCRIPTION
## Summary
- make direct source-resolution AV1 size targets queueable for real sampling instead of theoretical bitrate refusal
- preserve failed samples, stale proposals, non-positive budgets, and explicit visual rejection as stop-or-redirect evidence
- make same-series visual approvals authoritative without leaking unrelated approval memory
- remove low-bitrate and aggressive wording from the normal Folder Studio AV1 workflow

## Validation
- `bash scripts/pre-commit-check.sh` (638 backend tests, CLI smoke, frontend check/lint/tests/build, desktop+narrow web route smoke)
- scoped Ruff checks on changed Python files
- PyCharm changed-files inspection: GREEN, 0 findings
- manual browser review of review-ready and target-missed Folder Studio states at desktop and 390px; no horizontal overflow or low-bitrate/aggressive baseline copy

Closes #147