### PR TITLE
Separate routine dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,33 @@
 ---
 version: 2
 
-multi-ecosystem-groups:
-  dependencies:
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 2
-
 updates:
   - package-ecosystem: uv
     directory: "/"
-    patterns:
-      - "*"
-    multi-ecosystem-group: dependencies
+    open-pull-requests-limit: 5
+    schedule:
+      interval: weekly
+    cooldown:
+      semver-major-days: 30
     groups:
-      all-security-updates:
-        applies-to: security-updates
+      routine-version-updates:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: npm
     directory: "/frontend"
-    patterns:
-      - "*"
-    multi-ecosystem-group: dependencies
+    open-pull-requests-limit: 5
+    schedule:
+      interval: weekly
+    cooldown:
+      semver-major-days: 30
     groups:
-      all-security-updates:
-        applies-to: security-updates
+      routine-version-updates:
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch

--- a/docs/policies/coding-standards.md
+++ b/docs/policies/coding-standards.md
@@ -45,3 +45,14 @@
 - When behavior, workflows, or operator-facing expectations change, update the
   relevant docs in the same change
 - Keep cross-references current when style or workflow guidance moves
+
+## Dependency updates
+
+- Keep Python and frontend dependency updates independently reviewable rather
+  than combining unrelated ecosystems in one pull request.
+- Group routine minor and patch updates, but leave semantic-version majors as
+  separate compatibility decisions after a bounded cooldown.
+- Keep security updates ungrouped and independently mergeable so routine
+  version grouping cannot delay an urgent fix.
+- Fix dependency constraints or application compatibility instead of enabling
+  legacy peer resolution or weakening acceptance gates.


### PR DESCRIPTION
## Summary
- split Python and frontend Dependabot updates into independently reviewable PRs
- group routine minor/patch updates per ecosystem
- leave major upgrades separate after a 30-day cooldown
- keep security updates independently mergeable
- document the dependency-update policy

## Validation
- Dependabot schema validation — passed
- Markdown checks — passed
- full pre-commit acceptance suite — passed
- 638 backend tests, frontend checks/lint/tests/build, CLI and web-route smoke — passed

Closes #152
Parent workstream: cbusillo/launchplane#1629