### PR TITLE
Build content-aware quality risk and review authority

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@ Use this directory for guidance that should not live in `AGENTS.md`.
   complexity, versioned media fingerprint evidence, and review-moment selection
 - `docs/architecture/stream-budget-ledger.md`: production stream selection,
   non-video overhead, uncertainty, and deterministic size feasibility
+- `docs/architecture/quality-risk-contract.md`: versioned quality-risk facts,
+  gates, interpretation, and current review authority
 
 ## Design briefs
 

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -186,12 +186,20 @@ Guidance:
     output verification, and bounded retry candidate selection
 - `tuning_memory.py`
   - learned-memory session recording and artifact promotion helpers
+- `quality_risk.py`
+  - versioned quality-risk facts/gates/interpretation/operator-decision
+    contract
+  - allow-listed transform compilation checks, typed risk shaping, and
+    evidence-bound review-record precedence
 
 Guidance:
 
 - Keep calibration queue state, canonical size contracts, deterministic budget
   arithmetic, target-size candidate search, and learned-memory helpers under
   `mediaforce/tuning/`.
+- Keep quality-risk facts, deterministic gates, typed risk normalization, and
+  current review authority under `mediaforce/tuning/quality_risk.py` instead of
+  re-deriving them independently in routes, prompts, or the frontend.
 - The stream budget ledger is the only non-video arithmetic authority. Search,
   manifests, queued jobs, production, and API payloads may project compatibility
   fields from it, but must not add audio, subtitle, attachment, or container

--- a/docs/architecture/quality-risk-contract.md
+++ b/docs/architecture/quality-risk-contract.md
@@ -1,0 +1,103 @@
+# Quality-Risk Contract and Review Authority
+
+## Ownership
+
+- `mediaforce/tuning/quality_risk.py` owns the versioned quality-risk
+  contract, deterministic gate evaluation, typed risk normalization, safe public
+  views, and evidence-bound review-record precedence.
+- `mediaforce/web/runtime/folder_ai_tuning.py` attaches the contract to pending
+  bench proposals before anything queues.
+- `mediaforce/web/runtime/folder_actions.py` records the current authoritative
+  post-test approval at sample-approval time.
+- `mediaforce/web/app.py` publishes the safe typed route payload for the
+  workstation without exposing raw internal trace JSON.
+
+## Contract shape
+
+Quality-risk contract version 1 keeps four layers separate:
+
+- `facts`: immutable measured or operator-supplied inputs such as cadence,
+  fingerprint findings, review moments, sample result, stream budget, and the
+  current operator request.
+- `deterministic_gates`: cadence, allow-list, and budget checks that block or
+  redirect work without model interpretation.
+- `interpretation`: optional model or artifact-reading output that may add
+  explainable typed risks but never replaces measured facts.
+- `operator_decision`: the current evidence-bound human review record for this
+  source, reviewed policy hash, sample job, evidence IDs, and referenced review
+  moments.
+
+The public route view exposes only safe typed data such as `verdict`, typed
+risks, blocking reasons, comparison reasons, safe provenance identifiers, and
+current operator authority. Raw prompt traces and internal contract JSON stay on
+the proposal trace path only.
+
+Current and preview policy hashes remain distinct. A review of the current
+sample cannot authorize a pending preview whose policy hash differs.
+
+## Deterministic rules
+
+- Only existing allow-listed video transform and encode keys may be compiled.
+  Unknown keys are rejected before sampling.
+- Allowed values are range- and type-checked before normalization; invalid
+  values are rejected instead of being silently clamped into executable policy.
+- Cadence `mixed`, `unknown`, or transform-less interlaced/telecine outcomes
+  block automatic reuse and remain explicit operator-visible gates.
+- Arithmetic infeasibility remains deterministic and is never delegated to a
+  model.
+- Target-size search traces are schema-checked, source-scoped, and bound to a
+  validated transform-plan identity. The operator route receives a compact
+  typed summary instead of raw candidate arrays.
+- A blocked contract clears proposal queueability, and confirmation recomputes
+  the contract against current source, policy, calibration, and failed-job state
+  before a sample job is written.
+- Names, era, genre, or category may be carried as non-authoritative context,
+  but they do not trigger denoise, deinterlace, grain handling, resizing, or
+  audio changes.
+- Model interpretation may request comparison or add typed rationale, but it
+  cannot create an approval or turn a pending human decision into
+  `safe_to_sample`.
+
+## Typed risks
+
+Version 1 risk tags are:
+
+- `softness_detail_loss`
+- `motion_breakup`
+- `banding_dark_scene_damage`
+- `grain_noise_treatment`
+- `cadence_interlace_artifacts`
+- `audio_quality_layout`
+- `other`
+
+Each risk carries a label, level, rationale, evidence IDs when available, and
+review-moment indexes when the risk is tied to measured review moments.
+
+## Review authority and precedence
+
+- Current rejection outranks older approval.
+- A later explicit approval can resolve an older rejection for the exact same
+  binding.
+- A review record becomes authoritative only when its prefix, source ID,
+  reviewed policy hash, sample job ID, and complete evidence-ID set match the
+  current source-scoped contract. Referenced moment indexes must still exist.
+- Sibling seasons and unrelated folders may remain visible as contextual memory
+  or operator shortcuts, but they never gain authority for the current item.
+- Historical same-folder approvals are also contextual only. Current authority
+  comes from the exact source/policy/sample/evidence review record, not from a
+  retrieved learning artifact.
+- Stale policy hashes, stale sample jobs, or mismatched source IDs remain in the
+  history list but do not control the current verdict.
+
+## Pre-test and post-test records
+
+- Pre-test instructions are derived from current typed risks and measured review
+  moments, then bound to the current source ID, policy hash, sample job, and
+  moment evidence IDs.
+- Post-test approval or rejection records are stored with the same identifiers
+  so retries can distinguish current authoritative feedback from stale history.
+- Free-form feedback is deterministically mapped onto the first-class concern
+  tags. Rejected or concern-bearing post-test notes are persisted immediately,
+  even when the resulting next-sample proposal is not queueable.
+- Review records supplement facts; they do not overwrite the measured evidence
+  or rewrite unknown coverage into prose certainty.

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -576,6 +576,123 @@ export interface StreamBudgetLedgerPayload {
 	};
 }
 
+export type QualityRiskTag =
+	| 'softness_detail_loss'
+	| 'motion_breakup'
+	| 'banding_dark_scene_damage'
+	| 'grain_noise_treatment'
+	| 'cadence_interlace_artifacts'
+	| 'audio_quality_layout'
+	| 'other';
+
+export type QualityRiskLevel = 'low' | 'medium' | 'high' | 'unknown';
+export type QualityRiskOperatorStatus =
+	'pending' | 'approved' | 'rejected' | 'needs_operator_review';
+
+export type QualityRiskVerdict =
+	'safe_to_sample' | 'needs_operator_review' | 'request_comparison' | 'blocked';
+
+export interface QualityRiskItem {
+	tag: QualityRiskTag;
+	label: string;
+	level: QualityRiskLevel;
+	rationale: string;
+	evidence_ids?: string[];
+	moment_indexes?: number[];
+}
+
+export interface QualityRiskMomentRef {
+	moment: number;
+	timestamp_seconds: number;
+	role: string;
+	risk_tags: QualityRiskTag[];
+	evidence_id?: string | null;
+	rationale?: string | null;
+}
+
+export interface QualityRiskOperatorRecord {
+	kind?: string;
+	created_at?: string | null;
+	verdict?: string;
+	tags?: QualityRiskTag[];
+	details?: string;
+	evidence_id?: string | null;
+	evidence_ids?: string[];
+	moment_indexes?: number[];
+	sample_job_id?: string | null;
+	policy_hash?: string | null;
+	source_id?: string | null;
+	prefix?: string | null;
+	authoritative?: boolean;
+}
+
+export interface QualityRiskTargetSizeSearch {
+	trace_id?: string;
+	schema_version?: number;
+	status?: 'selected' | 'infeasible' | 'quality_conflict' | 'needs_review';
+	selection_reason?: string | null;
+	curve_shape?: 'single_point' | 'monotonic' | 'non_monotonic' | null;
+	candidate_count?: number;
+	max_candidates?: number;
+	target_bytes?: number | null;
+	lower_bound_bytes?: number | null;
+	upper_bound_bytes?: number | null;
+	selected_crf?: number | null;
+	selected_metric?: string | null;
+	selected_metric_score?: number | null;
+	minimum_metric_score?: number | null;
+	quality_floor_met?: boolean | null;
+	predicted_whole_episode_bytes?: number | null;
+	within_sample_band?: boolean | null;
+	transform_plan_id?: string | null;
+}
+
+export interface QualityRiskPreTestInstruction {
+	prefix?: string;
+	source_id?: string;
+	policy_hash?: string;
+	sample_job_id?: string | null;
+	focus_tags?: QualityRiskTag[];
+	focus_labels?: string[];
+	moments?: QualityRiskMomentRef[];
+}
+
+export interface QualityRiskPayload {
+	schema?: string;
+	version?: number;
+	verdict?: QualityRiskVerdict;
+	source_id?: string | null;
+	source_fingerprint?: string | null;
+	sample_job_id?: string | null;
+	evidence_ids?: string[];
+	policy_hash?: string | null;
+	current_policy_hash?: string | null;
+	preview_policy_hash?: string | null;
+	blocked?: boolean;
+	blocking_reasons?: string[];
+	request_comparison?: boolean;
+	comparison_reason?: string | null;
+	typed_risks?: QualityRiskItem[];
+	operator_decision?: {
+		status?: QualityRiskOperatorStatus;
+		current_rejection_outranks_approval?: boolean;
+		reviewed_policy_hash?: string;
+		records?: QualityRiskOperatorRecord[];
+		effective_record?: QualityRiskOperatorRecord | null;
+	} | null;
+	interpretation?: {
+		summary?: string;
+		verdict?: QualityRiskVerdict;
+		confidence?: QualityRiskLevel;
+		risks?: QualityRiskItem[];
+		suggested_actions?: string[];
+	} | null;
+	moment_count?: number;
+	review_moment_ids?: string[];
+	target_size_search?: QualityRiskTargetSizeSearch | null;
+	pre_test_instruction?: QualityRiskPreTestInstruction | null;
+}
+
 export interface FolderPayload {
 	prefix: string;
 	pending: boolean;
@@ -590,6 +707,7 @@ export interface FolderPayload {
 	resolved_operator_intent?: ResolvedOperatorIntentPayload;
 	stream_budget_ledger?: StreamBudgetLedgerPayload;
 	size_goal_options?: SizeGoalOptionPayload[];
+	quality_risk?: QualityRiskPayload | null;
 	approved_season_shortcut?: Record<string, unknown> | null;
 	series_context?: { prefix: string; title: string } | null;
 	pending_proposal?: Record<string, unknown> | null;

--- a/frontend/src/lib/components/season/SeasonExperience.svelte
+++ b/frontend/src/lib/components/season/SeasonExperience.svelte
@@ -10,6 +10,7 @@
 	} from '$lib/api/types';
 	import {
 		approvalGuardFromMessage,
+		compareRiskSummary,
 		currentEncodeProgress,
 		currentOperatorIntent,
 		detailSeasonState,
@@ -140,6 +141,7 @@
 	const sizeTargetMissed = $derived(
 		['over_target', 'under_target', 'missing_prediction'].includes(sizeTarget.status)
 	);
+	const riskSummary = $derived(compareRiskSummary(folder));
 	const crfLimitReached = $derived(
 		asNumber(sampleResult.chosen_crf) > 0 &&
 			asNumber(technicalVideo.max_crf) > 0 &&
@@ -1038,6 +1040,29 @@
 					</div>
 				{/if}
 
+				{#if riskSummary}
+					<div class={`risk-summary risk-summary--${riskSummary.tone}`}>
+						<div class="risk-summary__headline">
+							<span>Quality risk</span>
+							<strong>{riskSummary.verdict}</strong>
+						</div>
+						<div class="risk-summary__fact">
+							<span>Top concern</span>
+							<strong>{riskSummary.topRisk}</strong>
+							<small>{riskSummary.topRiskLevel}</small>
+						</div>
+						<div class="risk-summary__fact">
+							<span>Authority</span>
+							<strong>{riskSummary.authority}</strong>
+							<small>{riskSummary.authorityDetail}</small>
+						</div>
+						<p class="risk-summary__detail">{riskSummary.detail}</p>
+						{#if riskSummary.focusMoments.length}
+							<p class="risk-summary__focus">Review focus: {riskSummary.focusMoments[0]}</p>
+						{/if}
+					</div>
+				{/if}
+
 				<div class="size-story">
 					<div>
 						<span>Current {scopeSizeLabel}</span>
@@ -1080,9 +1105,16 @@
 					</p>
 				{/if}
 
-				<div class="decision" class:decision--target-miss={sizeTargetMissed}>
+				<div
+					class="decision"
+					class:decision--target-miss={sizeTargetMissed}
+					class:decision--blocked={Boolean(riskSummary?.blocked)}
+				>
 					<div>
-						{#if sizeTarget.status === 'over_target'}
+						{#if riskSummary?.blocked}
+							<h2>This test is not safe to approve yet.</h2>
+							<p>{riskSummary.detail}</p>
+						{:else if sizeTarget.status === 'over_target'}
 							<h2>This is a quality checkpoint, not your requested-size result.</h2>
 							<p>Compare it now, then make a smaller test that moves toward your goal.</p>
 						{:else if sizeTarget.status === 'under_target'}
@@ -1099,7 +1131,20 @@
 						{/if}
 					</div>
 					<div class="decision-actions">
-						{#if sizeTargetMissed}
+						{#if riskSummary?.blocked}
+							<button class="secondary-button" type="button" onclick={chooseDifferentSize}>
+								Choose a different goal
+							</button>
+							<button
+								class="primary-button primary-button--light"
+								type="button"
+								onclick={retryMeasuredTarget}
+								disabled={actionPhase !== 'idle' || noAvailableHosts}
+							>
+								Run another test after fixing this
+								<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 10h11M11 5l5 5-5 5" /></svg>
+							</button>
+						{:else if sizeTargetMissed}
 							<button class="text-link" type="button" onclick={chooseDifferentSize}>
 								Choose a different goal
 							</button>
@@ -1130,7 +1175,7 @@
 								class="primary-button primary-button--light"
 								type="button"
 								onclick={() => approveTest()}
-								disabled={!currentPair}
+								disabled={!currentPair || Boolean(riskSummary?.blocked)}
 							>
 								Looks good
 								<svg viewBox="0 0 20 20" aria-hidden="true"><path d="m4 10 3.5 3.5L16 5" /></svg>
@@ -2292,6 +2337,54 @@
 		text-align: center;
 	}
 
+	.risk-summary {
+		display: grid;
+		gap: 18px;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		margin-top: 26px;
+		padding: 18px 20px;
+		border: 1px solid rgba(125, 137, 128, 0.35);
+		border-radius: 18px;
+		background: rgba(20, 25, 22, 0.82);
+	}
+
+	.risk-summary--attention {
+		border-color: rgba(177, 98, 95, 0.6);
+		background: rgba(43, 21, 21, 0.84);
+	}
+
+	.risk-summary--ready {
+		border-color: rgba(86, 150, 137, 0.5);
+		background: rgba(20, 40, 36, 0.82);
+	}
+
+	.risk-summary span {
+		color: #9ba49e;
+		display: block;
+		font-size: 10px;
+		font-weight: 750;
+		letter-spacing: 0.09em;
+		margin-bottom: 6px;
+		text-transform: uppercase;
+	}
+
+	.risk-summary strong {
+		display: block;
+		font-size: 18px;
+		font-weight: 650;
+	}
+
+	.risk-summary p {
+		color: #d5dbd6;
+		font-size: 12px;
+		line-height: 1.5;
+		margin: 6px 0 0;
+	}
+
+	.risk-summary__moments {
+		grid-column: 1 / -1;
+	}
+
 	.decision {
 		align-items: center;
 		background: #e8eee8;
@@ -2877,6 +2970,10 @@
 		.size-story p {
 			grid-column: 1 / -1;
 			text-align: center;
+		}
+
+		.risk-summary {
+			grid-template-columns: 1fr;
 		}
 
 		.decision {
@@ -3889,6 +3986,11 @@
 	.decision--target-miss {
 		background: var(--mf-wait-bg);
 		border-color: var(--mf-wait-line);
+	}
+
+	.decision--blocked {
+		background: var(--mf-fail-bg);
+		border-color: var(--mf-fail-line);
 	}
 
 	.decision-actions {

--- a/frontend/src/lib/components/workstation/FolderStudioView.svelte
+++ b/frontend/src/lib/components/workstation/FolderStudioView.svelte
@@ -219,13 +219,16 @@
 	);
 	const benchRequestDisabled = $derived(benchRequestState.disabled);
 	function workflowActionState(action: WorkflowAction) {
+		const qualityRisk = studioFolder.quality_risk;
 		return resolveWorkflowActionState(action, {
 			reviewPackReady,
 			approvalReviewReady,
 			approvedProfileReady,
 			pendingProposal,
 			calibrationJob,
-			pendingAction: workflowPending
+			pendingAction: workflowPending,
+			qualityRiskBlocked: Boolean(qualityRisk?.blocked),
+			qualityRiskBlocker: qualityRisk?.blocking_reasons?.[0] ?? ''
 		});
 	}
 

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -13,6 +13,7 @@ import {
 	buildDecisionFacts,
 	buildFooterSignals,
 	buildOutputReviewRows,
+	buildQualityRiskFacts,
 	buildProcessingHostOptions,
 	buildReviewWorkspaceView,
 	buildRuntimeFacts,
@@ -1206,6 +1207,19 @@ describe('Folder Studio review request mapping', () => {
 		).toEqual({ disabled: false, title: '' });
 	});
 
+	it('blocks size approval when deterministic quality-risk evidence is blocked', () => {
+		expect(
+			resolveWorkflowActionState('approve-size-tradeoff', {
+				reviewPackReady: true,
+				approvalReviewReady: true,
+				pendingProposal: null,
+				calibrationJob: null,
+				qualityRiskBlocked: true,
+				qualityRiskBlocker: 'Cadence evidence is missing.'
+			})
+		).toEqual({ disabled: true, title: 'Cadence evidence is missing.' });
+	});
+
 	it('queues already approved folders even after review media goes stale', () => {
 		expect(
 			resolveWorkflowActionState('queue-encode', {
@@ -2249,5 +2263,82 @@ describe('Folder Studio review request mapping', () => {
 			)
 		).toBe('season');
 		expect(outputScopeLabel(folderPayload())).toBe('folder');
+	});
+});
+
+describe('quality risk facts', () => {
+	it('projects a compact operator-facing quality risk summary', () => {
+		const folder = folderPayload({
+			quality_risk: {
+				verdict: 'request_comparison',
+				request_comparison: true,
+				comparison_reason: 'Low-confidence grain findings require comparison.',
+				typed_risks: [
+					{
+						tag: 'grain_noise_treatment',
+						label: 'Grain / noise treatment',
+						level: 'medium',
+						rationale: 'Measured temporal noise may be grain rather than removable noise.'
+					}
+				],
+				operator_decision: {
+					status: 'pending'
+				}
+			}
+		});
+
+		expect(buildQualityRiskFacts(folder)).toEqual([
+			{
+				label: 'Risk verdict',
+				value: 'Request comparison',
+				detail: 'Low-confidence grain findings require comparison.',
+				tone: 'wait'
+			},
+			{
+				label: 'Top concern',
+				value: 'Grain / noise treatment',
+				detail: 'Medium risk',
+				tone: 'wait'
+			},
+			{
+				label: 'Authority',
+				value: 'No current decision',
+				detail: 'Older or sibling evidence is not treated as current authority.',
+				tone: 'idle'
+			}
+		]);
+	});
+
+	it('adds the top quality risk to decision facts', () => {
+		const folder = folderPayload({
+			quality_risk: {
+				verdict: 'blocked',
+				blocked: true,
+				blocking_reasons: ['Current rejection blocks automatic reuse.'],
+				typed_risks: [
+					{
+						tag: 'motion_breakup',
+						label: 'Motion breakup',
+						level: 'high',
+						rationale: 'The current sample breaks up in high motion.'
+					}
+				],
+				operator_decision: {
+					status: 'rejected'
+				}
+			}
+		});
+
+		const facts = buildDecisionFacts(folder, null, null);
+		expect(facts[3]).toEqual({
+			label: 'Risk verdict',
+			value: 'Blocked',
+			detail: 'Current rejection blocks automatic reuse.'
+		});
+		expect(facts.slice(3).map((fact) => fact.label)).toEqual([
+			'Risk verdict',
+			'Top concern',
+			'Authority'
+		]);
 	});
 });

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -18,6 +18,7 @@ import {
 	type FolderCalibrationState,
 	type FolderItemPlan,
 	type FolderPolicy,
+	type FolderQualityRisk,
 	type FolderSampleItem,
 	type FolderOperatorRequest,
 	type PendingSampleProposal,
@@ -131,6 +132,13 @@ export type DecisionFact = {
 	label: string;
 	value: string;
 	detail: string;
+};
+
+export type QualityRiskFact = {
+	label: string;
+	value: string;
+	detail: string;
+	tone: ShellTone;
 };
 
 export type RuntimeFact = {
@@ -442,7 +450,9 @@ export function resolveWorkflowActionState(
 		approvedProfileReady,
 		pendingProposal,
 		calibrationJob,
-		pendingAction
+		pendingAction,
+		qualityRiskBlocked = false,
+		qualityRiskBlocker = ''
 	}: {
 		reviewPackReady: boolean;
 		approvalReviewReady?: boolean;
@@ -450,6 +460,8 @@ export function resolveWorkflowActionState(
 		pendingProposal: PendingSampleProposal | null;
 		calibrationJob: FolderCalibrationJob | null;
 		pendingAction?: WorkflowAction | null;
+		qualityRiskBlocked?: boolean;
+		qualityRiskBlocker?: string;
 	}
 ): WorkflowActionState {
 	if (pendingAction) {
@@ -461,6 +473,12 @@ export function resolveWorkflowActionState(
 	if (action === 'focus-bench') return { disabled: false, title: '' };
 	if (action === 'open-completed') return { disabled: false, title: '' };
 	if (action === 'approve-size-tradeoff') {
+		if (qualityRiskBlocked) {
+			return {
+				disabled: true,
+				title: qualityRiskBlocker || 'Measured quality-risk evidence still blocks approval.'
+			};
+		}
 		return approvalReviewReady
 			? { disabled: false, title: '' }
 			: { disabled: true, title: 'Review media is not ready yet.' };
@@ -891,11 +909,17 @@ export function buildDecisionFacts(
 	pendingProposal: PendingSampleProposal | null,
 	workflow?: WorkflowState
 ): DecisionFact[] {
+	const riskFacts = buildQualityRiskFacts(folder).map((fact) => ({
+		label: fact.label,
+		value: fact.value,
+		detail: fact.detail
+	}));
 	const outputFact = buildOutputDecisionFact(folder.workflow_state ?? undefined, workflow);
 	if (outputFact) {
 		return [
 			outputFact,
 			buildOutputScopeFact(folder),
+			...riskFacts,
 			{
 				label: 'Next action',
 				value: workflow?.primary ?? 'Use the decision buttons',
@@ -981,7 +1005,8 @@ export function buildDecisionFacts(
 				])
 			},
 			{ label: 'Folder output', value: verdict.predictedFolderTotal, detail: 'Projected total' },
-			{ label: 'Reclaim', value: verdict.reclaim, detail: verdict.quality }
+			{ label: 'Reclaim', value: verdict.reclaim, detail: verdict.quality },
+			...riskFacts
 		];
 	}
 	return [
@@ -1001,7 +1026,8 @@ export function buildDecisionFacts(
 			label: 'Next action',
 			value: workflow?.primary ?? 'Use the decision buttons',
 			detail: workflowActionDetail(workflow)
-		}
+		},
+		...riskFacts
 	];
 }
 
@@ -1125,6 +1151,110 @@ export function buildSampleFacts(
 function itemPlan(folder: FolderPayload): FolderItemPlan | null {
 	const plan = record<Record<string, unknown>>(folder.item_plan);
 	return plan ? (plan as FolderItemPlan) : null;
+}
+
+export function qualityRisk(folder: FolderPayload): FolderQualityRisk | null {
+	return record<FolderQualityRisk>(folder.quality_risk);
+}
+
+function qualityRiskLevelLabel(level: string | null | undefined): string {
+	const normalized = String(level ?? '')
+		.trim()
+		.toLowerCase();
+	if (normalized === 'high') return 'High';
+	if (normalized === 'medium') return 'Medium';
+	if (normalized === 'low') return 'Low';
+	return 'Unknown';
+}
+
+function qualityRiskTone(level: string | null | undefined): ShellTone {
+	const normalized = String(level ?? '')
+		.trim()
+		.toLowerCase();
+	if (normalized === 'high') return 'fail';
+	if (normalized === 'medium') return 'wait';
+	if (normalized === 'low') return 'ready';
+	return 'idle';
+}
+
+function qualityRiskVerdictCopy(verdict: string | null | undefined): string {
+	const normalized = String(verdict ?? '')
+		.trim()
+		.toLowerCase();
+	if (normalized === 'safe_to_sample') return 'Safe to sample';
+	if (normalized === 'needs_operator_review') return 'Needs operator review';
+	if (normalized === 'request_comparison') return 'Request comparison';
+	if (normalized === 'blocked') return 'Blocked';
+	return 'Unknown';
+}
+
+function operatorAuthorityCopy(risk: FolderQualityRisk | null): { value: string; detail: string } {
+	const operatorDecision = record<Record<string, unknown>>(risk?.operator_decision);
+	const status = String(operatorDecision?.status ?? '')
+		.trim()
+		.toLowerCase();
+	if (status === 'rejected') {
+		return {
+			value: 'Current rejection',
+			detail: 'The latest authoritative rejection outranks older approvals.'
+		};
+	}
+	if (status === 'approved') {
+		return {
+			value: 'Current approval',
+			detail: 'The current authoritative approval matches this source, policy, and sample.'
+		};
+	}
+	return {
+		value: 'No current decision',
+		detail: 'Older or sibling evidence is not treated as current authority.'
+	};
+}
+
+export function buildQualityRiskFacts(folder: FolderPayload): QualityRiskFact[] {
+	const risk = qualityRisk(folder);
+	if (!risk) return [];
+	const typedRisks = (risk.typed_risks ?? []).filter(Boolean);
+	const highestRisk =
+		typedRisks.find((item) => item.level === 'high') ??
+		typedRisks.find((item) => item.level === 'medium') ??
+		typedRisks[0] ??
+		null;
+	const authority = operatorAuthorityCopy(risk);
+	const blockingReasons = (risk.blocking_reasons ?? []).filter(Boolean);
+	return [
+		{
+			label: 'Risk verdict',
+			value: qualityRiskVerdictCopy(risk.verdict),
+			detail:
+				blockingReasons[0] ??
+				risk.comparison_reason ??
+				String(
+					risk.interpretation?.summary ??
+						'Measured evidence and review authority drive this verdict.'
+				),
+			tone: risk.blocked ? 'fail' : risk.request_comparison ? 'wait' : 'ready'
+		},
+		{
+			label: 'Top concern',
+			value: highestRisk ? highestRisk.label : 'No elevated concern',
+			detail: highestRisk
+				? `${qualityRiskLevelLabel(highestRisk.level)} risk`
+				: 'No typed risks were published.',
+			tone: qualityRiskTone(highestRisk?.level)
+		},
+		{
+			label: 'Authority',
+			value: authority.value,
+			detail: authority.detail,
+			tone:
+				String(risk.operator_decision?.status ?? '')
+					.trim()
+					.toLowerCase() === 'rejected'
+					? 'fail'
+					: 'idle'
+		}
+	];
 }
 
 function reviewPackAudioSummary(

--- a/frontend/src/lib/folders/studio.ts
+++ b/frontend/src/lib/folders/studio.ts
@@ -318,6 +318,115 @@ export type FolderMultimodalReviewPack = {
 	} | null;
 };
 
+export type QualityRiskTag =
+	| 'softness_detail_loss'
+	| 'motion_breakup'
+	| 'banding_dark_scene_damage'
+	| 'grain_noise_treatment'
+	| 'cadence_interlace_artifacts'
+	| 'audio_quality_layout'
+	| 'other';
+
+export type QualityRiskLevel = 'low' | 'medium' | 'high' | 'unknown';
+export type QualityRiskVerdict =
+	'safe_to_sample' | 'needs_operator_review' | 'request_comparison' | 'blocked';
+
+export type QualityRiskItem = {
+	tag: QualityRiskTag;
+	label: string;
+	level: QualityRiskLevel;
+	rationale: string;
+	evidence_ids?: string[];
+	moment_indexes?: number[];
+};
+
+export type QualityRiskOperatorRecord = {
+	kind?: string;
+	created_at?: string | null;
+	verdict?: string;
+	tags?: string[];
+	details?: string;
+	evidence_id?: string | null;
+	evidence_ids?: string[];
+	moment_indexes?: number[];
+	sample_job_id?: string | null;
+	policy_hash?: string | null;
+	source_id?: string | null;
+	prefix?: string | null;
+	authoritative?: boolean;
+};
+
+export type QualityRiskMomentRef = {
+	moment: number;
+	timestamp_seconds: number;
+	role: string;
+	risk_tags: QualityRiskTag[];
+	evidence_id?: string | null;
+	rationale?: string | null;
+};
+
+export type QualityRiskPreTestInstruction = {
+	prefix?: string;
+	source_id?: string;
+	policy_hash?: string;
+	sample_job_id?: string | null;
+	focus_tags?: QualityRiskTag[];
+	focus_labels?: string[];
+	moments?: QualityRiskMomentRef[];
+};
+
+export type QualityRiskTargetSizeSearch = {
+	trace_id?: string;
+	status?: 'selected' | 'infeasible' | 'quality_conflict' | 'needs_review';
+	selection_reason?: string | null;
+	curve_shape?: 'single_point' | 'monotonic' | 'non_monotonic' | null;
+	candidate_count?: number;
+	max_candidates?: number;
+	target_bytes?: number | null;
+	selected_crf?: number | null;
+	selected_metric?: string | null;
+	selected_metric_score?: number | null;
+	minimum_metric_score?: number | null;
+	predicted_whole_episode_bytes?: number | null;
+	within_sample_band?: boolean | null;
+	transform_plan_id?: string | null;
+};
+
+export type FolderQualityRisk = {
+	schema?: string;
+	version?: number;
+	verdict?: QualityRiskVerdict;
+	source_id?: string | null;
+	source_fingerprint?: string | null;
+	sample_job_id?: string | null;
+	evidence_ids?: string[];
+	policy_hash?: string | null;
+	current_policy_hash?: string | null;
+	preview_policy_hash?: string | null;
+	blocked?: boolean;
+	blocking_reasons?: string[];
+	request_comparison?: boolean;
+	comparison_reason?: string | null;
+	typed_risks?: QualityRiskItem[];
+	operator_decision?: {
+		status?: string;
+		current_rejection_outranks_approval?: boolean;
+		records?: QualityRiskOperatorRecord[];
+		effective_record?: QualityRiskOperatorRecord | null;
+	} | null;
+	interpretation?: {
+		summary?: string;
+		verdict?: QualityRiskVerdict;
+		confidence?: QualityRiskLevel;
+		risks?: QualityRiskItem[];
+		suggested_actions?: string[];
+	} | null;
+	moment_count?: number;
+	review_moment_ids?: string[];
+	target_size_search?: QualityRiskTargetSizeSearch | null;
+	pre_test_instruction?: QualityRiskPreTestInstruction | null;
+};
+
 export function normalizeReviewArtifacts(
 	reviewPack: FolderMultimodalReviewPack | null | undefined
 ): VisibleReviewArtifact[] {
@@ -389,6 +498,7 @@ export type PendingSampleProposal = {
 	operator_signal?: string | null;
 	evidence_checked?: string[];
 	multimodal_review_pack?: FolderMultimodalReviewPack | null;
+	quality_risk?: FolderQualityRisk | null;
 	trace?: ProposalTrace | null;
 };
 export type ProposalTrace = {

--- a/frontend/src/lib/season/experience.test.ts
+++ b/frontend/src/lib/season/experience.test.ts
@@ -12,6 +12,7 @@ import type {
 import {
 	activeSeasonCards,
 	approvalGuardFromMessage,
+	compareRiskSummary,
 	currentOperatorIntent,
 	detailSeasonState,
 	episodeLabel,
@@ -218,6 +219,53 @@ describe('season experience translation', () => {
 		);
 
 		expect(videoPolicy.target_size_mb).toBe(200);
+	});
+
+	it('summarizes typed quality risk for the compare screen', () => {
+		const summary = compareRiskSummary(
+			folder({
+				quality_risk: {
+					verdict: 'request_comparison',
+					request_comparison: true,
+					comparison_reason: 'Low-confidence grain findings require comparison.',
+					typed_risks: [
+						{
+							tag: 'grain_noise_treatment',
+							label: 'Grain / noise treatment',
+							level: 'medium',
+							rationale: 'Measured temporal noise may be grain rather than removable noise.'
+						}
+					],
+					operator_decision: {
+						status: 'pending'
+					},
+					pre_test_instruction: {
+						moments: [
+							{
+								moment: 2,
+								timestamp_seconds: 89,
+								role: 'hard',
+								risk_tags: ['grain_noise_treatment']
+							}
+						]
+					}
+				}
+			})
+		);
+
+		expect(summary).toEqual({
+			verdict: 'Request comparison',
+			blocked: false,
+			tone: 'ready',
+			title: 'Grain / noise treatment',
+			detail: 'Low-confidence grain findings require comparison.',
+			topRisk: 'Grain / noise treatment',
+			topRiskLevel: 'medium risk',
+			topRiskDetail: 'Measured temporal noise may be grain rather than removable noise.',
+			authority: 'No current decision',
+			authorityDetail: 'Older, stale, or sibling evidence is not treated as authority here.',
+			focusMoments: ['Moment 2 · grain_noise_treatment']
+		});
 	});
 
 	it('falls through a pending proposal without video settings', () => {

--- a/frontend/src/lib/season/experience.ts
+++ b/frontend/src/lib/season/experience.ts
@@ -5,6 +5,7 @@ import type {
 	FolderPayload,
 	FolderStatusPayload,
 	OperatorIntentRequestPayload,
+	QualityRiskPayload,
 	SizeGoalMode
 } from '$lib/api/types';
 
@@ -77,6 +78,20 @@ export interface ReviewPair {
 	comparePath: string;
 }
 
+export interface CompareRiskSummary {
+	verdict: string;
+	blocked: boolean;
+	tone: HumanSeasonTone;
+	title: string;
+	detail: string;
+	topRisk: string;
+	topRiskLevel: string;
+	topRiskDetail: string;
+	authority: string;
+	authorityDetail: string;
+	focusMoments: string[];
+}
+
 const ACTIVE_JOB_STATUSES = new Set(['queued', 'running', 'starting', 'retry_backoff', 'stopping']);
 const FAILURE_JOB_STATUSES = new Set(['failed', 'stopped', 'needs_attention']);
 
@@ -97,6 +112,81 @@ function text(value: unknown): string {
 function numberValue(value: unknown): number {
 	const parsed = Number(value ?? 0);
 	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function qualityRisk(folder: FolderPayload): QualityRiskPayload | null {
+	const risk = record(folder.quality_risk);
+	return Object.keys(risk).length > 0 ? (risk as QualityRiskPayload) : null;
+}
+
+function riskVerdictCopy(verdict: string | null | undefined): string {
+	const normalized = text(verdict).toLowerCase();
+	if (normalized === 'blocked') return 'Blocked';
+	if (normalized === 'request_comparison') return 'Request comparison';
+	if (normalized === 'needs_operator_review') return 'Needs operator review';
+	if (normalized === 'safe_to_sample') return 'Safe to sample';
+	return 'Review evidence';
+}
+
+function riskTone(risk: QualityRiskPayload | null): HumanSeasonTone {
+	if (!risk) return 'quiet';
+	if (risk.blocked) return 'attention';
+	if (risk.request_comparison) return 'ready';
+	return 'quiet';
+}
+
+function riskAuthority(risk: QualityRiskPayload | null): { value: string; detail: string } {
+	const decision = record(risk?.operator_decision);
+	const status = text(decision.status).toLowerCase();
+	if (status === 'rejected') {
+		return {
+			value: 'Current rejection',
+			detail: 'The latest matching rejection outranks any older approval.'
+		};
+	}
+	if (status === 'approved') {
+		return {
+			value: 'Current approval',
+			detail: 'The current sample, source, and policy hash have an authoritative approval.'
+		};
+	}
+	return {
+		value: 'No current decision',
+		detail: 'Older, stale, or sibling evidence is not treated as authority here.'
+	};
+}
+
+export function compareRiskSummary(folder: FolderPayload): CompareRiskSummary | null {
+	const risk = qualityRisk(folder);
+	if (!risk) return null;
+	const typedRisks = Array.isArray(risk.typed_risks) ? risk.typed_risks : [];
+	const topRisk =
+		typedRisks.find((item) => text(item.level).toLowerCase() === 'high') ??
+		typedRisks.find((item) => text(item.level).toLowerCase() === 'medium') ??
+		typedRisks[0] ??
+		null;
+	const authority = riskAuthority(risk);
+	const focusMoments = (risk.pre_test_instruction?.moments ?? []).slice(0, 3).map((moment) => {
+		const labels = Array.isArray(moment.risk_tags) ? moment.risk_tags.join(', ') : 'review risk';
+		return `Moment ${moment.moment} · ${labels}`;
+	});
+	return {
+		verdict: riskVerdictCopy(risk.verdict),
+		blocked: Boolean(risk.blocked),
+		tone: riskTone(risk),
+		title: topRisk ? topRisk.label : riskVerdictCopy(risk.verdict),
+		detail:
+			(risk.blocking_reasons && risk.blocking_reasons[0]) ||
+			risk.comparison_reason ||
+			text(risk.interpretation?.summary) ||
+			'Measured evidence and review authority define the current risk state.',
+		topRisk: topRisk?.label ?? 'No elevated typed risk',
+		topRiskLevel: topRisk?.level ? `${topRisk.level} risk` : 'unknown risk',
+		topRiskDetail: topRisk?.rationale ?? 'No typed review focus was published for this sample.',
+		authority: authority.value,
+		authorityDetail: authority.detail,
+		focusMoments
+	};
 }
 
 function booleanValue(value: unknown): boolean {

--- a/mediaforce/tuning/quality_risk.py
+++ b/mediaforce/tuning/quality_risk.py
@@ -1,0 +1,1349 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import math
+import re
+from typing import Any, Mapping
+
+from mediaforce.advisor import apply_seed_policy
+from mediaforce.core.evidence import stable_json_hash, stable_policy_hash, stable_source_id
+from mediaforce.core.type_defs import float_value, int_value, object_dict, object_list
+from mediaforce.tuning.target_size_search import (
+    TARGET_SIZE_SEARCH_SCHEMA_VERSION,
+    target_size_transform_plan_valid,
+)
+
+QUALITY_RISK_CONTRACT_SCHEMA = "mediaforce.quality_risk_contract"
+QUALITY_RISK_CONTRACT_VERSION = 1
+
+QUALITY_RISK_VERDICTS = (
+    "safe_to_sample",
+    "needs_operator_review",
+    "request_comparison",
+    "blocked",
+)
+
+QUALITY_RISK_LEVELS = ("low", "medium", "high", "unknown")
+
+QUALITY_RISK_TAGS = (
+    "softness_detail_loss",
+    "motion_breakup",
+    "banding_dark_scene_damage",
+    "grain_noise_treatment",
+    "cadence_interlace_artifacts",
+    "audio_quality_layout",
+    "other",
+)
+
+QUALITY_RISK_TAG_LABELS = {
+    "softness_detail_loss": "Softness / detail loss",
+    "motion_breakup": "Motion breakup",
+    "banding_dark_scene_damage": "Banding / dark-scene damage",
+    "grain_noise_treatment": "Grain / noise treatment",
+    "cadence_interlace_artifacts": "Cadence / interlace artifacts",
+    "audio_quality_layout": "Audio quality / layout",
+    "other": "Other",
+}
+
+QUALITY_RISK_TAG_ALIASES = {
+    "softness": "softness_detail_loss",
+    "detail_loss": "softness_detail_loss",
+    "softness_detail_loss": "softness_detail_loss",
+    "motion_breakup": "motion_breakup",
+    "motion": "motion_breakup",
+    "high_motion": "motion_breakup",
+    "banding": "banding_dark_scene_damage",
+    "dark_scene_damage": "banding_dark_scene_damage",
+    "banding_dark_scene_damage": "banding_dark_scene_damage",
+    "dark_luma": "banding_dark_scene_damage",
+    "dark_gradient_banding_risk": "banding_dark_scene_damage",
+    "grain": "grain_noise_treatment",
+    "noise": "grain_noise_treatment",
+    "grain_noise_treatment": "grain_noise_treatment",
+    "likely_film_grain": "grain_noise_treatment",
+    "likely_analog_noise": "grain_noise_treatment",
+    "compression_noise_advisory": "grain_noise_treatment",
+    "uncertain_noise_mix": "grain_noise_treatment",
+    "texture_noise_advisory": "grain_noise_treatment",
+    "cadence": "cadence_interlace_artifacts",
+    "interlace": "cadence_interlace_artifacts",
+    "cadence_interlace_artifacts": "cadence_interlace_artifacts",
+    "duplicate_cadence": "cadence_interlace_artifacts",
+    "audio": "audio_quality_layout",
+    "audio_layout": "audio_quality_layout",
+    "audio_quality_layout": "audio_quality_layout",
+    "audio_complexity": "audio_quality_layout",
+    "audio_loudness_range": "audio_quality_layout",
+    "high_texture": "softness_detail_loss",
+    "animation_cues": "softness_detail_loss",
+    "other": "other",
+}
+
+RISK_INTERPRETATION_KEY = "quality_risk_interpretation"
+ALLOW_LISTED_POLICY_SECTIONS = frozenset({"video", "audio", "subtitle"})
+ALLOW_LISTED_VIDEO_TRANSFORM_KEYS = frozenset(
+    {
+        "encoder",
+        "pixel_format",
+        "crf_search",
+        "max_height",
+        "resolution_intent_mode",
+        "resolution_intent_source",
+        "downsample_algorithm",
+        "black_bar_handling",
+        "black_bar_detect_samples",
+        "black_bar_detect_seconds",
+        "black_bar_detect_limit",
+        "black_bar_detect_round",
+        "black_bar_detect_start_seconds",
+        "crop",
+        "default_grain",
+        "grain_denoise",
+        "min_crf",
+        "max_crf",
+        "max_encoded_percent",
+        "quality_metric",
+        "target_vmaf",
+        "min_target_vmaf",
+        "target_xpsnr",
+        "min_target_xpsnr",
+        "target_relax_step_vmaf",
+        "target_relax_step_xpsnr",
+        "sample_every",
+        "sample_duration",
+        "preset",
+        "thorough",
+        "target_size_mb",
+        "target_size_bytes",
+        "target_runtime_minutes",
+        "size_goal_schema_version",
+        "size_goal_mode",
+        "size_goal_source",
+        "sample_projection_tolerance_percent",
+        "final_output_tolerance_percent",
+    }
+)
+ALLOW_LISTED_AUDIO_KEYS = frozenset(
+    {
+        "keep_languages",
+        "copy_codecs",
+        "convert_to_opus_codecs",
+        "stereo_opus_bitrate",
+        "surround_5_1_opus_bitrate",
+        "surround_7_1_opus_bitrate",
+    }
+)
+ALLOW_LISTED_SUBTITLE_KEYS = frozenset({"keep_languages", "prefer_text", "keep_forced", "default_mode"})
+
+_QUALITY_RISK_TEXT_PATTERNS = {
+    "softness_detail_loss": re.compile(r"\b(?:soft|softness|blurr(?:y|ed|ing)?|detail\s+loss|faces?\s+look)\b", re.I),
+    "motion_breakup": re.compile(r"\b(?:motion|breaks?\s+up|blocking|blockiness|macroblocking|smear(?:ing)?)\b", re.I),
+    "banding_dark_scene_damage": re.compile(r"\b(?:banding|dark\s+scene|dark-scene|gradient|posterization)\b", re.I),
+    "grain_noise_treatment": re.compile(r"\b(?:grain|noise|denoise|film\s+texture)\b", re.I),
+    "cadence_interlace_artifacts": re.compile(r"\b(?:cadence|interlace|telecine|judder|combing)\b", re.I),
+    "audio_quality_layout": re.compile(
+        r"\b(?:audio\s+quality|surround|stereo|dialog(?:ue)?|channel\s+layout|"
+        r"sound(?:s|ed)?\s+(?:bad|thin|wrong|flat|distorted|missing))\b",
+        re.I,
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class QualityRiskDecisionRecord:
+    kind: str
+    created_at: str | None
+    verdict: str
+    tags: tuple[str, ...]
+    details: str
+    evidence_ids: tuple[str, ...]
+    moment_indexes: tuple[int, ...]
+    sample_job_id: str | None
+    policy_hash: str | None
+    source_id: str | None
+    prefix: str | None
+    authoritative: bool
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "created_at": self.created_at,
+            "verdict": self.verdict,
+            "tags": list(self.tags),
+            "details": self.details,
+            "evidence_id": self.evidence_ids[0] if self.evidence_ids else None,
+            "evidence_ids": list(self.evidence_ids),
+            "moment_indexes": list(self.moment_indexes),
+            "sample_job_id": self.sample_job_id,
+            "policy_hash": self.policy_hash,
+            "source_id": self.source_id,
+            "prefix": self.prefix,
+            "authoritative": self.authoritative,
+        }
+
+
+def quality_risk_tag_label(tag: str) -> str:
+    normalized = normalize_quality_risk_tag(tag)
+    return QUALITY_RISK_TAG_LABELS.get(normalized, QUALITY_RISK_TAG_LABELS["other"])
+
+
+def normalize_quality_risk_tag(tag: str | None) -> str:
+    candidate = str(tag or "").strip().lower().replace("-", "_").replace("/", "_").replace(" ", "_")
+    return QUALITY_RISK_TAG_ALIASES.get(candidate, "other")
+
+
+def normalize_quality_risk_tags(tags: list[Any] | tuple[Any, ...] | None) -> list[str]:
+    normalized = [normalize_quality_risk_tag(str(tag)) for tag in _sequence_values(tags)]
+    unique: list[str] = []
+    for tag in normalized:
+        if tag not in unique:
+            unique.append(tag)
+    return unique or ["other"]
+
+
+def quality_risk_tags_from_text(value: str | None) -> list[str]:
+    text = str(value or "").strip()
+    if not text:
+        return []
+    return [tag for tag, pattern in _QUALITY_RISK_TEXT_PATTERNS.items() if pattern.search(text)]
+
+
+def with_quality_risk_intent(
+        operator_request: Mapping[str, Any] | None,
+        *,
+        note: str,
+) -> dict[str, Any] | None:
+    tags = quality_risk_tags_from_text(note)
+    request = dict(object_dict(operator_request))
+    if not tags:
+        return request or None
+    request.setdefault("source", "operator_note")
+    request.setdefault("request_type", "quality_risk_feedback")
+    request.setdefault("request_text", note.strip())
+    request.setdefault("operator_confirmed", False)
+    request.setdefault("evidence_authority", "none")
+    request["quality_risk_tags"] = tags
+    request["quality_risk_details"] = note.strip()
+    return request
+
+
+def quality_risk_interpretation_payload(value: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    payload = object_dict(value)
+    if not payload:
+        return None
+    verdict = str(payload.get("verdict") or "").strip().lower()
+    if verdict not in QUALITY_RISK_VERDICTS:
+        verdict = "request_comparison"
+    confidence = str(payload.get("confidence") or "").strip().lower()
+    if confidence not in QUALITY_RISK_LEVELS:
+        confidence = "unknown"
+    summary = str(payload.get("summary") or "").strip()
+    if not summary:
+        return None
+    risks: list[dict[str, Any]] = []
+    for raw_risk in object_list(payload.get("risks")):
+        risk = object_dict(raw_risk)
+        tag = normalize_quality_risk_tag(risk.get("tag"))
+        level = str(risk.get("level") or "").strip().lower()
+        if level not in QUALITY_RISK_LEVELS:
+            level = "unknown"
+        rationale = str(risk.get("rationale") or "").strip()
+        if not rationale:
+            continue
+        risks.append(
+            {
+                "tag": tag,
+                "label": quality_risk_tag_label(tag),
+                "level": level,
+                "rationale": rationale,
+                "evidence_ids": _normalized_evidence_ids(risk.get("evidence_ids")),
+                "moment_indexes": _normalized_moment_indexes(risk.get("moment_indexes")),
+            }
+        )
+    suggested_actions = []
+    for raw_action in object_list(payload.get("suggested_actions")):
+        action = str(raw_action).strip()
+        if action and action not in suggested_actions:
+            suggested_actions.append(action)
+    return {
+        "summary": summary,
+        "verdict": verdict,
+        "confidence": confidence,
+        "risks": risks,
+        "suggested_actions": suggested_actions,
+    }
+
+
+def compile_allow_listed_transform_fragment(
+        base_policy: Mapping[str, Any],
+        transform_fragment: Mapping[str, Any] | None,
+) -> tuple[dict[str, Any], dict[str, Any], list[str]]:
+    fragment = object_dict(transform_fragment)
+    if not fragment:
+        policy_copy = json.loads(json.dumps(object_dict(base_policy)))
+        return policy_copy, {}, []
+    base_payload = json.loads(json.dumps(object_dict(base_policy)))
+    normalized_fragment: dict[str, Any] = {}
+    rejected_keys = [str(key) for key in fragment if key not in ALLOW_LISTED_POLICY_SECTIONS]
+    for section in ALLOW_LISTED_POLICY_SECTIONS:
+        if section not in fragment:
+            continue
+        raw_section = fragment.get(section)
+        if not isinstance(raw_section, Mapping):
+            rejected_keys.append(section)
+            continue
+        allowed_keys = set(object_dict(base_payload.get(section)))
+        if section == "video":
+            allowed_keys.update(ALLOW_LISTED_VIDEO_TRANSFORM_KEYS)
+        elif section == "audio":
+            allowed_keys.update(ALLOW_LISTED_AUDIO_KEYS)
+        elif section == "subtitle":
+            allowed_keys.update(ALLOW_LISTED_SUBTITLE_KEYS)
+        filtered_section: dict[str, Any] = {}
+        for key, value in raw_section.items():
+            if key not in allowed_keys:
+                rejected_keys.append(f"{section}.{key}")
+                continue
+            if value is not None and not _policy_value_valid(
+                    section,
+                    str(key),
+                    value,
+                    object_dict(base_payload.get(section)).get(key),
+            ):
+                rejected_keys.append(f"{section}.{key}")
+                continue
+            filtered_section[str(key)] = value
+        if filtered_section:
+            normalized_fragment[section] = filtered_section
+            base_section = base_payload.setdefault(section, {})
+            for key, value in filtered_section.items():
+                base_section.setdefault(key, value)
+    compiled_policy, applied_fragment = apply_seed_policy(
+        base_payload,
+        normalized_fragment,
+        mode="tune",
+    )
+    for section, requested_section in normalized_fragment.items():
+        applied_section = object_dict(applied_fragment.get(section))
+        for key, value in object_dict(requested_section).items():
+            if value is not None and key not in applied_section:
+                rejected_keys.append(f"{section}.{key}")
+    return compiled_policy, applied_fragment, sorted(set(rejected_keys))
+
+
+def _policy_value_valid(section: str, key: str, value: Any, base_value: Any) -> bool:
+    if section == "video":
+        enum_values = {
+            "quality_metric": {"auto", "vmaf", "xpsnr", "ssim", "psnr"},
+            "black_bar_handling": {"off", "auto", "smart"},
+            "downsample_algorithm": {
+                "fast_bilinear",
+                "bilinear",
+                "bicubic",
+                "area",
+                "lanczos",
+                "spline",
+                "neighbor",
+            },
+            "size_goal_mode": {"normalized", "absolute"},
+            "resolution_intent_mode": {"source", "max_height"},
+        }
+        if key in enum_values:
+            return isinstance(value, str) and value.strip().lower() in enum_values[key]
+        if key in {"encoder", "pixel_format", "size_goal_source", "resolution_intent_source"}:
+            return isinstance(value, str) and bool(value.strip())
+        if key in {"crf_search", "thorough"}:
+            return isinstance(value, bool)
+        numeric_ranges = {
+            "preset": (0, 13),
+            "target_vmaf": (70, 98),
+            "min_target_vmaf": (65, 97),
+            "target_xpsnr": (25, 41),
+            "min_target_xpsnr": (20, 40),
+            "target_relax_step_vmaf": (0.1, 5),
+            "target_relax_step_xpsnr": (0.1, 5),
+            "min_crf": (0, 63),
+            "max_crf": (0, 63),
+            "max_encoded_percent": (1, 100),
+            "max_height": (0, 4320),
+            "black_bar_detect_samples": (1, 5),
+            "black_bar_detect_seconds": (1, 120),
+            "black_bar_detect_limit": (1, 120),
+            "black_bar_detect_round": (2, 64),
+            "black_bar_detect_start_seconds": (0, 24 * 60 * 60),
+            "default_grain": (0, 50),
+            "grain_denoise": (0, 1),
+        }
+        if key in numeric_ranges:
+            minimum, maximum = numeric_ranges[key]
+            number = _strict_number(value)
+            return number is not None and minimum <= number <= maximum
+        if key in {"target_size_mb", "target_size_bytes", "target_runtime_minutes"}:
+            number = _strict_number(value)
+            return number is not None and number > 0
+        if key in {"sample_projection_tolerance_percent", "final_output_tolerance_percent"}:
+            number = _strict_number(value)
+            return number is not None and 0 < number <= 100
+        if key == "size_goal_schema_version":
+            return _strict_number(value) == 1
+        if key in {"sample_every", "sample_duration"}:
+            return isinstance(value, str) and bool(re.fullmatch(r"\s*\d+(?:\.\d+)?\s*(?:ms|s|m|h)\s*", value, re.I))
+        if key == "crop":
+            return isinstance(value, str) and (not value.strip() or bool(re.fullmatch(r"\d+:\d+:\d+:\d+", value.strip())))
+    if section == "audio":
+        if key in {"keep_languages", "copy_codecs", "convert_to_opus_codecs"}:
+            return _string_list_valid(value)
+        bitrate_ranges = {
+            "stereo_opus_bitrate": (48, 384),
+            "surround_5_1_opus_bitrate": (96, 512),
+            "surround_7_1_opus_bitrate": (128, 768),
+        }
+        if key in bitrate_ranges:
+            bitrate = _bitrate_kbps(value)
+            minimum, maximum = bitrate_ranges[key]
+            return bitrate is not None and minimum <= bitrate <= maximum
+    if section == "subtitle":
+        if key == "keep_languages":
+            return _string_list_valid(value)
+        if key in {"prefer_text", "keep_forced"}:
+            return isinstance(value, bool)
+        if key == "default_mode":
+            return isinstance(value, str) and bool(value.strip())
+    return _value_matches_base_type(value, base_value)
+
+
+def _strict_number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    number = float(value)
+    return number if math.isfinite(number) else None
+
+
+def _bitrate_kbps(value: Any) -> int | None:
+    if not isinstance(value, str):
+        return None
+    match = re.fullmatch(r"\s*(\d+(?:\.\d+)?)\s*(?:k|kbps)?\s*", value, re.I)
+    return int(float(match.group(1))) if match else None
+
+
+def _string_list_valid(value: Any) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) and bool(item.strip()) for item in value)
+
+
+def _value_matches_base_type(value: Any, base_value: Any) -> bool:
+    if isinstance(base_value, bool):
+        return isinstance(value, bool)
+    if isinstance(base_value, int) and not isinstance(base_value, bool):
+        return _strict_number(value) is not None and float(value).is_integer()
+    if isinstance(base_value, float):
+        return _strict_number(value) is not None
+    if isinstance(base_value, str):
+        return isinstance(value, str) and bool(value.strip())
+    if isinstance(base_value, list):
+        if all(isinstance(item, str) for item in base_value):
+            return _string_list_valid(value)
+        return isinstance(value, list)
+    return base_value is not None and type(value) is type(base_value)
+
+
+def build_quality_risk_contract(
+        *,
+        prefix: str,
+        sample_item: Mapping[str, Any],
+        current_policy: Mapping[str, Any],
+        preview_policy: Mapping[str, Any] | None = None,
+        operator_request: Mapping[str, Any] | None = None,
+        calibration: Mapping[str, Any] | None = None,
+        advice_state: Mapping[str, Any] | None = None,
+        latest_failed_sample_job: Mapping[str, Any] | None = None,
+        interpretation: Mapping[str, Any] | None = None,
+        proposed_policy: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    sample = object_dict(sample_item)
+    current_policy_payload = object_dict(current_policy)
+    preview_policy_payload = object_dict(preview_policy) or current_policy_payload
+    operator_request_payload = object_dict(operator_request)
+    calibration_payload = object_dict(calibration)
+    advice_payload = object_dict(advice_state)
+    failed_payload = object_dict(latest_failed_sample_job)
+    source_id = str(sample.get("representative_source_id") or sample.get("source_id") or stable_source_id(sample))
+    source_fingerprint = str(sample.get("source_fingerprint") or "").strip() or None
+    cadence_decision = object_dict(sample.get("cadence_decision"))
+    fingerprint_decision = object_dict(sample.get("media_fingerprint_decision"))
+    stream_budget = object_dict(sample.get("stream_budget_ledger"))
+    sample_result = object_dict(calibration_payload.get("sample_result"))
+    review_moments = _normalized_review_moments(calibration_payload.get("review_moments"))
+    sample_job_id = str(calibration_payload.get("job_id") or failed_payload.get("job_id") or "") or None
+    target_size_trace = _target_size_trace(
+        sample_result,
+        failed_payload,
+        current_sample_job_id=str(calibration_payload.get("job_id") or "") or None,
+    )
+    evidence_ids = _current_evidence_ids(
+        cadence_decision=cadence_decision,
+        fingerprint_decision=fingerprint_decision,
+        review_moments=review_moments,
+        sample_result=sample_result,
+    )
+    proposed_fragment = object_dict(proposed_policy) or _policy_difference(
+        current_policy_payload,
+        preview_policy_payload,
+    )
+    compiled_policy, applied_fragment, rejected_keys = compile_allow_listed_transform_fragment(
+        current_policy_payload,
+        proposed_fragment,
+    )
+    compiled_policy_matches_preview = _policy_values_equivalent(compiled_policy, preview_policy_payload)
+    gates = _deterministic_gates(
+        source_id=source_id,
+        cadence_decision=cadence_decision,
+        fingerprint_decision=fingerprint_decision,
+        stream_budget=stream_budget,
+        sample_result=sample_result,
+        target_size_trace=target_size_trace,
+        rejected_transform_keys=rejected_keys,
+        current_policy=current_policy_payload,
+        preview_policy=preview_policy_payload,
+        compiled_policy_matches_preview=compiled_policy_matches_preview,
+    )
+    interpretation_payload = quality_risk_interpretation_payload(interpretation)
+    operator_decision = resolve_quality_risk_operator_decision(
+        prefix=prefix,
+        source_id=source_id,
+        reviewed_policy=preview_policy_payload,
+        current_sample_job_id=sample_job_id,
+        current_evidence_ids=evidence_ids,
+        current_moment_count=len(review_moments),
+        advice_state=advice_payload,
+    )
+    risks = _typed_quality_risks(
+        cadence_decision=cadence_decision,
+        fingerprint_decision=fingerprint_decision,
+        operator_request=operator_request_payload,
+        stream_budget=stream_budget,
+        sample_result=sample_result,
+        target_size_trace=target_size_trace,
+        review_moments=review_moments,
+        interpretation=interpretation_payload,
+    )
+    verdict = _contract_verdict(gates=gates, operator_decision=operator_decision, interpretation=interpretation_payload)
+    return {
+        "schema": QUALITY_RISK_CONTRACT_SCHEMA,
+        "version": QUALITY_RISK_CONTRACT_VERSION,
+        "source_scope": {
+            "prefix": prefix,
+            "source_id": source_id,
+            "source_fingerprint": source_fingerprint,
+            "sample_job_id": sample_job_id,
+            "evidence_ids": evidence_ids,
+        },
+        "policy": {
+            "current_policy_hash": stable_policy_hash(current_policy_payload),
+            "preview_policy_hash": stable_policy_hash(preview_policy_payload),
+            "compiled_fragment": applied_fragment,
+            "rejected_transform_keys": rejected_keys,
+            "compiled_policy_matches_preview": compiled_policy_matches_preview,
+        },
+        "facts": {
+            "current_policy": current_policy_payload,
+            "preview_policy": preview_policy_payload,
+            "operator_request": operator_request_payload,
+            "sample_result": sample_result,
+            "review_moments": review_moments,
+            "cadence_decision": cadence_decision,
+            "media_fingerprint_decision": fingerprint_decision,
+            "stream_budget": stream_budget,
+            "target_size_trace": target_size_trace,
+        },
+        "deterministic_gates": gates,
+        "interpretation": interpretation_payload,
+        "operator_decision": operator_decision,
+        "typed_risks": risks,
+        "verdict": verdict,
+        "pre_test_instruction": pre_test_instruction_record(
+            prefix=prefix,
+            source_id=source_id,
+            policy_hash=stable_policy_hash(preview_policy_payload),
+            sample_job_id=sample_job_id,
+            review_moments=review_moments,
+            typed_risks=risks,
+        ),
+    }
+
+
+def target_size_search_public_view(trace: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    payload = object_dict(trace)
+    if not payload:
+        return None
+    target = object_dict(payload.get("target"))
+    curve = object_dict(payload.get("curve"))
+    quality_floor = object_dict(payload.get("quality_floor"))
+    selected = object_dict(payload.get("selected_candidate"))
+    transform_plan = object_dict(payload.get("transform_plan"))
+    return {
+        "trace_id": f"tss1_{stable_json_hash(payload)[:24]}",
+        "schema_version": int_value(payload.get("schema_version")),
+        "status": str(payload.get("status") or "needs_review"),
+        "selection_reason": str(payload.get("selection_reason") or "") or None,
+        "curve_shape": str(curve.get("shape") or "") or None,
+        "candidate_count": int_value(curve.get("candidate_count")),
+        "max_candidates": int_value(curve.get("max_candidates")),
+        "target_bytes": int_value(target.get("total_target_bytes")) or None,
+        "lower_bound_bytes": int_value(target.get("sample_lower_bound_bytes")) or None,
+        "upper_bound_bytes": int_value(target.get("sample_upper_bound_bytes")) or None,
+        "selected_crf": float_value(selected.get("crf")) if selected else None,
+        "selected_metric": str(selected.get("metric") or quality_floor.get("metric") or "") or None,
+        "selected_metric_score": float_value(selected.get("metric_score")) if selected else None,
+        "minimum_metric_score": float_value(quality_floor.get("minimum")) or None,
+        "quality_floor_met": bool(selected.get("quality_floor_met")) if selected else None,
+        "predicted_whole_episode_bytes": int_value(selected.get("predicted_whole_episode_bytes")) or None,
+        "within_sample_band": bool(selected.get("within_sample_band")) if selected else None,
+        "transform_plan_id": str(transform_plan.get("transform_plan_id") or "") or None,
+    }
+
+
+def quality_risk_public_view(contract: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    payload = object_dict(contract)
+    if not payload:
+        return None
+    source_scope = object_dict(payload.get("source_scope"))
+    gates = object_dict(payload.get("deterministic_gates"))
+    decision = object_dict(payload.get("operator_decision"))
+    interpretation = object_dict(payload.get("interpretation"))
+    typed_risks = [object_dict(item) for item in object_list(payload.get("typed_risks")) if object_dict(item)]
+    facts = object_dict(payload.get("facts"))
+    review_moments = [object_dict(item) for item in object_list(facts.get("review_moments"))]
+    policy = object_dict(payload.get("policy"))
+    return {
+        "schema": str(payload.get("schema") or QUALITY_RISK_CONTRACT_SCHEMA),
+        "version": int_value(payload.get("version")) or QUALITY_RISK_CONTRACT_VERSION,
+        "verdict": str(payload.get("verdict") or "request_comparison"),
+        "source_id": str(source_scope.get("source_id") or "") or None,
+        "source_fingerprint": str(source_scope.get("source_fingerprint") or "") or None,
+        "sample_job_id": str(source_scope.get("sample_job_id") or "") or None,
+        "evidence_ids": _normalized_evidence_ids(source_scope.get("evidence_ids")),
+        "policy_hash": str(policy.get("preview_policy_hash") or "") or None,
+        "current_policy_hash": str(policy.get("current_policy_hash") or "") or None,
+        "preview_policy_hash": str(policy.get("preview_policy_hash") or "") or None,
+        "blocked": bool(gates.get("blocked")),
+        "blocking_reasons": [str(reason) for reason in object_list(gates.get("blocking_reasons")) if str(reason).strip()],
+        "request_comparison": bool(gates.get("request_comparison")),
+        "comparison_reason": str(gates.get("comparison_reason") or "") or None,
+        "typed_risks": typed_risks,
+        "operator_decision": decision,
+        "interpretation": interpretation,
+        "moment_count": len(review_moments),
+        "review_moment_ids": _normalized_evidence_ids(
+            [moment.get("evidence_id") for moment in review_moments]
+        ),
+        "target_size_search": target_size_search_public_view(object_dict(facts.get("target_size_trace"))),
+        "pre_test_instruction": object_dict(payload.get("pre_test_instruction")) or None,
+    }
+
+
+def resolve_quality_risk_operator_decision(
+        *,
+        prefix: str,
+        source_id: str,
+        reviewed_policy: Mapping[str, Any],
+        current_sample_job_id: str | None,
+        current_evidence_ids: list[str],
+        current_moment_count: int,
+        advice_state: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    advice_payload = object_dict(advice_state)
+    current_policy_hash = stable_policy_hash(reviewed_policy)
+    records = quality_risk_decision_records(
+        prefix=prefix,
+        source_id=source_id,
+        current_policy_hash=current_policy_hash,
+        current_sample_job_id=current_sample_job_id,
+        current_evidence_ids=current_evidence_ids,
+        current_moment_count=current_moment_count,
+        advice_state=advice_payload,
+    )
+    effective = next(
+        (record for record in records if record.authoritative and record.kind == "post_test"),
+        None,
+    )
+    status = str(effective.verdict) if effective is not None else "pending"
+    return {
+        "status": status,
+        "current_rejection_outranks_approval": True,
+        "reviewed_policy_hash": current_policy_hash,
+        "records": [record.to_payload() for record in records],
+        "effective_record": effective.to_payload() if effective is not None else None,
+    }
+
+
+def quality_risk_decision_records(
+        *,
+        prefix: str,
+        source_id: str,
+        current_policy_hash: str,
+        current_sample_job_id: str | None,
+        current_evidence_ids: list[str],
+        current_moment_count: int,
+        advice_state: Mapping[str, Any] | None,
+) -> list[QualityRiskDecisionRecord]:
+    advice_payload = object_dict(advice_state)
+    raw_records = object_list(advice_payload.get("quality_risk_records"))
+    records: list[QualityRiskDecisionRecord] = []
+    expected_evidence_ids = tuple(sorted(_normalized_evidence_ids(current_evidence_ids)))
+    for raw_record in raw_records:
+        record = object_dict(raw_record)
+        record_evidence_ids = tuple(sorted(_record_evidence_ids(record)))
+        moment_indexes = tuple(_normalized_moment_indexes(record.get("moment_indexes")))
+        moments_current = all(index <= current_moment_count for index in moment_indexes)
+        authoritative = (
+            current_sample_job_id is not None
+            and bool(expected_evidence_ids)
+            and str(record.get("prefix") or "") == prefix
+            and str(record.get("source_id") or "") == source_id
+            and str(record.get("policy_hash") or "") == current_policy_hash
+            and str(record.get("sample_job_id") or "") == current_sample_job_id
+            and record_evidence_ids == expected_evidence_ids
+            and moments_current
+        )
+        records.append(
+            QualityRiskDecisionRecord(
+                kind=str(record.get("kind") or "post_test"),
+                created_at=str(record.get("created_at") or "") or None,
+                verdict=str(record.get("verdict") or "pending"),
+                tags=tuple(normalize_quality_risk_tags(record.get("tags"))),
+                details=str(record.get("details") or "").strip(),
+                evidence_ids=record_evidence_ids,
+                moment_indexes=moment_indexes,
+                sample_job_id=str(record.get("sample_job_id") or "") or None,
+                policy_hash=str(record.get("policy_hash") or "") or None,
+                source_id=str(record.get("source_id") or "") or None,
+                prefix=str(record.get("prefix") or "") or None,
+                authoritative=authoritative,
+            )
+        )
+    records.sort(
+        key=lambda item: (
+            item.created_at or "",
+            int(item.verdict == "rejected"),
+            item.kind,
+        ),
+        reverse=True,
+    )
+    return records
+
+
+def append_quality_risk_record(
+        existing_state: Mapping[str, Any] | None,
+        *,
+        prefix: str,
+        source_id: str,
+        policy_hash: str,
+        sample_job_id: str | None,
+        kind: str,
+        verdict: str,
+        tags: list[str] | tuple[str, ...] | None,
+        details: str,
+        created_at: str,
+        evidence_id: str | None = None,
+        evidence_ids: list[str] | tuple[str, ...] | None = None,
+        moment_indexes: list[int] | tuple[int, ...] | None = None,
+) -> dict[str, Any]:
+    payload = dict(object_dict(existing_state))
+    records = [object_dict(record) for record in object_list(payload.get("quality_risk_records"))]
+    normalized_evidence_ids = _normalized_evidence_ids(list(evidence_ids or []))
+    if evidence_id and evidence_id not in normalized_evidence_ids:
+        normalized_evidence_ids.append(evidence_id)
+    record_payload = {
+        "kind": kind,
+        "verdict": verdict,
+        "tags": normalize_quality_risk_tags(list(tags or [])),
+        "details": details.strip(),
+        "evidence_id": normalized_evidence_ids[0] if normalized_evidence_ids else None,
+        "evidence_ids": normalized_evidence_ids,
+        "moment_indexes": _normalized_moment_indexes(list(moment_indexes or [])),
+        "sample_job_id": sample_job_id,
+        "policy_hash": policy_hash,
+        "source_id": source_id,
+        "prefix": prefix,
+        "created_at": created_at,
+    }
+    binding_keys = ("kind", "verdict", "sample_job_id", "policy_hash", "source_id", "prefix")
+    records = [
+        record
+        for record in records
+        if not all(record.get(key) == record_payload.get(key) for key in binding_keys)
+    ]
+    records.append(record_payload)
+    payload["quality_risk_records"] = records[-100:]
+    return payload
+
+
+def pre_test_instruction_record(
+        *,
+        prefix: str,
+        source_id: str,
+        policy_hash: str,
+        sample_job_id: str | None,
+        review_moments: list[Mapping[str, Any]],
+        typed_risks: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    focus_tags = [
+        str(risk.get("tag") or "other")
+        for risk in typed_risks
+        if str(risk.get("level") or "unknown") in {"medium", "high"}
+    ]
+    unique_focus_tags: list[str] = []
+    for tag in focus_tags:
+        normalized = normalize_quality_risk_tag(tag)
+        if normalized not in unique_focus_tags:
+            unique_focus_tags.append(normalized)
+    moment_refs = []
+    for index, moment in enumerate(review_moments, start=1):
+        moment_payload = object_dict(moment)
+        if not moment_payload:
+            continue
+        moment_refs.append(
+            {
+                "moment": index,
+                "timestamp_seconds": float_value(moment_payload.get("timestamp_seconds")),
+                "role": str(moment_payload.get("role") or "typical"),
+                "risk_tags": normalize_quality_risk_tags(moment_payload.get("risk_tags")),
+                "evidence_id": str(moment_payload.get("evidence_id") or "") or None,
+                "rationale": str(moment_payload.get("rationale") or "").strip() or None,
+            }
+        )
+    return {
+        "prefix": prefix,
+        "source_id": source_id,
+        "policy_hash": policy_hash,
+        "sample_job_id": sample_job_id,
+        "focus_tags": unique_focus_tags,
+        "focus_labels": [quality_risk_tag_label(tag) for tag in unique_focus_tags],
+        "moments": moment_refs,
+    }
+
+
+def _normalized_review_moments(raw_moments: Any) -> list[dict[str, Any]]:
+    moments: list[dict[str, Any]] = []
+    for raw_moment in object_list(raw_moments):
+        moment = object_dict(raw_moment)
+        if not moment:
+            continue
+        moments.append(
+            {
+                "timestamp_seconds": float_value(moment.get("timestamp_seconds")),
+                "duration_seconds": float_value(moment.get("duration_seconds")),
+                "role": str(moment.get("role") or "typical"),
+                "risk_tags": normalize_quality_risk_tags(moment.get("risk_tags")),
+                "rationale": str(moment.get("rationale") or "").strip(),
+                "confidence": float_value(moment.get("confidence")),
+                "coverage": float_value(moment.get("coverage")),
+                "evidence_id": str(moment.get("evidence_id") or "") or None,
+            }
+        )
+    return moments
+
+
+def _normalized_evidence_ids(raw_ids: Any) -> list[str]:
+    evidence_ids: list[str] = []
+    for raw_id in _sequence_values(raw_ids):
+        if raw_id is None:
+            continue
+        value = str(raw_id).strip()
+        if value and value.lower() != 'none' and value not in evidence_ids:
+            evidence_ids.append(value)
+    return evidence_ids
+
+
+def _normalized_moment_indexes(raw_indexes: Any) -> list[int]:
+    indexes: list[int] = []
+    for raw_index in _sequence_values(raw_indexes):
+        value = int_value(raw_index)
+        if value > 0 and value not in indexes:
+            indexes.append(value)
+    return indexes
+
+
+def _sequence_values(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if value in (None, ""):
+        return []
+    return [value]
+
+
+def quality_risk_feedback_moment_indexes(
+        tags: list[str] | tuple[str, ...] | None,
+        review_moments: Any,
+) -> list[int]:
+    normalized_tags = {tag for tag in normalize_quality_risk_tags(tags) if tag != "other"}
+    if not normalized_tags:
+        return []
+    indexes: list[int] = []
+    for index, raw_moment in enumerate(object_list(review_moments), start=1):
+        moment_tags = {
+            tag
+            for tag in normalize_quality_risk_tags(object_dict(raw_moment).get("risk_tags"))
+            if tag != "other"
+        }
+        if normalized_tags & moment_tags:
+            indexes.append(index)
+    return indexes
+
+
+def _policy_difference(
+        current_policy: Mapping[str, Any],
+        preview_policy: Mapping[str, Any],
+) -> dict[str, Any]:
+    current = object_dict(current_policy)
+    preview = object_dict(preview_policy)
+    fragment: dict[str, Any] = {}
+    for section in sorted(set(current) | set(preview)):
+        current_section = current.get(section)
+        preview_section = preview.get(section)
+        if isinstance(current_section, Mapping) or isinstance(preview_section, Mapping):
+            current_values = object_dict(current_section)
+            preview_values = object_dict(preview_section)
+            changed = {
+                key: preview_values.get(key)
+                for key in sorted(set(current_values) | set(preview_values))
+                if current_values.get(key) != preview_values.get(key)
+            }
+            if changed:
+                fragment[section] = changed
+        elif current_section != preview_section:
+            fragment[section] = preview_section
+    return fragment
+
+
+def _policy_values_equivalent(left: Any, right: Any) -> bool:
+    if isinstance(left, Mapping) and isinstance(right, Mapping):
+        left_payload = object_dict(left)
+        right_payload = object_dict(right)
+        return set(left_payload) == set(right_payload) and all(
+            _policy_values_equivalent(left_payload[key], right_payload[key])
+            for key in left_payload
+        )
+    if isinstance(left, list) and isinstance(right, list):
+        return len(left) == len(right) and all(
+            _policy_values_equivalent(left_value, right_value)
+            for left_value, right_value in zip(left, right, strict=True)
+        )
+    if (
+            isinstance(left, int | float)
+            and not isinstance(left, bool)
+            and isinstance(right, int | float)
+            and not isinstance(right, bool)
+    ):
+        return math.isclose(float(left), float(right), rel_tol=0.0, abs_tol=0.01)
+    return left == right
+
+
+def _target_size_trace(
+        sample_result: Mapping[str, Any],
+        failed_sample_job: Mapping[str, Any],
+        *,
+        current_sample_job_id: str | None,
+) -> dict[str, Any]:
+    direct = object_dict(sample_result.get("target_size_trace"))
+    if direct:
+        return direct
+    failed_job_id = str(failed_sample_job.get("job_id") or "") or None
+    if current_sample_job_id is not None and failed_job_id != current_sample_job_id:
+        return {}
+    failed_result = object_dict(failed_sample_job.get("result"))
+    return (
+        object_dict(failed_result.get("target_size_trace"))
+        or object_dict(object_dict(failed_result.get("sample_result")).get("target_size_trace"))
+    )
+
+
+def _current_evidence_ids(
+        *,
+        cadence_decision: Mapping[str, Any],
+        fingerprint_decision: Mapping[str, Any],
+        review_moments: list[Mapping[str, Any]],
+        sample_result: Mapping[str, Any],
+) -> list[str]:
+    return _normalized_evidence_ids(
+        [
+            cadence_decision.get("evidence_id"),
+            fingerprint_decision.get("evidence_id"),
+            sample_result.get("cadence_evidence_id"),
+            sample_result.get("media_fingerprint_evidence_id"),
+            *[object_dict(moment).get("evidence_id") for moment in review_moments],
+        ]
+    )
+
+
+def _record_evidence_ids(record: Mapping[str, Any]) -> list[str]:
+    evidence_ids = _normalized_evidence_ids(record.get("evidence_ids"))
+    legacy_evidence_id = str(record.get("evidence_id") or "").strip()
+    if legacy_evidence_id and legacy_evidence_id not in evidence_ids:
+        evidence_ids.append(legacy_evidence_id)
+    return evidence_ids
+
+
+def _deterministic_gates(
+        *,
+        source_id: str,
+        cadence_decision: Mapping[str, Any],
+        fingerprint_decision: Mapping[str, Any],
+        stream_budget: Mapping[str, Any],
+        sample_result: Mapping[str, Any],
+        target_size_trace: Mapping[str, Any],
+        rejected_transform_keys: list[str],
+        current_policy: Mapping[str, Any],
+        preview_policy: Mapping[str, Any],
+        compiled_policy_matches_preview: bool,
+) -> dict[str, Any]:
+    blocking_reasons: list[str] = []
+    comparison_reason = ""
+    has_cadence_decision = bool(cadence_decision)
+    cadence_status = str(cadence_decision.get("classification") or "unknown")
+    cadence_transform = str(cadence_decision.get("transform") or "")
+    cadence_confidence = float_value(cadence_decision.get("confidence"))
+    if has_cadence_decision and (
+            cadence_status in {"mixed", "unknown"}
+            or (cadence_status in {"tff", "bff", "telecine"} and not cadence_transform)
+    ):
+        blocking_reasons.append(str(cadence_decision.get("rationale") or "Cadence needs more evidence before sampling."))
+    feasibility_status = str(object_dict(stream_budget.get("feasibility")).get("status") or "")
+    if feasibility_status == "arithmetically_infeasible":
+        blocking_reasons.append("The resolved stream budget leaves no positive video budget.")
+    if rejected_transform_keys:
+        blocking_reasons.append(
+            "The requested transform includes non-allow-listed keys: " + ", ".join(sorted(rejected_transform_keys))
+        )
+    if not compiled_policy_matches_preview:
+        blocking_reasons.append("The proposed policy does not match the deterministically compiled allow-listed policy.")
+    target_size_status = str(target_size_trace.get("status") or "")
+    if target_size_trace:
+        if int_value(target_size_trace.get("schema_version")) != TARGET_SIZE_SEARCH_SCHEMA_VERSION:
+            blocking_reasons.append("The target-size search trace uses an unsupported schema version.")
+        target_ledger = object_dict(target_size_trace.get("ledger"))
+        trace_source_id = str(target_ledger.get("source_id") or "")
+        if trace_source_id and trace_source_id != source_id:
+            blocking_reasons.append("The target-size search trace belongs to a different source item.")
+        current_ledger_id = str(stream_budget.get("ledger_id") or "")
+        trace_ledger_id = str(target_ledger.get("ledger_id") or "")
+        if current_ledger_id and trace_ledger_id and trace_ledger_id != current_ledger_id:
+            blocking_reasons.append("The target-size search trace belongs to a different stream-budget ledger.")
+        current_stream_plan_id = str(object_dict(stream_budget.get("stream_plan")).get("plan_id") or "")
+        trace_stream_plan_id = str(target_ledger.get("stream_plan_id") or "")
+        if current_stream_plan_id and trace_stream_plan_id and trace_stream_plan_id != current_stream_plan_id:
+            blocking_reasons.append("The target-size search trace belongs to a different production stream plan.")
+        transform_plan = object_dict(target_size_trace.get("transform_plan"))
+        if not target_size_transform_plan_valid(transform_plan):
+            blocking_reasons.append("The target-size search transform identity is missing or invalid.")
+        else:
+            transform_cadence_evidence_id = str(transform_plan.get("cadence_evidence_id") or "")
+            current_cadence_evidence_id = str(cadence_decision.get("evidence_id") or "")
+            if (
+                    current_cadence_evidence_id
+                    and transform_cadence_evidence_id != current_cadence_evidence_id
+            ):
+                blocking_reasons.append("The target-size search trace uses stale cadence evidence.")
+            if str(transform_plan.get("cadence_class") or "") != cadence_status:
+                blocking_reasons.append("The target-size search trace uses a different cadence classification.")
+            if str(transform_plan.get("cadence_transform") or "") != cadence_transform:
+                blocking_reasons.append("The target-size search trace uses a different cadence transform.")
+        if target_size_status == "infeasible":
+            blocking_reasons.append(
+                str(target_size_trace.get("selection_reason") or "The requested target size is arithmetically infeasible.")
+            )
+        elif target_size_status in {"quality_conflict", "needs_review"}:
+            comparison_reason = str(
+                target_size_trace.get("selection_reason")
+                or "The target-size search needs operator review before this policy can be reused."
+            )
+        elif target_size_status not in {"", "selected"}:
+            blocking_reasons.append("The target-size search trace has an unsupported status.")
+        if str(object_dict(target_size_trace.get("curve")).get("shape") or "") == "non_monotonic":
+            comparison_reason = comparison_reason or "The measured target-size curve is non-monotonic and needs comparison."
+    if not comparison_reason:
+        fingerprint_status = str(fingerprint_decision.get("status") or "unknown")
+        fingerprint_confidence = float_value(fingerprint_decision.get("confidence"))
+        low_confidence = object_list(fingerprint_decision.get("low_confidence_advisories"))
+        if not has_cadence_decision:
+            comparison_reason = "Cadence evidence is unavailable for this sample, so review or a fresh scan is safer than silent reuse."
+        elif fingerprint_status != "measured":
+            comparison_reason = str(fingerprint_decision.get("rationale") or "Fingerprint evidence is unknown.")
+        elif low_confidence:
+            comparison_reason = "Low-confidence fingerprint findings require comparison before destructive cleanup."
+        elif fingerprint_confidence < 0.55:
+            comparison_reason = "Measured fingerprint confidence is low, so comparison is safer than silent cleanup."
+        elif cadence_confidence < 0.8 and cadence_status not in {"progressive", "none"}:
+            comparison_reason = "Cadence confidence is too low for destructive treatment without comparison."
+    return {
+        "blocked": bool(blocking_reasons),
+        "blocking_reasons": blocking_reasons,
+        "request_comparison": bool(comparison_reason) and not blocking_reasons,
+        "comparison_reason": comparison_reason or None,
+        "cadence_gate": cadence_status,
+        "cadence_transform": cadence_transform or None,
+        "non_video_feasibility": feasibility_status or None,
+        "allow_list_rejections": rejected_transform_keys,
+        "policy_hash_matches_preview": stable_policy_hash(current_policy) == stable_policy_hash(preview_policy),
+        "compiled_policy_matches_preview": compiled_policy_matches_preview,
+        "sample_result_present": bool(sample_result),
+        "target_size_status": target_size_status or None,
+        "target_size_trace_present": bool(target_size_trace),
+    }
+
+
+def _typed_quality_risks(
+        *,
+        cadence_decision: Mapping[str, Any],
+        fingerprint_decision: Mapping[str, Any],
+        operator_request: Mapping[str, Any],
+        stream_budget: Mapping[str, Any],
+        sample_result: Mapping[str, Any],
+        target_size_trace: Mapping[str, Any],
+        review_moments: list[Mapping[str, Any]],
+        interpretation: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    risks_by_tag: dict[str, dict[str, Any]] = {}
+    findings = [object_dict(item) for item in object_list(fingerprint_decision.get("findings"))]
+    for finding in findings:
+        finding_id = str(finding.get("id") or "")
+        confidence = float_value(finding.get("confidence"))
+        rationale = str(finding.get("rationale") or "").strip()
+        if finding_id in {"likely_film_grain", "likely_analog_noise", "compression_noise_advisory", "uncertain_noise_mix"}:
+            _add_risk(
+                risks_by_tag,
+                tag="grain_noise_treatment",
+                level=_risk_level(confidence, high_threshold=0.78, medium_threshold=0.58),
+                rationale=rationale,
+                evidence_ids=_normalized_evidence_ids([fingerprint_decision.get("evidence_id")]),
+            )
+        elif finding_id in {"dark_luma", "dark_gradient_banding_risk"}:
+            _add_risk(
+                risks_by_tag,
+                tag="banding_dark_scene_damage",
+                level=_risk_level(confidence, high_threshold=0.72, medium_threshold=0.52),
+                rationale=rationale,
+                evidence_ids=_normalized_evidence_ids([fingerprint_decision.get("evidence_id")]),
+            )
+        elif finding_id in {"high_motion", "duplicate_cadence"}:
+            _add_risk(
+                risks_by_tag,
+                tag="motion_breakup",
+                level=_risk_level(confidence, high_threshold=0.74, medium_threshold=0.54),
+                rationale=rationale,
+                evidence_ids=_normalized_evidence_ids([fingerprint_decision.get("evidence_id")]),
+            )
+        elif finding_id in {"high_texture", "animation_cues"}:
+            _add_risk(
+                risks_by_tag,
+                tag="softness_detail_loss",
+                level=_risk_level(confidence, high_threshold=0.76, medium_threshold=0.56),
+                rationale=rationale,
+                evidence_ids=_normalized_evidence_ids([fingerprint_decision.get("evidence_id")]),
+            )
+        elif finding_id == "audio_complexity":
+            _add_risk(
+                risks_by_tag,
+                tag="audio_quality_layout",
+                level=_risk_level(confidence, high_threshold=0.72, medium_threshold=0.50),
+                rationale=rationale,
+                evidence_ids=_normalized_evidence_ids([fingerprint_decision.get("evidence_id")]),
+            )
+    cadence_class = str(cadence_decision.get("classification") or "unknown")
+    if cadence_class in {"mixed", "telecine", "tff", "bff", "unknown"}:
+        _add_risk(
+            risks_by_tag,
+            tag="cadence_interlace_artifacts",
+            level=_risk_level(float_value(cadence_decision.get("confidence")), high_threshold=0.80, medium_threshold=0.55),
+            rationale=str(cadence_decision.get("rationale") or "Measured cadence needs explicit review."),
+            evidence_ids=_normalized_evidence_ids([cadence_decision.get("evidence_id")]),
+        )
+    feasibility = object_dict(stream_budget.get("feasibility"))
+    feasibility_status = str(feasibility.get("status") or "")
+    if feasibility_status == "aggressive_but_measurable":
+        _add_risk(
+            risks_by_tag,
+            tag="softness_detail_loss",
+            level="medium",
+            rationale="The remaining video budget is aggressive enough that detail loss is more likely at the requested size.",
+            evidence_ids=[],
+        )
+    if feasibility_status == "requires_measurement":
+        _add_risk(
+            risks_by_tag,
+            tag="other",
+            level="unknown",
+            rationale="Non-video cost uncertainty still requires measurement before trusting the size tradeoff.",
+            evidence_ids=[],
+        )
+    if sample_result:
+        predicted_percent = float_value(sample_result.get("predicted_encode_percent"))
+        if predicted_percent > 0 and predicted_percent <= 8.0:
+            _add_risk(
+                risks_by_tag,
+                tag="softness_detail_loss",
+                level="medium",
+                rationale="The sampled result projects to a very small fraction of the source size, so preserved detail should be checked directly.",
+                evidence_ids=[],
+            )
+    target_size_status = str(target_size_trace.get("status") or "")
+    target_size_reason = str(target_size_trace.get("selection_reason") or "").strip()
+    if target_size_status == "quality_conflict":
+        _add_risk(
+            risks_by_tag,
+            tag="softness_detail_loss",
+            level="high",
+            rationale=target_size_reason or "The measured target cannot be reached without crossing the quality floor.",
+            evidence_ids=[],
+        )
+    elif target_size_status in {"needs_review", "infeasible"}:
+        _add_risk(
+            risks_by_tag,
+            tag="other",
+            level="high" if target_size_status == "infeasible" else "medium",
+            rationale=target_size_reason or "The measured target-size search needs operator review.",
+            evidence_ids=[],
+        )
+    if str(object_dict(target_size_trace.get("curve")).get("shape") or "") == "non_monotonic":
+        _add_risk(
+            risks_by_tag,
+            tag="other",
+            level="medium",
+            rationale="The measured target-size curve is non-monotonic, so another comparison is safer than extrapolation.",
+            evidence_ids=[],
+        )
+    if operator_request:
+        evidence_authority = str(operator_request.get("evidence_authority") or "none")
+        operator_tags = [
+            tag for tag in normalize_quality_risk_tags(operator_request.get("quality_risk_tags"))
+            if tag != "other"
+        ]
+        operator_rationale = str(
+            operator_request.get("quality_risk_details")
+            or operator_request.get("request_text")
+            or ""
+        ).strip()
+        for tag in operator_tags:
+            _add_risk(
+                risks_by_tag,
+                tag=tag,
+                level="high" if evidence_authority == "rejected_visual_result" else "medium",
+                rationale=operator_rationale or "The operator asked to preserve or review this quality dimension.",
+                evidence_ids=[],
+            )
+        if evidence_authority == "rejected_visual_result" and not operator_tags:
+            _add_risk(
+                risks_by_tag,
+                tag="other",
+                level="high",
+                rationale="The current operator note contains a visual or audible rejection of the current sample.",
+                evidence_ids=[],
+            )
+    for index, moment in enumerate(review_moments, start=1):
+        moment_payload = object_dict(moment)
+        for tag in normalize_quality_risk_tags(moment_payload.get("risk_tags")):
+            if tag == "other":
+                continue
+            _add_risk(
+                risks_by_tag,
+                tag=_moment_tag_to_contract_tag(tag),
+                level="medium",
+                rationale=str(moment_payload.get("rationale") or "Measured review moment highlights this risk."),
+                evidence_ids=_normalized_evidence_ids([moment_payload.get("evidence_id")]),
+                moment_indexes=[index],
+            )
+    interpretation_payload = object_dict(interpretation)
+    for risk in [object_dict(item) for item in object_list(interpretation_payload.get("risks"))]:
+        _add_risk(
+            risks_by_tag,
+            tag=str(risk.get("tag") or "other"),
+            level=str(risk.get("level") or "unknown"),
+            rationale=str(risk.get("rationale") or "").strip(),
+            evidence_ids=_normalized_evidence_ids(risk.get("evidence_ids")),
+            moment_indexes=_normalized_moment_indexes(risk.get("moment_indexes")),
+        )
+    ordered: list[dict[str, Any]] = []
+    for tag in QUALITY_RISK_TAGS:
+        risk = risks_by_tag.get(tag)
+        if risk is not None:
+            ordered.append(risk)
+    return ordered
+
+
+def _moment_tag_to_contract_tag(tag: str) -> str:
+    return normalize_quality_risk_tag(tag)
+
+
+def _add_risk(
+        risks_by_tag: dict[str, dict[str, Any]],
+        *,
+        tag: str,
+        level: str,
+        rationale: str,
+        evidence_ids: list[str],
+        moment_indexes: list[int] | None = None,
+) -> None:
+    normalized_tag = normalize_quality_risk_tag(tag)
+    normalized_level = level if level in QUALITY_RISK_LEVELS else "unknown"
+    existing = risks_by_tag.get(normalized_tag)
+    if existing is None:
+        risks_by_tag[normalized_tag] = {
+            "tag": normalized_tag,
+            "label": quality_risk_tag_label(normalized_tag),
+            "level": normalized_level,
+            "rationale": rationale,
+            "evidence_ids": list(evidence_ids),
+            "moment_indexes": list(moment_indexes or []),
+        }
+        return
+    existing["level"] = _max_risk_level(str(existing.get("level") or "unknown"), normalized_level)
+    if rationale and rationale not in str(existing.get("rationale") or ""):
+        joined = str(existing.get("rationale") or "").strip()
+        existing["rationale"] = f"{joined} {rationale}".strip() if joined else rationale
+    for evidence_id in evidence_ids:
+        if evidence_id and evidence_id not in object_list(existing.get("evidence_ids")):
+            object_list(existing.get("evidence_ids")).append(evidence_id)
+    for moment_index in moment_indexes or []:
+        if moment_index and moment_index not in object_list(existing.get("moment_indexes")):
+            object_list(existing.get("moment_indexes")).append(moment_index)
+
+
+def _max_risk_level(left: str, right: str) -> str:
+    order = {"unknown": 0, "low": 1, "medium": 2, "high": 3}
+    return left if order.get(left, 0) >= order.get(right, 0) else right
+
+
+def _risk_level(confidence: float, *, high_threshold: float, medium_threshold: float) -> str:
+    if confidence >= high_threshold:
+        return "high"
+    if confidence >= medium_threshold:
+        return "medium"
+    if confidence > 0:
+        return "low"
+    return "unknown"
+
+
+def _contract_verdict(
+        *,
+        gates: Mapping[str, Any],
+        operator_decision: Mapping[str, Any],
+        interpretation: Mapping[str, Any] | None,
+) -> str:
+    if bool(gates.get("blocked")):
+        return "blocked"
+    if str(operator_decision.get("status") or "") == "rejected":
+        return "blocked"
+    if bool(gates.get("request_comparison")):
+        return "request_comparison"
+    if str(operator_decision.get("status") or "") == "approved":
+        return "safe_to_sample"
+    if str(operator_decision.get("status") or "") == "needs_operator_review":
+        return "needs_operator_review"
+    interpretation_payload = object_dict(interpretation)
+    interpretation_verdict = str(interpretation_payload.get("verdict") or "")
+    if interpretation_verdict in {"blocked", "request_comparison"}:
+        return "request_comparison"
+    return "needs_operator_review"

--- a/mediaforce/tuning/tuning_memory.py
+++ b/mediaforce/tuning/tuning_memory.py
@@ -134,15 +134,6 @@ def retrieve_learning_context(
             learning_artifacts.c.summary,
             learning_artifacts.c.tags_json,
             learning_artifacts.c.updated_at,
-            tuning_sessions.c.applied_policy_json,
-            tuning_sessions.c.toolbelt_json,
-        )
-        .select_from(
-            learning_artifacts.join(
-                tuning_sessions,
-                learning_artifacts.c.session_id == tuning_sessions.c.session_id,
-                isouter=True,
-            )
         )
         .order_by(learning_artifacts.c.updated_at.desc())
     ).mappings().fetchall()
@@ -161,19 +152,14 @@ def retrieve_learning_context(
         same_prefix = int(artifact_prefix == normalized_prefix)
         artifact_series_root = _season_root_prefix(artifact_prefix) or _series_root_prefix(artifact_prefix)
         same_series = int(bool(requested_series_root and artifact_series_root == requested_series_root))
-        approved_visual = "approval:visual" in tag_set and "decision:accepted" in tag_set
-        approval_authoritative = approved_visual and bool(same_prefix or same_series)
-        if approved_visual and not approval_authoritative:
+        if not same_prefix and not same_series:
             continue
-        score = overlap + (same_prefix * 10) + (same_series * 6) + (20 if approval_authoritative else 0)
+        approved_visual = "approval:visual" in tag_set and "decision:accepted" in tag_set
+        score = overlap + (same_prefix * 10) + (same_series * 6) + (2 if approved_visual else 0)
         if score <= 0:
             continue
         artifact_path = Path(str(row["artifact_path"]))
         excerpt = _artifact_excerpt(artifact_path)
-        applied_policy = _json_object(row.get("applied_policy_json"))
-        toolbelt = _json_object(row.get("toolbelt_json"))
-        sample_result = object_dict(toolbelt.get("sample_result"))
-        run_verdict = object_dict(toolbelt.get("run_verdict"))
         ranked.append(
             (
                 score,
@@ -185,10 +171,10 @@ def retrieve_learning_context(
                     "tags": tags,
                     "updated_at": str(row["updated_at"]),
                     "excerpt": excerpt,
-                    "evidence_authority": "approved_visual_result" if approval_authoritative else "none",
-                    "approved_policy": applied_policy if approval_authoritative else {},
-                    "sample_result": sample_result if approval_authoritative else {},
-                    "run_verdict": run_verdict if approval_authoritative else {},
+                    "evidence_authority": "none",
+                    "approved_policy": {},
+                    "sample_result": {},
+                    "run_verdict": {},
                 },
             )
         )

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -96,6 +96,7 @@ from mediaforce.tuning.tuning_memory import (
     record_visual_approval_artifact,
     sibling_approved_season_memory,
 )
+from mediaforce.tuning.quality_risk import build_quality_risk_contract, quality_risk_public_view
 from mediaforce.tuning.size_goals import guided_size_goal_options, operator_intent_from_policy
 from mediaforce.core.type_defs import JSONValue, float_value, mapping_dict, object_dict, object_list
 from mediaforce.web.routes import register_completed_routes, register_dashboard_routes, register_folder_routes, \
@@ -580,6 +581,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     )
 
     def _folder_content_payload(normalized_prefix: str) -> tuple[dict[str, Any], int]:
+        latest_failed_sample_job_payload: dict[str, Any] | None = None
         with open_db(config.paths.db_path) as connection:
             calibration_job = _load_job_state(connection, config, normalized_prefix)
             if calibration_job and calibration_job.get("status") in {"queued", "running"}:
@@ -641,6 +643,9 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             encode_candidate_count = _folder_encode_candidate_count(connection, config, normalized_prefix)
             workflow_state = build_folder_workflow_state(connection, normalized_prefix).to_payload()
             series_context = _folder_series_context(normalized_prefix)
+            latest_failed_sample_job_payload = object_dict(
+                _load_latest_failed_sample_job_state(connection, config, normalized_prefix)
+            ) or None
         policy = _folder_display_policy(
             sample_item=sample_item,
             calibration=calibration,
@@ -686,6 +691,33 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             audio_policy=object_dict(policy.get("audio")),
             subtitle_policy=object_dict(policy.get("subtitle")),
         )
+        current_quality_risk_policy = (
+            object_dict(object_dict(calibration).get("policy"))
+            or object_dict(sample_item.get("resolved_policy"))
+            or policy
+        )
+        pending_preview_policy = object_dict(object_dict(pending_proposal_raw).get("preview_policy"))
+        quality_risk_preview_policy = (
+            current_quality_risk_policy
+            if calibration
+            else pending_preview_policy or current_quality_risk_policy
+        )
+        quality_risk_contract = build_quality_risk_contract(
+            prefix=normalized_prefix,
+            sample_item=budget_item,
+            current_policy=current_quality_risk_policy,
+            preview_policy=quality_risk_preview_policy,
+            operator_request=object_dict(object_dict(advice_state).get("operator_request")) or None,
+            calibration=calibration,
+            advice_state=advice_state,
+            latest_failed_sample_job=latest_failed_sample_job_payload,
+            interpretation=object_dict(object_dict(advice_state).get("quality_risk_interpretation")) or None,
+            proposed_policy=(
+                object_dict(object_dict(pending_proposal_raw).get("applied_policy"))
+                if not calibration
+                else None
+            ),
+        )
         resolved_metric, _ = select_quality_metric(str(video_policy.get("quality_metric", "auto")))
         sample_host_statuses = _sample_calibration_host_statuses(config)
         sample_host_key = _default_sample_host_key_from_statuses(sample_host_statuses)
@@ -706,6 +738,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 "resolved_operator_intent": resolved_operator_intent,
                 "stream_budget_ledger": stream_budget.to_payload(),
                 "size_goal_options": size_goal_options,
+                "quality_risk": quality_risk_public_view(quality_risk_contract),
                 "pending_proposal": pending_proposal,
                 "recent_tuning_sessions": recent_sessions,
                 "approved_season_shortcut": approved_season_shortcut,
@@ -838,6 +871,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             tuning_advice_payload=_tuning_advice_payload,
             load_pending_proposal=_load_pending_proposal,
             apply_policy_fragment=_apply_policy_fragment,
+            load_advice_state=_load_advice_state,
             save_advice_state=_save_advice_state,
             save_job_state=_save_job_state,
             clear_pending_proposal=_clear_pending_proposal,

--- a/mediaforce/web/runtime/folder_actions.py
+++ b/mediaforce/web/runtime/folder_actions.py
@@ -18,6 +18,8 @@ from mediaforce.encoding.encode_queue import ACTIVE_ENCODE_JOB_STATUSES, list_ch
 from mediaforce.encoding.staging import safe_unlink
 from mediaforce.library.workflow_state import build_folder_workflow_state
 from mediaforce.library.run_manifests import create_folder_manifest
+from mediaforce.tuning.quality_risk import build_quality_risk_contract
+from mediaforce.tuning.quality_risk import append_quality_risk_record
 from mediaforce.tuning.size_goals import operator_intent_from_policy
 from mediaforce.web.runtime.folder_tuning_helpers import (
     proposal_alignment_issue,
@@ -857,6 +859,25 @@ def save_profile_action(
                 status_code=409,
                 detail="This draft changed after the size tradeoff review. Review the result and confirm approval again.",
             )
+    quality_risk_contract = build_quality_risk_contract(
+        prefix=normalized_prefix,
+        sample_item=object_dict(calibration_payload.get("sample_item")),
+        current_policy=object_dict(calibration_payload.get("policy")),
+        preview_policy=object_dict(calibration_payload.get("policy")),
+        operator_request=operator_request or None,
+        calibration=calibration_payload,
+        advice_state=advice_state,
+    )
+    if bool(object_dict(quality_risk_contract.get("deterministic_gates")).get("blocked")):
+        blocking_reasons = [
+            str(reason)
+            for reason in object_list(object_dict(quality_risk_contract.get("deterministic_gates")).get("blocking_reasons"))
+            if str(reason).strip()
+        ]
+        raise HTTPException(
+            status_code=409,
+            detail=blocking_reasons[0] if blocking_reasons else "Measured review facts still block approval for this sample.",
+        )
     if str(calibration_payload.get("mode") or "sample") == "sample":
         if not calibration_payload.get("review_media_ready"):
             raise HTTPException(
@@ -869,6 +890,11 @@ def save_profile_action(
         calibration_payload["accepted_sample_job_id"] = str(calibration_payload.get("job_id") or "")
         save_calibration_state(config, normalized_prefix, calibration_payload)
         existing_approval = object_dict(advice_state.get("approval_artifact"))
+        approval_artifact = (
+            existing_approval
+            if str(existing_approval.get("sample_job_id") or "") == str(calibration_payload.get("job_id") or "")
+            else None
+        )
         if str(existing_approval.get("sample_job_id") or "") != str(calibration_payload.get("job_id") or ""):
             with open_db(config.paths.db_path) as connection:
                 approval_artifact = record_visual_approval_artifact(
@@ -881,17 +907,40 @@ def save_profile_action(
                     run_verdict=object_dict(advice_state.get("run_verdict")),
                     created_at=str(calibration_payload["accepted_at"]),
                 )
-            if approval_artifact is not None:
-                approval_artifact["sample_job_id"] = str(calibration_payload.get("job_id") or "")
-                merge_advice_state(
-                    config,
-                    normalized_prefix,
-                    {
-                        "approval_artifact": approval_artifact,
-                        "operator_approved_at": calibration_payload["accepted_at"],
-                        "operator_approved_size_tradeoff": bool(size_issue),
-                    },
-                )
+        if approval_artifact is not None:
+            approval_artifact["sample_job_id"] = str(calibration_payload.get("job_id") or "")
+        source_scope = object_dict(quality_risk_contract.get("source_scope"))
+        contract_policy = object_dict(quality_risk_contract.get("policy"))
+        review_tags = [
+            str(object_dict(risk).get("tag") or "")
+            for risk in object_list(quality_risk_contract.get("typed_risks"))
+            if str(object_dict(risk).get("tag") or "").strip()
+        ]
+        quality_risk_state = append_quality_risk_record(
+            advice_state,
+            prefix=normalized_prefix,
+            source_id=str(source_scope.get("source_id") or ""),
+            policy_hash=str(contract_policy.get("preview_policy_hash") or ""),
+            sample_job_id=str(source_scope.get("sample_job_id") or "") or None,
+            kind="post_test",
+            verdict="approved",
+            tags=review_tags or ["other"],
+            details=str(
+                object_dict(advice_state).get("operator_note")
+                or "Operator approved this sample after reviewing the current evidence."
+            ),
+            created_at=str(calibration_payload["accepted_at"]),
+            evidence_ids=[str(value) for value in object_list(source_scope.get("evidence_ids"))],
+            moment_indexes=list(range(1, len(object_list(calibration_payload.get("review_moments"))) + 1)),
+        )
+        advice_patch: ActionPayload = {
+            "operator_approved_at": calibration_payload["accepted_at"],
+            "operator_approved_size_tradeoff": bool(size_issue),
+            "quality_risk_records": object_list(quality_risk_state.get("quality_risk_records")),
+        }
+        if approval_artifact is not None:
+            advice_patch["approval_artifact"] = approval_artifact
+        merge_advice_state(config, normalized_prefix, advice_patch)
     upsert_override(
         config.paths.runtime_settings_path,
         normalized_prefix,

--- a/mediaforce/web/runtime/folder_ai_tuning.py
+++ b/mediaforce/web/runtime/folder_ai_tuning.py
@@ -10,6 +10,14 @@ from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient, open_db
 from mediaforce.core.type_defs import object_dict, object_list
 from mediaforce.execution import resolve_stream_budget_ledger
+from mediaforce.tuning.quality_risk import (
+    append_quality_risk_record,
+    build_quality_risk_contract,
+    normalize_quality_risk_tags,
+    quality_risk_feedback_moment_indexes,
+    quality_risk_public_view,
+    with_quality_risk_intent,
+)
 from mediaforce.tuning.size_goals import operator_intent_from_policy
 from mediaforce.web.runtime.folder_tuning_advice import operator_preserves_source_resolution, operator_request_from_intent
 from mediaforce.web.runtime.folder_tuning_helpers import (
@@ -56,6 +64,7 @@ class FolderAiTuneDeps:
     clear_pending_proposal: Any
     record_tuning_session: Any
     load_latest_failed_sample_job_state: Any | None = None
+    load_advice_state: Any | None = None
 
 
 def _job_sample_item_payload(sample_item: dict[str, Any]) -> dict[str, Any]:
@@ -239,8 +248,11 @@ def _proposal_can_queue(
         preview_policy: dict[str, Any],
         request_disposition: str | None,
         alignment_issue: str | None,
+        quality_risk_contract: dict[str, Any] | None = None,
 ) -> bool:
     if alignment_issue is not None:
+        return False
+    if str(object_dict(quality_risk_contract).get("verdict") or "") == "blocked":
         return False
     disposition = str(request_disposition or "").strip().lower()
     if disposition in NONQUEUEABLE_DISPOSITIONS:
@@ -248,6 +260,18 @@ def _proposal_can_queue(
     if applied_fragment:
         return True
     return bool(preview_policy) and disposition in QUEUEABLE_NO_CHANGE_DISPOSITIONS
+
+
+def _quality_risk_blocking_issue(contract: dict[str, Any] | None) -> str | None:
+    payload = object_dict(contract)
+    if str(payload.get("verdict") or "") != "blocked":
+        return None
+    gates = object_dict(payload.get("deterministic_gates"))
+    blocking_reasons = [str(value).strip() for value in object_list(gates.get("blocking_reasons")) if str(value).strip()]
+    if blocking_reasons:
+        return blocking_reasons[0]
+    effective_record = object_dict(object_dict(payload.get("operator_decision")).get("effective_record"))
+    return str(effective_record.get("details") or "Current quality-risk evidence blocks this sample plan.")
 
 
 def _proposal_ready_message(
@@ -264,6 +288,90 @@ def _proposal_ready_message(
     if can_queue:
         return f"The bench kept the current policy. Confirm when you are ready to rerun the {run_label} unchanged."
     return "The bench did not produce a queueable draft yet. Adjust the note and ask again."
+
+
+def _proposal_quality_risk_contract(
+        *,
+        prefix: str,
+        sample_item: dict[str, Any],
+        current_policy: dict[str, Any],
+        preview_policy: dict[str, Any],
+        operator_request: dict[str, Any] | None,
+        calibration: dict[str, Any] | None,
+        advice_state: dict[str, Any] | None,
+        latest_failed_sample_job: dict[str, Any] | None,
+        interpretation: dict[str, Any] | None = None,
+        proposed_policy: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    contract = build_quality_risk_contract(
+        prefix=prefix,
+        sample_item=sample_item,
+        current_policy=current_policy,
+        preview_policy=preview_policy,
+        operator_request=operator_request,
+        calibration=calibration,
+        advice_state=advice_state,
+        latest_failed_sample_job=latest_failed_sample_job,
+        interpretation=interpretation,
+        proposed_policy=proposed_policy,
+    )
+    contract["public_view"] = quality_risk_public_view(contract)
+    return contract
+
+
+def _persist_quality_risk_feedback(
+        config: MediaforceConfig,
+        deps: FolderAiTuneDeps,
+        *,
+        prefix: str,
+        note: str,
+        sample_item: dict[str, Any],
+        current_policy: dict[str, Any],
+        calibration: dict[str, Any],
+        operator_request: dict[str, Any] | None,
+        latest_failed_sample_job: dict[str, Any] | None,
+) -> dict[str, Any]:
+    request = object_dict(operator_request)
+    tags = normalize_quality_risk_tags(request.get("quality_risk_tags"))
+    authority = str(request.get("evidence_authority") or "none").strip().lower()
+    if tags == ["other"] and authority != "rejected_visual_result":
+        return object_dict(deps.load_advice_state(config, prefix)) if deps.load_advice_state is not None else {}
+    existing_state = (
+        object_dict(deps.load_advice_state(config, prefix))
+        if deps.load_advice_state is not None
+        else {}
+    )
+    contract = build_quality_risk_contract(
+        prefix=prefix,
+        sample_item=sample_item,
+        current_policy=current_policy,
+        preview_policy=current_policy,
+        operator_request=request,
+        calibration=calibration,
+        advice_state=existing_state,
+        latest_failed_sample_job=latest_failed_sample_job,
+    )
+    source_scope = object_dict(contract.get("source_scope"))
+    policy = object_dict(contract.get("policy"))
+    moment_indexes = quality_risk_feedback_moment_indexes(tags, calibration.get("review_moments"))
+    feedback_state = append_quality_risk_record(
+        existing_state,
+        prefix=prefix,
+        source_id=str(source_scope.get("source_id") or ""),
+        policy_hash=str(policy.get("preview_policy_hash") or ""),
+        sample_job_id=str(source_scope.get("sample_job_id") or "") or None,
+        kind="post_test",
+        verdict="rejected" if authority == "rejected_visual_result" else "needs_operator_review",
+        tags=tags,
+        details=str(request.get("quality_risk_details") or note).strip(),
+        created_at=deps.now_iso(),
+        evidence_ids=[str(value) for value in object_list(source_scope.get("evidence_ids"))],
+        moment_indexes=moment_indexes,
+    )
+    feedback_state["operator_note"] = note
+    feedback_state["operator_request"] = request
+    deps.save_advice_state(config, prefix, feedback_state)
+    return feedback_state
 
 
 def _size_budget_measurement_fragment(
@@ -334,19 +442,11 @@ def _operator_request_with_retrieved_memory_authority(
         operator_request: dict[str, Any] | None,
         learning_context: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
+    _ = learning_context
     request = object_dict(operator_request)
     if not request:
         return operator_request
-    authority = str(request.get("evidence_authority") or "none").strip().lower()
-    if authority != "none":
-        return request
-    if not any(
-            str(object_dict(memory).get("evidence_authority") or "none").strip().lower()
-            == "approved_visual_result"
-            for memory in learning_context
-    ):
-        return request
-    return {**request, "evidence_authority": "approved_visual_result"}
+    return request
 
 
 def _blocking_sample_evidence_issue(
@@ -480,6 +580,7 @@ def folder_ai_tune_preview_action(
             sample_item,
             current_policy=current_policy,
         )
+    operator_request = with_quality_risk_intent(operator_request, note=trimmed_note)
     current_operator_intent = operator_intent_from_policy(
         object_dict(current_policy.get("video")),
         default_video_policy=object_dict(config.raw.get("video")),
@@ -584,6 +685,30 @@ def folder_ai_tune_confirm_action(
         legacy_size_issue = _unconfirmed_legacy_size_issue(config, final_policy)
         if legacy_size_issue is not None:
             return {"ok": False, "message": legacy_size_issue}
+        current_advice_state = (
+            object_dict(deps.load_advice_state(config, normalized_prefix))
+            if deps.load_advice_state is not None
+            else {}
+        )
+        confirmation_advice_state = {**current_advice_state, **advice_payload}
+        latest_failed_loader = deps.load_latest_failed_sample_job_state or deps.load_retryable_sample_job_state
+        latest_failed_sample_job = _latest_failed_sample_job_payload(
+            latest_failed_loader(connection, config, normalized_prefix)
+        )
+        confirmation_quality_risk = _proposal_quality_risk_contract(
+            prefix=normalized_prefix,
+            sample_item=sample_item,
+            current_policy=policy_source,
+            preview_policy=final_policy,
+            operator_request=object_dict(pending_proposal.get("operator_request")) or None,
+            calibration=calibration,
+            advice_state=confirmation_advice_state,
+            latest_failed_sample_job=latest_failed_sample_job,
+            proposed_policy=applied_policy,
+        )
+        quality_risk_issue = _quality_risk_blocking_issue(confirmation_quality_risk)
+        if quality_risk_issue is not None:
+            return {"ok": False, "message": quality_risk_issue}
         if advice_payload:
             deps.save_advice_state(config, normalized_prefix, advice_payload)
 
@@ -645,6 +770,7 @@ def folder_ai_tune_confirm_action(
             "host": asdict(host),
             "action": action,
             "notes": operator_note,
+            "quality_risk_contract": confirmation_quality_risk,
             "policy": final_policy,
             "sample_item": _job_sample_item_payload(queued_sample_item),
             "created_at": deps.now_iso(),
@@ -886,11 +1012,25 @@ def _seed_preview_action(
             }
         )
         advice_details = object_dict(advice_payload)
+    quality_risk_contract = _proposal_quality_risk_contract(
+        prefix=normalized_prefix,
+        sample_item=sample_item,
+        current_policy=base_policy,
+        preview_policy=seeded_policy,
+        operator_request=operator_request,
+        calibration=None,
+        advice_state=advice_payload,
+        latest_failed_sample_job=latest_failed_sample_job,
+        proposed_policy=combined_fragment,
+    )
+    if alignment_issue is None:
+        alignment_issue = _quality_risk_blocking_issue(quality_risk_contract)
     can_queue = _proposal_can_queue(
         applied_fragment=combined_fragment,
         preview_policy=seeded_policy,
         request_disposition=advice_details.get("request_disposition"),
         alignment_issue=alignment_issue,
+        quality_risk_contract=quality_risk_contract,
     )
     proposal_message = _proposal_ready_message(
         can_queue=can_queue,
@@ -967,6 +1107,7 @@ def _seed_preview_action(
             ),
         },
     }
+    proposal_payload["quality_risk_contract"] = quality_risk_contract
     deps.save_pending_proposal(config, normalized_prefix, proposal_payload)
     return {
         "ok": True,
@@ -991,6 +1132,17 @@ def _tuned_preview_action(
     if not trimmed_note:
         raise HTTPException(status_code=400, detail="Add a note so the tuner knows what to change before running another sample.")
     current_policy = object_dict(calibration.get("policy")) if calibration else object_dict(sample_item.get("resolved_policy"))
+    quality_risk_feedback_state = _persist_quality_risk_feedback(
+        config,
+        deps,
+        prefix=normalized_prefix,
+        note=trimmed_note,
+        sample_item=sample_item,
+        current_policy=current_policy,
+        calibration=calibration,
+        operator_request=operator_request,
+        latest_failed_sample_job=latest_failed_sample_job,
+    )
     metric_support = deps.metric_support()
     with open_db(config.paths.db_path) as connection:
         learning_context = retrieve_learning_context(
@@ -1106,6 +1258,10 @@ def _tuned_preview_action(
     advice_payload["retrieved_memory"] = learning_context
     if operator_request:
         advice_payload["operator_request"] = operator_request
+    if object_list(quality_risk_feedback_state.get("quality_risk_records")):
+        advice_payload["quality_risk_records"] = object_list(
+            quality_risk_feedback_state.get("quality_risk_records")
+        )
     if combined_fragment:
         advice_payload["applied_policy"] = combined_fragment
     size_target_analysis = object_dict(runtime_toolbelt.get("size_target_analysis"))
@@ -1235,11 +1391,26 @@ def _tuned_preview_action(
                 "applied_policy": combined_fragment,
             }
         )
+    quality_risk_contract = _proposal_quality_risk_contract(
+        prefix=normalized_prefix,
+        sample_item=sample_item,
+        current_policy=current_policy,
+        preview_policy=tuned_policy,
+        operator_request=operator_request,
+        calibration=calibration,
+        advice_state=advice_payload,
+        latest_failed_sample_job=latest_failed_sample_job,
+        interpretation=review_artifact_critique,
+        proposed_policy=combined_fragment,
+    )
+    if alignment_issue is None:
+        alignment_issue = _quality_risk_blocking_issue(quality_risk_contract)
     can_queue = _proposal_can_queue(
         applied_fragment=combined_fragment,
         preview_policy=tuned_policy,
         request_disposition=request_disposition,
         alignment_issue=alignment_issue,
+        quality_risk_contract=quality_risk_contract,
     )
     proposal_message = _proposal_ready_message(
         can_queue=can_queue,
@@ -1326,6 +1497,7 @@ def _tuned_preview_action(
             },
         },
     }
+    tune_proposal_payload["quality_risk_contract"] = quality_risk_contract
     if public_review_pack is not None:
         tune_proposal_payload["multimodal_review_pack"] = public_review_pack
     deps.save_pending_proposal(config, normalized_prefix, tune_proposal_payload)

--- a/mediaforce/web/runtime/folder_state.py
+++ b/mediaforce/web/runtime/folder_state.py
@@ -6,6 +6,7 @@ from typing import Any
 from mediaforce.advisor import AdvisorResponse
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.type_defs import float_value, object_dict, object_list
+from mediaforce.tuning.quality_risk import quality_risk_public_view
 
 
 @dataclass(slots=True)
@@ -281,6 +282,7 @@ def pending_proposal_public_view(deps: FolderStateDeps, payload: dict[str, Any] 
         "operator_signal": payload.get("operator_signal"),
         "evidence_checked": object_list(payload.get("evidence_checked")),
         "multimodal_review_pack": object_dict(payload.get("multimodal_review_pack")) or None,
+        "quality_risk": quality_risk_public_view(object_dict(payload.get("quality_risk_contract"))),
         "trace": deps.pending_proposal_trace_public_view(object_dict(payload.get("trace"))),
     }
 

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -32,6 +32,7 @@ from mediaforce.core.db_tables import item_events
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.db_tables import scan_runs
 from mediaforce.core.db_tables import staged_artifacts
+from mediaforce.core.evidence import stable_policy_hash
 from mediaforce.core.models import ProbeSummary
 from mediaforce.core.process_control import ProcessCancelledError
 from mediaforce.core.type_defs import object_dict, object_list
@@ -5731,8 +5732,33 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             "sample_item": {
                 "library_item_id": 1,
                 "resolved_policy": {"video": {"target_vmaf": 85.0, "max_encoded_percent": 80}},
+                "representative_source_id": "src-show-episode",
+                "source_fingerprint": "fp-show-episode",
+                "cadence_decision": {
+                    "classification": "progressive",
+                    "confidence": 0.98,
+                    "transform": "none",
+                    "evidence_id": "ev1_cadence",
+                },
+                "media_fingerprint_decision": {
+                    "status": "measured",
+                    "confidence": 0.9,
+                    "evidence_id": "ev1_fingerprint",
+                    "findings": [],
+                },
             },
-            "sample_result": {"predicted_total_size_bytes": 376 * 1024 * 1024},
+            "sample_result": {
+                "predicted_total_size_bytes": 376 * 1024 * 1024,
+                "cadence_evidence_id": "ev1_cadence",
+                "media_fingerprint_evidence_id": "ev1_fingerprint",
+            },
+            "review_moments": [
+                {
+                    "timestamp_seconds": 90.0,
+                    "risk_tags": ["high_motion"],
+                    "evidence_id": "ev1_fingerprint",
+                }
+            ],
         }
 
         result = folder_actions_runtime.save_profile_action(
@@ -5765,6 +5791,12 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertTrue(result["queued"])
         self.assertEqual(saved_payloads[0]["accepted_at"], "2026-05-24T04:40:00+00:00")
         self.assertTrue(merged_advice[0]["operator_approved_size_tradeoff"])
+        quality_record = merged_advice[0]["quality_risk_records"][-1]
+        self.assertEqual(quality_record["source_id"], "src-show-episode")
+        self.assertEqual(quality_record["policy_hash"], stable_policy_hash(calibration_payload["policy"]))
+        self.assertEqual(quality_record["sample_job_id"], "sample-1")
+        self.assertEqual(quality_record["evidence_ids"], ["ev1_cadence", "ev1_fingerprint"])
+        self.assertEqual(quality_record["moment_indexes"], [1])
 
     def test_save_profile_action_rejects_stale_size_tradeoff_confirmation_hash(self) -> None:
         calibration_payload: folder_actions_runtime.ActionPayload = {

--- a/tests/test_quality_risk.py
+++ b/tests/test_quality_risk.py
@@ -1,0 +1,422 @@
+import unittest
+from types import SimpleNamespace
+
+from mediaforce.core.evidence import stable_policy_hash
+from mediaforce.tuning.quality_risk import (
+    build_quality_risk_contract,
+    compile_allow_listed_transform_fragment,
+    quality_risk_public_view,
+    with_quality_risk_intent,
+)
+from mediaforce.tuning.target_size_search import build_target_size_transform_plan
+from mediaforce.web.runtime.folder_ai_tuning import _persist_quality_risk_feedback
+
+
+class QualityRiskContractTests(unittest.TestCase):
+    def test_policy_compiler_rejects_unknown_sections_keys_and_invalid_values(self) -> None:
+        base_policy = {
+            "video": {"quality_metric": "vmaf", "target_vmaf": 90.0},
+            "audio": {"keep_languages": ["eng"]},
+            "subtitle": {"keep_languages": ["eng"]},
+        }
+
+        compiled, applied, rejected = compile_allow_listed_transform_fragment(
+            base_policy,
+            {
+                "video": {"quality_metric": "not-a-metric", "target_vmaf": 88.0},
+                "audio": {"keep_languages": ["eng", "jpn"], "replace_layout": "stereo"},
+                "container": {"format": "mp4"},
+            },
+        )
+
+        self.assertEqual(compiled["video"]["target_vmaf"], 88.0)
+        self.assertEqual(compiled["audio"]["keep_languages"], ["eng", "jpn"])
+        self.assertEqual(applied["video"], {"target_vmaf": 88.0, "min_target_vmaf": 88.0})
+        self.assertEqual(
+            rejected,
+            ["audio.replace_layout", "container", "video.quality_metric"],
+        )
+
+    def test_policy_compiler_rejects_out_of_range_and_wrong_typed_values(self) -> None:
+        base_policy = {
+            "video": {"target_vmaf": 90.0, "preset": 8},
+            "audio": {"stereo_opus_bitrate": "128k"},
+            "subtitle": {"keep_languages": ["eng"]},
+        }
+
+        compiled, applied, rejected = compile_allow_listed_transform_fragment(
+            base_policy,
+            {
+                "video": {"target_vmaf": -999, "preset": 99},
+                "audio": {"stereo_opus_bitrate": "-999k"},
+                "subtitle": {"keep_languages": [123]},
+            },
+        )
+
+        self.assertEqual(compiled, base_policy)
+        self.assertEqual(applied, {})
+        self.assertEqual(
+            rejected,
+            [
+                "audio.stereo_opus_bitrate",
+                "subtitle.keep_languages",
+                "video.preset",
+                "video.target_vmaf",
+            ],
+        )
+
+    def test_current_rejection_requires_exact_evidence_policy_source_and_job_binding(self) -> None:
+        policy = {"video": {"target_vmaf": 90.0}}
+        contract = self._contract(
+            policy=policy,
+            records=[
+                self._record(
+                    verdict="approved",
+                    policy_hash=stable_policy_hash(policy),
+                    job_id="job-123",
+                    evidence_ids=["ev1_cadence", "ev1_fingerprint"],
+                    created_at="2026-03-28T00:00:00+00:00",
+                ),
+                self._record(
+                    verdict="rejected",
+                    policy_hash=stable_policy_hash(policy),
+                    job_id="job-123",
+                    evidence_ids=["ev1_cadence", "ev1_fingerprint"],
+                    created_at="2026-03-29T00:00:00+00:00",
+                ),
+            ],
+        )
+
+        public = quality_risk_public_view(contract)
+        assert public is not None
+        self.assertEqual(public["verdict"], "blocked")
+        self.assertEqual(public["operator_decision"]["status"], "rejected")
+        self.assertTrue(public["operator_decision"]["effective_record"]["authoritative"])
+
+    def test_newer_approval_supersedes_older_rejection_for_same_binding(self) -> None:
+        policy = {"video": {"target_vmaf": 90.0}}
+        contract = self._contract(
+            policy=policy,
+            records=[
+                self._record(
+                    verdict="rejected",
+                    policy_hash=stable_policy_hash(policy),
+                    job_id="job-123",
+                    evidence_ids=["ev1_cadence", "ev1_fingerprint"],
+                    created_at="2026-03-28T00:00:00+00:00",
+                ),
+                self._record(
+                    verdict="approved",
+                    policy_hash=stable_policy_hash(policy),
+                    job_id="job-123",
+                    evidence_ids=["ev1_cadence", "ev1_fingerprint"],
+                    created_at="2026-03-29T00:00:00+00:00",
+                ),
+            ],
+        )
+
+        self.assertEqual(contract["operator_decision"]["status"], "approved")
+        self.assertEqual(contract["verdict"], "safe_to_sample")
+
+    def test_missing_current_job_and_stale_evidence_never_gain_authority(self) -> None:
+        policy = {"video": {"target_vmaf": 90.0}}
+        contract = self._contract(
+            policy=policy,
+            job_id=None,
+            records=[
+                self._record(
+                    verdict="approved",
+                    policy_hash=stable_policy_hash(policy),
+                    job_id="job-old",
+                    evidence_ids=["ev1_cadence"],
+                    created_at="2026-03-29T00:00:00+00:00",
+                )
+            ],
+        )
+
+        self.assertEqual(contract["operator_decision"]["status"], "pending")
+        self.assertFalse(contract["operator_decision"]["records"][0]["authoritative"])
+
+    def test_model_interpretation_cannot_replace_operator_approval(self) -> None:
+        contract = self._contract(
+            policy={"video": {"target_vmaf": 90.0}},
+            records=[],
+            interpretation={
+                "summary": "The sample appears safe.",
+                "verdict": "safe_to_sample",
+                "confidence": "high",
+            },
+        )
+
+        self.assertEqual(contract["verdict"], "needs_operator_review")
+
+    def test_target_size_quality_conflict_is_typed_without_exposing_raw_candidates(self) -> None:
+        trace = self._target_size_trace(status="quality_conflict")
+        contract = self._contract(
+            policy={"video": {"target_vmaf": 90.0}},
+            records=[],
+            sample_result={"predicted_encode_percent": 12.0, "target_size_trace": trace},
+        )
+
+        public = quality_risk_public_view(contract)
+        assert public is not None
+        self.assertEqual(public["verdict"], "request_comparison")
+        self.assertEqual(public["target_size_search"]["status"], "quality_conflict")
+        self.assertEqual(public["target_size_search"]["selected_crf"], 31.0)
+        self.assertNotIn("candidates", public["target_size_search"])
+        self.assertIn(
+            "softness_detail_loss",
+            [risk["tag"] for risk in public["typed_risks"]],
+        )
+
+    def test_old_failed_target_trace_does_not_block_newer_successful_calibration(self) -> None:
+        sample = self._sample()
+        sample["stream_budget_ledger"] = {
+            "ledger_id": "ledger-current",
+            "stream_plan": {"plan_id": "plan-current"},
+            "feasibility": {"status": "feasible"},
+        }
+        failed_trace = self._target_size_trace(status="infeasible")
+        failed_trace["ledger"] = {
+            "source_id": "src-house-s2",
+            "ledger_id": "ledger-old",
+            "stream_plan_id": "plan-old",
+        }
+
+        contract = build_quality_risk_contract(
+            prefix="tv/House/Season 2",
+            sample_item=sample,
+            current_policy={"video": {"target_vmaf": 90.0}},
+            preview_policy={"video": {"target_vmaf": 90.0}},
+            calibration={"job_id": "job-current", "sample_result": {}},
+            latest_failed_sample_job={
+                "job_id": "job-old",
+                "result": {"target_size_trace": failed_trace},
+            },
+        )
+
+        self.assertEqual(contract["facts"]["target_size_trace"], {})
+        self.assertNotIn("Old failed search.", contract["deterministic_gates"]["blocking_reasons"])
+
+    def test_current_target_trace_must_match_ledger_stream_plan_and_cadence(self) -> None:
+        sample = self._sample()
+        sample["stream_budget_ledger"] = {
+            "ledger_id": "ledger-current",
+            "stream_plan": {"plan_id": "plan-current"},
+            "feasibility": {"status": "feasible"},
+        }
+        trace = self._target_size_trace(status="selected")
+        trace["ledger"] = {
+            "source_id": "src-house-s2",
+            "ledger_id": "ledger-old",
+            "stream_plan_id": "plan-old",
+        }
+
+        contract = build_quality_risk_contract(
+            prefix="tv/House/Season 2",
+            sample_item=sample,
+            current_policy={"video": {"target_vmaf": 90.0}},
+            preview_policy={"video": {"target_vmaf": 90.0}},
+            calibration={
+                "job_id": "job-current",
+                "sample_result": {"target_size_trace": trace},
+            },
+        )
+
+        reasons = contract["deterministic_gates"]["blocking_reasons"]
+        self.assertIn("The target-size search trace belongs to a different stream-budget ledger.", reasons)
+        self.assertIn("The target-size search trace belongs to a different production stream plan.", reasons)
+
+    def test_operator_concern_examples_become_structured_tags(self) -> None:
+        request = with_quality_risk_intent(
+            None,
+            note="Faces look soft, motion breaks up, preserve the grain, and keep surround audio.",
+        )
+
+        assert request is not None
+        self.assertEqual(
+            request["quality_risk_tags"],
+            [
+                "softness_detail_loss",
+                "motion_breakup",
+                "grain_noise_treatment",
+                "audio_quality_layout",
+            ],
+        )
+
+    def test_rejected_post_test_feedback_is_persisted_with_current_binding(self) -> None:
+        saved_states: list[dict[str, object]] = []
+        policy = {"video": {"target_vmaf": 90.0}}
+        calibration = {
+            "job_id": "job-123",
+            "sample_result": {"predicted_encode_percent": 12.0},
+            "review_moments": [
+                {
+                    "risk_tags": ["high_motion"],
+                    "evidence_id": "ev1_fingerprint",
+                }
+            ],
+        }
+        deps = SimpleNamespace(
+            load_advice_state=lambda *_args: {
+                "quality_risk_records": [
+                    self._record(
+                        verdict="approved",
+                        policy_hash=stable_policy_hash(policy),
+                        job_id="job-123",
+                        evidence_ids=["ev1_cadence", "ev1_fingerprint"],
+                        created_at="2026-03-28T00:00:00+00:00",
+                    )
+                ]
+            },
+            save_advice_state=lambda _config, _prefix, payload: saved_states.append(payload),
+            now_iso=lambda: "2026-03-29T00:00:00+00:00",
+        )
+
+        state = _persist_quality_risk_feedback(
+            object(),
+            deps,
+            prefix="tv/House/Season 2",
+            note="I reject this sample because motion breaks up.",
+            sample_item=self._sample(),
+            current_policy=policy,
+            calibration=calibration,
+            operator_request={
+                "evidence_authority": "rejected_visual_result",
+                "quality_risk_tags": ["motion_breakup"],
+                "quality_risk_details": "Motion breaks up.",
+            },
+            latest_failed_sample_job=None,
+        )
+
+        self.assertEqual(len(saved_states), 1)
+        record = state["quality_risk_records"][-1]
+        self.assertEqual(record["verdict"], "rejected")
+        self.assertEqual(record["source_id"], "src-house-s2")
+        self.assertEqual(record["policy_hash"], stable_policy_hash(policy))
+        self.assertEqual(record["sample_job_id"], "job-123")
+        self.assertEqual(record["evidence_ids"], ["ev1_cadence", "ev1_fingerprint"])
+        self.assertEqual(record["moment_indexes"], [1])
+
+    def _contract(
+            self,
+            *,
+            policy: dict[str, object],
+            records: list[dict[str, object]],
+            job_id: str | None = "job-123",
+            interpretation: dict[str, object] | None = None,
+            sample_result: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        sample = self._sample()
+        calibration: dict[str, object] = {
+            "sample_result": sample_result or {"predicted_encode_percent": 12.0},
+            "review_moments": [
+                {
+                    "timestamp_seconds": 89.0,
+                    "duration_seconds": 8.0,
+                    "role": "hard",
+                    "risk_tags": ["high_motion"],
+                    "rationale": "Compare the motion-heavy range.",
+                    "confidence": 0.88,
+                    "coverage": 0.66,
+                    "evidence_id": "ev1_fingerprint",
+                }
+            ],
+        }
+        if job_id is not None:
+            calibration["job_id"] = job_id
+        return build_quality_risk_contract(
+            prefix="tv/House/Season 2",
+            sample_item=sample,
+            current_policy=policy,
+            preview_policy=policy,
+            calibration=calibration,
+            advice_state={"quality_risk_records": records},
+            interpretation=interpretation,
+        )
+
+    @staticmethod
+    def _sample() -> dict[str, object]:
+        return {
+            "rel_path": "tv/House/Season 2/Episode.mkv",
+            "representative_source_id": "src-house-s2",
+            "source_fingerprint": "fp-1",
+            "stream_budget_ledger": {"feasibility": {"status": "feasible"}},
+            "cadence_decision": {
+                "classification": "progressive",
+                "confidence": 0.98,
+                "transform": "none",
+                "evidence_id": "ev1_cadence",
+            },
+            "media_fingerprint_decision": {
+                "status": "measured",
+                "confidence": 0.88,
+                "evidence_id": "ev1_fingerprint",
+                "findings": [
+                    {
+                        "id": "high_motion",
+                        "confidence": 0.82,
+                        "rationale": "Motion stays elevated in the measured ranges.",
+                    }
+                ],
+            },
+        }
+
+    @staticmethod
+    def _record(
+            *,
+            verdict: str,
+            policy_hash: str,
+            job_id: str,
+            evidence_ids: list[str],
+            created_at: str,
+    ) -> dict[str, object]:
+        return {
+            "kind": "post_test",
+            "verdict": verdict,
+            "tags": ["motion_breakup"],
+            "details": f"{verdict} result.",
+            "prefix": "tv/House/Season 2",
+            "source_id": "src-house-s2",
+            "policy_hash": policy_hash,
+            "sample_job_id": job_id,
+            "evidence_ids": evidence_ids,
+            "moment_indexes": [1],
+            "created_at": created_at,
+        }
+
+    @staticmethod
+    def _target_size_trace(*, status: str) -> dict[str, object]:
+        transform_plan = build_target_size_transform_plan(
+            cadence_evidence_id="ev1_cadence",
+            cadence_class="progressive",
+            cadence_transform="none",
+            video_filter="scale=-2:1080:flags=lanczos",
+        )
+        return {
+            "schema_version": 1,
+            "status": status,
+            "selection_reason": "The size target conflicts with the measured quality floor.",
+            "ledger": {"source_id": "src-house-s2"},
+            "target": {
+                "total_target_bytes": 225_000_000,
+                "sample_lower_bound_bytes": 202_500_000,
+                "sample_upper_bound_bytes": 247_500_000,
+            },
+            "quality_floor": {"metric": "VMAF", "minimum": 85.0},
+            "curve": {"shape": "monotonic", "candidate_count": 4, "max_candidates": 6},
+            "transform_plan": transform_plan,
+            "selected_candidate": {
+                "crf": 31.0,
+                "metric": "VMAF",
+                "metric_score": 84.0,
+                "quality_floor_met": False,
+                "predicted_whole_episode_bytes": 225_000_000,
+                "within_sample_band": True,
+            },
+            "candidates": [{"crf": 31.0}],
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -52,7 +52,9 @@ from mediaforce.core.db_tables import learning_artifacts
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.db_tables import staged_artifacts
 from mediaforce.core.db_tables import tuning_sessions
+from mediaforce.core.evidence import stable_policy_hash
 from mediaforce.core.process_control import ProcessCancelledError
+from mediaforce.core.type_defs import object_dict
 from mediaforce.execution import resolve_stream_budget_ledger
 from mediaforce.hosts.types import HostStatus
 from mediaforce.tuning.tuning_memory import (
@@ -62,6 +64,7 @@ from mediaforce.tuning.tuning_memory import (
     retrieve_learning_context,
     sibling_approved_season_memory,
 )
+from mediaforce.tuning.quality_risk import build_quality_risk_contract, quality_risk_public_view
 from mediaforce.web.app import (
     _advice_file,
     _backfill_multimodal_review_pack,
@@ -587,7 +590,13 @@ class TuningRuntimeTests(unittest.TestCase):
             multimodal_review_pack_public_view=lambda *_args, **_kwargs: None,
             tuning_advice_payload=lambda *_args, **_kwargs: {},
             load_pending_proposal=lambda *_args, **_kwargs: None,
-            apply_policy_fragment=lambda current, fragment: {**current, **fragment},
+            apply_policy_fragment=lambda current, fragment: {
+                **current,
+                "video": {
+                    **object_dict(current.get("video")),
+                    **object_dict(fragment.get("video")),
+                },
+            },
             save_advice_state=lambda *_args, **_kwargs: None,
             save_job_state=lambda _connection, _config, _prefix, payload: saved_jobs.append(dict(payload)),
             clear_pending_proposal=lambda *_args, **_kwargs: None,
@@ -688,7 +697,13 @@ class TuningRuntimeTests(unittest.TestCase):
             multimodal_review_pack_public_view=lambda *_args, **_kwargs: None,
             tuning_advice_payload=lambda *_args, **_kwargs: {},
             load_pending_proposal=lambda *_args, **_kwargs: None,
-            apply_policy_fragment=lambda current, fragment: {**current, **fragment},
+            apply_policy_fragment=lambda current, fragment: {
+                **current,
+                "video": {
+                    **object_dict(current.get("video")),
+                    **object_dict(fragment.get("video")),
+                },
+            },
             save_advice_state=lambda *_args, **_kwargs: None,
             save_job_state=lambda *_args, **_kwargs: None,
             clear_pending_proposal=lambda *_args, **_kwargs: None,
@@ -770,7 +785,13 @@ class TuningRuntimeTests(unittest.TestCase):
             multimodal_review_pack_public_view=lambda *_args, **_kwargs: None,
             tuning_advice_payload=lambda *_args, **_kwargs: {},
             load_pending_proposal=lambda *_args, **_kwargs: None,
-            apply_policy_fragment=lambda current, fragment: {**current, **fragment},
+            apply_policy_fragment=lambda current, fragment: {
+                **current,
+                "video": {
+                    **object_dict(current.get("video")),
+                    **object_dict(fragment.get("video")),
+                },
+            },
             save_advice_state=lambda *_args, **_kwargs: None,
             save_job_state=lambda _connection, _config, _prefix, payload: saved_jobs.append(dict(payload)),
             clear_pending_proposal=lambda *_args, **_kwargs: None,
@@ -4427,7 +4448,7 @@ class TuningRuntimeTests(unittest.TestCase):
 
         self.assertTrue(result["ok"])
         proposal = saved_proposals[0]
-        self.assertTrue(proposal["can_queue"])
+        self.assertTrue(proposal["can_queue"], proposal["quality_risk_contract"])
         expected_fragment = _absolute_size_fragment(225.0, 87.996, preserve_source_resolution=True)
         self.assertEqual(
             proposal["preview_policy"],
@@ -4633,7 +4654,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertTrue(result["ok"])
         proposal = saved_proposals[0]
         expected_fragment = _absolute_size_fragment(225.0, 87.996, preserve_source_resolution=True)
-        self.assertTrue(proposal["can_queue"])
+        self.assertTrue(proposal["can_queue"], proposal["quality_risk_contract"])
         self.assertEqual(proposal["request_disposition"], "honored")
         self.assertTrue(proposal["advice_payload"]["ok"])
         self.assertEqual(proposal["confidence"], "low")
@@ -4868,7 +4889,13 @@ class TuningRuntimeTests(unittest.TestCase):
             multimodal_review_pack_public_view=lambda *_args, **_kwargs: None,
             tuning_advice_payload=lambda *_args, **_kwargs: {},
             load_pending_proposal=lambda *_args, **_kwargs: None,
-            apply_policy_fragment=lambda current, fragment: {**current, **fragment},
+            apply_policy_fragment=lambda current, fragment: {
+                **current,
+                "video": {
+                    **object_dict(current.get("video")),
+                    **object_dict(fragment.get("video")),
+                },
+            },
             save_advice_state=lambda *_args, **_kwargs: None,
             save_job_state=lambda *_args, **_kwargs: None,
             clear_pending_proposal=lambda *_args, **_kwargs: None,
@@ -6509,10 +6536,132 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertTrue(Path(artifact["artifact_path"]).exists())
         self.assertTrue(context)
         self.assertIn("Aggressive but acceptable", context[0]["summary"])
-        self.assertEqual(context[0]["evidence_authority"], "approved_visual_result")
-        self.assertEqual(context[0]["approved_policy"], calibration["policy"])
-        self.assertEqual(context[0]["sample_result"], calibration["sample_result"])
-        self.assertEqual(context[0]["run_verdict"]["summary"], "Aggressive but acceptable for this show.")
+        self.assertEqual(context[0]["evidence_authority"], "none")
+        self.assertEqual(context[0]["approved_policy"], {})
+        self.assertEqual(context[0]["sample_result"], {})
+        self.assertEqual(context[0]["run_verdict"], {})
+
+    def test_retrieve_learning_context_keeps_sibling_approval_non_authoritative(self) -> None:
+        approved_sample_item = {
+            "rel_path": "tv/House/Season 2/Episode.mkv",
+            "video_codec": "h264",
+            "recommendation": "priority_encode",
+            "resolved_policy": {"video": {"quality_metric": "vmaf"}},
+        }
+        with open_db(self.config.paths.db_path) as connection:
+            artifact = record_visual_approval_artifact(
+                connection,
+                self.config,
+                prefix="tv/House/Season 2",
+                note="Looks good after review.",
+                sample_item=approved_sample_item,
+                calibration={
+                    "job_id": "job-house-s2",
+                    "policy": {"video": {"target_vmaf": 88.0}},
+                    "sample_result": {"quality_metric": "VMAF", "quality_score": 89.0},
+                },
+                run_verdict={"summary": "Approved for House season 2."},
+                created_at="2026-03-29T23:45:00+00:00",
+            )
+            context = retrieve_learning_context(
+                connection,
+                prefix="tv/House/Season 3",
+                sample_item={
+                    "rel_path": "tv/House/Season 3/Episode.mkv",
+                    "video_codec": "h264",
+                    "recommendation": "priority_encode",
+                    "resolved_policy": {"video": {"quality_metric": "vmaf"}},
+                },
+                note="Need a smaller approved draft.",
+            )
+
+        self.assertIsNotNone(artifact)
+        self.assertTrue(context)
+        self.assertEqual(context[0]["evidence_authority"], "none")
+        self.assertEqual(context[0]["approved_policy"], {})
+
+    def test_quality_risk_contract_public_view_keeps_current_rejection_authoritative(self) -> None:
+        current_policy = {"video": {"target_vmaf": 90.0}}
+        contract = build_quality_risk_contract(
+            prefix="tv/House/Season 2",
+            sample_item={
+                "rel_path": "tv/House/Season 2/Episode.mkv",
+                "representative_source_id": "src-house-s2",
+                "source_fingerprint": "fp-1",
+                "stream_budget_ledger": {"feasibility": {"status": "feasible"}},
+                "cadence_decision": {
+                    "classification": "progressive",
+                    "confidence": 0.98,
+                    "transform": "none",
+                    "evidence_id": "ev1_cadence",
+                },
+                "media_fingerprint_decision": {
+                    "status": "measured",
+                    "confidence": 0.88,
+                    "evidence_id": "ev1_fingerprint",
+                    "findings": [
+                        {
+                            "id": "high_motion",
+                            "confidence": 0.82,
+                            "rationale": "Motion stays elevated in the measured ranges.",
+                        }
+                    ],
+                },
+            },
+            current_policy=current_policy,
+            preview_policy=current_policy,
+            calibration={
+                "job_id": "job-123",
+                "sample_result": {"predicted_encode_percent": 12.0},
+                "review_moments": [
+                    {
+                        "timestamp_seconds": 89.0,
+                        "duration_seconds": 8.0,
+                        "role": "hard",
+                        "risk_tags": ["high_motion"],
+                        "rationale": "Compare the motion-heavy range.",
+                        "confidence": 0.88,
+                        "coverage": 0.66,
+                        "evidence_id": "ev1_fingerprint",
+                    }
+                ],
+            },
+            advice_state={
+                "quality_risk_records": [
+                    {
+                        "kind": "post_test",
+                        "verdict": "approved",
+                        "tags": ["motion_breakup"],
+                        "details": "Older approval.",
+                        "prefix": "tv/House/Season 2",
+                        "source_id": "src-house-s2",
+                        "policy_hash": "sha256:wrong",
+                        "sample_job_id": "job-old",
+                        "created_at": "2026-03-28T00:00:00+00:00",
+                    },
+                    {
+                        "kind": "post_test",
+                        "verdict": "rejected",
+                        "tags": ["motion_breakup"],
+                        "details": "Current rejection.",
+                        "prefix": "tv/House/Season 2",
+                        "source_id": "src-house-s2",
+                        "policy_hash": stable_policy_hash(current_policy),
+                        "sample_job_id": "job-123",
+                        "evidence_ids": ["ev1_cadence", "ev1_fingerprint"],
+                        "moment_indexes": [1],
+                        "created_at": "2026-03-29T00:00:00+00:00",
+                    },
+                ]
+            },
+        )
+
+        public_view = quality_risk_public_view(contract)
+        assert public_view is not None
+        self.assertEqual(public_view["verdict"], "blocked")
+        self.assertEqual(public_view["operator_decision"]["status"], "rejected")
+        self.assertEqual(public_view["operator_decision"]["effective_record"]["details"], "Current rejection.")
+        self.assertEqual(public_view["pre_test_instruction"]["moments"][0]["evidence_id"], "ev1_fingerprint")
 
     def test_retrieve_learning_context_ignores_unrelated_visual_approval(self) -> None:
         approved_sample_item = {
@@ -6857,6 +7006,20 @@ class TuningRuntimeTests(unittest.TestCase):
             )
         )
 
+    def test_quality_risk_blocker_prevents_sample_queue(self) -> None:
+        self.assertFalse(
+            _proposal_can_queue(
+                applied_fragment={"video": {"target_vmaf": 87.0}},
+                preview_policy={"video": {"target_vmaf": 87.0}},
+                request_disposition="honored",
+                alignment_issue=None,
+                quality_risk_contract={
+                    "verdict": "blocked",
+                    "deterministic_gates": {"blocking_reasons": ["Mixed cadence needs review."]},
+                },
+            )
+        )
+
     def test_proposal_alignment_issue_allows_explicit_combined_metric_target(self) -> None:
         issue = proposal_alignment_issue(
             operator_request={
@@ -7038,7 +7201,7 @@ class TuningRuntimeTests(unittest.TestCase):
 
         self.assertIsNone(issue)
 
-    def test_retrieved_visual_approval_authorizes_alignment_without_overriding_current_rejection(self) -> None:
+    def test_retrieved_visual_approval_remains_context_without_overriding_current_authority(self) -> None:
         request = {
             "request_type": "size_budget",
             "budget_label": "250 MB per episode",
@@ -7052,8 +7215,8 @@ class TuningRuntimeTests(unittest.TestCase):
         )
 
         assert effective_request is not None
-        self.assertEqual(effective_request["evidence_authority"], "approved_visual_result")
-        self.assertIsNone(
+        self.assertEqual(effective_request["evidence_authority"], "none")
+        self.assertIsNotNone(
             proposal_alignment_issue(
                 operator_request=effective_request,
                 request_disposition="honored",


### PR DESCRIPTION
## Summary

- add a versioned facts / deterministic gates / interpretation / operator-decision quality-risk contract
- allow-list and strictly validate policy transforms before sampling, including target-search identity and queue blocking
- persist source-, policy-, job-, evidence-, and moment-bound operator feedback with current rejection precedence
- expose safe typed risk, concern, provenance, and authority details in the season and workstation review surfaces
- document the contract and extend backend/frontend regression coverage

## Validation

- `bash scripts/pre-commit-check.sh` (`757` backend tests plus CLI, frontend check/lint/tests/build, and desktop/narrow browser-route smoke)
- `uv build`
- changed-file Ruff checks
- PyCharm changed-files inspection: green
- real-browser review of review-ready, approved, and blocked-risk fixtures; no raw JSON or machine-local paths exposed
- independent final review: no actionable findings

Closes #162
