### PR TITLE
Route advisor tasks through evaluated Codex Lab models

### DIFF
--- a/config/defaults.toml
+++ b/config/defaults.toml
@@ -97,6 +97,22 @@ missing_english_audio_penalty = -30
 [validation]
 require_size_reduction = true
 
+[advisor]
+command = "codex-lab"
+telemetry_max_records = 5000
+
+[advisor.routes.operator_note_parse]
+models = ["gpt-5.6-luna", "gpt-5.6-terra"]
+
+[advisor.routes.seed_policy]
+models = ["gpt-5.6-terra", "gpt-5.6-sol"]
+
+[advisor.routes.note_tuning]
+models = ["gpt-5.6-terra", "gpt-5.6-sol"]
+
+[advisor.routes.review_artifact_critique]
+models = ["gpt-5.6-terra", "gpt-5.6-sol"]
+
 [planning.codec_bonus]
 h264 = 40
 hevc = 12

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,8 @@ Use this directory for guidance that should not live in `AGENTS.md`.
   non-video overhead, uncertainty, and deterministic size feasibility
 - `docs/architecture/quality-risk-contract.md`: versioned quality-risk facts,
   gates, interpretation, and current review authority
+- `docs/architecture/advisor-routing.md`: evaluated task routing, Codex Lab
+  execution, deterministic bypasses, privacy-safe telemetry, and eval operation
 
 ## Design briefs
 

--- a/docs/architecture/advisor-routing.md
+++ b/docs/architecture/advisor-routing.md
@@ -1,0 +1,150 @@
+# Advisor Routing and Evaluation
+
+Mediaforce routes bounded advisor work by task instead of treating one model as
+a product invariant. The default mapping is checked in, overrideable through
+configuration, and activated only when the media-safe evaluation suite passes.
+
+## Authority boundary
+
+Models may interpret ambiguous language, combine supplied evidence, propose an
+allow-listed policy fragment, and explain tradeoffs. They never become the
+authority for measurements, stream budgets, cadence transforms, target-size
+search, quality floors, or operator approval.
+
+The following paths are deterministic and do not invoke a model:
+
+- explicit operator-note patterns that the local parser can classify safely
+- non-positive video-budget rejection
+- run-verdict summaries derived from typed size and quality results
+- structural tuning self-checks and audio-tradeoff guardrails
+
+If a model request fails, Mediaforce returns a non-queueable operator-visible
+failure. It never accepts unvalidated text as an executable policy.
+
+## Default routes
+
+| Task | Primary | Bounded fallback | Notes |
+| --- | --- | --- | --- |
+| Operator-note parse | `gpt-5.6-luna` | `gpt-5.6-terra` | Used only after deterministic extraction cannot classify the note. This low-risk route cannot reach Sol. |
+| Seed policy | `gpt-5.6-terra` | `gpt-5.6-sol` | Sol is recorded escalation for a failed Terra attempt, not the default. |
+| Note tuning | `gpt-5.6-terra` | `gpt-5.6-sol` | Deterministic policy normalization and review gates remain authoritative. |
+| Review-artifact critique | `gpt-5.6-terra` | `gpt-5.6-sol` | Receives only bounded review artifacts and supplied metadata. |
+
+Routes live under `[advisor.routes]` in `config/defaults.toml`. A local config
+may replace model identifiers or the Codex Lab command without changing code:
+
+```toml
+[advisor]
+command = "codex-lab"
+telemetry_max_records = 5000
+# auth_profile = "mediaforce"
+
+[advisor.routes.operator_note_parse]
+models = ["gpt-5.6-luna", "gpt-5.6-terra"]
+
+[advisor.routes.seed_policy]
+models = ["gpt-5.6-terra", "gpt-5.6-sol"]
+```
+
+Optional `[advisor.model_pricing.<model>]` entries may provide
+`input_usd_per_million`, `cached_input_usd_per_million`, and
+`output_usd_per_million`. Without explicit pricing, telemetry records token
+usage but does not invent a monetary estimate.
+
+The web app resolves this configuration at startup; restart `mediaforce-web`
+after changing command, authentication, route, or pricing settings.
+
+## Codex Lab boundary
+
+The adapter runs `codex-lab exec` with an ephemeral session, ignored user
+configuration and rules, a read-only empty temporary work directory, JSONL
+events, and an output schema for structured tasks. The prompt is sent on stdin.
+
+Review images are copied into the temporary work directory with generic names.
+The original machine-local path is never placed in the command. Mediaforce
+accepts a result only when all of these conditions hold:
+
+- Codex Lab exits successfully
+- a terminal `turn.completed` event is present
+- no tool-use item was emitted
+- the final agent message is present
+- structured tasks return one exact JSON object
+
+Raw non-event output, incomplete turns, tool use, malformed JSON, timeouts, and
+provider failures are rejected. Only provider/model response failures can move
+to the next configured model. Missing local images, unsupported image formats,
+an unavailable command, and local transport failures stop immediately because
+another model cannot repair them. A timeout terminates the complete Codex Lab
+process group so shell shims or provider children cannot continue in the
+background.
+
+`cbusillo/codex-lab#319` tracks a future lightweight structured-request command.
+When that command lands, Mediaforce should replace only this adapter and verify
+the token and latency improvement; routing policy and advisor contracts should
+not change.
+
+## Privacy and retention
+
+Before prompt assembly, Mediaforce removes machine-local path fields, relative
+media names, raw fingerprint envelopes, raw prior responses, and image lists.
+Absolute paths and email addresses embedded in necessary operator text are
+redacted. Images are supplied only as temporary generic copies.
+
+Local advisor telemetry contains task/model/prompt version, status, latency,
+token usage, optional estimated cost, fallback reason, image count, input size,
+and sanitized evidence field names. It does not contain prompts, operator-note
+text, model output, raw frames, audio, image paths, or machine-local media paths.
+The bounded JSONL file is written under the configured web-state directory as
+`advisor-routing.jsonl` and defaults to the most recent 5,000 attempts.
+
+Codex Lab runs with `--ephemeral`, so Mediaforce does not request local session
+persistence. Provider-side request retention is outside Mediaforce and follows
+the policy of the configured Codex Lab authentication/provider account.
+
+## Evaluation gate
+
+Run the checked-in synthetic corpus with the default candidate mapping:
+
+```bash
+uv run python -m mediaforce.advising.evals \
+  --output /tmp/mediaforce-advisor-eval.json
+```
+
+Use `--model <model>` to compare one candidate across every model-backed case,
+or repeat `--case <case-id>` for a bounded subset. The recommended run exercises
+the checked-in primary and bounded fallback route; a model override intentionally
+uses only that candidate so failures are not hidden by fallback. The corpus covers ambiguous
+intent, runtime and absolute sizing, explicit constraint preservation,
+grain/noise, cadence, dark gradients, motion, animation cues, audio priorities,
+measured retries, arithmetic infeasibility, multimodal critique, and
+deterministic outcome summaries. Synthetic review images are generated at run
+time; no runtime media or historical operator text is checked in.
+
+Activation requires a 100% pass rate for the recommended suite. Checks cover
+schema-valid completion, required response fields, explicit constraint
+preservation, forbidden unsupported claims, deterministic bypass results,
+telemetry validity, and usage availability. Latency, token usage, fallback, and
+optional configured cost are reported per case but are not converted into
+invented monetary values. The summary also reports how many cases needed a
+fallback; a nonzero count must be reviewed before changing a primary mapping,
+even when the bounded route still passes.
+
+The report stores check outcomes and aggregate telemetry only. It intentionally
+does not retain prompts, operator notes, model responses, or generated images.
+
+## Activated evaluation
+
+The recommended suite was last verified at `2026-07-12T03:52:19Z` using Codex
+Lab and the checked-in routes. All 11 cases passed, including both deterministic
+cases, and no case required fallback.
+
+| Primary model | Cases | Observed latency | Input tokens | Output tokens |
+| --- | ---: | ---: | ---: | ---: |
+| `gpt-5.6-luna` | 2 | 12.4–13.3 s | 28,446 | 323 |
+| `gpt-5.6-terra` | 5 | 13.4–30.3 s | 85,351 | 2,963 |
+| `gpt-5.6-sol` | 2 | 18.1–23.8 s | 31,965 | 1,008 |
+
+No model pricing was configured, so the report correctly left estimated USD
+cost unset. The roughly 14,000–18,000 input tokens per model-backed case include
+the full Codex Lab exec harness. This validates the current adapter while also
+supporting the lightweight side-channel work tracked in `codex-lab#319`.

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -226,18 +226,31 @@ Guidance:
 
 ### `mediaforce/advising/`
 
-- `models.py`
-  - response dataclasses and constants
+- `policy.py`
+  - structured schemas, policy normalization, and deterministic budget checks
 - `prompts.py`
-  - seed/tune/verdict prompt assembly
-- `schemas.py`
-  - structured response schemas
-- `runner.py`
-  - Code CLI subprocess invocation
-- `parsing.py`
-  - normalization and response shaping
+  - sanitized seed, tune, artifact-critique, and note-parse prompt assembly
+- `privacy.py`
+  - prompt minimization, path/PII redaction, and safe evidence references
+- `routing.py`
+  - typed task routes, defaults, config resolution, and optional model pricing
+- `runtime.py`
+  - isolated Codex Lab execution, JSONL validation, and bounded fallback
+- `telemetry.py`
+  - bounded privacy-safe attempt telemetry and optional cost calculation
+- `evals.py`
+  - media-safe synthetic evaluation corpus, scorer, and CLI
 
 `mediaforce.advisor` remains the stable compatibility wrapper surface.
+
+Guidance:
+
+- Keep model identifiers and fallback order in routing configuration, not in
+  prompts or web handlers.
+- Keep deterministic measurements, constraints, quality-risk gates, and current
+  operator authority outside the model boundary.
+- Do not retain prompts, model output, operator-note text, review media, or
+  machine-local paths in advisor telemetry.
 
 ### `mediaforce/cli.py`
 

--- a/mediaforce/advising/evals.py
+++ b/mediaforce/advising/evals.py
@@ -1,0 +1,638 @@
+import argparse
+import json
+import struct
+import tempfile
+import zlib
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+from mediaforce.advisor import (
+    request_note_tuning,
+    request_operator_note_parse,
+    request_review_artifact_critique,
+    request_run_verdict,
+    request_seed_policy,
+)
+from mediaforce.advising.routing import AdvisorRouting, AdvisorTask, advisor_routing_for_models
+from mediaforce.advising.policy import has_nonpositive_video_budget
+
+
+EVAL_SCHEMA_VERSION = 1
+REQUIRED_PASS_RATE = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisorEvalCase:
+    case_id: str
+    task: AdvisorTask | str
+    model: str | None
+    payload: dict[str, Any]
+    fallback_models: tuple[str, ...] = ()
+    expected_values: tuple[tuple[str, Any], ...] = ()
+    expected_one_of: tuple[tuple[str, tuple[Any, ...]], ...] = ()
+    required_nonempty: tuple[str, ...] = ()
+    forbidden_terms: tuple[str, ...] = ()
+    preserve_surround_audio: bool = False
+
+
+def recommended_eval_cases() -> tuple[AdvisorEvalCase, ...]:
+    base_policy = _base_policy()
+    explicit_size_fragment = {
+        "video": {
+            "size_goal_schema_version": 1,
+            "size_goal_mode": "absolute",
+            "size_goal_source": "operator_note",
+            "sample_projection_tolerance_percent": 10.0,
+            "final_output_tolerance_percent": 5.0,
+            "target_size_bytes": 300_000_000,
+            "target_size_mb": 300.0,
+            "target_runtime_minutes": 45.0,
+        }
+    }
+    requested_size = {
+        "request_type": "size_budget",
+        "operator_confirmed": True,
+        "budget_bytes": 300_000_000,
+        "applied_policy": explicit_size_fragment,
+        "request_text": "Target 300 MB per episode.",
+    }
+    return (
+        AdvisorEvalCase(
+            case_id="luna-note-size-budget",
+            task=AdvisorTask.OPERATOR_NOTE_PARSE,
+            model="gpt-5.6-luna",
+            fallback_models=("gpt-5.6-terra",),
+            payload={"operator_note": "Can you target 300MB per episode?"},
+            expected_values=(
+                ("request_type", "size_budget"),
+                ("operator_confirmed", True),
+                ("size_budget_value", 300),
+                ("size_budget_unit", "mb"),
+            ),
+            required_nonempty=("summary", "reasoning_note"),
+        ),
+        AdvisorEvalCase(
+            case_id="luna-note-exploratory",
+            task=AdvisorTask.OPERATOR_NOTE_PARSE,
+            model="gpt-5.6-luna",
+            fallback_models=("gpt-5.6-terra",),
+            payload={"operator_note": "I want to understand if 300MB per episode is realistic."},
+            expected_values=(("intent_type", "exploratory_question"), ("operator_confirmed", False)),
+            required_nonempty=("summary", "reasoning_note"),
+        ),
+        AdvisorEvalCase(
+            case_id="terra-seed-size-first",
+            task=AdvisorTask.SEED_POLICY,
+            model="gpt-5.6-terra",
+            fallback_models=("gpt-5.6-sol",),
+            payload={
+                "operator_note": "Target 300 MB per episode while keeping source resolution.",
+                "base_policy": base_policy,
+                "requested_experiment": requested_size,
+                "runtime_toolbelt": {"decision_defaults": {"decision_model": "size_first_review"}},
+            },
+            expected_values=(
+                ("ok", True),
+                ("proposed_policy.video.target_size_bytes", 300_000_000),
+                ("request_disposition", "honored"),
+            ),
+            required_nonempty=("summary", "diagnosis", "request_response"),
+        ),
+        AdvisorEvalCase(
+            case_id="terra-seed-content-evidence",
+            task=AdvisorTask.SEED_POLICY,
+            model="gpt-5.6-terra",
+            fallback_models=("gpt-5.6-sol",),
+            payload={
+                "operator_note": (
+                    "Keep source resolution, visible grain, and surround presentation while making a careful "
+                    "smaller first test from the measured content evidence."
+                ),
+                "base_policy": base_policy,
+                "runtime_toolbelt": {
+                    "cadence_decision": {
+                        "status": "measured",
+                        "classification": "mixed",
+                        "confidence": 0.72,
+                        "transform": "none",
+                    },
+                    "media_fingerprint_decision": {
+                        "status": "measured",
+                        "confidence": 0.84,
+                        "traits": [
+                            "likely_film_grain",
+                            "dark_gradient_banding_risk",
+                            "high_motion",
+                            "animation_cues",
+                        ],
+                    },
+                },
+            },
+            expected_values=(("ok", True),),
+            required_nonempty=("summary", "diagnosis", "request_response"),
+            forbidden_terms=("because it is old", "title implies", "genre proves"),
+            preserve_surround_audio=True,
+        ),
+        AdvisorEvalCase(
+            case_id="terra-tune-preserve-surround",
+            task=AdvisorTask.NOTE_TUNING,
+            model="gpt-5.6-terra",
+            fallback_models=("gpt-5.6-sol",),
+            payload={
+                "operator_note": "Faces look soft. Keep the surround audio and try a slightly safer video pass.",
+                "policy": base_policy,
+                "requested_experiment": {
+                    "request_type": "metric_target",
+                    "operator_confirmed": True,
+                    "metric": "vmaf",
+                    "target": 88.0,
+                    "applied_policy": {"video": {"target_vmaf": 88.0}},
+                    "request_text": "Try a VMAF target of 88 and keep surround audio.",
+                },
+                "runtime_toolbelt": {
+                    "audio_tradeoff_hint": {
+                        "policy_key": "surround_5_1_opus_bitrate",
+                        "recommended_seed_action": "hold",
+                        "review_confidence": "low",
+                        "review_risk_summary": "Preserve surround audio unless the operator explicitly trades it.",
+                    }
+                },
+            },
+            expected_values=(
+                ("ok", True),
+                ("proposed_policy.video.target_vmaf", 88.0),
+                ("self_check.source", "deterministic"),
+            ),
+            expected_one_of=(("request_disposition", ("honored", "honored_with_risk")),),
+            required_nonempty=("summary", "diagnosis", "request_response"),
+            preserve_surround_audio=True,
+        ),
+        AdvisorEvalCase(
+            case_id="terra-artifact-critique",
+            task=AdvisorTask.REVIEW_ARTIFACT_CRITIQUE,
+            model="gpt-5.6-terra",
+            fallback_models=("gpt-5.6-sol",),
+            payload=_artifact_payload(),
+            expected_values=(("ok", True),),
+            required_nonempty=("summary", "recommendation"),
+            forbidden_terms=("audio sync damage", "motion breakup was observed"),
+        ),
+        AdvisorEvalCase(
+            case_id="terra-tune-measured-retry",
+            task=AdvisorTask.NOTE_TUNING,
+            model="gpt-5.6-terra",
+            fallback_models=("gpt-5.6-sol",),
+            payload={
+                "operator_note": (
+                    "The measured draft missed the approved size band. Try one smaller measured retry, keep "
+                    "source resolution, and do not spend surround quality."
+                ),
+                "policy": base_policy,
+                "requested_experiment": {
+                    "request_type": "size_budget",
+                    "operator_confirmed": True,
+                    "measured_size_followup": True,
+                    "budget_bytes": 280_000_000,
+                    "applied_policy": {
+                        "video": {
+                            "size_goal_schema_version": 1,
+                            "size_goal_mode": "absolute",
+                            "size_goal_source": "operator_note",
+                            "target_size_bytes": 280_000_000,
+                            "target_size_mb": 280.0,
+                            "target_runtime_minutes": 45.0,
+                            "sample_projection_tolerance_percent": 10.0,
+                            "final_output_tolerance_percent": 5.0,
+                            "resolution_intent_mode": "source",
+                            "resolution_intent_source": "operator",
+                            "max_height": 0,
+                        }
+                    },
+                },
+                "latest_failed_sample_job": {
+                    "status": "failed",
+                    "failure_kind": "target_size_needs_review",
+                    "target_size_verification": {"status": "over_target"},
+                },
+                "runtime_toolbelt": {
+                    "audio_tradeoff_hint": {
+                        "policy_key": "surround_5_1_opus_bitrate",
+                        "leverage": "low",
+                        "recommended_seed_action": "hold",
+                    }
+                },
+            },
+            expected_values=(
+                ("ok", True),
+                ("proposed_policy.video.target_size_bytes", 280_000_000),
+                ("proposed_policy.video.max_height", 0),
+                ("self_check.source", "deterministic"),
+            ),
+            expected_one_of=(("request_disposition", ("honored", "honored_with_risk")),),
+            required_nonempty=("summary", "diagnosis", "request_response"),
+            preserve_surround_audio=True,
+        ),
+        AdvisorEvalCase(
+            case_id="sol-seed-ambiguity",
+            task=AdvisorTask.SEED_POLICY,
+            model="gpt-5.6-sol",
+            payload={
+                "operator_note": "Keep the grain and surround presentation, but make a careful smaller first test.",
+                "base_policy": base_policy,
+                "runtime_toolbelt": {
+                    "media_fingerprint_decision": {
+                        "status": "measured",
+                        "traits": ["likely_film_grain", "dark_gradient_banding_risk"],
+                    }
+                },
+            },
+            expected_values=(("ok", True),),
+            required_nonempty=("summary", "diagnosis", "request_response"),
+            forbidden_terms=("era alone", "title implies"),
+            preserve_surround_audio=True,
+        ),
+        AdvisorEvalCase(
+            case_id="sol-artifact-critique",
+            task=AdvisorTask.REVIEW_ARTIFACT_CRITIQUE,
+            model="gpt-5.6-sol",
+            payload=_artifact_payload(),
+            expected_values=(("ok", True),),
+            required_nonempty=("summary", "recommendation"),
+            forbidden_terms=("audio sync damage", "motion breakup was observed"),
+        ),
+        AdvisorEvalCase(
+            case_id="deterministic-run-verdict",
+            task="run_verdict",
+            model=None,
+            payload={
+                "operator_request": {"request_type": "size_budget", "budget_bytes": 300_000_000},
+                "sample_result": {"quality_score": 88.4, "quality_target": 85.0},
+                "size_target_analysis": {"status": "inside_target_band"},
+            },
+            expected_values=(
+                ("ok", True),
+                ("outcome", "strong_match"),
+                ("confidence", "high"),
+            ),
+            required_nonempty=("summary", "next_step"),
+        ),
+        AdvisorEvalCase(
+            case_id="deterministic-nonpositive-video-budget",
+            task="nonpositive_video_budget",
+            model=None,
+            payload={
+                "requested_experiment": {
+                    "request_type": "size_budget",
+                    "stream_budget_ledger": {
+                        "feasibility": {"status": "arithmetically_infeasible"},
+                        "totals": {"remaining_video_bytes": 0},
+                    },
+                }
+            },
+            expected_values=(("blocked", True), ("source", "deterministic")),
+        ),
+    )
+
+
+def run_recommended_evals(
+        *,
+        project_root: Path,
+        command: str = "codex-lab",
+        model_override: str | None = None,
+        case_ids: set[str] | None = None,
+) -> dict[str, Any]:
+    results: list[dict[str, Any]] = []
+    for case in recommended_eval_cases():
+        if case_ids and case.case_id not in case_ids:
+            continue
+        models = (
+            (model_override,)
+            if case.model is not None and model_override
+            else (case.model, *case.fallback_models) if case.model is not None else ()
+        )
+        results.append(_run_eval_case(case, project_root=project_root, command=command, models=models))
+    passed = sum(1 for result in results if result["passed"])
+    pass_rate = passed / len(results) if results else 0.0
+    fallback_case_count = sum(
+        1
+        for result in results
+        if int(dict(result.get("telemetry") or {}).get("attempt_count") or 0) > 1
+    )
+    return {
+        "schema_version": EVAL_SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "suite": "recommended",
+        "model_override": model_override,
+        "summary": {
+            "case_count": len(results),
+            "passed": passed,
+            "failed": len(results) - passed,
+            "pass_rate": round(pass_rate, 4),
+            "required_pass_rate": REQUIRED_PASS_RATE,
+            "fallback_case_count": fallback_case_count,
+            "all_passed": bool(results) and pass_rate >= REQUIRED_PASS_RATE,
+        },
+        "results": results,
+    }
+
+
+def _run_eval_case(
+        case: AdvisorEvalCase,
+        *,
+        project_root: Path,
+        command: str,
+        models: tuple[str, ...],
+) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="mediaforce-advisor-eval-") as temp_dir:
+        temp_root = Path(temp_dir)
+        payload = json.loads(json.dumps(case.payload))
+        if case.task == AdvisorTask.REVIEW_ARTIFACT_CRITIQUE:
+            image_path = temp_root / "synthetic-review.png"
+            _write_synthetic_review_png(image_path)
+            payload["multimodal_review_pack"]["images"] = [str(image_path)]
+        telemetry_path = temp_root / "telemetry.jsonl"
+        if isinstance(case.task, AdvisorTask):
+            assert models
+            routing = advisor_routing_for_models(
+                {case.task: models},
+                command=command,
+                telemetry_path=telemetry_path,
+            )
+            response = _run_model_case(
+                case.task,
+                project_root=project_root,
+                payload=payload,
+                routing=routing,
+            )
+        elif case.task == "run_verdict":
+            response = request_run_verdict(project_root=project_root, payload=payload)
+        elif case.task == "nonpositive_video_budget":
+            response = {
+                "blocked": has_nonpositive_video_budget(payload.get("requested_experiment")),
+                "source": "deterministic",
+            }
+        else:
+            raise ValueError(f"Unsupported deterministic eval task: {case.task}")
+        public_response = _public_response(response)
+        telemetry = _load_telemetry(telemetry_path)
+    checks = _score_case(case, public_response, telemetry)
+    return {
+        "case_id": case.case_id,
+        "task": case.task.value if isinstance(case.task, AdvisorTask) else case.task,
+        "model": models[0] if models else None,
+        "route_models": list(models),
+        "passed": all(check["passed"] for check in checks),
+        "checks": checks,
+        "telemetry": _telemetry_summary(telemetry),
+    }
+
+
+def _run_model_case(
+        task: AdvisorTask,
+        *,
+        project_root: Path,
+        payload: dict[str, Any],
+        routing: AdvisorRouting,
+) -> Any:
+    if task == AdvisorTask.OPERATOR_NOTE_PARSE:
+        return request_operator_note_parse(project_root=project_root, payload=payload, routing=routing)
+    if task == AdvisorTask.SEED_POLICY:
+        return request_seed_policy(project_root=project_root, payload=payload, routing=routing)
+    if task == AdvisorTask.NOTE_TUNING:
+        return request_note_tuning(project_root=project_root, payload=payload, routing=routing)
+    if task == AdvisorTask.REVIEW_ARTIFACT_CRITIQUE:
+        return request_review_artifact_critique(project_root=project_root, payload=payload, routing=routing)
+    raise ValueError(f"Unsupported eval task: {task.value}")
+
+
+def _public_response(response: Any) -> dict[str, Any]:
+    if response is None:
+        return {}
+    if isinstance(response, dict):
+        return response
+    if is_dataclass(response) and not isinstance(response, type):
+        payload = asdict(response)
+        payload.pop("raw", None)
+        return payload
+    return {}
+
+
+def _score_case(
+        case: AdvisorEvalCase,
+        response: dict[str, Any],
+        telemetry: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    for path, expected in case.expected_values:
+        actual = _path_value(response, path)
+        checks.append(_check(f"expected:{path}", actual == expected, f"expected {expected!r}, received {actual!r}"))
+    for path, expected_values in case.expected_one_of:
+        actual = _path_value(response, path)
+        checks.append(
+            _check(
+                f"expected_one_of:{path}",
+                actual in expected_values,
+                f"expected one of {expected_values!r}, received {actual!r}",
+            )
+        )
+    for path in case.required_nonempty:
+        actual = _path_value(response, path)
+        checks.append(_check(f"nonempty:{path}", bool(actual), f"received {actual!r}"))
+    response_text = json.dumps(response, sort_keys=True).lower()
+    for term in case.forbidden_terms:
+        checks.append(
+            _check(
+                f"forbidden:{term}",
+                term.lower() not in response_text,
+                "forbidden unsupported claim was present",
+            )
+        )
+    if case.preserve_surround_audio:
+        bitrate = _path_value(response, "proposed_policy.audio.surround_5_1_opus_bitrate")
+        checks.append(
+            _check(
+                "preserve:surround_5_1_opus_bitrate",
+                bitrate in {None, "256k"},
+                f"received {bitrate!r}",
+            )
+        )
+    if case.model is not None:
+        checks.append(_check("telemetry:recorded", bool(telemetry), "no telemetry record was produced"))
+        checks.append(
+            _check(
+                "telemetry:valid",
+                bool(telemetry) and bool(telemetry[-1].get("valid")),
+                str(telemetry[-1].get("status") if telemetry else "missing"),
+            )
+        )
+        usage = telemetry[-1].get("usage") if telemetry else {}
+        checks.append(
+            _check(
+                "telemetry:usage",
+                isinstance(usage, dict) and int(usage.get("input_tokens") or 0) > 0,
+                "input token usage was unavailable",
+            )
+        )
+    return checks
+
+
+def _check(name: str, passed: bool, detail: str) -> dict[str, Any]:
+    return {"name": name, "passed": passed, "detail": "" if passed else detail}
+
+
+def _path_value(payload: dict[str, Any], path: str) -> Any:
+    value: Any = payload
+    for segment in path.split("."):
+        if not isinstance(value, dict):
+            return None
+        value = value.get(segment)
+    return value
+
+
+def _load_telemetry(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _telemetry_summary(records: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "attempt_count": len(records),
+        "models": [record.get("model") for record in records],
+        "statuses": [record.get("status") for record in records],
+        "latency_ms": sum(int(record.get("latency_ms") or 0) for record in records),
+        "usage": {
+            key: sum(int(dict(record.get("usage") or {}).get(key) or 0) for record in records)
+            for key in ("input_tokens", "cached_input_tokens", "output_tokens", "reasoning_output_tokens")
+        },
+        "estimated_cost_usd": (
+            round(sum(float(record.get("estimated_cost_usd") or 0) for record in records), 8)
+            if records and all(record.get("estimated_cost_usd") is not None for record in records)
+            else None
+        ),
+    }
+
+
+def _base_policy() -> dict[str, Any]:
+    return {
+        "video": {
+            "encoder": "libsvtav1",
+            "pixel_format": "yuv420p10le",
+            "preset": 4,
+            "quality_metric": "vmaf",
+            "target_vmaf": 85.0,
+            "min_target_vmaf": 80.0,
+            "target_xpsnr": 39.0,
+            "min_target_xpsnr": 35.0,
+            "sample_every": "8m",
+            "sample_duration": "20s",
+            "min_crf": 18,
+            "max_crf": 38,
+            "max_encoded_percent": 80,
+            "target_size_bytes": 300_000_000,
+            "target_size_mb": 300.0,
+            "target_runtime_minutes": 45.0,
+            "size_goal_schema_version": 1,
+            "size_goal_mode": "normalized",
+            "size_goal_source": "eval_fixture",
+            "sample_projection_tolerance_percent": 10.0,
+            "final_output_tolerance_percent": 5.0,
+            "default_grain": 8,
+            "grain_denoise": 0,
+            "max_height": 0,
+            "resolution_intent_mode": "source",
+            "resolution_intent_source": "eval_fixture",
+        },
+        "audio": {
+            "keep_languages": ["eng"],
+            "copy_codecs": ["aac", "opus"],
+            "convert_to_opus_codecs": ["ac3", "eac3", "dts", "truehd"],
+            "stereo_opus_bitrate": "128k",
+            "surround_5_1_opus_bitrate": "256k",
+            "surround_7_1_opus_bitrate": "320k",
+        },
+        "subtitle": {
+            "keep_languages": ["eng"],
+            "prefer_text": True,
+            "keep_forced": True,
+            "default_mode": "first_english",
+        },
+    }
+
+
+def _artifact_payload() -> dict[str, Any]:
+    return {
+        "operator_note": "Compare the synthetic dark gradient and edge detail without inferring motion or audio.",
+        "runtime_toolbelt": {
+            "review_media_context": {
+                "review_media_ready": True,
+                "moment_count": 1,
+                "evidence_scope": "synthetic_fixture",
+            }
+        },
+        "multimodal_review_pack": {
+            "artifacts": [
+                {
+                    "label": "Synthetic dark gradient",
+                    "detail": "Top half is the source-style reference; bottom half is the encoded-style reference.",
+                }
+            ],
+            "images": [],
+        },
+    }
+
+
+def _write_synthetic_review_png(path: Path) -> None:
+    width = 96
+    height = 64
+    rows = bytearray()
+    for y in range(height):
+        rows.append(0)
+        for x in range(width):
+            smooth_gradient = int(12 + (x / max(1, width - 1)) * 80)
+            reference_half = y < height // 2
+            gradient = smooth_gradient if reference_half else (smooth_gradient // 8) * 8
+            edge = (55 if reference_half else 34) if x in {31, 32, 63, 64} else 0
+            checker_strength = 14 if reference_half else 6
+            checker = checker_strength if (x // 8 + y // 8) % 2 == 0 else 0
+            rows.extend((min(255, gradient + edge + checker), gradient, min(255, gradient + checker)))
+    signature = b"\x89PNG\r\n\x1a\n"
+    path.write_bytes(
+        signature
+        + _png_chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+        + _png_chunk(b"IDAT", zlib.compress(bytes(rows), level=9))
+        + _png_chunk(b"IEND", b"")
+    )
+
+
+def _png_chunk(kind: bytes, payload: bytes) -> bytes:
+    return struct.pack(">I", len(payload)) + kind + payload + struct.pack(">I", zlib.crc32(kind + payload) & 0xFFFFFFFF)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the media-safe Mediaforce advisor evaluation suite.")
+    parser.add_argument("--project-root", type=Path, default=Path.cwd())
+    parser.add_argument("--command", default="codex-lab")
+    parser.add_argument("--model", dest="model_override")
+    parser.add_argument("--case", action="append", dest="case_ids")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args(argv)
+    report = run_recommended_evals(
+        project_root=args.project_root.resolve(),
+        command=args.command,
+        model_override=args.model_override,
+        case_ids=set(args.case_ids or []),
+    )
+    serialized = json.dumps(report, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(f"{serialized}\n")
+    else:
+        print(serialized)
+    return 0 if report["summary"]["all_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mediaforce/advising/policy.py
+++ b/mediaforce/advising/policy.py
@@ -56,46 +56,6 @@ def _advice_response_schema(policy_schema: dict[str, Any], *, request_dispositio
     }
 
 
-def tune_self_check_schema() -> dict[str, Any]:
-    return {
-        "type": "object",
-        "additionalProperties": False,
-        "required": ["status", "summary", "issues", "surround_audio_guardrail"],
-        "properties": {
-            "status": {"type": "string", "enum": ["pass", "warn", "fail"]},
-            "summary": {"type": "string"},
-            "issues": {"type": "array", "items": {"type": "string"}},
-            "surround_audio_guardrail": {
-                "type": "object",
-                "additionalProperties": False,
-                "required": ["status", "reason"],
-                "properties": {
-                    "status": {"type": "string", "enum": ["ok", "prefer_preserve_current"]},
-                    "reason": {"type": "string"},
-                },
-            },
-        },
-    }
-
-
-def run_verdict_schema() -> dict[str, Any]:
-    return {
-        "type": "object",
-        "additionalProperties": False,
-        "required": ["summary", "outcome", "confidence", "next_step", "evidence_checked"],
-        "properties": {
-            "summary": {"type": "string"},
-            "outcome": {
-                "type": "string",
-                "enum": ["strong_match", "acceptable_experiment", "needs_review", "poor_fit"],
-            },
-            "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
-            "next_step": {"type": ["string", "null"]},
-            "evidence_checked": {"type": "array", "items": {"type": "string"}},
-        },
-    }
-
-
 def review_artifact_critique_schema() -> dict[str, Any]:
     return {
         "type": "object",
@@ -223,22 +183,6 @@ def try_load_json(raw: str) -> JSONValue:
         return json.loads(raw)
     except json.JSONDecodeError:
         return None
-
-
-def try_load_first_json_object(raw: str) -> JSONValue:
-    decoder = json.JSONDecoder()
-    candidate = raw.lstrip()
-    while candidate:
-        try:
-            parsed, _ = decoder.raw_decode(candidate)
-        except json.JSONDecodeError:
-            next_start = candidate.find("{", 1)
-            if next_start == -1:
-                return None
-            candidate = candidate[next_start:]
-            continue
-        return parsed
-    return None
 
 
 def policy_key_paths(policy: dict[str, Any]) -> list[str]:

--- a/mediaforce/advising/privacy.py
+++ b/mediaforce/advising/privacy.py
@@ -1,0 +1,100 @@
+import re
+from typing import Any
+
+
+_PRIVATE_KEYS = frozenset(
+    {
+        "artifact_path",
+        "file_name",
+        "images",
+        "library_item_id",
+        "manifest_path",
+        "media_fingerprint",
+        "output_path",
+        "parent_dir",
+        "raw",
+        "rel_path",
+        "review_dir",
+        "seed_raw_response",
+        "source_path",
+        "staging_path",
+    }
+)
+_PRIVATE_SUFFIXES = ("_path", "_paths")
+_FILE_URI_RE = re.compile(r"file://[^\s\"']+", re.IGNORECASE)
+_UNIX_PATH_RE = re.compile(
+    r"(?<![\w.])/(?:Users|Volumes|home|private|tmp|var/folders)/[^\s\"']+",
+    re.IGNORECASE,
+)
+_WINDOWS_PATH_RE = re.compile(r"\b[A-Za-z]:\\[^\s\"']+")
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_PRIVATE_REFERENCE_KEYS = frozenset(
+    {
+        "diagnosis",
+        "folder",
+        "message",
+        "note",
+        "operator_note",
+        "reasoning_note",
+        "request_response",
+        "request_text",
+        "summary",
+    }
+)
+
+
+def sanitize_advisor_payload(value: Any) -> Any:
+    if isinstance(value, dict):
+        sanitized: dict[str, Any] = {}
+        for raw_key, item in value.items():
+            key = str(raw_key)
+            lowered = key.lower()
+            if lowered == "images":
+                sanitized["image_count"] = len(item) if isinstance(item, list) else 0
+                continue
+            if lowered in _PRIVATE_KEYS or lowered.endswith(_PRIVATE_SUFFIXES):
+                continue
+            sanitized[key] = sanitize_advisor_payload(item)
+        return sanitized
+    if isinstance(value, list):
+        return [sanitize_advisor_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return [sanitize_advisor_payload(item) for item in value]
+    if isinstance(value, str):
+        return redact_sensitive_text(value)
+    return value
+
+
+def redact_sensitive_text(value: str, *, limit: int | None = None) -> str:
+    text = _FILE_URI_RE.sub("[redacted-path]", value)
+    text = _UNIX_PATH_RE.sub("[redacted-path]", text)
+    text = _WINDOWS_PATH_RE.sub("[redacted-path]", text)
+    text = _EMAIL_RE.sub("[redacted-email]", text)
+    if limit is not None and len(text) > limit:
+        return f"{text[:limit].rstrip()}..."
+    return text
+
+
+def advisor_evidence_references(payload: dict[str, Any]) -> list[str]:
+    references: list[str] = []
+    _collect_evidence_references(sanitize_advisor_payload(payload), prefix="", references=references)
+    return references[:64]
+
+
+def _collect_evidence_references(value: Any, *, prefix: str, references: list[str]) -> None:
+    if len(references) >= 64:
+        return
+    if isinstance(value, dict):
+        for raw_key, item in value.items():
+            key = str(raw_key)
+            if key.lower() in _PRIVATE_REFERENCE_KEYS:
+                continue
+            path = f"{prefix}.{key}" if prefix else key
+            _collect_evidence_references(item, prefix=path, references=references)
+        return
+    if isinstance(value, list):
+        if value and prefix and prefix not in references:
+            references.append(prefix)
+        return
+    if value is not None and value != "" and prefix and prefix not in references:
+        references.append(prefix)

--- a/mediaforce/advising/prompts.py
+++ b/mediaforce/advising/prompts.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Callable
 
+from mediaforce.advising.privacy import sanitize_advisor_payload
 from mediaforce.core.type_defs import object_dict, object_list
 
 
@@ -30,26 +31,13 @@ def _audio_tradeoff_key_copy(hint: dict[str, Any] | None) -> str:
     return policy_key or "the hinted audio bitrate"
 
 
-def build_prompt(payload: dict[str, Any]) -> str:
-    serialized = json.dumps(payload, indent=2, sort_keys=True)
-    return (
-        "You are advising a personal media re-encoding calibration workflow. "
-        "Bias slightly toward smaller files, but do not recommend obvious quality damage. "
-        f"{AV1_EVIDENCE_PRECEDENCE}"
-        "Return short markdown with these sections exactly: "
-        "Recommendation, Why, Setting changes, Audio/Subtitles notes. "
-        "Use plain language for a human reviewing TV encodes. Here is the calibration context:\n\n"
-        f"{serialized}"
-    )
-
-
 def build_seed_prompt(
         payload: dict[str, Any],
         *,
         policy_key_paths: Callable[[dict[str, Any]], list[str]],
         policy_shape_example: Callable[[dict[str, Any]], dict[str, Any]],
 ) -> str:
-    serialized = json.dumps(payload, indent=2, sort_keys=True)
+    serialized = json.dumps(sanitize_advisor_payload(payload), indent=2, sort_keys=True)
     base_policy = object_dict(payload.get("base_policy"))
     hinted_audio_key = _audio_tradeoff_key_copy(object_dict(payload.get("audio_tradeoff_hint")))
     valid_keys = policy_key_paths(base_policy)
@@ -98,7 +86,7 @@ def build_tune_prompt(
     review_pack = object_dict(prompt_payload.get("multimodal_review_pack"))
     if review_pack:
         prompt_payload["multimodal_review_pack"] = _summarize_multimodal_review_pack(review_pack)
-    serialized = json.dumps(prompt_payload, indent=2, sort_keys=True)
+    serialized = json.dumps(sanitize_advisor_payload(prompt_payload), indent=2, sort_keys=True)
     current_policy = object_dict(payload.get("policy"))
     hinted_audio_key = _audio_tradeoff_key_copy(
         object_dict(object_dict(payload.get("runtime_toolbelt")).get("audio_tradeoff_hint"))
@@ -149,7 +137,7 @@ def build_review_artifact_critique_prompt(payload: dict[str, Any]) -> str:
     review_pack = object_dict(prompt_payload.get("multimodal_review_pack"))
     if review_pack:
         prompt_payload["multimodal_review_pack"] = _summarize_multimodal_review_pack(review_pack)
-    serialized = json.dumps(prompt_payload, indent=2, sort_keys=True)
+    serialized = json.dumps(sanitize_advisor_payload(prompt_payload), indent=2, sort_keys=True)
     return (
         "You are reviewing source-versus-draft media artifacts extracted from actual sampled review clips. "
         "Use the attached images as visual evidence from the real clips, but never claim to watch motion or hear audio beyond what those artifacts can support. "
@@ -163,24 +151,8 @@ def build_review_artifact_critique_prompt(payload: dict[str, Any]) -> str:
     )
 
 
-def build_run_verdict_prompt(payload: dict[str, Any]) -> str:
-    serialized = json.dumps(payload, indent=2, sort_keys=True)
-    return (
-        "You are GPT-5.4 summarizing a completed media encode calibration run for a human operator. "
-        "The run is already measured by deterministic tools; do not invent metrics. "
-        f"{AV1_EVIDENCE_PRECEDENCE}"
-        "If the operator requested an explicit experiment, judge the outcome against that request instead of generic conservative defaults. "
-        "When size_target_analysis is present, use its status and target band directly: inside_target_band means the size request is satisfied, under_target means the run is smaller than requested without implying quality damage, and over_target means another measured sample may be needed if the operator still wants that size. "
-        "Keep the answer short, practical, and honest about risk. "
-        "Return valid JSON only with this exact shape: "
-        '{"summary":"short verdict","outcome":"strong_match|acceptable_experiment|needs_review|poor_fit","confidence":"high|medium|low","next_step":"optional short suggestion","evidence_checked":["..."]}. '
-        "Here is the completed calibration context:\n\n"
-        f"{serialized}"
-    )
-
-
 def build_operator_note_parse_prompt(payload: dict[str, Any]) -> str:
-    serialized = json.dumps(payload, indent=2, sort_keys=True)
+    serialized = json.dumps(sanitize_advisor_payload(payload), indent=2, sort_keys=True)
     return (
         "You are classifying a media encode operator note before policy compilation. "
         "Decide whether the note is a direct request to execute now, an exploratory question, approval feedback, or something else. "

--- a/mediaforce/advising/routing.py
+++ b/mediaforce/advising/routing.py
@@ -1,0 +1,137 @@
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Mapping
+
+from mediaforce.core.config import MediaforceConfig
+from mediaforce.core.type_defs import int_value, object_dict, object_list
+
+
+class AdvisorTask(StrEnum):
+    SEED_POLICY = "seed_policy"
+    NOTE_TUNING = "note_tuning"
+    REVIEW_ARTIFACT_CRITIQUE = "review_artifact_critique"
+    OPERATOR_NOTE_PARSE = "operator_note_parse"
+
+
+DEFAULT_ADVISOR_MODELS: Mapping[AdvisorTask, tuple[str, ...]] = {
+    AdvisorTask.SEED_POLICY: ("gpt-5.6-terra", "gpt-5.6-sol"),
+    AdvisorTask.NOTE_TUNING: ("gpt-5.6-terra", "gpt-5.6-sol"),
+    AdvisorTask.REVIEW_ARTIFACT_CRITIQUE: ("gpt-5.6-terra", "gpt-5.6-sol"),
+    AdvisorTask.OPERATOR_NOTE_PARSE: ("gpt-5.6-luna", "gpt-5.6-terra"),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisorModelPricing:
+    input_usd_per_million: float | None = None
+    cached_input_usd_per_million: float | None = None
+    output_usd_per_million: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisorRoute:
+    task: AdvisorTask
+    models: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AdvisorRouting:
+    command: str
+    routes: Mapping[AdvisorTask, AdvisorRoute]
+    auth_profile: str | None = None
+    telemetry_path: Path | None = None
+    telemetry_max_records: int = 5000
+    model_pricing: Mapping[str, AdvisorModelPricing] | None = None
+
+    def route_for(self, task: AdvisorTask) -> AdvisorRoute:
+        route = self.routes.get(task)
+        if route is not None and route.models:
+            return route
+        return AdvisorRoute(task=task, models=DEFAULT_ADVISOR_MODELS[task])
+
+    def pricing_for(self, model: str) -> AdvisorModelPricing | None:
+        return (self.model_pricing or {}).get(model)
+
+
+def default_advisor_routing(*, telemetry_path: Path | None = None) -> AdvisorRouting:
+    return AdvisorRouting(
+        command="codex-lab",
+        routes={
+            task: AdvisorRoute(task=task, models=models)
+            for task, models in DEFAULT_ADVISOR_MODELS.items()
+        },
+        telemetry_path=telemetry_path,
+    )
+
+
+def advisor_routing_from_config(config: MediaforceConfig) -> AdvisorRouting:
+    raw = object_dict(config.raw.get("advisor"))
+    command = str(raw.get("command") or "codex-lab").strip() or "codex-lab"
+    route_payloads = object_dict(raw.get("routes"))
+    routes: dict[AdvisorTask, AdvisorRoute] = {}
+    for task, default_models in DEFAULT_ADVISOR_MODELS.items():
+        route_payload = object_dict(route_payloads.get(task.value))
+        models = _model_list(route_payload.get("models")) or default_models
+        routes[task] = AdvisorRoute(task=task, models=models)
+    telemetry_max_records = max(100, int_value(raw.get("telemetry_max_records")) or 5000)
+    return AdvisorRouting(
+        command=command,
+        routes=routes,
+        auth_profile=str(raw.get("auth_profile") or "").strip() or None,
+        telemetry_path=config.paths.web_state_dir / "advisor-routing.jsonl",
+        telemetry_max_records=telemetry_max_records,
+        model_pricing=_model_pricing(raw.get("model_pricing")),
+    )
+
+
+def advisor_routing_for_models(
+        task_models: Mapping[AdvisorTask, tuple[str, ...]],
+        *,
+        command: str = "codex-lab",
+        auth_profile: str | None = None,
+        telemetry_path: Path | None = None,
+        model_pricing: Mapping[str, AdvisorModelPricing] | None = None,
+) -> AdvisorRouting:
+    routes = {
+        task: AdvisorRoute(task=task, models=task_models.get(task) or default_models)
+        for task, default_models in DEFAULT_ADVISOR_MODELS.items()
+    }
+    return AdvisorRouting(
+        command=command,
+        routes=routes,
+        auth_profile=auth_profile,
+        telemetry_path=telemetry_path,
+        model_pricing=model_pricing,
+    )
+
+
+def _model_list(value: Any) -> tuple[str, ...]:
+    values = object_list(value) if isinstance(value, list) else [value] if isinstance(value, str) else []
+    models: list[str] = []
+    for item in values:
+        model = str(item or "").strip()
+        if model and model not in models:
+            models.append(model)
+    return tuple(models)
+
+
+def _model_pricing(value: Any) -> dict[str, AdvisorModelPricing]:
+    pricing: dict[str, AdvisorModelPricing] = {}
+    for model, raw_payload in object_dict(value).items():
+        payload = object_dict(raw_payload)
+        pricing[str(model)] = AdvisorModelPricing(
+            input_usd_per_million=_optional_nonnegative_float(payload.get("input_usd_per_million")),
+            cached_input_usd_per_million=_optional_nonnegative_float(
+                payload.get("cached_input_usd_per_million")
+            ),
+            output_usd_per_million=_optional_nonnegative_float(payload.get("output_usd_per_million")),
+        )
+    return pricing
+
+
+def _optional_nonnegative_float(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    number = float(value)
+    return number if number >= 0 else None

--- a/mediaforce/advising/runtime.py
+++ b/mediaforce/advising/runtime.py
@@ -1,9 +1,31 @@
+import json
+import os
+import signal
+import shutil
 import subprocess
 import tempfile
-import json
+import time
+import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Mapping
+
+from mediaforce.advising.privacy import redact_sensitive_text
+from mediaforce.advising.routing import AdvisorRouting, AdvisorTask, default_advisor_routing
+from mediaforce.advising.telemetry import append_advisor_telemetry, estimated_cost_usd
+
+
+_FALLBACK_STATUSES = frozenset(
+    {
+        "empty_response",
+        "incomplete_turn",
+        "invalid_structured_output",
+        "provider_error",
+        "timeout",
+        "tool_use_rejected",
+    }
+)
 
 
 @dataclass(slots=True)
@@ -15,12 +37,70 @@ class StructuredLLMFailure:
         return "\n".join(self.attempts)
 
 
+@dataclass(slots=True)
+class _CodexLabAttempt:
+    status: str
+    text: str
+    payload: dict[str, Any] | None
+    diagnostic: str
+    latency_ms: int
+    usage: dict[str, int]
+
+
+def run_codex_lab_process(
+        cmd: list[str],
+        *,
+        input: str,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+        cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    if not capture_output or not text:
+        raise ValueError("Codex Lab execution requires captured text output.")
+    process = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        cwd=cwd,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(input=input, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        stdout, stderr = _terminate_process_group(process)
+        raise subprocess.TimeoutExpired(
+            cmd=cmd,
+            timeout=timeout,
+            output=stdout,
+            stderr=stderr,
+        ) from exc
+    except BaseException:
+        _terminate_process_group(process)
+        raise
+    return subprocess.CompletedProcess(cmd, process.returncode, stdout, stderr)
+
+
+def _terminate_process_group(process: subprocess.Popen[str]) -> tuple[str, str]:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        return process.communicate(timeout=2)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        return process.communicate()
+
+
 def _trim_diagnostic(value: Any, *, limit: int = 1200) -> str:
     text = value.decode(errors="replace") if isinstance(value, bytes) else str(value or "")
-    text = text.strip()
-    if len(text) <= limit:
-        return text
-    return f"{text[:limit].rstrip()}..."
+    return redact_sensitive_text(text.strip(), limit=limit)
 
 
 def _attempt_diagnostic(attempt: int, message: str, detail: Any = None) -> str:
@@ -30,55 +110,6 @@ def _attempt_diagnostic(attempt: int, message: str, detail: Any = None) -> str:
     return f"attempt {attempt}: {message}"
 
 
-def run_code_prompt(
-        *,
-        project_root: Path,
-        prompt: str,
-        max_seconds: int,
-        advisor_model: str,
-        memory_disabled_code_args: Callable[[], list[str]],
-        advisor_response_factory: Callable[..., Any],
-        subprocess_run: Callable[..., Any],
-) -> Any:
-    with tempfile.NamedTemporaryFile(prefix="mediaforce-advice-", suffix=".txt", delete=False) as handle:
-        output_path = Path(handle.name)
-    cmd = [
-        "code",
-        *memory_disabled_code_args(),
-        "exec",
-        "--model",
-        advisor_model,
-        "--sandbox",
-        "danger-full-access",
-        "--skip-git-repo-check",
-        "--max-seconds",
-        str(max_seconds),
-        "--output-last-message",
-        str(output_path),
-        "-C",
-        str(project_root),
-        prompt,
-    ]
-    try:
-        result = subprocess_run(cmd, capture_output=True, text=True, timeout=75)
-    except FileNotFoundError as exc:
-        return advisor_response_factory(ok=False, summary="`code` is required but not installed.", raw=str(exc))
-    except (OSError, subprocess.SubprocessError) as exc:
-        return advisor_response_factory(ok=False, summary="`code` failed to run.", raw=str(exc))
-
-    try:
-        raw = output_path.read_text().strip()
-    finally:
-        output_path.unlink(missing_ok=True)
-
-    if result.returncode != 0 and not raw:
-        message = result.stderr.strip() or result.stdout.strip() or "Unknown `code` failure"
-        return advisor_response_factory(ok=False, summary="GPT recommendation failed.", raw=message)
-
-    summary = raw.splitlines()[0] if raw else "No recommendation returned."
-    return advisor_response_factory(ok=bool(raw), summary=summary, raw=raw or (result.stderr.strip() or result.stdout.strip()))
-
-
 def run_structured_llm_request(
         *,
         project_root: Path,
@@ -86,54 +117,53 @@ def run_structured_llm_request(
         message: str,
         schema: dict[str, Any],
         max_seconds: int,
-        advisor_model: str,
-        memory_disabled_code_args: Callable[[], list[str]],
+        task: AdvisorTask,
+        prompt_version: str,
+        routing: AdvisorRouting | None,
+        evidence_references: list[str],
         subprocess_run: Callable[..., Any],
         try_load_json: Callable[[str], Any],
-        try_load_first_json_object: Callable[[str], Any],
+        images: list[str] | None = None,
 ) -> dict[str, Any] | StructuredLLMFailure | None:
-    cmd = [
-        "code",
-        *memory_disabled_code_args(),
-        "llm",
-        "request",
-        "--model",
-        advisor_model,
-        "--developer",
-        developer,
-        "--message",
-        message,
-        "--format-name",
-        "mediaforce_tuning",
-        "--schema-json",
-        __import__("json").dumps(schema, sort_keys=True),
-        "--format-strict",
-    ]
+    resolved_routing = routing or default_advisor_routing()
+    request_id = uuid.uuid4().hex
     failures: list[str] = []
-    for attempt in range(1, 3):
-        try:
-            result = subprocess_run(cmd, capture_output=True, text=True, timeout=max_seconds + 15, cwd=project_root)
-        except subprocess.TimeoutExpired as exc:
-            diagnostic = _trim_diagnostic(exc.stderr) or _trim_diagnostic(exc.stdout)
-            failures.append(_attempt_diagnostic(attempt, f"timed out after {exc.timeout}s", diagnostic))
-            continue
-        except FileNotFoundError as exc:
-            failures.append(_attempt_diagnostic(attempt, "`code` is required but was not found", exc))
-            continue
-        except (OSError, subprocess.SubprocessError) as exc:
-            failures.append(_attempt_diagnostic(attempt, "`code llm request` failed to run", exc))
-            continue
-        raw = result.stdout.strip() or result.stderr.strip()
-        if result.returncode != 0 or not raw:
-            detail = result.stderr.strip() or result.stdout.strip() or "no output"
-            failures.append(_attempt_diagnostic(attempt, f"returned {result.returncode}", detail))
-            continue
-        parsed = try_load_json(raw)
-        if parsed is None:
-            parsed = try_load_first_json_object(raw)
-        if isinstance(parsed, dict):
-            return parsed
-        failures.append(_attempt_diagnostic(attempt, "returned unparseable structured JSON", raw))
+    fallback_reason: str | None = None
+    resolved_images = [str(Path(path).expanduser().resolve()) for path in images or []]
+    route = resolved_routing.route_for(task)
+    for route_index, model in enumerate(route.models):
+        attempt = _run_codex_lab_attempt(
+            project_root=project_root,
+            developer=developer,
+            message=message,
+            images=resolved_images,
+            schema=schema,
+            max_seconds=max_seconds,
+            command=resolved_routing.command,
+            auth_profile=resolved_routing.auth_profile,
+            model=model,
+            subprocess_run=subprocess_run,
+            try_load_json=try_load_json,
+        )
+        _record_attempt(
+            routing=resolved_routing,
+            request_id=request_id,
+            task=task,
+            prompt_version=prompt_version,
+            model=model,
+            route_index=route_index,
+            fallback_reason=fallback_reason,
+            attempt=attempt,
+            input_characters=len(developer) + len(message),
+            image_count=len(resolved_images),
+            evidence_references=evidence_references,
+        )
+        if attempt.status == "success" and attempt.payload is not None:
+            return attempt.payload
+        failures.append(_attempt_diagnostic(route_index + 1, attempt.status, attempt.diagnostic))
+        fallback_reason = attempt.status
+        if attempt.status not in _FALLBACK_STATUSES:
+            break
     return StructuredLLMFailure(failures) if failures else None
 
 
@@ -145,60 +175,261 @@ def run_multimodal_tune_request(
         images: list[str],
         schema: dict[str, Any],
         max_seconds: int,
-        advisor_model: str,
-        memory_disabled_code_args: Callable[[], list[str]],
+        task: AdvisorTask,
+        prompt_version: str,
+        routing: AdvisorRouting | None,
+        evidence_references: list[str],
         subprocess_run: Callable[..., Any],
         try_load_json: Callable[[str], Any],
-        try_load_first_json_object: Callable[[str], Any],
-) -> dict[str, Any] | None:
-    with tempfile.NamedTemporaryFile(prefix="mediaforce-tune-", suffix=".txt", delete=False) as handle:
-        output_path = Path(handle.name)
-    with tempfile.NamedTemporaryFile(prefix="mediaforce-schema-", suffix=".json", delete=False, mode="w") as handle:
-        json.dump(schema, handle, sort_keys=True)
-        schema_path = Path(handle.name)
-    cmd = [
-        "code",
-        *memory_disabled_code_args(),
-        "exec",
-        "--model",
-        advisor_model,
-        "--sandbox",
-        "read-only",
-        "--skip-git-repo-check",
-        "--max-seconds",
-        str(max_seconds),
-        "--output-last-message",
-        str(output_path),
-        "--output-schema",
-        str(schema_path),
-        "--demo",
-        developer,
-        "-C",
-        str(project_root),
-    ]
-    for image_path in images:
-        cmd.extend(["--image", image_path])
-    cmd.append(message)
-    for _attempt in range(2):
+) -> dict[str, Any] | StructuredLLMFailure | None:
+    return run_structured_llm_request(
+        project_root=project_root,
+        developer=developer,
+        message=message,
+        schema=schema,
+        max_seconds=max_seconds,
+        task=task,
+        prompt_version=prompt_version,
+        routing=routing,
+        evidence_references=evidence_references,
+        subprocess_run=subprocess_run,
+        try_load_json=try_load_json,
+        images=images,
+    )
+
+
+def _run_codex_lab_attempt(
+        *,
+        project_root: Path,
+        developer: str,
+        message: str,
+        images: list[str],
+        schema: dict[str, Any] | None,
+        max_seconds: int,
+        command: str,
+        auth_profile: str | None,
+        model: str,
+        subprocess_run: Callable[..., Any],
+        try_load_json: Callable[[str], Any],
+) -> _CodexLabAttempt:
+    del project_root
+    started = time.monotonic()
+    with tempfile.TemporaryDirectory(prefix="mediaforce-advisor-") as temp_dir:
+        work_dir = Path(temp_dir)
+        cmd = [
+            command,
+            "exec",
+            "--ephemeral",
+            "--ignore-user-config",
+            "--ignore-rules",
+            "--sandbox",
+            "read-only",
+            "--skip-git-repo-check",
+            "--json",
+            "--model",
+            model,
+            "-C",
+            str(work_dir),
+        ]
+        if auth_profile:
+            cmd.extend(["--auth-profile", auth_profile])
+        if schema is not None:
+            schema_path = work_dir / "response-schema.json"
+            schema_path.write_text(json.dumps(schema, separators=(",", ":"), sort_keys=True))
+            cmd.extend(["--output-schema", str(schema_path)])
+        for image_index, image_path in enumerate(images, start=1):
+            source_image = Path(image_path)
+            if not source_image.is_file():
+                return _attempt_result(
+                    started,
+                    status="missing_image",
+                    diagnostic=f"review image was unavailable: {image_path}",
+                )
+            suffix = source_image.suffix.lower()
+            if suffix not in {".jpeg", ".jpg", ".png", ".webp"}:
+                return _attempt_result(
+                    started,
+                    status="unsupported_image",
+                    diagnostic=f"review image format was unsupported: {suffix or 'unknown'}",
+                )
+            copied_image = work_dir / f"review-image-{image_index}{suffix}"
+            shutil.copyfile(source_image, copied_image)
+            cmd.extend(["--image", str(copied_image)])
+        cmd.extend(["--color", "never"])
+        cmd.extend(["-c", f"developer_instructions={json.dumps(_codex_lab_developer_instruction(developer))}"])
+        cmd.append("-")
         try:
-            result = subprocess_run(cmd, capture_output=True, text=True, timeout=max_seconds + 30)
-        except (OSError, subprocess.SubprocessError):
-            continue
+            result = subprocess_run(
+                cmd,
+                input=message.strip(),
+                capture_output=True,
+                text=True,
+                timeout=max_seconds + 30,
+                cwd=work_dir,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return _attempt_result(
+                started,
+                status="timeout",
+                diagnostic=f"Codex Lab timed out after {exc.timeout}s.",
+            )
+        except FileNotFoundError:
+            return _attempt_result(
+                started,
+                status="command_unavailable",
+                diagnostic="The configured Codex Lab command was unavailable.",
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return _attempt_result(
+                started,
+                status="transport_error",
+                diagnostic=f"Codex Lab transport failed with {exc.__class__.__name__}.",
+            )
+    stdout = str(result.stdout or "").strip()
+    if result.returncode != 0:
+        return _attempt_result(
+            started,
+            status="provider_error",
+            diagnostic=f"Codex Lab returned exit code {result.returncode}.",
+        )
+    final_text, usage, tool_used, completed = _codex_lab_output(stdout)
+    if not completed:
+        return _attempt_result(
+            started,
+            status="incomplete_turn",
+            diagnostic="Codex Lab ended without a terminal turn.completed event.",
+            usage=usage,
+        )
+    if tool_used:
+        return _attempt_result(
+            started,
+            status="tool_use_rejected",
+            diagnostic="The model attempted to use an agent tool in a side-channel request.",
+            usage=usage,
+        )
+    if not final_text:
+        return _attempt_result(
+            started,
+            status="empty_response",
+            diagnostic="Codex Lab returned no final agent message.",
+            usage=usage,
+        )
+    if schema is None:
+        return _attempt_result(started, status="success", text=final_text, usage=usage)
+    parsed = try_load_json(final_text)
+    if not isinstance(parsed, dict):
+        return _attempt_result(
+            started,
+            status="invalid_structured_output",
+            diagnostic=f"Codex Lab returned {len(final_text)} bytes that did not parse as the requested object.",
+            usage=usage,
+        )
+    return _attempt_result(started, status="success", text=final_text, payload=parsed, usage=usage)
+
+
+def _attempt_result(
+        started: float,
+        *,
+        status: str,
+        text: str = "",
+        payload: dict[str, Any] | None = None,
+        diagnostic: Any = "",
+        usage: Mapping[str, Any] | None = None,
+) -> _CodexLabAttempt:
+    return _CodexLabAttempt(
+        status=status,
+        text=text,
+        payload=payload,
+        diagnostic=_trim_diagnostic(diagnostic),
+        latency_ms=max(0, int(round((time.monotonic() - started) * 1000))),
+        usage={
+            key: max(0, int(value))
+            for key, value in (usage or {}).items()
+            if key in {"input_tokens", "cached_input_tokens", "output_tokens", "reasoning_output_tokens"}
+            and isinstance(value, int | float)
+        },
+    )
+
+
+def _codex_lab_developer_instruction(developer: str) -> str:
+    return (
+        "Do not use tools, inspect files, or infer facts outside the supplied user content. "
+        f"{developer.strip()}"
+    )
+
+
+def _codex_lab_output(raw: str) -> tuple[str, dict[str, int], bool, bool]:
+    final_text = ""
+    usage: dict[str, int] = {}
+    parsed_event = False
+    tool_used = False
+    completed = False
+    for line in raw.splitlines():
         try:
-            raw = output_path.read_text().strip()
-        except OSError:
-            raw = ""
-        finally:
-            output_path.unlink(missing_ok=True)
-        if result.returncode != 0 and not raw:
-            raw = result.stderr.strip() or result.stdout.strip()
-        if not raw:
+            event = json.loads(line)
+        except json.JSONDecodeError:
             continue
-        parsed = try_load_json(raw)
-        if parsed is None:
-            parsed = try_load_first_json_object(raw)
-        if isinstance(parsed, dict):
-            schema_path.unlink(missing_ok=True)
-            return parsed
-    schema_path.unlink(missing_ok=True)
-    return None
+        if not isinstance(event, dict) or not isinstance(event.get("type"), str):
+            continue
+        parsed_event = True
+        if event["type"] == "item.completed":
+            item = event.get("item")
+            if not isinstance(item, dict):
+                continue
+            item_type = str(item.get("type") or "")
+            if item_type == "agent_message":
+                final_text = str(item.get("text") or "").strip()
+            elif item_type not in {"reasoning"}:
+                tool_used = True
+        elif event["type"] == "turn.completed" and isinstance(event.get("usage"), dict):
+            completed = True
+            usage = {
+                key: max(0, int(value))
+                for key, value in event["usage"].items()
+                if key in {"input_tokens", "cached_input_tokens", "output_tokens", "reasoning_output_tokens"}
+                and isinstance(value, int | float)
+            }
+    if not parsed_event:
+        return "", {}, False, False
+    return final_text, usage, tool_used, completed
+
+
+def _record_attempt(
+        *,
+        routing: AdvisorRouting,
+        request_id: str,
+        task: AdvisorTask,
+        prompt_version: str,
+        model: str,
+        route_index: int,
+        fallback_reason: str | None,
+        attempt: _CodexLabAttempt,
+        input_characters: int,
+        image_count: int,
+        evidence_references: list[str],
+) -> None:
+    try:
+        append_advisor_telemetry(
+            routing.telemetry_path,
+            {
+                "schema_version": 1,
+                "recorded_at": datetime.now(timezone.utc).isoformat(),
+                "request_id": request_id,
+                "task": task.value,
+                "prompt_version": prompt_version,
+                "model": model,
+                "route_index": route_index,
+                "fallback_reason": fallback_reason,
+                "status": attempt.status,
+                "valid": attempt.status == "success",
+                "latency_ms": attempt.latency_ms,
+                "usage": attempt.usage,
+                "estimated_cost_usd": estimated_cost_usd(attempt.usage, routing.pricing_for(model)),
+                "input_characters": max(0, input_characters),
+                "image_count": max(0, image_count),
+                "evidence_references": sorted(set(evidence_references))[:64],
+            },
+            max_records=routing.telemetry_max_records,
+        )
+    except OSError:
+        return

--- a/mediaforce/advising/telemetry.py
+++ b/mediaforce/advising/telemetry.py
@@ -1,0 +1,91 @@
+import json
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+from mediaforce.advising.privacy import redact_sensitive_text
+from mediaforce.advising.routing import AdvisorModelPricing
+
+
+_PRIVATE_TELEMETRY_KEYS = frozenset(
+    {
+        "images",
+        "message",
+        "model_output",
+        "operator_note",
+        "prompt",
+        "raw",
+        "response",
+        "stderr",
+        "stdout",
+    }
+)
+
+
+def estimated_cost_usd(usage: dict[str, int], pricing: AdvisorModelPricing | None) -> float | None:
+    if pricing is None:
+        return None
+    input_rate = pricing.input_usd_per_million
+    cached_rate = pricing.cached_input_usd_per_million
+    output_rate = pricing.output_usd_per_million
+    if input_rate is None or output_rate is None:
+        return None
+    input_tokens = max(0, int(usage.get("input_tokens") or 0))
+    cached_tokens = min(input_tokens, max(0, int(usage.get("cached_input_tokens") or 0)))
+    uncached_tokens = input_tokens - cached_tokens
+    output_tokens = max(0, int(usage.get("output_tokens") or 0))
+    cached_cost = cached_tokens * (input_rate if cached_rate is None else cached_rate)
+    total = (uncached_tokens * input_rate + cached_cost + output_tokens * output_rate) / 1_000_000
+    return round(total, 8)
+
+
+def append_advisor_telemetry(path: Path | None, record: dict[str, Any], *, max_records: int) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    safe_record = _safe_record(record)
+    serialized = json.dumps(safe_record, separators=(",", ":"), sort_keys=True)
+    with _locked_file(path):
+        existing = path.read_text().splitlines() if path.exists() else []
+        lines = [*existing[-max(0, max_records - 1):], serialized]
+        with tempfile.NamedTemporaryFile(
+                prefix=f".{path.name}.",
+                suffix=".tmp",
+                dir=path.parent,
+                delete=False,
+                mode="w",
+        ) as handle:
+            handle.write("\n".join(lines))
+            handle.write("\n")
+            temp_path = Path(handle.name)
+        os.replace(temp_path, path)
+
+
+def _safe_record(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): _safe_record(item)
+            for key, item in value.items()
+            if str(key).lower() not in _PRIVATE_TELEMETRY_KEYS
+        }
+    if isinstance(value, list):
+        return [_safe_record(item) for item in value]
+    if isinstance(value, str):
+        return redact_sensitive_text(value, limit=500)
+    return value
+
+
+@contextmanager
+def _locked_file(path: Path) -> Iterator[None]:
+    lock_path = path.with_suffix(f"{path.suffix}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+") as lock_file:
+        import fcntl
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/mediaforce/advisor.py
+++ b/mediaforce/advisor.py
@@ -1,6 +1,5 @@
 import json
 import re
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -10,10 +9,10 @@ from mediaforce.advising.policy import compact_policy_payload as _compact_policy
     extract_seed_payload as _extract_seed_payload_impl, normalize_policy_section as _normalize_policy_section_impl, \
     policy_key_paths as _policy_key_paths_impl, policy_response_schema as _policy_response_schema_impl, \
     policy_section_schema as _policy_section_schema_impl, policy_shape_example as _policy_shape_example_impl, \
-    policy_value_schema as _policy_value_schema_impl, run_verdict_schema as _run_verdict_schema_impl, \
-    seed_response_schema as _seed_response_schema_impl, try_load_first_json_object as _try_load_first_json_object_impl, \
-    try_load_json as _try_load_json_impl, tune_response_schema as _tune_response_schema_impl, \
-    tune_self_check_schema as _tune_self_check_schema_impl, review_artifact_critique_schema as _review_artifact_critique_schema_impl, normalize_policy_value as _normalize_policy_value_impl, \
+    policy_value_schema as _policy_value_schema_impl, \
+    seed_response_schema as _seed_response_schema_impl, try_load_json as _try_load_json_impl, \
+    tune_response_schema as _tune_response_schema_impl, \
+    review_artifact_critique_schema as _review_artifact_critique_schema_impl, normalize_policy_value as _normalize_policy_value_impl, \
     normalize_video_policy_value as _normalize_video_policy_value_impl, \
     normalize_audio_policy_value as _normalize_audio_policy_value_impl, \
     normalize_subtitle_policy_value as _normalize_subtitle_policy_value_impl, \
@@ -24,18 +23,20 @@ from mediaforce.advising.policy import compact_policy_payload as _compact_policy
     parse_bitrate_kbps as _parse_bitrate_kbps_impl, \
     clamp_float as _clamp_float_impl, clamp_int as _clamp_int_impl, \
     operator_note_parse_schema as _operator_note_parse_schema_impl
-from mediaforce.advising.prompts import build_prompt as _build_prompt_impl, \
-    build_review_artifact_critique_prompt as _build_review_artifact_critique_prompt_impl, build_run_verdict_prompt as _build_run_verdict_prompt_impl, build_seed_prompt as _build_seed_prompt_impl, \
+from mediaforce.advising.prompts import \
+    build_review_artifact_critique_prompt as _build_review_artifact_critique_prompt_impl, build_seed_prompt as _build_seed_prompt_impl, \
     build_tune_prompt as _build_tune_prompt_impl, build_operator_note_parse_prompt as _build_operator_note_parse_prompt_impl
-from mediaforce.advising.runtime import StructuredLLMFailure, run_code_prompt as _run_code_prompt_impl, \
+from mediaforce.advising.privacy import advisor_evidence_references
+from mediaforce.advising.runtime import StructuredLLMFailure, \
+    run_codex_lab_process as _run_codex_lab_process_impl, \
     run_multimodal_tune_request as _run_multimodal_tune_request_impl, \
     run_structured_llm_request as _run_structured_llm_request_impl
+from mediaforce.advising.routing import AdvisorRouting, AdvisorTask
 
-ADVISOR_MODEL = "gpt-5.4"
 SEED_PROMPT_VERSION = "seed-v9"
 TUNE_PROMPT_VERSION = "tune-v10"
-TUNE_SELF_CHECK_VERSION = "tune-self-check-v1"
-RUN_VERDICT_PROMPT_VERSION = "run-verdict-v2"
+TUNE_SELF_CHECK_VERSION = "tune-self-check-v2-deterministic"
+RUN_VERDICT_PROMPT_VERSION = "run-verdict-v3-deterministic"
 REVIEW_ARTIFACT_CRITIQUE_PROMPT_VERSION = "review-artifact-critique-v1"
 OPERATOR_NOTE_PARSE_PROMPT_VERSION = "operator-note-parse-v2"
 REQUEST_DISPOSITIONS = ("honored", "honored_with_risk", "softened", "rejected", "unclear")
@@ -215,24 +216,6 @@ def _force_repeated_tune_experiment(
     return applied_fragment
 
 
-def _memory_disabled_code_args() -> list[str]:
-    return [
-        "-c",
-        "features.memories=false",
-        "-c",
-        "memories.use_memories=false",
-        "-c",
-        "memories.generate_memories=false",
-    ]
-
-
-@dataclass(slots=True)
-class AdvisorResponse:
-    ok: bool
-    summary: str
-    raw: str
-
-
 @dataclass(slots=True)
 class SeedPolicyResponse:
     ok: bool
@@ -293,12 +276,12 @@ class ReviewArtifactCritiqueResponse:
     evidence_checked: list[str]
 
 
-def request_tuning_advice(*, project_root: Path, payload: dict[str, Any]) -> AdvisorResponse:
-    prompt = _build_prompt(payload)
-    return _run_code_prompt(project_root=project_root, prompt=prompt, max_seconds=60)
-
-
-def request_seed_policy(*, project_root: Path, payload: dict[str, Any]) -> SeedPolicyResponse:
+def request_seed_policy(
+        *,
+        project_root: Path,
+        payload: dict[str, Any],
+        routing: AdvisorRouting | None = None,
+) -> SeedPolicyResponse:
     prompt = _build_seed_prompt(payload)
     base_policy = object_dict(payload.get("base_policy"))
     parsed = _run_structured_llm_request(
@@ -310,6 +293,10 @@ def request_seed_policy(*, project_root: Path, payload: dict[str, Any]) -> SeedP
         message=prompt,
         schema=_seed_response_schema(base_policy),
         max_seconds=75,
+        task=AdvisorTask.SEED_POLICY,
+        prompt_version=SEED_PROMPT_VERSION,
+        routing=routing,
+        evidence_references=advisor_evidence_references(payload),
     )
     if not isinstance(parsed, dict):
         return SeedPolicyResponse(
@@ -389,7 +376,12 @@ def request_seed_policy(*, project_root: Path, payload: dict[str, Any]) -> SeedP
     )
 
 
-def request_note_tuning(*, project_root: Path, payload: dict[str, Any]) -> TuningPolicyResponse:
+def request_note_tuning(
+        *,
+        project_root: Path,
+        payload: dict[str, Any],
+        routing: AdvisorRouting | None = None,
+) -> TuningPolicyResponse:
     prompt = _build_tune_prompt(payload)
     current_policy = object_dict(payload.get("policy"))
     review_pack = object_dict(payload.get("multimodal_review_pack")) or None
@@ -410,6 +402,10 @@ def request_note_tuning(*, project_root: Path, payload: dict[str, Any]) -> Tunin
             images=review_images,
             schema=_tune_response_schema(current_policy),
             max_seconds=90,
+            task=AdvisorTask.NOTE_TUNING,
+            prompt_version=TUNE_PROMPT_VERSION,
+            routing=routing,
+            evidence_references=advisor_evidence_references(payload),
         )
     else:
         parsed = _run_structured_llm_request(
@@ -421,6 +417,10 @@ def request_note_tuning(*, project_root: Path, payload: dict[str, Any]) -> Tunin
             message=prompt,
             schema=_tune_response_schema(current_policy),
             max_seconds=90,
+            task=AdvisorTask.NOTE_TUNING,
+            prompt_version=TUNE_PROMPT_VERSION,
+            routing=routing,
+            evidence_references=advisor_evidence_references(payload),
         )
     if not isinstance(parsed, dict):
         return TuningPolicyResponse(
@@ -566,7 +566,12 @@ def request_note_tuning(*, project_root: Path, payload: dict[str, Any]) -> Tunin
     )
 
 
-def request_review_artifact_critique(*, project_root: Path, payload: dict[str, Any]) -> ReviewArtifactCritiqueResponse:
+def request_review_artifact_critique(
+        *,
+        project_root: Path,
+        payload: dict[str, Any],
+        routing: AdvisorRouting | None = None,
+) -> ReviewArtifactCritiqueResponse:
     review_pack = object_dict(payload.get("multimodal_review_pack"))
     review_images = [
         str(path)
@@ -597,6 +602,10 @@ def request_review_artifact_critique(*, project_root: Path, payload: dict[str, A
         images=review_images,
         schema=_review_artifact_critique_schema(),
         max_seconds=75,
+        task=AdvisorTask.REVIEW_ARTIFACT_CRITIQUE,
+        prompt_version=REVIEW_ARTIFACT_CRITIQUE_PROMPT_VERSION,
+        routing=routing,
+        evidence_references=advisor_evidence_references(payload),
     )
     if not isinstance(parsed, dict):
         return ReviewArtifactCritiqueResponse(
@@ -629,43 +638,102 @@ def request_review_artifact_critique(*, project_root: Path, payload: dict[str, A
     )
 
 
-def request_run_verdict(*, project_root: Path, payload: dict[str, Any]) -> RunVerdictResponse:
-    parsed = _run_structured_llm_request(
-        project_root=project_root,
-        developer=(
-            "You are a media encode calibration reviewer. No tools are available. "
-            "Use only the provided measured result context and return concise JSON that satisfies the schema exactly."
-        ),
-        message=_build_run_verdict_prompt(payload),
-        schema=_run_verdict_schema(),
-        max_seconds=60,
+def request_run_verdict(
+        *,
+        project_root: Path,
+        payload: dict[str, Any],
+        routing: AdvisorRouting | None = None,
+) -> RunVerdictResponse:
+    del project_root, routing
+    sample_result = object_dict(payload.get("sample_result"))
+    size_target = object_dict(payload.get("size_target_analysis"))
+    operator_request = object_dict(payload.get("operator_request"))
+    size_status = str(size_target.get("status") or "").strip().lower()
+    quality_score = _optional_number(sample_result.get("quality_score"))
+    quality_target = _optional_number(sample_result.get("quality_target"))
+    if quality_target is None:
+        quality_target = _optional_number(operator_request.get("target"))
+    quality_met = None if quality_score is None or quality_target is None else quality_score >= quality_target
+
+    if size_status in {"infeasible", "quality_conflict", "over_target"} or quality_met is False:
+        outcome = "needs_review"
+    elif size_status in {"inside_target_band", "under_target"}:
+        outcome = "strong_match"
+    else:
+        outcome = "acceptable_experiment"
+    confidence = "high" if size_status and quality_met is not None else "medium" if sample_result else "low"
+    summary = _deterministic_run_verdict_summary(
+        size_status=size_status,
+        quality_score=quality_score,
+        quality_target=quality_target,
+        quality_met=quality_met,
     )
-    if not isinstance(parsed, dict):
-        return RunVerdictResponse(
-            ok=False,
-            summary="Measured calibration finished, but no model verdict was returned.",
-            raw=_raw_failure_payload(parsed),
-            prompt_version=RUN_VERDICT_PROMPT_VERSION,
-            outcome="unknown",
-            confidence="low",
-            next_step=None,
-            evidence_checked=[],
-        )
-    evidence_checked_raw = parsed.get("evidence_checked")
-    evidence_checked = evidence_checked_raw if isinstance(evidence_checked_raw, list) else []
+    next_step = (
+        "Review the comparison and choose a measured retry before approval."
+        if outcome == "needs_review"
+        else "Review the sampled moments, then approve the current evidence if picture and sound hold up."
+    )
+    evidence_checked = ["sample_result"]
+    if size_target:
+        evidence_checked.append("size_target_analysis")
+    if operator_request:
+        evidence_checked.append("operator_request")
+    verdict_payload = {
+        "summary": summary,
+        "outcome": outcome,
+        "confidence": confidence,
+        "next_step": next_step,
+        "evidence_checked": evidence_checked,
+        "source": "deterministic",
+    }
     return RunVerdictResponse(
-        ok=True,
-        summary=str(parsed.get("summary") or "Measured calibration finished."),
-        raw=json.dumps(parsed, indent=2, sort_keys=True),
+        ok=bool(sample_result),
+        summary=summary,
+        raw=json.dumps(verdict_payload, indent=2, sort_keys=True),
         prompt_version=RUN_VERDICT_PROMPT_VERSION,
-        outcome=str(parsed.get("outcome") or "unknown"),
-        confidence=str(parsed.get("confidence") or "unknown"),
-        next_step=(str(parsed.get("next_step")) if parsed.get("next_step") else None),
-        evidence_checked=[str(item) for item in evidence_checked],
+        outcome=outcome if sample_result else "unknown",
+        confidence=confidence,
+        next_step=next_step if sample_result else None,
+        evidence_checked=evidence_checked if sample_result else [],
     )
 
 
-def request_operator_note_parse(*, project_root: Path, payload: dict[str, Any]) -> dict[str, Any] | None:
+def _deterministic_run_verdict_summary(
+        *,
+        size_status: str,
+        quality_score: float | None,
+        quality_target: float | None,
+        quality_met: bool | None,
+) -> str:
+    if size_status == "infeasible":
+        return "The approved stream plan cannot fit inside the requested size budget."
+    if size_status == "quality_conflict":
+        return "The measured sample reached a quality-floor conflict before it could satisfy the requested size."
+    if size_status == "over_target":
+        return "The measured sample is above the requested whole-episode size band."
+    if quality_met is False and quality_score is not None and quality_target is not None:
+        return f"The measured quality score {quality_score:g} is below the requested floor {quality_target:g}."
+    if size_status == "inside_target_band":
+        return "The measured sample is inside the requested whole-episode size band."
+    if size_status == "under_target":
+        return "The measured sample is smaller than the requested whole-episode size without a measured quality-floor miss."
+    if quality_met is True:
+        return "The measured sample met the requested quality floor; review the current picture and sound before approval."
+    return "The measured calibration completed; review the current picture, sound, and size evidence before approval."
+
+
+def _optional_number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    return float(value)
+
+
+def request_operator_note_parse(
+        *,
+        project_root: Path,
+        payload: dict[str, Any],
+        routing: AdvisorRouting | None = None,
+) -> dict[str, Any] | None:
     parsed = _run_structured_llm_request(
         project_root=project_root,
         developer=(
@@ -675,6 +743,10 @@ def request_operator_note_parse(*, project_root: Path, payload: dict[str, Any]) 
         message=_build_operator_note_parse_prompt(payload),
         schema=_operator_note_parse_schema(),
         max_seconds=45,
+        task=AdvisorTask.OPERATOR_NOTE_PARSE,
+        prompt_version=OPERATOR_NOTE_PARSE_PROMPT_VERSION,
+        routing=routing,
+        evidence_references=advisor_evidence_references(payload),
     )
     return parsed if isinstance(parsed, dict) else None
 
@@ -703,18 +775,6 @@ def apply_seed_policy(
     return applied_policy, applied_fragment
 
 
-def _run_code_prompt(*, project_root: Path, prompt: str, max_seconds: int) -> AdvisorResponse:
-    return _run_code_prompt_impl(
-        project_root=project_root,
-        prompt=prompt,
-        max_seconds=max_seconds,
-        advisor_model=ADVISOR_MODEL,
-        memory_disabled_code_args=_memory_disabled_code_args,
-        advisor_response_factory=AdvisorResponse,
-        subprocess_run=subprocess.run,
-    )
-
-
 def _run_structured_llm_request(
         *,
         project_root: Path,
@@ -722,6 +782,10 @@ def _run_structured_llm_request(
         message: str,
         schema: dict[str, Any],
         max_seconds: int,
+        task: AdvisorTask,
+        prompt_version: str,
+        routing: AdvisorRouting | None = None,
+        evidence_references: list[str] | None = None,
 ) -> dict[str, Any] | StructuredLLMFailure | None:
     return _run_structured_llm_request_impl(
         project_root=project_root,
@@ -729,11 +793,12 @@ def _run_structured_llm_request(
         message=message,
         schema=schema,
         max_seconds=max_seconds,
-        advisor_model=ADVISOR_MODEL,
-        memory_disabled_code_args=_memory_disabled_code_args,
-        subprocess_run=subprocess.run,
+        task=task,
+        prompt_version=prompt_version,
+        routing=routing,
+        evidence_references=evidence_references or [],
+        subprocess_run=_run_codex_lab_process_impl,
         try_load_json=_try_load_json,
-        try_load_first_json_object=_try_load_first_json_object,
     )
 
 
@@ -745,7 +810,11 @@ def _run_multimodal_tune_request(
         images: list[str],
         schema: dict[str, Any],
         max_seconds: int,
-) -> dict[str, Any] | None:
+        task: AdvisorTask,
+        prompt_version: str,
+        routing: AdvisorRouting | None = None,
+        evidence_references: list[str] | None = None,
+) -> dict[str, Any] | StructuredLLMFailure | None:
     return _run_multimodal_tune_request_impl(
         project_root=project_root,
         developer=developer,
@@ -753,16 +822,13 @@ def _run_multimodal_tune_request(
         images=images,
         schema=schema,
         max_seconds=max_seconds,
-        advisor_model=ADVISOR_MODEL,
-        memory_disabled_code_args=_memory_disabled_code_args,
-        subprocess_run=subprocess.run,
+        task=task,
+        prompt_version=prompt_version,
+        routing=routing,
+        evidence_references=evidence_references or [],
+        subprocess_run=_run_codex_lab_process_impl,
         try_load_json=_try_load_json,
-        try_load_first_json_object=_try_load_first_json_object,
     )
-
-
-def _build_prompt(payload: dict[str, Any]) -> str:
-    return _build_prompt_impl(payload)
 
 
 def _build_seed_prompt(payload: dict[str, Any]) -> str:
@@ -785,41 +851,33 @@ def _build_review_artifact_critique_prompt(payload: dict[str, Any]) -> str:
     return _build_review_artifact_critique_prompt_impl(payload)
 
 
-def _build_run_verdict_prompt(payload: dict[str, Any]) -> str:
-    return _build_run_verdict_prompt_impl(payload)
-
-
 def _build_operator_note_parse_prompt(payload: dict[str, Any]) -> str:
     return _build_operator_note_parse_prompt_impl(payload)
 
 
-def _run_tune_self_check(*, project_root: Path, tuning_context: dict[str, Any], proposal: dict[str, Any]) -> dict[
-                                                                                                                 str, Any] | None:
-    payload = {
-        "context": tuning_context,
-        "proposal": proposal,
+def _run_tune_self_check(
+        *,
+        project_root: Path,
+        tuning_context: dict[str, Any],
+        proposal: dict[str, Any],
+) -> dict[str, Any]:
+    del project_root, tuning_context
+    proposed_policy = object_dict(proposal.get("policy"))
+    if not proposed_policy:
+        return {
+            "status": "fail",
+            "summary": "The proposed draft did not contain an executable allow-listed policy fragment.",
+            "issues": ["No executable policy fragment was returned."],
+            "source": "deterministic",
+            "version": TUNE_SELF_CHECK_VERSION,
+        }
+    return {
+        "status": "pass",
+        "summary": "The normalized draft can proceed to deterministic quality-risk and operator-review gates.",
+        "issues": [],
+        "source": "deterministic",
+        "version": TUNE_SELF_CHECK_VERSION,
     }
-    hint = object_dict(object_dict(tuning_context.get("runtime_toolbelt")).get("audio_tradeoff_hint"))
-    hinted_audio_key = str(hint.get("policy_key") or "hinted audio bitrate").strip() or "hinted audio bitrate"
-    message = (
-        "Perform one fast self-check on the proposed next calibration draft. "
-        "Use only the provided context and proposal. Return whether the draft is acceptable, needs caution, or should be rejected. "
-        f"Also act as an audio-tradeoff referee: if the proposal lowers {hinted_audio_key}, "
-        "treat that as review risk according to context.runtime_toolbelt.audio_tradeoff_hint.review_risk_summary. "
-        "When context.runtime_toolbelt.audio_tradeoff_hint says the savings are low leverage or modest, prefer preserving the current hinted bitrate unless the operator explicitly asked to spend audio quality or the size target clearly depends on that audio cut. "
-        "Use surround_audio_guardrail.status=prefer_preserve_current when the overall draft is still usable but the hinted audio bitrate cut should be rolled back.\n\n"
-        f"{json.dumps(payload, indent=2, sort_keys=True)}"
-    )
-    return _run_structured_llm_request(
-        project_root=project_root,
-        developer=(
-            "You are validating a media encode tuning proposal. No tools are available. "
-            "Return JSON that satisfies the schema exactly and keep the summary concise."
-        ),
-        message=message,
-        schema=_tune_self_check_schema(),
-        max_seconds=45,
-    )
 
 
 def _tune_response_schema(current_policy: dict[str, Any]) -> dict[str, Any]:
@@ -828,10 +886,6 @@ def _tune_response_schema(current_policy: dict[str, Any]) -> dict[str, Any]:
 
 def _seed_response_schema(base_policy: dict[str, Any]) -> dict[str, Any]:
     return _seed_response_schema_impl(base_policy, request_dispositions=REQUEST_DISPOSITIONS)
-
-
-def _tune_self_check_schema() -> dict[str, Any]:
-    return _tune_self_check_schema_impl()
 
 
 def _apply_surround_audio_guardrail(
@@ -1007,12 +1061,26 @@ def _audio_guardrail_backstop_reason(
     hint = object_dict(object_dict(tuning_context.get("runtime_toolbelt")).get("audio_tradeoff_hint"))
     policy_key = str(hint.get("policy_key") or "").strip()
     leverage = str(hint.get("leverage") or "").strip().lower()
-    if policy_key not in _GUARDED_AUDIO_POLICY_KEYS or leverage not in {"low", "medium"}:
+    if leverage not in {"low", "medium"}:
         return None
     if _operator_note_mentions_audio(str(tuning_context.get("operator_note") or "")):
         return None
     current_audio = object_dict(current_policy.get("audio"))
     proposed_audio = object_dict(proposed_policy.get("audio"))
+    if policy_key not in _GUARDED_AUDIO_POLICY_KEYS:
+        lowered_keys = [
+            key
+            for key in _GUARDED_AUDIO_POLICY_KEYS
+            if current_audio.get(key) is not None
+            and proposed_audio.get(key) is not None
+            and _surround_audio_bitrate_was_lowered(
+                current_value=current_audio.get(key),
+                proposed_value=proposed_audio.get(key),
+            )
+        ]
+        if len(lowered_keys) != 1:
+            return None
+        policy_key = lowered_keys[0]
     current_value = current_audio.get(policy_key)
     proposed_value = proposed_audio.get(policy_key)
     if current_value is None or proposed_value is None:
@@ -1102,10 +1170,6 @@ def _rerun_tune_self_check_after_surround_guardrail(
     }
 
 
-def _run_verdict_schema() -> dict[str, Any]:
-    return _run_verdict_schema_impl()
-
-
 def _review_artifact_critique_schema() -> dict[str, Any]:
     return _review_artifact_critique_schema_impl()
 
@@ -1120,10 +1184,6 @@ def _extract_seed_payload(raw: str) -> JSONObject:
 
 def _try_load_json(raw: str) -> JSONValue:
     return _try_load_json_impl(raw)
-
-
-def _try_load_first_json_object(raw: str) -> JSONValue:
-    return _try_load_first_json_object_impl(raw)
 
 
 def _policy_key_paths(policy: dict[str, Any]) -> list[str]:

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -30,10 +30,8 @@ from sqlalchemy import literal_column
 from sqlalchemy import or_
 from sqlalchemy import select
 
-from mediaforce.advisor import (
-    AdvisorResponse,
-    TuningPolicyResponse,
-)
+from mediaforce.advisor import TuningPolicyResponse
+from mediaforce.advising.routing import advisor_routing_from_config
 from mediaforce.tuning.calibration_jobs import load_active_job, load_job, \
     list_queue_summary
 from mediaforce.core.config import DEFAULT_CONFIG_PATH, MediaforceConfig, load_config, update_runtime_settings, \
@@ -321,6 +319,7 @@ def _record_run_verdict(config: MediaforceConfig, prefix: str, calibration_paylo
 
 def create_app(config_path: Path | None = None) -> FastAPI:
     config = load_config(config_path or DEFAULT_CONFIG_PATH)
+    advisor_routing = advisor_routing_from_config(config)
     cleanup_lock = threading.Lock()
 
     @asynccontextmanager
@@ -843,6 +842,21 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             allow_measured_size_quality_increase=allow_measured_size_quality_increase,
         )
 
+    def _operator_requested_experiment_for_config(
+            note: str,
+            sample_item: dict[str, Any] | None = None,
+            *,
+            parsed_note: dict[str, Any] | None = None,
+            current_policy: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        return runtime_operator_requested_experiment(
+            note,
+            sample_item,
+            parsed_note=parsed_note,
+            current_policy=current_policy,
+            advisor_routing=advisor_routing,
+        )
+
     def _folder_ai_tune_deps() -> FolderAiTuneDeps:
         return FolderAiTuneDeps(
             resolve_sample_host=_resolve_sample_host,
@@ -850,7 +864,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             load_retryable_sample_job_state=_load_retryable_sample_job_state,
             load_latest_failed_sample_job_state=_load_latest_failed_sample_job_state,
             sample_item=_sample_item,
-            operator_requested_experiment=_operator_requested_experiment,
+            operator_requested_experiment=_operator_requested_experiment_for_config,
             load_calibration_state=_load_calibration_state,
             recent_tuning_sessions=_recent_tuning_sessions,
             matching_request_history=runtime_matching_request_history,
@@ -873,6 +887,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             apply_policy_fragment=_apply_policy_fragment,
             load_advice_state=_load_advice_state,
             save_advice_state=_save_advice_state,
+            advisor_routing=advisor_routing,
             save_job_state=_save_job_state,
             clear_pending_proposal=_clear_pending_proposal,
             record_tuning_session=record_tuning_session,
@@ -2489,7 +2504,7 @@ def _review_pair_key(timestamp_seconds: float) -> int:
     return review_pair_key(timestamp_seconds)
 
 
-def _save_advice_state(config: MediaforceConfig, prefix: str, advice: AdvisorResponse | ActionPayload) -> None:
+def _save_advice_state(config: MediaforceConfig, prefix: str, advice: ActionPayload) -> None:
     save_advice_state(_advice_file(config, prefix), advice)
 
 

--- a/mediaforce/web/runtime/folder_ai_tuning.py
+++ b/mediaforce/web/runtime/folder_ai_tuning.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 
 from mediaforce.advisor import apply_seed_policy, request_note_tuning, request_review_artifact_critique
 from mediaforce.advising.policy import has_nonpositive_video_budget, merge_policy_fragments
+from mediaforce.advising.routing import AdvisorRouting
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient, open_db
 from mediaforce.core.type_defs import object_dict, object_list
@@ -65,6 +66,7 @@ class FolderAiTuneDeps:
     record_tuning_session: Any
     load_latest_failed_sample_job_state: Any | None = None
     load_advice_state: Any | None = None
+    advisor_routing: AdvisorRouting | None = None
 
 
 def _job_sample_item_payload(sample_item: dict[str, Any]) -> dict[str, Any]:
@@ -1143,6 +1145,19 @@ def _tuned_preview_action(
         operator_request=operator_request,
         latest_failed_sample_job=latest_failed_sample_job,
     )
+    if has_nonpositive_video_budget(object_dict(operator_request)):
+        return {
+            "ok": False,
+            "kind": "tuned_preview",
+            "summary": "The requested total size leaves no positive video budget.",
+            "message": (
+                "Increase the total target or explicitly change the selected stream allocation before another "
+                "sample can queue."
+            ),
+            "request_disposition": "rejected",
+            "operator_request": operator_request,
+            "can_queue": False,
+        }
     metric_support = deps.metric_support()
     with open_db(config.paths.db_path) as connection:
         learning_context = retrieve_learning_context(
@@ -1156,6 +1171,8 @@ def _tuned_preview_action(
         note=trimmed_note,
         sample_item=sample_item,
         recent_sessions_payload=recent_sessions_payload,
+        current_request=operator_request,
+        **({"advisor_routing": deps.advisor_routing} if deps.advisor_routing is not None else {}),
     )
     runtime_toolbelt = deps.build_tuning_runtime_toolbelt(
         sample_item=sample_item,
@@ -1183,23 +1200,25 @@ def _tuned_preview_action(
     public_review_pack = deps.multimodal_review_pack_public_view(config, multimodal_review_pack)
     review_artifact_critique: dict[str, Any] | None = None
     if multimodal_review_pack is not None:
+        critique_payload = {
+            "folder": normalized_prefix,
+            "operator_note": trimmed_note,
+            "requested_experiment": operator_request,
+            "sample_item": {
+                "rel_path": sample_item["rel_path"],
+                "source_size_bytes": sample_item["source_size_bytes"],
+                "duration_seconds": sample_item["duration_seconds"],
+                "audio_summary": sample_item["audio_summary"],
+            },
+            "recent_calibration": calibration,
+            "current_policy": current_policy,
+            "runtime_toolbelt": runtime_toolbelt,
+            "multimodal_review_pack": multimodal_review_pack,
+        }
         critique = request_review_artifact_critique(
             project_root=config.paths.project_root,
-            payload={
-                "folder": normalized_prefix,
-                "operator_note": trimmed_note,
-                "requested_experiment": operator_request,
-                "sample_item": {
-                    "rel_path": sample_item["rel_path"],
-                    "source_size_bytes": sample_item["source_size_bytes"],
-                    "duration_seconds": sample_item["duration_seconds"],
-                    "audio_summary": sample_item["audio_summary"],
-                },
-                "recent_calibration": calibration,
-                "current_policy": current_policy,
-                "runtime_toolbelt": runtime_toolbelt,
-                "multimodal_review_pack": multimodal_review_pack,
-            },
+            payload=critique_payload,
+            **({"routing": deps.advisor_routing} if deps.advisor_routing is not None else {}),
         )
         if critique.ok:
             review_artifact_critique = {
@@ -1220,7 +1239,6 @@ def _tuned_preview_action(
         "summary": summary,
         "sample_item": {
             "rel_path": sample_item["rel_path"],
-            "source_path": sample_item["source_path"],
             "source_size_bytes": sample_item["source_size_bytes"],
             "video_codec": sample_item["video_codec"],
             "duration_seconds": sample_item["duration_seconds"],
@@ -1236,10 +1254,18 @@ def _tuned_preview_action(
         "latest_failed_sample_job": latest_failed_sample_job,
     }
     if multimodal_review_pack is not None:
-        tuning_payload["multimodal_review_pack"] = multimodal_review_pack
+        tuning_payload["multimodal_review_pack"] = (
+            {key: value for key, value in multimodal_review_pack.items() if key != "images"}
+            if review_artifact_critique is not None
+            else multimodal_review_pack
+        )
     if review_artifact_critique is not None:
         tuning_payload["review_artifact_critique"] = review_artifact_critique
-    tuning = request_note_tuning(project_root=config.paths.project_root, payload=tuning_payload)
+    tuning = request_note_tuning(
+        project_root=config.paths.project_root,
+        payload=tuning_payload,
+        **({"routing": deps.advisor_routing} if deps.advisor_routing is not None else {}),
+    )
     tuned_policy, applied_fragment = apply_seed_policy(current_policy, object_dict(tuning.proposed_policy), mode="tune")
     measurement_fragment = _size_budget_measurement_fragment(operator_request, sample_item)
     combined_fragment = _honor_operator_source_resolution(

--- a/mediaforce/web/runtime/folder_state.py
+++ b/mediaforce/web/runtime/folder_state.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from mediaforce.advisor import AdvisorResponse
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.type_defs import float_value, object_dict, object_list
 from mediaforce.tuning.quality_risk import quality_risk_public_view
@@ -215,12 +214,8 @@ def review_pair_key(timestamp_seconds: float) -> int:
     return int(round(timestamp_seconds * 1000))
 
 
-def save_advice_state(advice_file: Path, advice: AdvisorResponse | dict[str, Any]) -> None:
-    if isinstance(advice, AdvisorResponse):
-        payload = {"ok": advice.ok, "summary": advice.summary, "raw": advice.raw}
-    else:
-        payload = dict(advice)
-    advice_file.write_text(json.dumps(payload, indent=2) + "\n")
+def save_advice_state(advice_file: Path, advice: dict[str, Any]) -> None:
+    advice_file.write_text(json.dumps(dict(advice), indent=2) + "\n")
 
 
 def load_pending_proposal(proposal_file: Path) -> dict[str, Any] | None:

--- a/mediaforce/web/runtime/folder_tuning_advice.py
+++ b/mediaforce/web/runtime/folder_tuning_advice.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from mediaforce.advisor import apply_seed_policy, request_operator_note_parse, request_run_verdict, request_seed_policy
 from mediaforce.advising.policy import has_nonpositive_video_budget, merge_policy_fragments, policy_key_paths
+from mediaforce.advising.routing import AdvisorRouting, advisor_routing_from_config
 from mediaforce.core.binaries import ffmpeg_binary
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
@@ -79,6 +80,10 @@ _MEASURED_SIZE_FOLLOWUP_RE = re.compile(
     re.IGNORECASE,
 )
 _METRIC_TARGET_RE = re.compile(r"\b(?P<metric>vmaf|xpsnr)\s*(?:of\s*)?(?:around\s*)?(?P<target>\d+(?:\.\d+)?)\b", re.IGNORECASE)
+_REVERSED_METRIC_TARGET_RE = re.compile(
+    r"\b(?P<target>\d+(?:\.\d+)?)\s*(?P<metric>vmaf|xpsnr)\b",
+    re.IGNORECASE,
+)
 _METRIC_DIRECTIVE_RE = re.compile(
     r"\b(?:use|using|with|evaluate(?:\s+with)?|measure(?:\s+with)?|run(?:\s+with)?|metric(?:\s+is)?)\s+"
     r"(?P<metric>vmaf|xpsnr)\b",
@@ -221,7 +226,7 @@ def _heuristic_operator_note_parse(note: str) -> dict[str, Any] | None:
         evidence_authority = "operator_observed"
 
     size_budget_match = _positive_size_budget_match(trimmed)
-    metric_match = _METRIC_TARGET_RE.search(trimmed)
+    metric_match = _METRIC_TARGET_RE.search(trimmed) or _REVERSED_METRIC_TARGET_RE.search(trimmed)
     metric_directive_match = _METRIC_DIRECTIVE_RE.search(trimmed)
     scale_match = _SCALE_HEIGHT_RE.search(trimmed)
     crop_match = _CROP_VALUE_RE.search(trimmed)
@@ -310,67 +315,6 @@ def _heuristic_operator_note_parse(note: str) -> dict[str, Any] | None:
         "measured_size_followup": measured_size_followup,
         "reasoning_note": "Local heuristic recovered the explicit operator request from the note text.",
     }
-
-
-def _explicit_note_part_count(parsed: dict[str, Any] | None) -> int:
-    payload = object_dict(parsed)
-    if not payload:
-        return 0
-    return sum(
-        value is not None
-        for value in (
-            payload.get("metric_target") if payload.get("metric_target") is not None else payload.get("metric"),
-            payload.get("size_budget_value"),
-            payload.get("scale_height"),
-            payload.get("black_bar_handling"),
-            payload.get("crop"),
-        )
-    )
-
-
-def _merge_operator_note_parse(
-        structured_parse: dict[str, Any] | None,
-        heuristic_parse: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    structured = object_dict(structured_parse)
-    heuristic = object_dict(heuristic_parse)
-    if not structured:
-        return heuristic or None
-    if not heuristic:
-        return structured
-    if _explicit_note_part_count(heuristic) > _explicit_note_part_count(structured):
-        return heuristic
-    merged = dict(structured)
-    for key in (
-            "metric",
-            "metric_target",
-            "size_budget_value",
-            "size_budget_unit",
-            "scale_height",
-            "black_bar_handling",
-            "crop",
-            "evidence_authority",
-    ):
-        if merged.get(key) in {None, ""} and heuristic.get(key) is not None and heuristic.get(key) != "":
-            merged[key] = heuristic.get(key)
-    if not merged.get("operator_confirmed") and heuristic.get("operator_confirmed"):
-        merged["operator_confirmed"] = True
-        if str(merged.get("intent_type") or "").strip().lower() in {"unclear", "other"}:
-            merged["intent_type"] = "direct_request"
-    if heuristic.get("measured_size_followup"):
-        merged["measured_size_followup"] = True
-    structured_authority = str(merged.get("evidence_authority") or "none")
-    heuristic_authority = str(heuristic.get("evidence_authority") or "none")
-    if heuristic_authority == "rejected_visual_result":
-        merged["evidence_authority"] = heuristic_authority
-    elif structured_authority == "none" and heuristic_authority != "none":
-        merged["evidence_authority"] = heuristic_authority
-    merged = _normalize_operator_note_parse(merged)
-    if merged is None:
-        return heuristic
-    if _explicit_note_part_count(merged) < _explicit_note_part_count(heuristic):
-        return heuristic
-    return merged
 
 
 def parse_audio_bitrate_kbps(value: JSONValue, fallback: float) -> float:
@@ -490,21 +434,24 @@ def audio_tradeoff_hint(
     }
 
 
-def _parsed_operator_note(note: str) -> dict[str, Any] | None:
+def _parsed_operator_note(note: str, *, routing: AdvisorRouting | None = None) -> dict[str, Any] | None:
     trimmed = note.strip()
     if not trimmed:
         return None
-    structured_parse = _normalize_operator_note_parse(
-        request_operator_note_parse(
-            project_root=_PROJECT_ROOT,
-            payload={
-                "operator_note": trimmed,
-                "goal": "Classify the operator note into a concrete tuning request, if one exists.",
-            },
-        )
-    )
     heuristic_parse = _heuristic_operator_note_parse(trimmed)
-    return _merge_operator_note_parse(structured_parse, heuristic_parse)
+    if heuristic_parse is not None:
+        return heuristic_parse
+    request_kwargs: dict[str, Any] = {
+        "project_root": _PROJECT_ROOT,
+        "payload": {
+            "operator_note": trimmed,
+            "goal": "Classify the operator note into a concrete tuning request, if one exists.",
+        },
+    }
+    if routing is not None:
+        request_kwargs["routing"] = routing
+    structured_parse = _normalize_operator_note_parse(request_operator_note_parse(**request_kwargs))
+    return structured_parse
 
 
 def size_budget_request(
@@ -703,11 +650,12 @@ def operator_requested_experiment(
         *,
         parsed_note: dict[str, Any] | None = None,
         current_policy: dict[str, Any] | None = None,
+        advisor_routing: AdvisorRouting | None = None,
 ) -> dict[str, Any] | None:
     trimmed = note.strip()
     if not trimmed:
         return None
-    note_parse = object_dict(parsed_note) or object_dict(_parsed_operator_note(trimmed))
+    note_parse = object_dict(parsed_note) or object_dict(_parsed_operator_note(trimmed, routing=advisor_routing))
     request_type = str(note_parse.get("request_type") or "").strip().lower()
     if request_type == "none":
         evidence_authority = str(note_parse.get("evidence_authority") or "none").strip().lower()
@@ -957,8 +905,13 @@ def matching_request_history(
         sample_item: dict[str, Any] | None,
         recent_sessions_payload: list[dict[str, Any]],
         current_request: dict[str, Any] | None = None,
+        advisor_routing: AdvisorRouting | None = None,
 ) -> dict[str, Any] | None:
-    resolved_current_request = object_dict(current_request) or operator_requested_experiment(note, sample_item)
+    resolved_current_request = object_dict(current_request) or operator_requested_experiment(
+        note,
+        sample_item,
+        advisor_routing=advisor_routing,
+    )
     if not bool(object_dict(resolved_current_request).get("operator_confirmed")):
         return None
     current_signature = operator_request_signature(resolved_current_request)
@@ -975,6 +928,7 @@ def matching_request_history(
                     str(session.get("note") or ""),
                     sample_item,
                     parsed_note=prior_note_parse,
+                    advisor_routing=advisor_routing,
                 )
             )
         if operator_request_signature(prior_request) != current_signature:
@@ -1283,9 +1237,14 @@ def build_seed_policy_payload(
         requested_experiment: dict[str, Any] | None = None,
         latest_failed_sample_job: dict[str, Any] | None = None,
         learning_context_payload: list[dict[str, Any]] | None = None,
+        advisor_routing: AdvisorRouting | None = None,
 ) -> dict[str, Any]:
     suggested_override = object_dict(summary.get("suggested_override"))
-    resolved_requested_experiment = object_dict(requested_experiment) or operator_requested_experiment(user_note, sample_item)
+    resolved_requested_experiment = object_dict(requested_experiment) or operator_requested_experiment(
+        user_note,
+        sample_item,
+        advisor_routing=advisor_routing,
+    )
     recent_sessions = list(recent_sessions_payload) if recent_sessions_payload is not None else []
     requested_budget_bytes = int_value(object_dict(resolved_requested_experiment).get("budget_bytes")) or None
     repeat_signal = matching_request_history(
@@ -1293,6 +1252,7 @@ def build_seed_policy_payload(
         sample_item=sample_item,
         recent_sessions_payload=recent_sessions,
         current_request=resolved_requested_experiment,
+        advisor_routing=advisor_routing,
     )
     return {
         "folder": prefix,
@@ -1455,6 +1415,7 @@ def maybe_seed_baseline_policy(
         sample_item=sample_item,
         note=user_note,
     )
+    advisor_routing = advisor_routing_from_config(config)
     payload = build_seed_policy_payload(
         prefix=prefix,
         user_note=user_note,
@@ -1466,10 +1427,15 @@ def maybe_seed_baseline_policy(
         requested_experiment=requested_experiment,
         latest_failed_sample_job=latest_failed_sample_job,
         learning_context_payload=learning_context,
+        advisor_routing=advisor_routing,
     )
     if connection.in_transaction():
         connection.commit()
-    seed_response = request_seed_policy(project_root=project_root, payload=payload)
+    seed_response = request_seed_policy(
+        project_root=project_root,
+        payload=payload,
+        routing=advisor_routing,
+    )
     maybe_force_repeated_seed_experiment(
         base_policy=base_policy,
         seed_response=seed_response,

--- a/tests/test_advisor_routing.py
+++ b/tests/test_advisor_routing.py
@@ -1,0 +1,460 @@
+import json
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from typing import Any
+
+from mediaforce.advisor import request_operator_note_parse
+from mediaforce.advising.evals import recommended_eval_cases
+from mediaforce.advising.privacy import advisor_evidence_references, sanitize_advisor_payload
+from mediaforce.advising.routing import (
+    AdvisorModelPricing,
+    AdvisorTask,
+    advisor_routing_for_models,
+    advisor_routing_from_config,
+)
+from mediaforce.advising.runtime import (
+    StructuredLLMFailure,
+    _codex_lab_output,
+    run_codex_lab_process,
+    run_structured_llm_request,
+)
+from mediaforce.advising.telemetry import append_advisor_telemetry, estimated_cost_usd
+from mediaforce.core.config import ConfigPaths, MediaforceConfig
+
+
+def _jsonl(final_text: str, *, item_type: str = "agent_message", completed: bool = True) -> str:
+    events: list[dict[str, Any]] = [
+        {"type": "thread.started", "thread_id": "test-thread"},
+        {
+            "type": "item.completed",
+            "item": {"id": "test-item", "type": item_type, "text": final_text},
+        },
+    ]
+    if completed:
+        events.append(
+            {
+                "type": "turn.completed",
+                "usage": {"input_tokens": 120, "cached_input_tokens": 20, "output_tokens": 30},
+            }
+        )
+    return "\n".join(json.dumps(event, separators=(",", ":")) for event in events)
+
+
+def _load_json(raw: str) -> Any:
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+class AdvisorRoutingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_config_resolves_task_routes_telemetry_and_optional_pricing(self) -> None:
+        config = MediaforceConfig(
+            raw={
+                "advisor": {
+                    "command": "custom-codex-lab",
+                    "auth_profile": "mediaforce",
+                    "telemetry_max_records": 250,
+                    "routes": {
+                        "operator_note_parse": {"models": ["test-luna", "test-terra", "test-terra"]},
+                    },
+                    "model_pricing": {
+                        "test-luna": {
+                            "input_usd_per_million": 1.0,
+                            "cached_input_usd_per_million": 0.25,
+                            "output_usd_per_million": 4.0,
+                        }
+                    },
+                }
+            },
+            paths=self._paths(),
+        )
+
+        routing = advisor_routing_from_config(config)
+
+        self.assertEqual(routing.command, "custom-codex-lab")
+        self.assertEqual(routing.auth_profile, "mediaforce")
+        self.assertEqual(routing.telemetry_max_records, 250)
+        self.assertEqual(
+            routing.route_for(AdvisorTask.OPERATOR_NOTE_PARSE).models,
+            ("test-luna", "test-terra"),
+        )
+        self.assertEqual(
+            routing.route_for(AdvisorTask.SEED_POLICY).models,
+            ("gpt-5.6-terra", "gpt-5.6-sol"),
+        )
+        self.assertEqual(routing.telemetry_path, self.root / "web" / "advisor-routing.jsonl")
+        self.assertEqual(routing.pricing_for("test-luna").output_usd_per_million, 4.0)
+
+    def test_low_risk_fallback_records_reason_without_retaining_prompt(self) -> None:
+        telemetry_path = self.root / "telemetry.jsonl"
+        routing = advisor_routing_for_models(
+            {AdvisorTask.OPERATOR_NOTE_PARSE: ("test-luna", "test-terra")},
+            telemetry_path=telemetry_path,
+        )
+        commands: list[list[str]] = []
+        inputs: list[str] = []
+        valid_response = {
+            "summary": "No executable tuning request was present.",
+            "intent_type": "other",
+            "request_type": "none",
+            "operator_confirmed": False,
+            "measured_size_followup": False,
+            "evidence_authority": "none",
+            "metric": None,
+            "metric_target": None,
+            "size_budget_value": None,
+            "size_budget_unit": None,
+            "scale_height": None,
+            "black_bar_handling": None,
+            "crop": None,
+            "reasoning_note": "The note only supplied private context.",
+        }
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> object:
+            commands.append(cmd)
+            inputs.append(str(kwargs.get("input") or ""))
+            model = cmd[cmd.index("--model") + 1]
+            stdout = _jsonl("not-json" if model == "test-luna" else json.dumps(valid_response))
+            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+
+        from unittest.mock import patch
+
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
+            response = request_operator_note_parse(
+                project_root=self.root,
+                payload={
+                    "operator_note": "Look at /Users/alice/Videos/private.mkv and ask alice@example.com.",
+                    "goal": "Classify only the supplied note.",
+                },
+                routing=routing,
+            )
+
+        self.assertIsNotNone(response)
+        self.assertEqual([cmd[cmd.index("--model") + 1] for cmd in commands], ["test-luna", "test-terra"])
+        self.assertTrue(all("gpt-5.6-sol" not in cmd for cmd in commands))
+        self.assertTrue(all("/Users/alice" not in prompt for prompt in inputs))
+        self.assertTrue(all("alice@example.com" not in prompt for prompt in inputs))
+        self.assertTrue(all("[redacted-path]" in prompt for prompt in inputs))
+        records = self._telemetry(telemetry_path)
+        self.assertEqual([record["status"] for record in records], ["invalid_structured_output", "success"])
+        self.assertIsNone(records[0]["fallback_reason"])
+        self.assertEqual(records[1]["fallback_reason"], "invalid_structured_output")
+        self.assertEqual(records[1]["evidence_references"], ["goal"])
+        retained = telemetry_path.read_text()
+        self.assertNotIn("private.mkv", retained)
+        self.assertNotIn("alice@example.com", retained)
+        self.assertNotIn("Look at", retained)
+
+    def test_missing_image_is_nonretryable_and_path_is_redacted(self) -> None:
+        telemetry_path = self.root / "telemetry.jsonl"
+        routing = advisor_routing_for_models(
+            {AdvisorTask.REVIEW_ARTIFACT_CRITIQUE: ("test-terra", "test-sol")},
+            telemetry_path=telemetry_path,
+        )
+        run_calls = 0
+
+        def fake_run(*_args: Any, **_kwargs: Any) -> object:
+            nonlocal run_calls
+            run_calls += 1
+            raise AssertionError("subprocess should not start for a missing image")
+
+        result = run_structured_llm_request(
+            project_root=self.root,
+            developer="Return JSON.",
+            message="Review the supplied artifact.",
+            schema={"type": "object"},
+            max_seconds=10,
+            task=AdvisorTask.REVIEW_ARTIFACT_CRITIQUE,
+            prompt_version="test-v1",
+            routing=routing,
+            evidence_references=["multimodal_review_pack.image_count"],
+            subprocess_run=fake_run,
+            try_load_json=_load_json,
+            images=[str(self.root / "private" / "missing.png")],
+        )
+
+        self.assertIsInstance(result, StructuredLLMFailure)
+        self.assertEqual(run_calls, 0)
+        records = self._telemetry(telemetry_path)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["status"], "missing_image")
+        self.assertNotIn(str(self.root), telemetry_path.read_text())
+
+    def test_unavailable_command_stops_without_trying_another_model(self) -> None:
+        telemetry_path = self.root / "telemetry.jsonl"
+        routing = advisor_routing_for_models(
+            {AdvisorTask.SEED_POLICY: ("test-terra", "test-sol")},
+            telemetry_path=telemetry_path,
+        )
+        run_calls = 0
+
+        def fake_run(*_args: Any, **_kwargs: Any) -> object:
+            nonlocal run_calls
+            run_calls += 1
+            raise FileNotFoundError("/Users/alice/bin/codex-lab")
+
+        result = run_structured_llm_request(
+            project_root=self.root,
+            developer="Return JSON.",
+            message="Draft one policy.",
+            schema={"type": "object"},
+            max_seconds=10,
+            task=AdvisorTask.SEED_POLICY,
+            prompt_version="test-v1",
+            routing=routing,
+            evidence_references=["base_policy"],
+            subprocess_run=fake_run,
+            try_load_json=_load_json,
+        )
+
+        self.assertIsInstance(result, StructuredLLMFailure)
+        self.assertEqual(run_calls, 1)
+        records = self._telemetry(telemetry_path)
+        self.assertEqual([record["status"] for record in records], ["command_unavailable"])
+        self.assertNotIn("/Users/alice", telemetry_path.read_text())
+
+    def test_provider_failures_exhaust_only_the_configured_models(self) -> None:
+        telemetry_path = self.root / "telemetry.jsonl"
+        routing = advisor_routing_for_models(
+            {AdvisorTask.SEED_POLICY: ("test-terra", "test-sol")},
+            telemetry_path=telemetry_path,
+        )
+        models: list[str] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> object:
+            models.append(cmd[cmd.index("--model") + 1])
+            return type(
+                "Result",
+                (),
+                {"returncode": 1, "stdout": "", "stderr": "requested model is unavailable"},
+            )()
+
+        result = run_structured_llm_request(
+            project_root=self.root,
+            developer="Return JSON.",
+            message="Draft one policy.",
+            schema={"type": "object"},
+            max_seconds=10,
+            task=AdvisorTask.SEED_POLICY,
+            prompt_version="test-v1",
+            routing=routing,
+            evidence_references=["base_policy"],
+            subprocess_run=fake_run,
+            try_load_json=_load_json,
+        )
+
+        self.assertIsInstance(result, StructuredLLMFailure)
+        self.assertEqual(models, ["test-terra", "test-sol"])
+        records = self._telemetry(telemetry_path)
+        self.assertEqual([record["status"] for record in records], ["provider_error", "provider_error"])
+        self.assertEqual(records[1]["fallback_reason"], "provider_error")
+
+    def test_image_command_uses_isolated_generic_copy(self) -> None:
+        source_image = self.root / "private-title.png"
+        source_image.write_bytes(b"not-a-real-png-but-copyable")
+        telemetry_path = self.root / "telemetry.jsonl"
+        routing = advisor_routing_for_models(
+            {AdvisorTask.REVIEW_ARTIFACT_CRITIQUE: ("test-terra",)},
+            telemetry_path=telemetry_path,
+        )
+        captured_image: Path | None = None
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> object:
+            nonlocal captured_image
+            captured_image = Path(cmd[cmd.index("--image") + 1])
+            self.assertTrue(captured_image.is_file())
+            self.assertEqual(captured_image.name, "review-image-1.png")
+            self.assertNotIn(str(source_image), cmd)
+            return type(
+                "Result",
+                (),
+                {"returncode": 0, "stdout": _jsonl(json.dumps({"ok": True})), "stderr": ""},
+            )()
+
+        result = run_structured_llm_request(
+            project_root=self.root,
+            developer="Return JSON.",
+            message="Review the supplied artifact.",
+            schema={"type": "object"},
+            max_seconds=10,
+            task=AdvisorTask.REVIEW_ARTIFACT_CRITIQUE,
+            prompt_version="test-v1",
+            routing=routing,
+            evidence_references=["multimodal_review_pack.image_count"],
+            subprocess_run=fake_run,
+            try_load_json=_load_json,
+            images=[str(source_image)],
+        )
+
+        self.assertEqual(result, {"ok": True})
+        self.assertIsNotNone(captured_image)
+        self.assertFalse(captured_image.exists())
+        self.assertEqual(self._telemetry(telemetry_path)[0]["image_count"], 1)
+
+    def test_jsonl_parser_rejects_raw_or_incomplete_output_and_tool_use(self) -> None:
+        self.assertEqual(_codex_lab_output('{"ok":true}'), ("", {}, False, False))
+        text, usage, tool_used, completed = _codex_lab_output(_jsonl("{}", completed=False))
+        self.assertEqual(text, "{}")
+        self.assertEqual(usage, {})
+        self.assertFalse(tool_used)
+        self.assertFalse(completed)
+        _text, _usage, tool_used, completed = _codex_lab_output(
+            _jsonl("", item_type="command_execution")
+        )
+        self.assertTrue(tool_used)
+        self.assertTrue(completed)
+
+    def test_process_timeout_terminates_spawned_process_group(self) -> None:
+        started = time.monotonic()
+        with self.assertRaises(subprocess.TimeoutExpired) as raised:
+            run_codex_lab_process(
+                ["sh", "-c", "sleep 30 & echo $!; wait"],
+                input="",
+                capture_output=True,
+                text=True,
+                timeout=0.1,
+                cwd=self.root,
+            )
+
+        self.assertLess(time.monotonic() - started, 3.0)
+        child_pid = int(str(raised.exception.output).strip().splitlines()[0])
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            try:
+                os.kill(child_pid, 0)
+            except ProcessLookupError:
+                break
+            time.sleep(0.02)
+        else:
+            self.fail(f"timed-out child process {child_pid} was still running")
+
+    def test_payload_sanitization_and_evidence_references_do_not_expose_private_values(self) -> None:
+        payload = {
+            "operator_note": "Inspect file:///Users/alice/private.mkv and email alice@example.com.",
+            "source_path": "/Users/alice/private.mkv",
+            "sample_item": {
+                "rel_path": "tv/private/episode.mkv",
+                "duration_seconds": 2700,
+                "source_size_bytes": 2_000_000_000,
+            },
+            "multimodal_review_pack": {"images": ["/Users/alice/frame.png"]},
+        }
+
+        sanitized = sanitize_advisor_payload(payload)
+        references = advisor_evidence_references(payload)
+
+        serialized = json.dumps(sanitized, sort_keys=True)
+        self.assertNotIn("/Users/alice", serialized)
+        self.assertNotIn("alice@example.com", serialized)
+        self.assertNotIn("rel_path", serialized)
+        self.assertNotIn("source_path", serialized)
+        self.assertIn("[redacted-path]", serialized)
+        self.assertIn("[redacted-email]", serialized)
+        self.assertEqual(
+            references,
+            [
+                "sample_item.duration_seconds",
+                "sample_item.source_size_bytes",
+                "multimodal_review_pack.image_count",
+            ],
+        )
+
+    def test_telemetry_is_bounded_redacted_and_can_estimate_configured_cost(self) -> None:
+        path = self.root / "telemetry.jsonl"
+        for index in range(3):
+            append_advisor_telemetry(
+                path,
+                {
+                    "index": index,
+                    "diagnostic": f"/Users/alice/private-{index}.mkv",
+                    "operator_note": "private operator text",
+                    "prompt": "private prompt",
+                },
+                max_records=2,
+            )
+
+        records = self._telemetry(path)
+        self.assertEqual([record["index"] for record in records], [1, 2])
+        self.assertNotIn("/Users/alice", path.read_text())
+        self.assertNotIn("private operator text", path.read_text())
+        self.assertNotIn("private prompt", path.read_text())
+        self.assertEqual(
+            estimated_cost_usd(
+                {"input_tokens": 1_000_000, "cached_input_tokens": 500_000, "output_tokens": 250_000},
+                AdvisorModelPricing(
+                    input_usd_per_million=2.0,
+                    cached_input_usd_per_million=0.5,
+                    output_usd_per_million=8.0,
+                ),
+            ),
+            3.25,
+        )
+
+    def test_eval_corpus_covers_every_routing_tier_without_machine_local_media(self) -> None:
+        cases = recommended_eval_cases()
+        models = {case.model for case in cases if case.model is not None}
+        tasks = {case.task for case in cases}
+        serialized = json.dumps([case.payload for case in cases], sort_keys=True)
+
+        self.assertEqual(models, {"gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"})
+        self.assertTrue(
+            all(
+                case.fallback_models == ("gpt-5.6-terra",)
+                for case in cases
+                if case.model == "gpt-5.6-luna"
+            )
+        )
+        self.assertTrue(
+            all(
+                case.fallback_models == ("gpt-5.6-sol",)
+                for case in cases
+                if case.model == "gpt-5.6-terra"
+            )
+        )
+        self.assertTrue(
+            all(not case.fallback_models for case in cases if case.model == "gpt-5.6-sol")
+        )
+        self.assertTrue(
+            {
+                AdvisorTask.OPERATOR_NOTE_PARSE,
+                AdvisorTask.SEED_POLICY,
+                AdvisorTask.NOTE_TUNING,
+                AdvisorTask.REVIEW_ARTIFACT_CRITIQUE,
+                "run_verdict",
+            }.issubset(tasks)
+        )
+        self.assertNotIn("/Users/", serialized)
+        self.assertNotIn("/Volumes/", serialized)
+        self.assertNotIn("source_path", serialized)
+        self.assertNotIn("rel_path", serialized)
+
+    def _paths(self) -> ConfigPaths:
+        return ConfigPaths(
+            project_root=self.root,
+            config_path=self.root / "config.toml",
+            db_path=self.root / "library.sqlite3",
+            run_manifest_dir=self.root / "runs",
+            web_state_dir=self.root / "web",
+            review_dir=self.root / "review",
+            runtime_settings_path=self.root / "runtime.json",
+        )
+
+    @staticmethod
+    def _telemetry(path: Path) -> list[dict[str, Any]]:
+        return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -22,25 +22,19 @@ from mediaforce.advisor import (
     SEED_PROMPT_VERSION,
     SeedPolicyResponse,
     TuningPolicyResponse,
-    _build_prompt,
     _build_review_artifact_critique_prompt,
     _build_tune_prompt,
     _build_operator_note_parse_prompt,
     _extract_seed_payload,
     _filter_audio_specific_guardrail_issues,
     _force_repeated_tune_experiment,
-    _memory_disabled_code_args,
     _policy_response_schema,
     _run_tune_self_check,
-    _tune_self_check_schema,
-    _build_run_verdict_prompt,
-    _try_load_first_json_object,
     _build_seed_prompt,
     apply_seed_policy,
     request_review_artifact_critique,
     request_operator_note_parse,
     request_seed_policy,
-    request_tuning_advice,
     request_note_tuning,
     request_run_verdict,
 )
@@ -167,7 +161,31 @@ def _absolute_size_fragment(
     return {"video": video}
 
 
-def _fake_operator_note_parse(*, project_root: Path, payload: dict[str, object]) -> dict[str, object] | None:
+def _codex_lab_jsonl(final_text: str) -> str:
+    events = [
+        {"type": "thread.started", "thread_id": "test-thread"},
+        {
+            "type": "item.completed",
+            "item": {"id": "test-message", "type": "agent_message", "text": final_text},
+        },
+        {
+            "type": "turn.completed",
+            "usage": {
+                "input_tokens": 128,
+                "cached_input_tokens": 0,
+                "output_tokens": max(1, len(final_text) // 4),
+            },
+        },
+    ]
+    return "\n".join(json.dumps(event, separators=(",", ":")) for event in events)
+
+
+def _fake_operator_note_parse(
+        *,
+        project_root: Path,
+        payload: dict[str, object],
+        **_: object,
+) -> dict[str, object] | None:
     project_root.as_posix()
     note_value = payload.get("operator_note")
     note = note_value.strip() if isinstance(note_value, str) else ""
@@ -315,13 +333,19 @@ class TuningRuntimeTests(unittest.TestCase):
         def fake_run(cmd: list[str], **kwargs: object) -> object:
             self.assertIsInstance(kwargs, dict)
             commands.append(cmd)
-            return type("Result", (), {"returncode": 0, "stdout": response_body, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(response_body), "stderr": ""})()
 
         return commands, fake_run
 
     def _assert_structured_subprocess_call(self, commands: list[list[str]]) -> None:
         self.assertTrue(commands)
-        self.assertEqual(commands[0][1:7], _memory_disabled_code_args())
+        command = commands[0]
+        self.assertEqual(command[:3], ["codex-lab", "exec", "--ephemeral"])
+        self.assertIn("--ignore-user-config", command)
+        self.assertIn("--ignore-rules", command)
+        self.assertIn("--output-schema", command)
+        self.assertIn("--json", command)
+        self.assertEqual(command[-1], "-")
 
     def _insert_promoted_artifact(
             self,
@@ -426,7 +450,7 @@ class TuningRuntimeTests(unittest.TestCase):
             )
         )
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             parsed = request_operator_note_parse(
                 project_root=self.root,
                 payload={"operator_note": "Can you target 300MB per episode?"},
@@ -436,8 +460,6 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertTrue(parsed["operator_confirmed"])
         self.assertEqual(parsed["evidence_authority"], "none")
         self._assert_structured_subprocess_call(commands)
-        self.assertIn("llm", commands[0])
-        self.assertIn(_build_operator_note_parse_prompt({"operator_note": "Can you target 300MB per episode?"}), commands[0])
 
     def test_folder_display_policy_prefers_pending_preview_before_first_sample(self) -> None:
         sample_item = {
@@ -1125,9 +1147,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(kwargs, dict)
             commands.append(cmd)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -1146,8 +1168,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(response.proposed_policy["video"]["target_xpsnr"], 34.5)
         self.assertEqual(response.request_disposition, "honored")
         self.assertIn("smaller", response.request_response)
-        self.assertTrue(commands)
-        self.assertEqual(commands[0][1:7], _memory_disabled_code_args())
+        self._assert_structured_subprocess_call(commands)
 
     def test_archive_cleanup_summary_counts_files_and_size(self) -> None:
         archive_root = self.config.archive_root
@@ -1994,28 +2015,6 @@ class TuningRuntimeTests(unittest.TestCase):
 
         self.assertFalse(cleanup_lock.locked())
 
-    def test_request_tuning_advice_reads_last_message_output(self) -> None:
-        commands: list[list[str]] = []
-
-        def fake_run(cmd: list[str], **kwargs: object) -> object:
-            self.assertIsInstance(kwargs, dict)
-            commands.append(cmd)
-            output_index = cmd.index("--output-last-message") + 1
-            Path(cmd[output_index]).write_text("Recommendation\nTry one smaller sample.")
-            return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
-
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
-            response = request_tuning_advice(
-                project_root=self.root,
-                payload={"folder": "tv/House/Season 2", "sample_result": {"quality_score": 91.4}},
-            )
-
-        self.assertTrue(response.ok)
-        self.assertEqual(response.summary, "Recommendation")
-        self.assertIn("smaller sample", response.raw)
-        self.assertTrue(commands)
-        self.assertEqual(commands[0][1:7], _memory_disabled_code_args())
-
     def test_request_note_tuning_uses_multimodal_exec_when_review_pack_present(self) -> None:
         image_path = self.root / "review-pack.png"
         image_path.write_bytes(b"png")
@@ -2025,24 +2024,21 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(kwargs, dict)
             commands.append(cmd)
             if "exec" in cmd:
-                output_index = cmd.index("--output-last-message") + 1
-                Path(cmd[output_index]).write_text(
-                    json.dumps(
-                        {
-                            "request_response": "The attached review pack still looks clean enough to push a bit smaller.",
-                            "request_disposition": "honored_with_risk",
-                            "summary": "Use the review pack to justify one smaller pass.",
-                            "diagnosis": "The attached source-versus-draft contact sheets do not show obvious new damage on the sampled moments.",
-                            "confidence": "medium",
-                            "evidence_checked": ["multimodal_review_pack.artifacts[0]",
-                                                 "runtime_toolbelt.review_media_context"],
-                            "suggested_follow_up": "If the next draft softens faces or dark scenes, stop there.",
-                            "feasibility_note": None,
-                            "policy": {"video": {"target_vmaf": 88.5, "max_crf": 41}},
-                        }
-                    )
+                response_body = json.dumps(
+                    {
+                        "request_response": "The attached review pack still looks clean enough to push a bit smaller.",
+                        "request_disposition": "honored_with_risk",
+                        "summary": "Use the review pack to justify one smaller pass.",
+                        "diagnosis": "The attached source-versus-draft contact sheets do not show obvious new damage on the sampled moments.",
+                        "confidence": "medium",
+                        "evidence_checked": ["multimodal_review_pack.artifacts[0]",
+                                             "runtime_toolbelt.review_media_context"],
+                        "suggested_follow_up": "If the next draft softens faces or dark scenes, stop there.",
+                        "feasibility_note": None,
+                        "policy": {"video": {"target_vmaf": 88.5, "max_crf": 41}},
+                    }
                 )
-                return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(response_body), "stderr": ""})()
             return type(
                 "Result",
                 (),
@@ -2059,7 +2055,7 @@ class TuningRuntimeTests(unittest.TestCase):
                 },
             )()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -2081,7 +2077,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertTrue(commands)
         self.assertIn("exec", commands[0])
         self.assertIn("--image", commands[0])
-        self.assertEqual(commands[0][1:7], _memory_disabled_code_args())
+        self._assert_structured_subprocess_call(commands)
 
     def test_request_review_artifact_critique_uses_multimodal_exec(self) -> None:
         image_path = self.root / "review-pack.png"
@@ -2091,23 +2087,20 @@ class TuningRuntimeTests(unittest.TestCase):
         def fake_run(cmd: list[str], **kwargs: object) -> object:
             self.assertIsInstance(kwargs, dict)
             commands.append(cmd)
-            output_index = cmd.index("--output-last-message") + 1
-            Path(cmd[output_index]).write_text(
-                json.dumps(
-                    {
-                        "summary": "The hallway moment looks like the most fragile visual tradeoff.",
-                        "confidence": "medium",
-                        "weakest_moments": ["Moment 2 looks softer in dark material."],
-                        "preserved_strengths": ["Dialogue close-ups still look stable."],
-                        "artifacts_to_recheck": ["Compare timeline for review moment 2"],
-                        "recommendation": "Treat dark material as the veto moment for the next draft.",
-                        "evidence_checked": ["multimodal_review_pack.artifacts[0]"],
-                    }
-                )
+            response_body = json.dumps(
+                {
+                    "summary": "The hallway moment looks like the most fragile visual tradeoff.",
+                    "confidence": "medium",
+                    "weakest_moments": ["Moment 2 looks softer in dark material."],
+                    "preserved_strengths": ["Dialogue close-ups still look stable."],
+                    "artifacts_to_recheck": ["Compare timeline for review moment 2"],
+                    "recommendation": "Treat dark material as the veto moment for the next draft.",
+                    "evidence_checked": ["multimodal_review_pack.artifacts[0]"],
+                }
             )
-            return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(response_body), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_review_artifact_critique(
                 project_root=self.root,
                 payload={
@@ -2142,22 +2135,23 @@ class TuningRuntimeTests(unittest.TestCase):
                     "policy": {"video": {"default_grain": 20}},
                 }
             ),
-            json.dumps(
-                {
-                    "status": "fail",
-                    "summary": "The proposal is too aggressive for the stated goal.",
-                    "issues": ["Default grain increase is not supported by the supplied evidence."],
-                }
-            ),
         ]
 
         def fake_run(cmd: list[str], **kwargs: object) -> object:
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
+            "mediaforce.advisor._run_tune_self_check",
+            return_value={
+                "status": "fail",
+                "summary": "The proposal is too aggressive for the stated goal.",
+                "issues": ["Default grain increase is not supported by the supplied evidence."],
+                "source": "deterministic",
+            },
+        ):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -2216,9 +2210,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -2271,7 +2265,17 @@ class TuningRuntimeTests(unittest.TestCase):
                     },
                 }
             ),
-            json.dumps(
+        ]
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            self.assertIsInstance(cmd, list)
+            self.assertIsInstance(kwargs, dict)
+            stdout = responses.pop(0)
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
+
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
+            "mediaforce.advisor._run_tune_self_check",
+            side_effect=[
                 {
                     "status": "fail",
                     "summary": "The surround audio cut is not a safe trade for this draft.",
@@ -2280,28 +2284,15 @@ class TuningRuntimeTests(unittest.TestCase):
                         "status": "prefer_preserve_current",
                         "reason": "Dropping 5.1 Opus from 224k to 192k is low-leverage here, so preserve the current surround bitrate and spend the size budget on video instead.",
                     },
-                }
-            ),
-            json.dumps(
+                },
                 {
                     "status": "warn",
                     "summary": "The remaining video-only draft is usable, but verify it against the review clips.",
                     "issues": ["The cap may still land a bit under the requested budget."],
-                    "surround_audio_guardrail": {
-                        "status": "ok",
-                        "reason": "",
-                    },
-                }
-            ),
-        ]
-
-        def fake_run(cmd: list[str], **kwargs: object) -> object:
-            self.assertIsInstance(cmd, list)
-            self.assertIsInstance(kwargs, dict)
-            stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
-
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+                    "surround_audio_guardrail": {"status": "ok", "reason": ""},
+                },
+            ],
+        ):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -2362,7 +2353,7 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
         initial_fail_self_check = {
             "status": "fail",
@@ -2374,7 +2365,7 @@ class TuningRuntimeTests(unittest.TestCase):
             },
         }
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run), patch(
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
             "mediaforce.advisor._run_tune_self_check",
             side_effect=[initial_fail_self_check, None],
         ):
@@ -2434,9 +2425,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run), patch(
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
             "mediaforce.advisor._run_tune_self_check",
             side_effect=[
                 {
@@ -2539,9 +2530,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -2611,9 +2602,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -2683,9 +2674,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -2760,9 +2751,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -2828,9 +2819,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -2855,8 +2846,8 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIsNone(response.proposed_policy)
         assert response.self_check is not None
         self.assertEqual(response.self_check["status"], "warn")
-        self.assertEqual(response.self_check["summary"], "Dropping stereo Opus from 128k to 112k is low-leverage here.")
-        self.assertEqual(response.suggested_follow_up, "Dropping stereo Opus from 128k to 112k is low-leverage here.")
+        self.assertIn("Dropping current stereo bitrate from 128k to 112k is low-leverage here", response.self_check["summary"])
+        self.assertIn("Dropping current stereo bitrate from 128k to 112k is low-leverage here", response.suggested_follow_up)
 
     def test_request_note_tuning_applies_audio_guardrail_when_self_check_is_missing(self) -> None:
         responses = [
@@ -2882,9 +2873,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run), patch(
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
             "mediaforce.advisor._run_tune_self_check",
             return_value=None,
         ):
@@ -2947,9 +2938,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run), patch(
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
             "mediaforce.advisor._run_tune_self_check",
             side_effect=[
                 {
@@ -3022,9 +3013,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run), patch(
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
             "mediaforce.advisor._run_tune_self_check",
             return_value={
                 "status": "pass",
@@ -3087,9 +3078,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run), patch(
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
             "mediaforce.advisor._run_tune_self_check",
             return_value={
                 "status": "pass",
@@ -3150,9 +3141,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run), patch(
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
             "mediaforce.advisor._run_tune_self_check",
             return_value={
                 "status": "pass",
@@ -3213,9 +3204,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run), patch(
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
             "mediaforce.advisor._run_tune_self_check",
             return_value={
                 "status": "pass",
@@ -3276,9 +3267,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run), patch(
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
             "mediaforce.advisor._run_tune_self_check",
             side_effect=[
                 {
@@ -3370,9 +3361,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -3398,7 +3389,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertTrue(response.ok)
         self.assertEqual(response.summary, "Kept the non-audio tightening, but preserved the current surround bitrate.")
         self.assertIn("lowering the current surround bitrate was not the right trade here", response.diagnosis)
-        self.assertIn("Dropping 5.1 Opus from 224k to 192k is low-leverage here", response.diagnosis)
+        self.assertIn("Dropping current surround bitrate from 224k to 192k is low-leverage here", response.diagnosis)
 
     def test_request_note_tuning_filters_audio_only_issues_after_guardrail_warn(self) -> None:
         responses = [
@@ -3418,7 +3409,17 @@ class TuningRuntimeTests(unittest.TestCase):
                     },
                 }
             ),
-            json.dumps(
+        ]
+
+        def fake_run(cmd: list[str], **kwargs: object) -> object:
+            self.assertIsInstance(cmd, list)
+            self.assertIsInstance(kwargs, dict)
+            stdout = responses.pop(0)
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
+
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
+            "mediaforce.advisor._run_tune_self_check",
+            side_effect=[
                 {
                     "status": "warn",
                     "summary": "The draft is mostly usable, but the surround audio cut is not the best lever here.",
@@ -3430,25 +3431,15 @@ class TuningRuntimeTests(unittest.TestCase):
                         "status": "prefer_preserve_current",
                         "reason": "Dropping 5.1 Opus from 224k to 192k is low-leverage here, so preserve the current surround bitrate and spend the size budget on video instead.",
                     },
-                }
-            ),
-            json.dumps(
+                },
                 {
                     "status": "warn",
                     "summary": "The remaining video-only draft is usable, but the cap may still land a bit under the requested budget.",
                     "issues": ["The cap may still land a bit under the requested budget."],
                     "surround_audio_guardrail": {"status": "ok", "reason": ""},
-                }
-            ),
-        ]
-
-        def fake_run(cmd: list[str], **kwargs: object) -> object:
-            self.assertIsInstance(cmd, list)
-            self.assertIsInstance(kwargs, dict)
-            stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
-
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+                },
+            ],
+        ):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -3522,9 +3513,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -3582,9 +3573,9 @@ class TuningRuntimeTests(unittest.TestCase):
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -3618,19 +3609,8 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(response.proposed_policy["video"]["min_target_vmaf"], 87.0)
         self.assertEqual(response.proposed_policy["video"]["max_encoded_percent"], 8)
 
-    def test_request_run_verdict_uses_structured_runtime_path(self) -> None:
-        response_body = json.dumps(
-            {
-                "summary": "This aggressive sample landed much smaller and still looks usable on the checked moments.",
-                "outcome": "acceptable_experiment",
-                "confidence": "medium",
-                "next_step": "Approve it if the remaining review moments still look clean.",
-                "evidence_checked": ["sample_result", "operator_request"],
-            }
-        )
-        commands, fake_run = self._capture_subprocess_commands(response_body)
-
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+    def test_request_run_verdict_uses_deterministic_evidence(self) -> None:
+        with patch("mediaforce.advisor._run_codex_lab_process_impl") as subprocess_run:
             response = request_run_verdict(
                 project_root=self.root,
                 payload={
@@ -3643,8 +3623,9 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertTrue(response.ok)
         self.assertEqual(response.prompt_version, RUN_VERDICT_PROMPT_VERSION)
         self.assertEqual(response.outcome, "acceptable_experiment")
-        self.assertEqual(response.next_step, "Approve it if the remaining review moments still look clean.")
-        self._assert_structured_subprocess_call(commands)
+        self.assertEqual(response.confidence, "medium")
+        self.assertIn("met the requested quality floor", response.summary)
+        subprocess_run.assert_not_called()
 
     def test_request_seed_policy_uses_structured_runner(self) -> None:
         response_body = json.dumps(
@@ -3662,7 +3643,7 @@ class TuningRuntimeTests(unittest.TestCase):
         )
         commands, fake_run = self._capture_subprocess_commands(response_body)
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_seed_policy(
                 project_root=self.root,
                 payload={
@@ -3692,7 +3673,7 @@ class TuningRuntimeTests(unittest.TestCase):
         )
         commands, fake_run = self._capture_subprocess_commands(response_body)
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_seed_policy(
                 project_root=self.root,
                 payload={
@@ -3735,7 +3716,7 @@ class TuningRuntimeTests(unittest.TestCase):
         )
         commands, fake_run = self._capture_subprocess_commands(response_body)
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_seed_policy(
                 project_root=self.root,
                 payload={
@@ -3774,7 +3755,7 @@ class TuningRuntimeTests(unittest.TestCase):
         )
         commands, fake_run = self._capture_subprocess_commands(response_body)
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_seed_policy(
                 project_root=self.root,
                 payload={
@@ -3825,18 +3806,18 @@ class TuningRuntimeTests(unittest.TestCase):
             timeout = kwargs.get("timeout")
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=float(timeout or 0), stderr="model timed out")
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run):
             response = request_seed_policy(
                 project_root=self.root,
                 payload={
                     "folder": "tv/lucifer/season-2",
                     "base_policy": {"video": {"target_size_mb": 300.0}},
                 },
-            )
+        )
 
         self.assertFalse(response.ok)
-        self.assertIn("attempt 1: timed out", response.raw)
-        self.assertIn("model timed out", response.raw)
+        self.assertIn("attempt 1: timeout: Codex Lab timed out", response.raw)
+        self.assertNotIn("model timed out", response.raw)
 
     def test_operator_requested_experiment_detects_literal_vmaf_target(self) -> None:
         request = _operator_requested_experiment("I want to try 85 VMAF on this show.")
@@ -3904,6 +3885,41 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIsNone(request["applied_max_encoded_percent"])
         self.assertEqual(request["applied_policy"]["video"]["size_goal_mode"], "absolute")
         self.assertEqual(request["applied_policy"]["video"]["target_size_bytes"], 200_000_000)
+
+    def test_operator_requested_experiment_uses_model_for_ambiguous_worded_budget(self) -> None:
+        parsed_note = {
+            "summary": "Target roughly three hundred megabytes per episode.",
+            "intent_type": "direct_request",
+            "request_type": "size_budget",
+            "operator_confirmed": True,
+            "measured_size_followup": False,
+            "evidence_authority": "none",
+            "metric": None,
+            "metric_target": None,
+            "size_budget_value": 300,
+            "size_budget_unit": "mb",
+            "scale_height": None,
+            "black_bar_handling": None,
+            "crop": None,
+            "reasoning_note": "The amount was written as words.",
+        }
+        with patch(
+            "mediaforce.web.runtime.folder_tuning_advice.request_operator_note_parse",
+            return_value=parsed_note,
+        ) as note_parser:
+            request = _operator_requested_experiment(
+                "Please aim for roughly three hundred megabytes per episode.",
+                {
+                    "source_size_bytes": 3_519_516_042,
+                    "duration_seconds": 2561.35,
+                    "audio_summary": [{"channels": 6}],
+                    "resolved_policy": {"audio": {"surround_5_1_opus_bitrate": "224k"}},
+                },
+            )
+
+        assert request is not None
+        self.assertEqual(request["budget_bytes"], 300_000_000)
+        note_parser.assert_called_once()
 
     def test_operator_requested_experiment_detects_generated_measured_followup(self) -> None:
         note = (
@@ -4128,7 +4144,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertFalse(request["measured_size_followup"])
         self.assertFalse(request["hard_size_cap"])
 
-    def test_operator_requested_experiment_keeps_heuristic_followup_when_structured_parse_misses_it(self) -> None:
+    def test_operator_requested_experiment_uses_deterministic_followup_without_model(self) -> None:
         structured_parse = {
             "summary": "Size follow-up request.",
             "intent_type": "direct_request",
@@ -4149,7 +4165,7 @@ class TuningRuntimeTests(unittest.TestCase):
         with patch(
             "mediaforce.web.runtime.folder_tuning_advice.request_operator_note_parse",
             return_value=structured_parse,
-        ):
+        ) as note_parser:
             request = _operator_requested_experiment(
                 "Revise this sample smaller toward 300 MB per episode. The last sample was 766 MiB, 2.6x target.",
                 {
@@ -4168,6 +4184,7 @@ class TuningRuntimeTests(unittest.TestCase):
 
         assert request is not None
         self.assertTrue(request["measured_size_followup"])
+        note_parser.assert_not_called()
 
     def test_operator_requested_experiment_detects_scale_target_request(self) -> None:
         request = _operator_requested_experiment("Downsample the 4K files to 1080p for this folder.")
@@ -5028,7 +5045,12 @@ class TuningRuntimeTests(unittest.TestCase):
                     merged[section] = values
             return merged
 
-        def fake_request_note_tuning(*, project_root: Path, payload: dict[str, object]) -> TuningPolicyResponse:
+        def fake_request_note_tuning(
+                *,
+                project_root: Path,
+                payload: dict[str, object],
+                **_: object,
+        ) -> TuningPolicyResponse:
             self.assertEqual(project_root, self.config.paths.project_root)
             self.assertEqual(payload["requested_experiment"], operator_request)
             return TuningPolicyResponse(
@@ -5302,7 +5324,12 @@ class TuningRuntimeTests(unittest.TestCase):
                     merged[section] = values
             return merged
 
-        def fake_request_note_tuning(*, project_root: Path, payload: dict[str, object]) -> TuningPolicyResponse:
+        def fake_request_note_tuning(
+                *,
+                project_root: Path,
+                payload: dict[str, object],
+                **_: object,
+        ) -> TuningPolicyResponse:
             self.assertEqual(project_root, self.config.paths.project_root)
             self.assertEqual(payload["requested_experiment"], operator_request)
             return TuningPolicyResponse(
@@ -5448,7 +5475,12 @@ class TuningRuntimeTests(unittest.TestCase):
             missing_paths=[],
         )
 
-        def fake_request_note_tuning(*, project_root: Path, payload: dict[str, object]) -> TuningPolicyResponse:
+        def fake_request_note_tuning(
+                *,
+                project_root: Path,
+                payload: dict[str, object],
+                **_: object,
+        ) -> TuningPolicyResponse:
             self.assertEqual(project_root, self.config.paths.project_root)
             captured_payloads.append(payload)
             return TuningPolicyResponse(
@@ -5700,8 +5732,11 @@ class TuningRuntimeTests(unittest.TestCase):
 
         self.assertEqual(fragment, {})
 
-    def test_operator_requested_experiment_returns_none_when_structured_parse_fails(self) -> None:
-        with patch("mediaforce.web.runtime.folder_tuning_advice.request_operator_note_parse", return_value=None):
+    def test_operator_requested_experiment_uses_deterministic_budget_when_model_unavailable(self) -> None:
+        with patch(
+            "mediaforce.web.runtime.folder_tuning_advice.request_operator_note_parse",
+            return_value=None,
+        ) as note_parser:
             request = _operator_requested_experiment(
                 "Can you target 300MB per episode?",
                 {
@@ -5715,8 +5750,9 @@ class TuningRuntimeTests(unittest.TestCase):
         assert request is not None
         self.assertEqual(request["request_type"], "size_budget")
         self.assertTrue(request["operator_confirmed"])
+        note_parser.assert_not_called()
 
-    def test_operator_requested_experiment_recovers_combined_request_when_structured_parse_drops_scale(self) -> None:
+    def test_operator_requested_experiment_uses_deterministic_combined_request_without_model(self) -> None:
         with patch(
                 "mediaforce.web.runtime.folder_tuning_advice.request_operator_note_parse",
                 return_value={
@@ -5733,7 +5769,7 @@ class TuningRuntimeTests(unittest.TestCase):
                     "crop": None,
                     "reasoning_note": "Structured parse dropped the explicit scale target.",
                 },
-        ):
+        ) as note_parser:
             request = _operator_requested_experiment(
                 "Can we drop this to 1080P and try to hit around 300MB?",
                 {
@@ -5749,6 +5785,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(request["scale_height"], 1080)
         self.assertEqual(request["applied_policy"]["video"]["max_height"], 1080)
         self.assertEqual(request["budget_label"], "300 MB per episode")
+        note_parser.assert_not_called()
 
     def test_build_seed_policy_payload_carries_requested_experiment(self) -> None:
         payload = _build_seed_policy_payload(
@@ -6017,7 +6054,12 @@ class TuningRuntimeTests(unittest.TestCase):
             "policy": {"video": {"target_vmaf": 97.0, "max_encoded_percent": 14}},
         }
 
-        def fake_request_seed_policy(*, project_root: Path, payload: dict[str, object]) -> SeedPolicyResponse:
+        def fake_request_seed_policy(
+                *,
+                project_root: Path,
+                payload: dict[str, object],
+                **_: object,
+        ) -> SeedPolicyResponse:
             self.assertEqual(project_root, self.config.paths.project_root)
             self.assertFalse(connection.in_transaction())
             captured_payloads.append(payload)
@@ -6092,22 +6134,23 @@ class TuningRuntimeTests(unittest.TestCase):
                     "policy": {"video": {"target_vmaf": 89.0, "min_target_vmaf": 87.5}},
                 }
             ),
-            json.dumps(
-                {
-                    "status": "fail",
-                    "summary": "The bench explanation has caveats, but the explicit experiment is still coherent enough to review.",
-                    "issues": ["The fallback wording is weaker than the draft policy itself."],
-                }
-            ),
         ]
 
         def fake_run(cmd: list[str], **kwargs: object) -> object:
             self.assertIsInstance(cmd, list)
             self.assertIsInstance(kwargs, dict)
             stdout = responses.pop(0)
-            return type("Result", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+            return type("Result", (), {"returncode": 0, "stdout": _codex_lab_jsonl(stdout), "stderr": ""})()
 
-        with patch("mediaforce.advisor.subprocess.run", side_effect=fake_run):
+        with patch("mediaforce.advisor._run_codex_lab_process_impl", side_effect=fake_run), patch(
+            "mediaforce.advisor._run_tune_self_check",
+            return_value={
+                "status": "fail",
+                "summary": "The bench explanation has caveats, but the explicit experiment is still coherent enough to review.",
+                "issues": ["The fallback wording is weaker than the draft policy itself."],
+                "source": "deterministic",
+            },
+        ):
             response = request_note_tuning(
                 project_root=self.root,
                 payload={
@@ -7930,14 +7973,6 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(payload["summary"], "safe")
         self.assertEqual(payload["policy"], {"video": {}})
 
-    def test_try_load_first_json_object_skips_leading_text(self) -> None:
-        raw = "noise before {\"status\":\"pass\",\"summary\":\"ok\",\"issues\":[]} trailing"
-
-        payload = _try_load_first_json_object(raw)
-
-        assert isinstance(payload, dict)
-        self.assertEqual(payload["status"], "pass")
-
     def test_policy_response_schema_tracks_policy_shape(self) -> None:
         schema = _policy_response_schema(
             {
@@ -7997,25 +8032,18 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(applied["video"]["black_bar_detect_samples"], 5)
         self.assertEqual(applied["video"]["crop"], "1920:800:0:140")
 
-    def test_tune_self_check_schema_requires_surround_audio_guardrail(self) -> None:
-        schema = _tune_self_check_schema()
+    def test_tune_self_check_is_deterministic_and_requires_policy(self) -> None:
+        failed = _run_tune_self_check(project_root=self.root, tuning_context={}, proposal={})
+        passed = _run_tune_self_check(
+            project_root=self.root,
+            tuning_context={},
+            proposal={"policy": {"video": {"target_vmaf": 88.0}}},
+        )
 
-        self.assertIn("surround_audio_guardrail", schema["required"])
-        guardrail = schema["properties"]["surround_audio_guardrail"]
-        self.assertEqual(guardrail["required"], ["status", "reason"])
-        self.assertEqual(guardrail["properties"]["status"]["enum"], ["ok", "prefer_preserve_current"])
-
-    def test_generic_and_verdict_prompts_embed_context_and_shape(self) -> None:
-        generic_prompt = _build_prompt({"folder": "tv/House/Season 2", "sample": {"score": 91.4}})
-        verdict_prompt = _build_run_verdict_prompt(
-            {"folder": "tv/House/Season 2", "sample_result": {"quality_score": 91.4}})
-
-        self.assertIn("Recommendation, Why, Setting changes, Audio/Subtitles notes", generic_prompt)
-        self.assertIn("tv/House/Season 2", generic_prompt)
-        self.assertIn("acceptable_experiment", verdict_prompt)
-        self.assertIn("sample_result", verdict_prompt)
-        self.assertIn("Evidence precedence is strict", verdict_prompt)
-        self.assertIn("without implying quality damage", verdict_prompt)
+        self.assertEqual(failed["status"], "fail")
+        self.assertEqual(failed["source"], "deterministic")
+        self.assertEqual(passed["status"], "pass")
+        self.assertEqual(passed["source"], "deterministic")
 
     def test_tune_prompt_mentions_review_media_conversation(self) -> None:
         prompt = _build_tune_prompt(
@@ -8462,20 +8490,8 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIn("legacy H.264 or HEVC bitrate intuition", prompt)
         self.assertIn("high-80s VMAF", prompt)
 
-    def test_tune_self_check_prompt_references_hinted_audio_key(self) -> None:
-        captured_messages: list[str] = []
-
-        def fake_request(**kwargs: object) -> dict[str, object]:
-            message = kwargs["message"]
-            captured_messages.append(message if isinstance(message, str) else "")
-            return {
-                "status": "warn",
-                "summary": "ok",
-                "issues": [],
-                "surround_audio_guardrail": {"status": "ok", "reason": ""},
-            }
-
-        with patch("mediaforce.advisor._run_structured_llm_request", side_effect=fake_request):
+    def test_tune_self_check_bypasses_model_for_audio_hint(self) -> None:
+        with patch("mediaforce.advisor._run_structured_llm_request") as structured_request:
             result = _run_tune_self_check(
                 project_root=self.root,
                 tuning_context={
@@ -8491,9 +8507,9 @@ class TuningRuntimeTests(unittest.TestCase):
             )
 
         assert result is not None
-        self.assertTrue(captured_messages)
-        self.assertIn("stereo_opus_bitrate", captured_messages[0])
-        self.assertNotIn("surround_5_1_opus_bitrate", captured_messages[0])
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["source"], "deterministic")
+        structured_request.assert_not_called()
 
     def test_shutdown_cleanup_cancels_managed_processes(self) -> None:
         from mediaforce.web import app as web_app


### PR DESCRIPTION
## Summary
- replace the single advisor model with typed, configuration-driven Luna/Terra/Sol task routes and bounded recorded fallback
- add an isolated Codex Lab JSONL/schema adapter with process-group cleanup, deterministic bypasses, sanitized prompts/images, and privacy-safe telemetry
- add the checked-in synthetic advisor evaluation corpus, failure-injection/privacy tests, and architecture/operations documentation

## Evaluation
- recommended suite: 11/11 cases passed, 100% pass rate, zero fallbacks
- Luna extraction cases: 12.4–13.3s
- Terra planning/critique cases: 13.4–30.3s
- Sol escalation cases: 18.1–23.8s
- token usage is recorded; USD estimates remain unset unless pricing is explicitly configured

## Validation
- `bash scripts/pre-commit-check.sh`
- `uv run --with pytest pytest` (766 passed)
- `npm --prefix frontend test` (179 passed)
- frontend lint, typecheck, build, and web route smoke
- `uv build`
- PyCharm changed-files inspection: GREEN, 0 findings
- independent privacy/runtime review: no findings

Closes #163