### PR TITLE
Guide runtime-correct season size review

### DIFF
--- a/docs/development/browser-qa-matrix.md
+++ b/docs/development/browser-qa-matrix.md
@@ -44,11 +44,25 @@ The managed smoke seeds a compact but non-empty workflow dataset:
 - Retryable state: `/folders/tv/Retry%20Show/Season%201`, with a failed sample
   job that exposes retry copy.
 - Review-ready state: `/folders/tv/Review%20Ready/Season%201`, with retained
-  review media and visible review-pack artifacts.
+  review media, explicit target/band/sample-byte facts, and picture/sound risk.
+- Absolute-target state: `/folders/tv/Absolute%20Goal/Season%201`, proving an
+  explicit 225 MB episode goal remains 225 MB for an 88-minute episode.
+- Under- and over-target states: `/folders/tv/Undershoot%20Show/Season%201` and
+  `/folders/tv/Overshoot%20Show/Season%201`, with contextual measured retries.
+- Infeasible and quality-conflict states:
+  `/folders/tv/Infeasible%20Goal/Season%201` and
+  `/folders/tv/Quality%20Conflict/Season%201`, proving arithmetic impossibility
+  is explained separately from a measured quality-floor conflict.
+- Approved state: `/folders/tv/Approved%20Show/Season%201`, where approval is
+  complete but production remains unqueued until `Make the season` is chosen.
 - Active processing state: `/folders/tv/Encoding%20Show/Season%201`, with a
   running folder processing row.
 - Retryable processing state: `/folders/tv/Failed%20Encode/Season%201`, with a
   needs-attention processing row that exposes recovery copy.
+- Delivery states: `/folders/tv/Validation%20Ready/Season%201`,
+  `/folders/tv/Promotion%20Ready/Season%201`, and
+  `/folders/tv/Finished%20Show/Season%201` cover validation, promotion, and
+  completed folder states.
 - Unavailable worker state: `config/web-smoke.toml` includes a smoke-only remote
   host that is unavailable, so `/ops` can expose the no-ready-host blocker while
   queued encode work exists.
@@ -76,8 +90,17 @@ Every browser QA pass should cover these routes:
 - `/folders/tv/Sampling%20Show/Season%201`: active sample queue state.
 - `/folders/tv/Retry%20Show/Season%201`: retryable sample state.
 - `/folders/tv/Review%20Ready/Season%201`: review-pack-ready sample state.
+- `/folders/tv/Absolute%20Goal/Season%201`: absolute 225 MB target state.
+- `/folders/tv/Overshoot%20Show/Season%201`: over-target comparison state.
+- `/folders/tv/Undershoot%20Show/Season%201`: under-target comparison state.
+- `/folders/tv/Infeasible%20Goal/Season%201`: arithmetic infeasibility state.
+- `/folders/tv/Quality%20Conflict/Season%201`: quality-floor conflict state.
+- `/folders/tv/Approved%20Show/Season%201`: approved, not-yet-queued state.
 - `/folders/tv/Encoding%20Show/Season%201`: running processing state.
 - `/folders/tv/Failed%20Encode/Season%201`: retryable processing state.
+- `/folders/tv/Validation%20Ready/Season%201`: validation-ready state.
+- `/folders/tv/Promotion%20Ready/Season%201`: promotion-ready state.
+- `/folders/tv/Finished%20Show/Season%201`: completed state.
 - `/ops`: blockers, worker readiness, queues, and collapsed history.
 - `/completed`: no-action history and cleanup-ready work.
 - `/settings`: basic, advanced, and danger-zone settings sections.

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -439,6 +439,10 @@ export interface OperatorIntentRequestPayload {
 		audio?: Record<string, unknown>;
 		subtitle?: Record<string, unknown>;
 	};
+	quality_risk_tags?: QualityRiskTag[];
+	quality_risk_details?: string;
+	evidence_authority?:
+		'none' | 'operator_observed' | 'approved_visual_result' | 'rejected_visual_result';
 }
 
 export interface ResolvedSizeGoalPayload {
@@ -454,6 +458,10 @@ export interface ResolvedSizeGoalPayload {
 	target_size_mb?: number | null;
 	sample_projection_tolerance_percent: number;
 	final_output_tolerance_percent: number;
+	sample_lower_bound_bytes?: number | null;
+	sample_upper_bound_bytes?: number | null;
+	final_lower_bound_bytes?: number | null;
+	final_upper_bound_bytes?: number | null;
 	rationale: string;
 }
 

--- a/frontend/src/lib/components/season/SeasonExperience.svelte
+++ b/frontend/src/lib/components/season/SeasonExperience.svelte
@@ -6,9 +6,11 @@
 	import type {
 		FolderPayload,
 		FolderStatusPayload,
-		OperatorIntentRequestPayload
+		OperatorIntentRequestPayload,
+		QualityRiskTag
 	} from '$lib/api/types';
 	import {
+		REVIEW_CONCERNS,
 		approvalGuardFromMessage,
 		compareRiskSummary,
 		currentEncodeProgress,
@@ -17,7 +19,6 @@
 		episodeLabel,
 		folderSizeTargetAnalysis,
 		formatDecimalFileSize,
-		formatFileSize,
 		goalRequest,
 		isSizeGoalSelectionConfirmed,
 		isSeriesPrefix,
@@ -25,10 +26,15 @@
 		normalizeReviewPairs,
 		plainFailureMessage,
 		predictedEpisodeSize,
+		resolvedTargetSummary,
+		reviewFeedbackIntent,
+		reviewFeedbackRequest,
 		reviewSampleSizes,
 		seasonIdentity,
 		sizeGoals,
+		targetConstraintSummary,
 		technicalVideoPolicy,
+		testRequestWithInstructions,
 		type SizeGoal
 	} from '$lib/season/experience';
 
@@ -92,6 +98,10 @@
 	let actionMessage = $state('');
 	let actionStartedAt = $state(0);
 	let clock = $state(Date.now());
+	let showInstructions = $state(false);
+	let operatorInstructions = $state('');
+	let selectedConcerns = $state<QualityRiskTag[]>([]);
+	let reviewFeedback = $state('');
 	let sourceVideo = $state<HTMLVideoElement | null>(null);
 	let previewVideo = $state<HTMLVideoElement | null>(null);
 	let goalButtons = $state<HTMLButtonElement[]>([]);
@@ -107,7 +117,6 @@
 	);
 	const scopeName = $derived(isSeriesScope ? identity.show : identity.season);
 	const scopeNoun = $derived(isSeriesScope ? 'show' : 'season');
-	const scopeSizeLabel = $derived(isSeriesScope ? 'show' : 'season');
 	const humanState = $derived(detailSeasonState(folder, status));
 	const goals = $derived(sizeGoals(folder));
 	const selectedGoal = $derived(goals.find((goal) => goal.key === selectedGoalKey) ?? goals[0]);
@@ -132,25 +141,44 @@
 	const expectedEpisodeBytes = $derived(predictedEpisodeSize(folder));
 	const actualSampleSizes = $derived(reviewSampleSizes(folder));
 	const sizeTarget = $derived(folderSizeTargetAnalysis(folder));
+	const targetSummary = $derived(resolvedTargetSummary(folder));
+	const targetConstraint = $derived(targetConstraintSummary(folder));
 	const technicalVideo = $derived(technicalVideoPolicy(folder));
 	const expectedSeasonBytes = $derived(expectedEpisodeBytes * episodeCount);
-	const targetSeasonBytes = $derived(sizeTarget.budgetBytes * episodeCount);
+	const currentTargetBytes = $derived(
+		targetSummary?.targetBytes || sizeTarget.budgetBytes || selectedGoal?.targetSizeBytes || 0
+	);
 	const sizeTargetLabel = $derived(
-		sizeTarget.budgetBytes > 0 ? formatFileSize(sizeTarget.budgetBytes) : 'the requested size'
+		currentTargetBytes > 0 ? formatDecimalFileSize(currentTargetBytes) : 'the requested size'
 	);
 	const sizeTargetMissed = $derived(
 		['over_target', 'under_target', 'missing_prediction'].includes(sizeTarget.status)
 	);
 	const riskSummary = $derived(compareRiskSummary(folder));
+	const approvalBlocked = $derived(Boolean(targetConstraint || riskSummary?.blocked));
+	const hasReviewFeedback = $derived(
+		selectedConcerns.length > 0 || reviewFeedback.trim().length > 0
+	);
+	const selectedGoalSampleLower = $derived(
+		selectedGoal
+			? Math.round(
+					selectedGoal.targetSizeBytes *
+						(1 - selectedGoal.operatorIntent.size_goal.sample_projection_tolerance_percent / 100)
+				)
+			: 0
+	);
+	const selectedGoalSampleUpper = $derived(
+		selectedGoal
+			? Math.round(
+					selectedGoal.targetSizeBytes *
+						(1 + selectedGoal.operatorIntent.size_goal.sample_projection_tolerance_percent / 100)
+				)
+			: 0
+	);
 	const crfLimitReached = $derived(
 		asNumber(sampleResult.chosen_crf) > 0 &&
 			asNumber(technicalVideo.max_crf) > 0 &&
 			asNumber(sampleResult.chosen_crf) >= asNumber(technicalVideo.max_crf)
-	);
-	const expectedSavingsPercent = $derived(
-		originalSeasonSize > 0 && expectedSeasonBytes > 0
-			? Math.max(0, Math.round((1 - expectedSeasonBytes / originalSeasonSize) * 100))
-			: 0
 	);
 	const selectedHost = $derived(
 		hostOptions.find((host) => host.key === selectedHostKey) ?? hostOptions[0]
@@ -261,17 +289,43 @@
 			actionError = 'Choose how this legacy size should behave before making a test.';
 			return;
 		}
-		await startTest(goalRequest(selectedGoal), selectedGoal.operatorIntent);
+		await startTest(
+			testRequestWithInstructions(goalRequest(selectedGoal), operatorInstructions),
+			selectedGoal.operatorIntent
+		);
 	}
 
 	async function retryMeasuredTarget() {
-		const note = measuredFollowupRequest(sizeTarget);
+		const measuredRequest = measuredFollowupRequest(sizeTarget);
+		const baseRequest =
+			measuredRequest ||
+			`Keep the ${sizeTargetLabel} whole-episode goal and current resolution. Make another representative test that addresses the operator's review concerns without changing the size target.`;
+		const note = hasReviewFeedback
+			? reviewFeedbackRequest(baseRequest, selectedConcerns, reviewFeedback, operatorInstructions)
+			: testRequestWithInstructions(baseRequest, operatorInstructions);
 		if (!note) {
 			actionError =
 				'The previous test did not preserve its requested size. Choose a size and try again.';
 			return;
 		}
-		await startTest(note, currentOperatorIntent(folder));
+		const operatorIntent = hasReviewFeedback
+			? reviewFeedbackIntent(currentOperatorIntent(folder), selectedConcerns, reviewFeedback)
+			: currentOperatorIntent(folder);
+		await startTest(note, operatorIntent);
+	}
+
+	async function submitReviewFeedback() {
+		if (!hasReviewFeedback) {
+			actionError = 'Choose a concern or describe what should change before making a revised test.';
+			return;
+		}
+		await retryMeasuredTarget();
+	}
+
+	function toggleConcern(tag: QualityRiskTag) {
+		selectedConcerns = selectedConcerns.includes(tag)
+			? selectedConcerns.filter((selectedTag) => selectedTag !== tag)
+			: [...selectedConcerns, tag];
 	}
 
 	async function startTest(
@@ -619,13 +673,13 @@
 	async function confirmSizeTradeoff() {
 		await openSafetyDialog({
 			kind: 'approval',
-			title: `Accept ${formatFileSize(expectedEpisodeBytes)} per episode instead of ${sizeTargetLabel}?`,
+			title: `Accept ${formatDecimalFileSize(expectedEpisodeBytes)} per episode instead of ${sizeTargetLabel}?`,
 			detail: `This saves the tested settings as the ${scopeNoun} profile and queues the full ${scopeNoun} encode. It does not change this result to ${sizeTargetLabel} per episode.`,
 			primaryLabel: `Accept and queue ${scopeNoun}`,
 			confirmSizeTradeoff: true,
 			changes: [
 				`Requested: ${sizeTargetLabel} per episode`,
-				`Measured estimate: ${formatFileSize(expectedEpisodeBytes)} per episode`,
+				`Measured estimate: ${formatDecimalFileSize(expectedEpisodeBytes)} per episode`,
 				`Next action: queue the full ${scopeNoun}`
 			]
 		});
@@ -795,8 +849,8 @@
 					<p class="lede">
 						{episodeCount} episodes{isSeriesScope
 							? ` across ${seriesSeasonCount} ${seriesSeasonLabel}`
-							: ''} · {formatFileSize(originalSeasonSize)} now. You will compare one representative test
-						before Mediaforce makes the rest.
+							: ''} · {formatDecimalFileSize(originalSeasonSize)} now. You will compare one representative
+						test before Mediaforce makes the rest.
 					</p>
 				</div>
 
@@ -829,6 +883,61 @@
 							</span>
 						</button>
 					{/each}
+				</div>
+
+				{#if selectedGoal}
+					<div class="goal-contract" aria-live="polite">
+						<div>
+							<span>Whole-episode target</span>
+							<strong>{formatDecimalFileSize(selectedGoal.targetSizeBytes)}</strong>
+						</div>
+						<div>
+							<span>Representative test band</span>
+							<strong
+								>{formatDecimalFileSize(selectedGoalSampleLower)}–{formatDecimalFileSize(
+									selectedGoalSampleUpper
+								)}</strong
+							>
+							<small
+								>±{selectedGoal.operatorIntent.size_goal.sample_projection_tolerance_percent}% while
+								testing</small
+							>
+						</div>
+						<div class="goal-contract__truth">
+							<strong>Size is the target.</strong>
+							<span>Picture and sound decide whether that size is worth keeping.</span>
+						</div>
+					</div>
+				{/if}
+
+				<div class="optional-instructions">
+					<button
+						type="button"
+						class="optional-instructions__toggle"
+						onclick={() => (showInstructions = !showInstructions)}
+						aria-expanded={showInstructions}
+						aria-controls="operator-instructions"
+					>
+						<span>
+							<strong>Tell us more</strong>
+							<small>Optional priorities for picture, sound, subtitles, or source treatment</small>
+						</span>
+						<svg viewBox="0 0 20 20" aria-hidden="true"><path d="m5 7.5 5 5 5-5" /></svg>
+					</button>
+					{#if showInstructions}
+						<label id="operator-instructions" class="operator-instructions">
+							<span>Additional priorities</span>
+							<textarea
+								bind:value={operatorInstructions}
+								maxlength="600"
+								rows="3"
+								placeholder="For example: preserve the original surround layout and keep intentional grain."
+							></textarea>
+							<small
+								>{operatorInstructions.length}/600 · The selected size remains authoritative.</small
+							>
+						</label>
+					{/if}
 				</div>
 
 				<div class="goal-action">
@@ -881,9 +990,22 @@
 					<p class="eyebrow">Test in progress</p>
 					<h1>Making your test</h1>
 					<p class="lede">
-						{sampleEpisode} is being used to find a smaller version that matches your goal.
+						{sampleEpisode} is being used to target {sizeTargetLabel} for the whole episode, then check
+						whether the picture and sound hold up.
 					</p>
 					<div class="active-facts">
+						<div>
+							<span>Whole-episode target</span><strong>{sizeTargetLabel}</strong>
+						</div>
+						{#if targetSummary}
+							<div>
+								<span>Representative test band</span><strong
+									>{formatDecimalFileSize(
+										targetSummary.sampleLowerBoundBytes
+									)}–{formatDecimalFileSize(targetSummary.sampleUpperBoundBytes)}</strong
+								>
+							</div>
+						{/if}
 						<div>
 							<span>Current step</span><strong>{jobStageLabel(activeSampleJob.status)}</strong>
 						</div>
@@ -912,10 +1034,14 @@
 			<section class="compare-room">
 				<div class="compare-heading">
 					<div>
-						<p class={sizeTargetMissed ? 'eyebrow eyebrow--missed' : 'eyebrow'}>
-							{sizeTargetMissed ? 'Size goal not met' : 'Your test is ready'}
+						<p class={sizeTargetMissed || targetConstraint ? 'eyebrow eyebrow--missed' : 'eyebrow'}>
+							{targetConstraint
+								? 'Target needs a change'
+								: sizeTargetMissed
+									? 'Size goal not met'
+									: 'Looks good'}
 						</p>
-						<h1>Compare your test</h1>
+						<h1>{targetConstraint ? targetConstraint.title : 'Review picture and sound'}</h1>
 						<p>{sampleEpisode} · Compare the same moment on both sides.</p>
 					</div>
 					{#if reviewPairs.length > 1}
@@ -934,13 +1060,25 @@
 					{/if}
 				</div>
 
-				{#if sizeTarget.status === 'over_target'}
+				{#if targetConstraint}
+					<div class="target-warning target-warning--constraint" role="status">
+						<div>
+							<span
+								>{targetConstraint.kind === 'arithmetic_infeasible'
+									? 'Size cannot fit'
+									: 'Quality floor'}</span
+							>
+							<strong>{targetConstraint.title}</strong>
+						</div>
+						<p>{targetConstraint.detail}</p>
+					</div>
+				{:else if sizeTarget.status === 'over_target'}
 					<div class="target-warning" role="status">
 						<div>
 							<span>Requested size</span>
 							<strong
-								>This test estimates {formatFileSize(expectedEpisodeBytes)} per episode, not
-								{formatFileSize(sizeTarget.budgetBytes)}.</strong
+								>This test estimates {formatDecimalFileSize(expectedEpisodeBytes)} per episode, not
+								{formatDecimalFileSize(sizeTarget.budgetBytes)}.</strong
 							>
 						</div>
 						<p>
@@ -955,8 +1093,9 @@
 						<div>
 							<span>Requested size</span>
 							<strong
-								>This test estimates {formatFileSize(expectedEpisodeBytes)} per episode, below your
-								{formatFileSize(sizeTarget.budgetBytes)} goal.</strong
+								>This test estimates {formatDecimalFileSize(expectedEpisodeBytes)} per episode, below
+								your
+								{formatDecimalFileSize(sizeTarget.budgetBytes)} goal.</strong
 							>
 						</div>
 						<p>Make another test that spends the unused size on picture and sound quality.</p>
@@ -980,7 +1119,7 @@
 						<div class="video-card">
 							<div class="video-label">
 								<span>Original</span><small
-									>{formatFileSize(asNumber(sampleItem.source_size_bytes))} episode</small
+									>{formatDecimalFileSize(asNumber(sampleItem.source_size_bytes))} episode</small
 								>
 							</div>
 							<video
@@ -998,7 +1137,7 @@
 								<span>New</span>
 								<small
 									>{expectedEpisodeBytes
-										? `about ${formatFileSize(expectedEpisodeBytes)} episode`
+										? `about ${formatDecimalFileSize(expectedEpisodeBytes)} episode`
 										: 'test version'}</small
 								>
 							</div>
@@ -1047,9 +1186,14 @@
 							<strong>{riskSummary.verdict}</strong>
 						</div>
 						<div class="risk-summary__fact">
-							<span>Top concern</span>
-							<strong>{riskSummary.topRisk}</strong>
-							<small>{riskSummary.topRiskLevel}</small>
+							<span>Picture</span>
+							<strong>{riskSummary.picture.label}</strong>
+							<small>{riskSummary.picture.level} · {riskSummary.picture.detail}</small>
+						</div>
+						<div class="risk-summary__fact">
+							<span>Sound</span>
+							<strong>{riskSummary.sound.label}</strong>
+							<small>{riskSummary.sound.level} · {riskSummary.sound.detail}</small>
 						</div>
 						<div class="risk-summary__fact">
 							<span>Authority</span>
@@ -1063,55 +1207,141 @@
 					</div>
 				{/if}
 
-				<div class="size-story">
+				<div class="comparison-ledger" aria-label="Size comparison facts">
 					<div>
-						<span>Current {scopeSizeLabel}</span>
-						<strong>{formatFileSize(originalSeasonSize)}</strong>
-					</div>
-					<svg viewBox="0 0 34 16" aria-hidden="true"><path d="M1 8h30M25 2l6 6-6 6" /></svg>
-					<div>
-						<span>Rough {scopeNoun} projection from this episode</span>
-						<strong
-							>{expectedSeasonBytes
-								? formatFileSize(expectedSeasonBytes)
-								: 'Still estimating'}</strong
+						<span>Whole-episode target</span>
+						<strong>{sizeTargetLabel}</strong>
+						<small
+							>{targetSummary?.mode === 'normalized'
+								? 'Runtime-normalized goal'
+								: 'Per-episode goal'}</small
 						>
 					</div>
-					{#if sizeTarget.status === 'over_target'}
-						<p>
-							<b class="target-missed"
-								>{sizeTarget.predictedToBudgetRatio.toFixed(1)}× over your goal</b
-							>
-							{#if targetSeasonBytes}
-								· Your target is about {formatFileSize(targetSeasonBytes)} total.{/if}
-						</p>
-					{:else if sizeTarget.status === 'under_target'}
-						<p>
-							<b class="target-under">Below your goal</b>
-							{#if targetSeasonBytes}
-								· Your target is about {formatFileSize(targetSeasonBytes)} total.{/if}
-						</p>
-					{:else if expectedSavingsPercent}
-						<p><b>{expectedSavingsPercent}% smaller</b> based on this episode</p>
-					{/if}
+					<div>
+						<span>Representative test band</span>
+						<strong
+							>{targetSummary
+								? `${formatDecimalFileSize(targetSummary.sampleLowerBoundBytes)}–${formatDecimalFileSize(targetSummary.sampleUpperBoundBytes)}`
+								: 'Not available'}</strong
+						>
+						<small
+							>{targetSummary
+								? `±${targetSummary.sampleTolerancePercent}% while testing`
+								: 'Waiting for target evidence'}</small
+						>
+					</div>
+					<div class:comparison-ledger__missed={sizeTargetMissed || Boolean(targetConstraint)}>
+						<span>Predicted whole episode</span>
+						<strong
+							>{expectedEpisodeBytes
+								? formatDecimalFileSize(expectedEpisodeBytes)
+								: 'No usable estimate'}</strong
+						>
+						<small>
+							{sizeTarget.status === 'inside_target_band'
+								? 'Inside the representative band'
+								: sizeTarget.status === 'over_target'
+									? 'Above the representative band'
+									: sizeTarget.status === 'under_target'
+										? 'Below the representative band'
+										: 'Estimate requires another test'}
+						</small>
+					</div>
+					<div>
+						<span>Actual review clips</span>
+						<strong
+							>{actualSampleSizes.original && actualSampleSizes.smaller
+								? `${formatDecimalFileSize(actualSampleSizes.original)} → ${formatDecimalFileSize(actualSampleSizes.smaller)}`
+								: 'Clip bytes unavailable'}</strong
+						>
+						<small
+							>{actualSampleSizes.durationSeconds
+								? `${Math.round(actualSampleSizes.durationSeconds)} seconds sampled · not the episode size`
+								: 'Short review media only · not the episode size'}</small
+						>
+					</div>
 				</div>
-				{#if actualSampleSizes.original && actualSampleSizes.smaller}
-					<p class="actual-sample">
-						Across {Math.round(actualSampleSizes.durationSeconds)} seconds of review clips:
-						{formatFileSize(actualSampleSizes.original)} original →
-						{formatFileSize(actualSampleSizes.smaller)} new. That is {actualSampleSizes.ratioPercent}%
-						as large. Those clip bytes are only for picture-and-sound comparison; the measured
-						full-episode estimate is {formatFileSize(expectedEpisodeBytes)}.
-					</p>
-				{/if}
+
+				<div class="season-estimate-note">
+					<span>Estimated {scopeNoun} total</span>
+					<strong
+						>{expectedSeasonBytes
+							? formatDecimalFileSize(expectedSeasonBytes)
+							: 'Still estimating'}</strong
+					>
+					<small
+						>Representative estimate only; each production episode uses its own runtime target.</small
+					>
+				</div>
+
+				<div class="review-feedback-panel">
+					<div class="review-feedback-panel__heading">
+						<div>
+							<span>Want a revision?</span>
+							<h2>Tell Mediaforce what should change.</h2>
+						</div>
+						<p>The same size target stays in place unless you choose a different goal.</p>
+					</div>
+					<div class="concern-options" role="group" aria-label="Review concerns">
+						{#each REVIEW_CONCERNS as concern (concern.tag)}
+							<button
+								type="button"
+								class:active={selectedConcerns.includes(concern.tag)}
+								onclick={() => toggleConcern(concern.tag)}
+								aria-pressed={selectedConcerns.includes(concern.tag)}
+							>
+								{concern.label}
+							</button>
+						{/each}
+					</div>
+					<div class="review-feedback-fields">
+						<label>
+							<span>What did you notice?</span>
+							<textarea
+								bind:value={reviewFeedback}
+								maxlength="600"
+								rows="3"
+								placeholder="For example: fast movement loses texture around faces in Moment 2."
+							></textarea>
+							<small>{reviewFeedback.length}/600</small>
+						</label>
+						<label>
+							<span>Other priorities for the next test <small>(optional)</small></span>
+							<textarea
+								bind:value={operatorInstructions}
+								maxlength="600"
+								rows="3"
+								placeholder="Preserve surround audio, intentional grain, subtitle behavior, or another priority."
+							></textarea>
+							<small>{operatorInstructions.length}/600</small>
+						</label>
+					</div>
+					<div class="review-feedback-panel__action">
+						<p>
+							Submitting a concern records the current evidence as rejected and starts a revised
+							representative test.
+						</p>
+						<button
+							class="secondary-button"
+							type="button"
+							onclick={submitReviewFeedback}
+							disabled={!hasReviewFeedback || noAvailableHosts}
+						>
+							Make a revised test
+						</button>
+					</div>
+				</div>
 
 				<div
 					class="decision"
-					class:decision--target-miss={sizeTargetMissed}
-					class:decision--blocked={Boolean(riskSummary?.blocked)}
+					class:decision--target-miss={sizeTargetMissed || Boolean(targetConstraint)}
+					class:decision--blocked={approvalBlocked}
 				>
 					<div>
-						{#if riskSummary?.blocked}
+						{#if targetConstraint}
+							<h2>{targetConstraint.title}</h2>
+							<p>{targetConstraint.detail}</p>
+						{:else if riskSummary?.blocked}
 							<h2>This test is not safe to approve yet.</h2>
 							<p>{riskSummary.detail}</p>
 						{:else if sizeTarget.status === 'over_target'}
@@ -1131,7 +1361,16 @@
 						{/if}
 					</div>
 					<div class="decision-actions">
-						{#if riskSummary?.blocked}
+						{#if targetConstraint}
+							<button
+								class="primary-button primary-button--light"
+								type="button"
+								onclick={chooseDifferentSize}
+							>
+								{targetConstraint.recoveryLabel}
+								<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 10h11M11 5l5 5-5 5" /></svg>
+							</button>
+						{:else if riskSummary?.blocked}
 							<button class="secondary-button" type="button" onclick={chooseDifferentSize}>
 								Choose a different goal
 							</button>
@@ -1175,7 +1414,7 @@
 								class="primary-button primary-button--light"
 								type="button"
 								onclick={() => approveTest()}
-								disabled={!currentPair || Boolean(riskSummary?.blocked)}
+								disabled={!currentPair || approvalBlocked}
 							>
 								Looks good
 								<svg viewBox="0 0 20 20" aria-hidden="true"><path d="m4 10 3.5 3.5L16 5" /></svg>
@@ -1197,17 +1436,21 @@
 					Mediaforce will make all {episodeCount} episodes{isSeriesScope
 						? ` across ${seriesSeasonCount} ${seriesSeasonLabel}`
 						: ' in this season'} with the same settings. New files stay separate until they pass their
-					checks.
+					checks. Nothing is queued until you choose the action below.
 				</p>
 				<div class="ready-summary">
 					<div><span>Episodes</span><strong>{episodeCount}</strong></div>
-					<div><span>Current size</span><strong>{formatFileSize(originalSeasonSize)}</strong></div>
+					<div><span>Approved episode target</span><strong>{sizeTargetLabel}</strong></div>
 					<div>
-						<span>Expected size</span><strong
+						<span>Current size</span><strong>{formatDecimalFileSize(originalSeasonSize)}</strong>
+					</div>
+					<div>
+						<span>Estimated {scopeNoun} total</span><strong
 							>{expectedSeasonBytes
-								? formatFileSize(expectedSeasonBytes)
+								? formatDecimalFileSize(expectedSeasonBytes)
 								: 'Varies by episode'}</strong
 						>
+						<small>Each episode gets its own runtime-derived target.</small>
 					</div>
 				</div>
 				<button class="primary-button" type="button" onclick={queueSeason}>
@@ -1301,11 +1544,14 @@
 		{:else if humanState.key === 'needs_help'}
 			<section class="help-room">
 				<div class="help-mark" aria-hidden="true">!</div>
-				<p class="eyebrow">A small snag</p>
-				<h1>{humanState.label}.</h1>
-				<p class="lede">{plainFailureMessage(folder, status)}</p>
+				<p class="eyebrow">{targetConstraint ? 'Size needs a change' : 'A small snag'}</p>
+				<h1>{targetConstraint?.title || `${humanState.label}.`}</h1>
+				<p class="lede">{targetConstraint?.detail || plainFailureMessage(folder, status)}</p>
 				<div class="help-safety">
-					{#if humanState.recoveryKind === 'test'}
+					{#if targetConstraint}
+						<strong>No quality rule was silently relaxed.</strong>
+						<span>Choose a viable goal, then Mediaforce can make a fresh representative test.</span>
+					{:else if humanState.recoveryKind === 'test'}
 						<strong>Your library is safe.</strong>
 						<span>Nothing was replaced. Trying again rebuilds the comparison.</span>
 					{:else}
@@ -1320,8 +1566,17 @@
 						<span>episodes already made</span>
 					</div>
 				{/if}
-				<button class="primary-button" type="button" onclick={recoverSeason}>
-					{recoveryNeedsAdjustment ? 'Review retry' : 'Try again'}
+				<button
+					class="primary-button"
+					type="button"
+					onclick={() => (targetConstraint ? chooseDifferentSize() : recoverSeason())}
+				>
+					{targetConstraint?.recoveryLabel ||
+						(recoveryNeedsAdjustment
+							? 'Review retry'
+							: humanState.recoveryKind === 'test'
+								? 'Retry the sample'
+								: 'Retry unfinished episodes')}
 				</button>
 			</section>
 		{/if}
@@ -1405,11 +1660,47 @@
 					</div>
 					<div>
 						<span>Target</span><strong
-							>{selectedGoal?.megabytesPerEpisode ||
-								asNumber(technicalPolicy().target_size_mb) ||
-								'—'} MB / episode</strong
+							>{targetSummary?.targetBytes
+								? `${formatDecimalFileSize(targetSummary.targetBytes)} / episode`
+								: 'Not resolved'}</strong
 						>
 					</div>
+					{#if targetSummary}
+						<div>
+							<span>Target mode</span><strong
+								>{targetSummary.mode === 'normalized'
+									? 'Runtime-normalized'
+									: 'Absolute per episode'}</strong
+							>
+						</div>
+						<div>
+							<span>Sample band</span><strong
+								>{formatDecimalFileSize(
+									targetSummary.sampleLowerBoundBytes
+								)}–{formatDecimalFileSize(targetSummary.sampleUpperBoundBytes)}</strong
+							>
+						</div>
+						<div>
+							<span>Final output band</span><strong
+								>{formatDecimalFileSize(targetSummary.finalLowerBoundBytes)}–{formatDecimalFileSize(
+									targetSummary.finalUpperBoundBytes
+								)}</strong
+							>
+						</div>
+					{/if}
+					<div>
+						<span>Stream feasibility</span><strong
+							>{targetConstraint?.kind === 'arithmetic_infeasible'
+								? 'Cannot fit required streams'
+								: folder.stream_budget_ledger?.feasibility.status?.replaceAll('_', ' ') ||
+									'Awaiting measurement'}</strong
+						>
+					</div>
+					{#if riskSummary}
+						<div>
+							<span>Review authority</span><strong>{riskSummary.authority}</strong>
+						</div>
+					{/if}
 					{#if asNumber(sampleResult.chosen_crf)}<div>
 							<span>Chosen CRF</span><strong>{asNumber(sampleResult.chosen_crf)}</strong>
 						</div>{/if}
@@ -1425,10 +1716,10 @@
 					</button>
 				{/if}
 				{#if humanState.key === 'needs_help'}
-					<pre>{asText(asRecord(status.retryable_sample_job).error) ||
-							asText(activeSampleJob.error) ||
-							folder.encode_job?.error ||
-							'No technical error was recorded.'}</pre>
+					<p class="detail-error">
+						<strong>Recorded outcome</strong>
+						<span>{targetConstraint?.detail || plainFailureMessage(folder, status)}</span>
+					</p>
 				{/if}
 			</div>
 		</details>
@@ -1534,8 +1825,7 @@
 	.back-link svg,
 	.primary-button svg,
 	.details-drawer svg,
-	.safety-note svg,
-	.size-story svg {
+	.safety-note svg {
 		fill: none;
 		stroke: currentColor;
 		stroke-linecap: round;
@@ -2283,60 +2573,6 @@
 		color: var(--muted);
 	}
 
-	.size-story {
-		align-items: center;
-		border-bottom: 1px solid var(--line);
-		border-top: 1px solid var(--line);
-		display: grid;
-		gap: 24px;
-		grid-template-columns: 1fr 34px 1fr auto;
-		margin-top: 38px;
-		padding: 23px 0;
-	}
-
-	.size-story div {
-		display: flex;
-		flex-direction: column;
-		gap: 6px;
-	}
-
-	.size-story span {
-		color: var(--muted);
-		font-size: 10px;
-		font-weight: 750;
-		letter-spacing: 0.09em;
-		text-transform: uppercase;
-	}
-
-	.size-story strong {
-		font-family: 'Iowan Old Style', Georgia, serif;
-		font-size: 27px;
-		font-weight: 500;
-	}
-
-	.size-story svg {
-		color: #64766a;
-		width: 34px;
-	}
-
-	.size-story p {
-		color: #aeb7b0;
-		font-size: 12px;
-		margin: 0;
-	}
-
-	.size-story b {
-		color: #9cd0af;
-		font-size: 14px;
-	}
-
-	.actual-sample {
-		color: #8e9690;
-		font-size: 11px;
-		margin: 12px 0 0;
-		text-align: center;
-	}
-
 	.risk-summary {
 		display: grid;
 		gap: 18px;
@@ -2881,23 +3117,6 @@
 		text-decoration: underline;
 	}
 
-	.details-content pre {
-		background: rgb(0 0 0 / 8%);
-		border-radius: 10px;
-		font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-		font-size: 11px;
-		line-height: 1.5;
-		margin: 22px 0 0;
-		max-height: 220px;
-		overflow: auto;
-		padding: 14px;
-		white-space: pre-wrap;
-	}
-
-	.cinematic .details-content pre {
-		background: rgb(0 0 0 / 25%);
-	}
-
 	.experience-footer {
 		align-items: center;
 		border-top: 1px solid var(--line);
@@ -2940,6 +3159,42 @@
 			grid-template-columns: 1fr;
 		}
 
+		.goal-contract,
+		.review-feedback-fields {
+			grid-template-columns: 1fr;
+		}
+
+		.goal-contract > div + div {
+			border-left: 0;
+			border-top: 1px solid var(--mf-line-muted);
+		}
+
+		.comparison-ledger,
+		.risk-summary,
+		.risk-summary--attention,
+		.risk-summary--ready {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		.comparison-ledger > div:nth-child(3) {
+			border-left: 0;
+			border-top: 1px solid var(--mf-line-muted);
+		}
+
+		.comparison-ledger > div:nth-child(4) {
+			border-top: 1px solid var(--mf-line-muted);
+		}
+
+		.review-feedback-panel__heading,
+		.review-feedback-panel__action {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.season-estimate-note {
+			grid-template-columns: 1fr;
+		}
+
 		.goal-options button {
 			min-height: 0;
 		}
@@ -2961,15 +3216,6 @@
 		.compare-heading {
 			align-items: flex-start;
 			flex-direction: column;
-		}
-
-		.size-story {
-			grid-template-columns: 1fr 28px 1fr;
-		}
-
-		.size-story p {
-			grid-column: 1 / -1;
-			text-align: center;
 		}
 
 		.risk-summary {
@@ -3150,14 +3396,6 @@
 		.safety-dialog__actions {
 			align-items: stretch;
 			flex-direction: column-reverse;
-		}
-
-		.size-story {
-			gap: 12px;
-		}
-
-		.size-story strong {
-			font-size: 21px;
 		}
 
 		.decision {
@@ -3903,67 +4141,6 @@
 		margin-top: 4px;
 	}
 
-	.size-story {
-		align-items: center;
-		background: var(--mf-bg-panel-2);
-		border: 1px solid var(--mf-line-muted);
-		border-radius: var(--mf-radius-3);
-		display: grid;
-		gap: 14px;
-		grid-template-columns: 1fr auto 1fr minmax(160px, 0.9fr);
-		margin: 0;
-		padding: 13px 15px;
-	}
-
-	.size-story div {
-		display: grid;
-		gap: 2px;
-	}
-
-	.size-story span {
-		color: var(--mf-fg-tertiary);
-		font-size: 11px;
-		font-weight: 600;
-		letter-spacing: 0.04em;
-		text-transform: uppercase;
-	}
-
-	.size-story strong {
-		color: var(--mf-fg-primary);
-		font-family: var(--mf-font-sans);
-		font-size: 18px;
-		font-weight: 600;
-	}
-
-	.size-story svg {
-		stroke: var(--mf-fg-tertiary);
-	}
-
-	.size-story p {
-		color: var(--mf-fg-secondary);
-		font-size: 12px;
-		text-align: right;
-	}
-
-	.size-story b {
-		color: var(--mf-ready-fg);
-	}
-
-	.size-story b.target-missed {
-		color: var(--mf-fail-fg);
-	}
-
-	.size-story b.target-under {
-		color: var(--mf-wait-fg);
-	}
-
-	.actual-sample {
-		color: var(--mf-fg-tertiary);
-		font-size: 12px;
-		margin: -8px 0 0;
-		text-align: center;
-	}
-
 	.decision {
 		align-items: center;
 		background: var(--mf-active-bg);
@@ -4269,16 +4446,8 @@
 		border-radius: var(--mf-radius-2);
 	}
 
-	.detail-grid strong,
-	.details-content pre {
+	.detail-grid strong {
 		color: var(--mf-fg-primary);
-	}
-
-	.details-content pre {
-		background: var(--mf-bg-stage);
-		border-radius: var(--mf-radius-2);
-		color: #dfe5e1;
-		font-family: var(--mf-font-mono);
 	}
 
 	.detail-download {
@@ -4311,6 +4480,342 @@
 
 	.safety-dialog li {
 		color: var(--mf-fg-primary);
+	}
+
+	.goal-contract {
+		background: var(--mf-bg-panel-2);
+		border: 1px solid var(--mf-line-muted);
+		border-radius: var(--mf-radius-3);
+		display: grid;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	.goal-contract > div {
+		display: grid;
+		gap: 3px;
+		padding: 13px 14px;
+	}
+
+	.goal-contract > div + div {
+		border-left: 1px solid var(--mf-line-muted);
+	}
+
+	.goal-contract span,
+	.goal-contract small {
+		color: var(--mf-fg-secondary);
+		font-size: 11px;
+	}
+
+	.goal-contract strong {
+		color: var(--mf-fg-primary);
+		font-size: 15px;
+	}
+
+	.goal-contract__truth {
+		background: var(--mf-active-bg);
+	}
+
+	.optional-instructions {
+		border: 1px solid var(--mf-line-muted);
+		border-radius: var(--mf-radius-3);
+		overflow: hidden;
+	}
+
+	.optional-instructions__toggle {
+		align-items: center;
+		background: var(--mf-bg-panel);
+		border: 0;
+		color: var(--mf-fg-primary);
+		display: flex;
+		justify-content: space-between;
+		min-height: 52px;
+		padding: 9px 14px;
+		text-align: left;
+		width: 100%;
+	}
+
+	.optional-instructions__toggle > span {
+		display: grid;
+		gap: 2px;
+	}
+
+	.optional-instructions__toggle strong {
+		font-size: 13px;
+	}
+
+	.optional-instructions__toggle small {
+		color: var(--mf-fg-tertiary);
+		font-size: 11px;
+	}
+
+	.optional-instructions__toggle svg {
+		fill: none;
+		height: 18px;
+		stroke: currentColor;
+		stroke-width: 1.7;
+		transition: transform 140ms ease;
+		width: 18px;
+	}
+
+	.optional-instructions__toggle[aria-expanded='true'] svg {
+		transform: rotate(180deg);
+	}
+
+	.operator-instructions,
+	.review-feedback-fields label {
+		background: var(--mf-bg-panel-2);
+		border-top: 1px solid var(--mf-line-muted);
+		display: grid;
+		gap: 7px;
+		padding: 13px 14px;
+	}
+
+	.operator-instructions > span,
+	.review-feedback-fields label > span {
+		color: var(--mf-fg-primary);
+		font-size: 12px;
+		font-weight: 650;
+	}
+
+	.operator-instructions textarea,
+	.review-feedback-fields textarea {
+		background: var(--mf-bg-input);
+		border: 1px solid var(--mf-line-strong);
+		border-radius: var(--mf-radius-2);
+		color: var(--mf-fg-primary);
+		font: inherit;
+		line-height: 1.45;
+		min-height: 76px;
+		padding: 10px 11px;
+		resize: vertical;
+		width: 100%;
+	}
+
+	.operator-instructions small,
+	.review-feedback-fields small {
+		color: var(--mf-fg-tertiary);
+		font-size: 10px;
+	}
+
+	.active-facts {
+		grid-template-columns: repeat(5, minmax(0, 1fr));
+	}
+
+	.target-warning--constraint {
+		background: var(--mf-fail-bg);
+		border-color: var(--mf-fail-line);
+	}
+
+	.risk-summary,
+	.risk-summary--attention,
+	.risk-summary--ready {
+		background: var(--mf-bg-panel-2);
+		border: 1px solid var(--mf-line-muted);
+		border-radius: var(--mf-radius-3);
+		color: var(--mf-fg-primary);
+		display: grid;
+		gap: 12px;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		margin: 0;
+		padding: 14px 15px;
+	}
+
+	.risk-summary--attention {
+		background: var(--mf-fail-bg);
+		border-color: var(--mf-fail-line);
+	}
+
+	.risk-summary--ready {
+		background: var(--mf-ready-bg);
+		border-color: var(--mf-ready-line);
+	}
+
+	.risk-summary span {
+		color: var(--mf-fg-tertiary);
+		font-size: 10px;
+		margin-bottom: 4px;
+	}
+
+	.risk-summary strong {
+		color: var(--mf-fg-primary);
+		font-size: 14px;
+	}
+
+	.risk-summary small {
+		color: var(--mf-fg-secondary);
+		display: block;
+		font-size: 10px;
+		line-height: 1.4;
+		margin-top: 3px;
+	}
+
+	.risk-summary__detail,
+	.risk-summary__focus {
+		color: var(--mf-fg-secondary) !important;
+		grid-column: 1 / -1;
+		margin: 0 !important;
+	}
+
+	.comparison-ledger {
+		border: 1px solid var(--mf-line-muted);
+		border-radius: var(--mf-radius-3);
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		overflow: hidden;
+	}
+
+	.comparison-ledger > div {
+		background: var(--mf-bg-panel-2);
+		display: grid;
+		gap: 3px;
+		padding: 13px 14px;
+	}
+
+	.comparison-ledger > div + div {
+		border-left: 1px solid var(--mf-line-muted);
+	}
+
+	.comparison-ledger span,
+	.season-estimate-note span {
+		color: var(--mf-fg-tertiary);
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+
+	.comparison-ledger strong,
+	.season-estimate-note strong {
+		color: var(--mf-fg-primary);
+		font-size: 15px;
+	}
+
+	.comparison-ledger small,
+	.season-estimate-note small {
+		color: var(--mf-fg-secondary);
+		font-size: 10px;
+		line-height: 1.4;
+	}
+
+	.comparison-ledger__missed {
+		background: var(--mf-wait-bg) !important;
+	}
+
+	.season-estimate-note {
+		align-items: center;
+		background: var(--mf-bg-panel-2);
+		border: 1px solid var(--mf-line-muted);
+		border-radius: var(--mf-radius-3);
+		display: grid;
+		gap: 3px 14px;
+		grid-template-columns: auto auto minmax(0, 1fr);
+		padding: 10px 14px;
+	}
+
+	.review-feedback-panel {
+		background: var(--mf-bg-panel-2);
+		border: 1px solid var(--mf-line-muted);
+		border-radius: var(--mf-radius-3);
+		display: grid;
+		gap: 13px;
+		padding: 15px;
+	}
+
+	.review-feedback-panel__heading,
+	.review-feedback-panel__action {
+		align-items: center;
+		display: flex;
+		gap: 16px;
+		justify-content: space-between;
+	}
+
+	.review-feedback-panel__heading > div {
+		display: grid;
+		gap: 3px;
+	}
+
+	.review-feedback-panel__heading span {
+		color: var(--mf-active-fg);
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+
+	.review-feedback-panel__heading h2,
+	.review-feedback-panel__heading p,
+	.review-feedback-panel__action p {
+		margin: 0;
+	}
+
+	.review-feedback-panel__heading p,
+	.review-feedback-panel__action p {
+		font-size: 11px;
+		max-width: 420px;
+	}
+
+	.concern-options {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+	}
+
+	.concern-options button {
+		background: var(--mf-bg-panel);
+		border: 1px solid var(--mf-line-strong);
+		border-radius: 999px;
+		color: var(--mf-fg-secondary);
+		font-size: 11px;
+		font-weight: 600;
+		min-height: 32px;
+		padding: 0 11px;
+	}
+
+	.concern-options button.active {
+		background: var(--mf-fail-bg);
+		border-color: var(--mf-fail-line);
+		color: var(--mf-fail-fg);
+	}
+
+	.review-feedback-fields {
+		display: grid;
+		gap: 10px;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.review-feedback-fields label {
+		border: 1px solid var(--mf-line-muted);
+		border-radius: var(--mf-radius-2);
+	}
+
+	.review-feedback-panel__action {
+		border-top: 1px solid var(--mf-line-muted);
+		padding-top: 12px;
+	}
+
+	.ready-summary {
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		max-width: 820px;
+	}
+
+	.ready-summary small {
+		color: var(--mf-fg-tertiary);
+		font-size: 10px;
+	}
+
+	.detail-error {
+		background: var(--mf-wait-bg);
+		border: 1px solid var(--mf-wait-line);
+		border-radius: var(--mf-radius-2);
+		display: grid;
+		gap: 3px;
+		padding: 11px 12px;
+	}
+
+	.detail-error strong,
+	.detail-error span {
+		color: var(--mf-wait-fg);
+		font-size: 12px;
 	}
 
 	@keyframes working-bar {
@@ -4376,15 +4881,6 @@
 			grid-template-columns: 1fr;
 		}
 
-		.size-story {
-			grid-template-columns: 1fr auto 1fr;
-		}
-
-		.size-story p {
-			grid-column: 1 / -1;
-			text-align: left;
-		}
-
 		.season-progress-room {
 			grid-template-columns: minmax(0, 1fr) 130px;
 		}
@@ -4443,12 +4939,28 @@
 			text-align: center;
 		}
 
-		.size-story {
+		.comparison-ledger,
+		.risk-summary,
+		.risk-summary--attention,
+		.risk-summary--ready {
 			grid-template-columns: 1fr;
 		}
 
-		.size-story svg {
-			display: none;
+		.review-feedback-fields,
+		.season-estimate-note {
+			align-items: start;
+			grid-template-columns: 1fr;
+		}
+
+		.comparison-ledger > div + div,
+		.comparison-ledger > div:nth-child(3),
+		.comparison-ledger > div:nth-child(4) {
+			border-left: 0;
+			border-top: 1px solid var(--mf-line-muted);
+		}
+
+		.concern-options button {
+			flex: 1 1 calc(50% - 6px);
 		}
 
 		.decision-actions,

--- a/frontend/src/lib/components/season/SeasonExperience.svelte
+++ b/frontend/src/lib/components/season/SeasonExperience.svelte
@@ -117,6 +117,9 @@
 	);
 	const scopeName = $derived(isSeriesScope ? identity.show : identity.season);
 	const scopeNoun = $derived(isSeriesScope ? 'show' : 'season');
+	const makeActionLabel = $derived(
+		isSeriesScope ? `Make all ${seriesSeasonCount} ${seriesSeasonLabel}` : 'Make the season'
+	);
 	const humanState = $derived(detailSeasonState(folder, status));
 	const goals = $derived(sizeGoals(folder));
 	const selectedGoal = $derived(goals.find((goal) => goal.key === selectedGoalKey) ?? goals[0]);
@@ -660,7 +663,7 @@
 
 	async function focusSafetyDialog() {
 		await tick();
-		(document.querySelector('.safety-dialog .primary-button') as HTMLElement | null)?.focus();
+		(document.querySelector('.safety-dialog .secondary-button') as HTMLElement | null)?.focus();
 	}
 
 	async function openSafetyDialog(dialog: SafetyDialog) {
@@ -674,13 +677,13 @@
 		await openSafetyDialog({
 			kind: 'approval',
 			title: `Accept ${formatDecimalFileSize(expectedEpisodeBytes)} per episode instead of ${sizeTargetLabel}?`,
-			detail: `This saves the tested settings as the ${scopeNoun} profile and queues the full ${scopeNoun} encode. It does not change this result to ${sizeTargetLabel} per episode.`,
-			primaryLabel: `Accept and queue ${scopeNoun}`,
+			detail: `This saves the tested settings as the ${scopeNoun} profile. Production remains separate until you choose ${makeActionLabel}. It does not change this result to ${sizeTargetLabel} per episode.`,
+			primaryLabel: 'Accept this result',
 			confirmSizeTradeoff: true,
 			changes: [
 				`Requested: ${sizeTargetLabel} per episode`,
 				`Measured estimate: ${formatDecimalFileSize(expectedEpisodeBytes)} per episode`,
-				`Next action: queue the full ${scopeNoun}`
+				`Next action: choose ${makeActionLabel} when you are ready`
 			]
 		});
 	}
@@ -1454,7 +1457,7 @@
 					</div>
 				</div>
 				<button class="primary-button" type="button" onclick={queueSeason}>
-					{isSeriesScope ? `Make all ${seriesSeasonCount} ${seriesSeasonLabel}` : 'Make the season'}
+					{makeActionLabel}
 					<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 10h11M11 5l5 5-5 5" /></svg>
 				</button>
 			</section>

--- a/frontend/src/lib/season/experience.test.ts
+++ b/frontend/src/lib/season/experience.test.ts
@@ -25,9 +25,14 @@ import {
 	measuredFollowupRequest,
 	librarySeasonState,
 	normalizeReviewPairs,
+	resolvedTargetSummary,
+	reviewFeedbackIntent,
+	reviewFeedbackRequest,
 	reviewSampleSizes,
 	seasonIdentity,
 	sizeGoals,
+	targetConstraintSummary,
+	testRequestWithInstructions,
 	technicalVideoPolicy
 } from './experience';
 
@@ -264,7 +269,17 @@ describe('season experience translation', () => {
 			topRiskDetail: 'Measured temporal noise may be grain rather than removable noise.',
 			authority: 'No current decision',
 			authorityDetail: 'Older, stale, or sibling evidence is not treated as authority here.',
-			focusMoments: ['Moment 2 · grain_noise_treatment']
+			focusMoments: ['Moment 2 · grain_noise_treatment'],
+			picture: {
+				label: 'Grain / noise treatment',
+				level: 'medium risk',
+				detail: 'Measured temporal noise may be grain rather than removable noise.'
+			},
+			sound: {
+				label: 'No specific sound warning',
+				level: 'No specific warning',
+				detail: 'Listen for clarity, channel layout, balance, and anything distracting.'
+			}
 		});
 	});
 
@@ -375,6 +390,21 @@ describe('season experience translation', () => {
 
 		expect(request).toContain('225 MB per episode');
 		expect(request).toContain('previous run did not produce a usable full-episode size estimate');
+	});
+
+	it('keeps an inside-target goal fixed when the operator requests a revision', () => {
+		const request = measuredFollowupRequest({
+			status: 'inside_target_band',
+			budgetBytes: 587_000_000,
+			predictedBytes: 590_000_000,
+			lowerBoundBytes: 528_300_000,
+			upperBoundBytes: 645_700_000,
+			predictedToBudgetRatio: 1.005
+		});
+
+		expect(request).toContain('Measured revision');
+		expect(request).toContain('keep the 587 MB per episode goal');
+		expect(request).toContain('without changing the size target');
 	});
 
 	it('distinguishes a whole show from one season', () => {
@@ -502,6 +532,47 @@ describe('season experience translation', () => {
 		).toMatchObject({ key: 'needs_help', label: 'The test needs another try' });
 	});
 
+	it('returns an approved sample to review when current evidence is rejected', () => {
+		expect(
+			detailSeasonState(
+				folder({
+					calibration: {
+						job_id: 'sample-1',
+						draft_hash: 'draft-1',
+						accepted_draft_hash: 'draft-1',
+						review_media_ready: true
+					},
+					review_gate: { status: 'accepted', can_confirm_full: true },
+					quality_risk: {
+						operator_decision: { status: 'rejected' }
+					}
+				}),
+				status
+			)
+		).toMatchObject({ key: 'ready_to_compare', label: 'Test ready' });
+	});
+
+	it('trusts an accepted review gate when non-policy draft metadata changed', () => {
+		expect(
+			detailSeasonState(
+				folder({
+					calibration: {
+						job_id: 'sample-1',
+						draft_hash: 'draft-with-refreshed-metadata',
+						accepted_draft_hash: 'original-draft',
+						review_media_ready: true
+					},
+					review_gate: { status: 'accepted', can_confirm_full: true },
+					quality_risk: {
+						blocked: false,
+						operator_decision: { status: 'approved' }
+					}
+				}),
+				status
+			)
+		).toMatchObject({ key: 'ready_to_make', label: 'Test approved' });
+	});
+
 	it.each([
 		['validate', 'ready_to_check'],
 		['promote', 'ready_to_finish'],
@@ -540,6 +611,150 @@ describe('season experience translation', () => {
 		expect(goals.map((goal) => goal.megabytesPerEpisode)).toEqual([587, 440, 880]);
 		expect(goals[0].mode).toBe('normalized');
 		expect(goalRequest(goals[0])).toContain('300 MB / 45 minute runtime-normalized goal');
+	});
+
+	it('publishes explicit sample and final bands for the active whole-episode target', () => {
+		const option = sizeOption('recommended', 'normalized', 300, 586.667, 45);
+		const target = resolvedTargetSummary(
+			folder({
+				resolved_operator_intent: {
+					schema_version: 1,
+					requires_confirmation: false,
+					size_goal: {
+						...option.resolved_size_goal,
+						item_runtime_seconds: 88 * 60,
+						sample_lower_bound_bytes: 528_000_300,
+						sample_upper_bound_bytes: 645_333_700,
+						final_lower_bound_bytes: 557_333_650,
+						final_upper_bound_bytes: 616_000_350
+					},
+					resolution: { mode: 'source' },
+					request: option.operator_intent
+				}
+			})
+		);
+
+		expect(target).toMatchObject({
+			targetBytes: 586_667_000,
+			sampleLowerBoundBytes: 528_000_300,
+			sampleUpperBoundBytes: 645_333_700,
+			finalLowerBoundBytes: 557_333_650,
+			finalUpperBoundBytes: 616_000_350,
+			itemRuntimeSeconds: 5280,
+			mode: 'normalized'
+		});
+	});
+
+	it('distinguishes arithmetic infeasibility from a quality-floor conflict', () => {
+		expect(
+			targetConstraintSummary(
+				folder({
+					stream_budget_ledger: {
+						schema_version: 1,
+						ledger_id: 'ledger-1',
+						source: {
+							source_id: 'source-1',
+							source_fingerprint: null,
+							source_size_bytes: 1_000_000_000,
+							source_video_bitrate_bps: 5_000_000,
+							duration_seconds: 5280
+						},
+						policy_hash: 'policy-1',
+						size_goal: sizeOption('recommended', 'absolute', 1, 1).resolved_size_goal,
+						stream_plan: {
+							schema_version: 1,
+							plan_id: 'plan-1',
+							source_id: 'source-1',
+							source_fingerprint: null,
+							policy_hash: 'policy-1',
+							output_container: 'mkv',
+							attachments_known: true,
+							copy_unknown_attachments: false,
+							streams: []
+						},
+						entries: [],
+						totals: {
+							total_target_bytes: 1_000_000,
+							audio_bytes: 2_000_000,
+							subtitle_bytes: 0,
+							attachment_bytes: 0,
+							container_bytes: 0,
+							non_video_bytes: 2_000_000,
+							minimum_non_video_bytes: 2_000_000,
+							maximum_non_video_bytes: 2_000_000,
+							remaining_video_bytes: 0,
+							remaining_video_bitrate_bps: 0
+						},
+						source_relative_cap: {
+							configured_total_percent: null,
+							total_cap_bytes: null,
+							video_cap_bytes: null,
+							video_cap_bitrate_bps: null,
+							video_cap_percent: null,
+							status: 'arithmetically_infeasible'
+						},
+						feasibility: {
+							status: 'arithmetically_infeasible',
+							reasons: ['required streams exceed target'],
+							arithmetic_infeasible: true,
+							aggressive: false,
+							requires_measurement: false
+						},
+						uncertainty: {
+							confidence: 'exact',
+							requires_measurement: false,
+							minimum_non_video_bytes: 2_000_000,
+							maximum_non_video_bytes: 2_000_000
+						}
+					}
+				})
+			)
+		).toMatchObject({ kind: 'arithmetic_infeasible', recoveryLabel: 'Choose a size that can fit' });
+
+		expect(
+			targetConstraintSummary(
+				folder({
+					quality_risk: {
+						target_size_search: {
+							status: 'quality_conflict',
+							selected_metric: 'vmaf',
+							minimum_metric_score: 93
+						}
+					}
+				})
+			)
+		).toMatchObject({
+			kind: 'quality_conflict',
+			recoveryLabel: 'Choose a roomier goal',
+			detail: expect.stringContaining('VMAF floor of 93')
+		});
+	});
+
+	it('preserves typed size intent while recording structured review feedback', () => {
+		const intent = sizeOption('recommended', 'normalized', 300, 586.667, 45).operator_intent;
+		const feedbackIntent = reviewFeedbackIntent(
+			intent,
+			['motion_breakup', 'audio_quality_layout'],
+			'Moment 2 loses texture and the center channel sounds thin.'
+		);
+		const request = reviewFeedbackRequest(
+			'Keep the 587 MB goal.',
+			['motion_breakup', 'audio_quality_layout'],
+			'Moment 2 loses texture.',
+			'Preserve the original surround layout.'
+		);
+
+		expect(feedbackIntent).toMatchObject({
+			size_goal: intent.size_goal,
+			quality_risk_tags: ['motion_breakup', 'audio_quality_layout'],
+			evidence_authority: 'rejected_visual_result'
+		});
+		expect(request).toContain('Motion breaks up');
+		expect(request).toContain('Sound quality or layout is wrong');
+		expect(request).toContain('Preserve the original surround layout.');
+		expect(testRequestWithInstructions('Keep the target.', 'Preserve grain.')).toBe(
+			'Keep the target. Additional operator priorities: Preserve grain.'
+		);
 	});
 
 	it('preserves an API-resolved absolute per-episode target', () => {

--- a/frontend/src/lib/season/experience.ts
+++ b/frontend/src/lib/season/experience.ts
@@ -6,6 +6,7 @@ import type {
 	FolderStatusPayload,
 	OperatorIntentRequestPayload,
 	QualityRiskPayload,
+	QualityRiskTag,
 	SizeGoalMode
 } from '$lib/api/types';
 
@@ -90,7 +91,52 @@ export interface CompareRiskSummary {
 	authority: string;
 	authorityDetail: string;
 	focusMoments: string[];
+	picture: CompareRiskFact;
+	sound: CompareRiskFact;
 }
+
+export interface CompareRiskFact {
+	label: string;
+	level: string;
+	detail: string;
+}
+
+export interface ResolvedTargetSummary {
+	targetBytes: number;
+	sampleLowerBoundBytes: number;
+	sampleUpperBoundBytes: number;
+	finalLowerBoundBytes: number;
+	finalUpperBoundBytes: number;
+	sampleTolerancePercent: number;
+	finalTolerancePercent: number;
+	mode: SizeGoalMode | '';
+	rationale: string;
+	itemRuntimeSeconds: number;
+	referenceSizeBytes: number;
+	referenceRuntimeMinutes: number;
+}
+
+export interface TargetConstraintSummary {
+	kind: 'arithmetic_infeasible' | 'quality_conflict';
+	title: string;
+	detail: string;
+	recoveryLabel: string;
+}
+
+export interface ReviewConcern {
+	tag: QualityRiskTag;
+	label: string;
+}
+
+export const REVIEW_CONCERNS: readonly ReviewConcern[] = [
+	{ tag: 'softness_detail_loss', label: 'Picture looks soft' },
+	{ tag: 'motion_breakup', label: 'Motion breaks up' },
+	{ tag: 'banding_dark_scene_damage', label: 'Dark scenes or gradients look wrong' },
+	{ tag: 'grain_noise_treatment', label: 'Grain or noise looks wrong' },
+	{ tag: 'cadence_interlace_artifacts', label: 'Motion cadence looks uneven' },
+	{ tag: 'audio_quality_layout', label: 'Sound quality or layout is wrong' },
+	{ tag: 'other', label: 'Something else' }
+];
 
 const ACTIVE_JOB_STATUSES = new Set(['queued', 'running', 'starting', 'retry_backoff', 'stopping']);
 const FAILURE_JOB_STATUSES = new Set(['failed', 'stopped', 'needs_attention']);
@@ -156,6 +202,26 @@ function riskAuthority(risk: QualityRiskPayload | null): { value: string; detail
 	};
 }
 
+function compareRiskFact(
+	risks: NonNullable<QualityRiskPayload['typed_risks']>,
+	predicate: (tag: QualityRiskTag) => boolean,
+	fallbackLabel: string,
+	fallbackDetail: string
+): CompareRiskFact {
+	const risk =
+		risks.find((item) => predicate(item.tag) && text(item.level).toLowerCase() === 'high') ??
+		risks.find((item) => predicate(item.tag) && text(item.level).toLowerCase() === 'medium') ??
+		risks.find((item) => predicate(item.tag));
+	if (!risk) {
+		return { label: fallbackLabel, level: 'No specific warning', detail: fallbackDetail };
+	}
+	return {
+		label: risk.label,
+		level: `${risk.level} risk`,
+		detail: risk.rationale
+	};
+}
+
 export function compareRiskSummary(folder: FolderPayload): CompareRiskSummary | null {
 	const risk = qualityRisk(folder);
 	if (!risk) return null;
@@ -166,6 +232,18 @@ export function compareRiskSummary(folder: FolderPayload): CompareRiskSummary | 
 		typedRisks[0] ??
 		null;
 	const authority = riskAuthority(risk);
+	const picture = compareRiskFact(
+		typedRisks,
+		(tag) => tag !== 'audio_quality_layout',
+		'No specific picture warning',
+		'Judge detail, motion, dark scenes, grain, and cadence in the selected moments.'
+	);
+	const sound = compareRiskFact(
+		typedRisks,
+		(tag) => tag === 'audio_quality_layout',
+		'No specific sound warning',
+		'Listen for clarity, channel layout, balance, and anything distracting.'
+	);
 	const focusMoments = (risk.pre_test_instruction?.moments ?? []).slice(0, 3).map((moment) => {
 		const labels = Array.isArray(moment.risk_tags) ? moment.risk_tags.join(', ') : 'review risk';
 		return `Moment ${moment.moment} · ${labels}`;
@@ -185,7 +263,9 @@ export function compareRiskSummary(folder: FolderPayload): CompareRiskSummary | 
 		topRiskDetail: topRisk?.rationale ?? 'No typed review focus was published for this sample.',
 		authority: authority.value,
 		authorityDetail: authority.detail,
-		focusMoments
+		focusMoments,
+		picture,
+		sound
 	};
 }
 
@@ -346,6 +426,123 @@ export function sizeGoals(folder: FolderPayload): SizeGoal[] {
 	});
 }
 
+export function resolvedTargetSummary(folder: FolderPayload): ResolvedTargetSummary | null {
+	const analysis = folderSizeTargetAnalysis(folder);
+	const resolved = folder.resolved_operator_intent?.size_goal;
+	const targetBytes = analysis.budgetBytes || numberValue(resolved?.target_size_bytes);
+	if (targetBytes <= 0) return null;
+	const sampleTolerancePercent = numberValue(resolved?.sample_projection_tolerance_percent) || 10;
+	const finalTolerancePercent = numberValue(resolved?.final_output_tolerance_percent) || 5;
+	const sampleRatio = sampleTolerancePercent / 100;
+	const finalRatio = finalTolerancePercent / 100;
+	return {
+		targetBytes,
+		sampleLowerBoundBytes:
+			analysis.lowerBoundBytes ||
+			numberValue(resolved?.sample_lower_bound_bytes) ||
+			Math.round(targetBytes * (1 - sampleRatio)),
+		sampleUpperBoundBytes:
+			analysis.upperBoundBytes ||
+			numberValue(resolved?.sample_upper_bound_bytes) ||
+			Math.round(targetBytes * (1 + sampleRatio)),
+		finalLowerBoundBytes:
+			numberValue(resolved?.final_lower_bound_bytes) || Math.round(targetBytes * (1 - finalRatio)),
+		finalUpperBoundBytes:
+			numberValue(resolved?.final_upper_bound_bytes) || Math.round(targetBytes * (1 + finalRatio)),
+		sampleTolerancePercent,
+		finalTolerancePercent,
+		mode: resolved?.mode === 'normalized' || resolved?.mode === 'absolute' ? resolved.mode : '',
+		rationale: text(resolved?.rationale),
+		itemRuntimeSeconds: numberValue(resolved?.item_runtime_seconds),
+		referenceSizeBytes: numberValue(resolved?.reference_size_mb) * 1_000_000,
+		referenceRuntimeMinutes: numberValue(resolved?.reference_runtime_minutes)
+	};
+}
+
+export function targetConstraintSummary(folder: FolderPayload): TargetConstraintSummary | null {
+	const search = folder.quality_risk?.target_size_search;
+	const feasibility = folder.stream_budget_ledger?.feasibility;
+	if (feasibility?.arithmetic_infeasible || search?.status === 'infeasible') {
+		return {
+			kind: 'arithmetic_infeasible',
+			title: 'This size cannot fit the required streams.',
+			detail:
+				'Audio, subtitles, attachments, and container overhead leave no positive video budget at this size. Choose a roomier goal before making another test.',
+			recoveryLabel: 'Choose a size that can fit'
+		};
+	}
+	if (search?.status === 'quality_conflict') {
+		const metric = text(search.selected_metric).toUpperCase();
+		const minimum = numberValue(search.minimum_metric_score);
+		const floor =
+			metric && minimum > 0 ? ` the ${metric} floor of ${minimum}` : ' the quality floor';
+		return {
+			kind: 'quality_conflict',
+			title: 'This size conflicts with the quality floor.',
+			detail: `Every measured candidate that fit the size fell below${floor}. Choose a roomier goal instead of silently lowering quality.`,
+			recoveryLabel: 'Choose a roomier goal'
+		};
+	}
+	return null;
+}
+
+function normalizedOperatorText(value: string, limit = 600): string {
+	return value.trim().replaceAll(/\s+/g, ' ').slice(0, limit);
+}
+
+export function testRequestWithInstructions(baseRequest: string, instructions: string): string {
+	const detail = normalizedOperatorText(instructions);
+	return detail
+		? `${baseRequest.trim()} Additional operator priorities: ${detail}`
+		: baseRequest.trim();
+}
+
+export function reviewFeedbackRequest(
+	baseRequest: string,
+	tags: readonly QualityRiskTag[],
+	details: string,
+	instructions = ''
+): string {
+	const selectedLabels = REVIEW_CONCERNS.filter((concern) => tags.includes(concern.tag)).map(
+		(concern) => concern.label
+	);
+	const feedbackDetail = normalizedOperatorText(details);
+	const feedback = [
+		selectedLabels.length ? `Operator review concerns: ${selectedLabels.join(', ')}.` : '',
+		feedbackDetail ? `Operator review detail: ${feedbackDetail}` : ''
+	]
+		.filter(Boolean)
+		.join(' ');
+	return testRequestWithInstructions(`${baseRequest.trim()} ${feedback}`.trim(), instructions);
+}
+
+export function reviewFeedbackIntent(
+	intent: OperatorIntentRequestPayload | null,
+	tags: readonly QualityRiskTag[],
+	details: string
+): OperatorIntentRequestPayload | null {
+	if (!intent) return null;
+	const feedbackDetail = normalizedOperatorText(details, 2000);
+	const normalizedTags: QualityRiskTag[] = tags.length ? [...new Set(tags)] : ['other'];
+	return {
+		...intent,
+		size_goal: { ...intent.size_goal },
+		resolution: { ...intent.resolution },
+		...(intent.quality ? { quality: { ...intent.quality } } : {}),
+		...(intent.streams
+			? {
+					streams: {
+						...(intent.streams.audio ? { audio: { ...intent.streams.audio } } : {}),
+						...(intent.streams.subtitle ? { subtitle: { ...intent.streams.subtitle } } : {})
+					}
+				}
+			: {}),
+		quality_risk_tags: normalizedTags,
+		quality_risk_details: feedbackDetail,
+		evidence_authority: 'rejected_visual_result'
+	};
+}
+
 export function isSizeGoalSelectionConfirmed(
 	goals: readonly SizeGoal[],
 	selectedGoalKey: SizeGoal['key'],
@@ -401,6 +598,9 @@ export function measuredFollowupRequest(analysis: SizeTargetAnalysis): string {
 	}
 	if (analysis.status === 'under_target' && analysis.predictedBytes > 0) {
 		return `Measured follow-up: keep the ${targetMegabytes} MB per episode goal. The last representative test landed below that goal. Keep the current resolution and make the next representative test spend more of the available size on picture and sound quality.`;
+	}
+	if (analysis.status === 'inside_target_band' && analysis.predictedBytes > 0) {
+		return `Measured revision: keep the ${targetMegabytes} MB per episode goal and current resolution. Make another representative test that addresses the operator's picture or sound concerns without changing the size target.`;
 	}
 	return `Aim for about ${targetMegabytes} MB per episode. Keep the current resolution and repeat the representative test because the previous run did not produce a usable full-episode size estimate.`;
 }
@@ -637,6 +837,14 @@ export function detailSeasonState(
 	}
 	const reviewReady =
 		booleanValue(calibration.browser_review_ready) || booleanValue(calibration.review_media_ready);
+	const currentRisk = qualityRisk(folder);
+	const currentRiskStatus = text(record(currentRisk?.operator_decision).status).toLowerCase();
+	const currentRiskBlocksApproval =
+		Boolean(currentRisk?.blocked) ||
+		['rejected', 'needs_operator_review'].includes(currentRiskStatus);
+	const currentDraftIsApproved =
+		!currentRiskBlocksApproval &&
+		(booleanValue(reviewGate.can_confirm_full) || (draftHash && draftHash === acceptedHash));
 	if (
 		reviewGateStatus === 'missing_review_media' ||
 		(priorTestJobId && !draftHash && !reviewReady)
@@ -649,7 +857,7 @@ export function detailSeasonState(
 			recoveryKind: 'test'
 		};
 	}
-	if (reviewReady && draftHash && draftHash !== acceptedHash) {
+	if (reviewReady && draftHash && !currentDraftIsApproved) {
 		return {
 			key: 'ready_to_compare',
 			label: 'Test ready',
@@ -657,7 +865,7 @@ export function detailSeasonState(
 			tone: 'ready'
 		};
 	}
-	if (booleanValue(reviewGate.can_confirm_full) || (draftHash && draftHash === acceptedHash)) {
+	if (currentDraftIsApproved) {
 		return {
 			key: 'ready_to_make',
 			label: 'Test approved',

--- a/mediaforce/tuning/calibration_jobs.py
+++ b/mediaforce/tuning/calibration_jobs.py
@@ -56,6 +56,28 @@ def load_latest_failed_sample_job(connection: DBClient, prefix: str) -> dict[str
     return _hydrate_job(row) if row is not None else None
 
 
+def load_latest_failed_target_size_sample_job(connection: DBClient, prefix: str) -> dict[str, Any] | None:
+    rows = connection.execute(
+        _calibration_job_select()
+        .where(calibration_jobs.c.prefix == prefix)
+        .where(calibration_jobs.c.lane == "sample")
+        .where(calibration_jobs.c.status.in_(("failed", "stopped")))
+        .where(calibration_jobs.c.action.in_(("baseline", "ai_tune")))
+        .order_by(calibration_jobs.c.created_at.desc(), _rowid_column().desc())
+    ).mappings().fetchall()
+    for row in rows:
+        payload = _hydrate_job(row)
+        result = payload.get("result")
+        if not isinstance(result, dict):
+            continue
+        trace = result.get("target_size_trace")
+        trace_status = trace.get("status") if isinstance(trace, dict) else None
+        target_status = str(result.get("target_size_status") or trace_status or "").strip().lower()
+        if target_status in {"infeasible", "quality_conflict"}:
+            return payload
+    return None
+
+
 def load_latest_retryable_sample_job(connection: DBClient, prefix: str) -> dict[str, Any] | None:
     return load_latest_failed_sample_job(connection, prefix)
 

--- a/mediaforce/tuning/quality_risk.py
+++ b/mediaforce/tuning/quality_risk.py
@@ -16,6 +16,8 @@ from mediaforce.tuning.target_size_search import (
 
 QUALITY_RISK_CONTRACT_SCHEMA = "mediaforce.quality_risk_contract"
 QUALITY_RISK_CONTRACT_VERSION = 1
+MAX_QUALITY_RISK_FEEDBACK_TAGS = 7
+MAX_QUALITY_RISK_FEEDBACK_DETAILS = 2000
 
 QUALITY_RISK_VERDICTS = (
     "safe_to_sample",
@@ -214,17 +216,20 @@ def with_quality_risk_intent(
         *,
         note: str,
 ) -> dict[str, Any] | None:
-    tags = quality_risk_tags_from_text(note)
     request = dict(object_dict(operator_request))
-    if not tags:
+    explicit_tags = object_list(request.get("quality_risk_tags"))
+    inferred_tags = quality_risk_tags_from_text(note)
+    if not explicit_tags and not inferred_tags:
         return request or None
+    tags = normalize_quality_risk_tags(explicit_tags or inferred_tags)[:MAX_QUALITY_RISK_FEEDBACK_TAGS]
+    details = str(request.get("quality_risk_details") or note).strip()[:MAX_QUALITY_RISK_FEEDBACK_DETAILS]
     request.setdefault("source", "operator_note")
     request.setdefault("request_type", "quality_risk_feedback")
     request.setdefault("request_text", note.strip())
     request.setdefault("operator_confirmed", False)
     request.setdefault("evidence_authority", "none")
     request["quality_risk_tags"] = tags
-    request["quality_risk_details"] = note.strip()
+    request["quality_risk_details"] = details
     return request
 
 

--- a/mediaforce/tuning/quality_risk.py
+++ b/mediaforce/tuning/quality_risk.py
@@ -219,10 +219,13 @@ def with_quality_risk_intent(
     request = dict(object_dict(operator_request))
     explicit_tags = object_list(request.get("quality_risk_tags"))
     inferred_tags = quality_risk_tags_from_text(note)
-    if not explicit_tags and not inferred_tags:
+    explicit_details = str(request.get("quality_risk_details") or "").strip()
+    if not explicit_tags and not inferred_tags and not explicit_details:
         return request or None
-    tags = normalize_quality_risk_tags(explicit_tags or inferred_tags)[:MAX_QUALITY_RISK_FEEDBACK_TAGS]
-    details = str(request.get("quality_risk_details") or note).strip()[:MAX_QUALITY_RISK_FEEDBACK_DETAILS]
+    tags = normalize_quality_risk_tags(explicit_tags or inferred_tags or ["other"])[
+        :MAX_QUALITY_RISK_FEEDBACK_TAGS
+    ]
+    details = str(explicit_details or note).strip()[:MAX_QUALITY_RISK_FEEDBACK_DETAILS]
     request.setdefault("source", "operator_note")
     request.setdefault("request_type", "quality_risk_feedback")
     request.setdefault("request_text", note.strip())

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -123,7 +123,7 @@ from mediaforce.web.runtime import FolderCard, cached_folder_cards, dashboard_fo
     settings_page_payload, stop_calibration_queue_action, stop_encode_queue_action, \
     validate_folder_outputs_action, \
     build_multimodal_review_pack, build_tuning_runtime_toolbelt, load_latest_failed_sample_job_state, \
-    load_retryable_sample_job_state
+    load_latest_failed_target_size_job_state, load_retryable_sample_job_state
 from mediaforce.web.runtime.folder_actions import ActionPayload, FolderItem
 from mediaforce.web.runtime.folder_cards import list_folder_cards
 from mediaforce.library.workflow_state import build_folder_workflow_state
@@ -290,7 +290,7 @@ def _read_advice_state(path: Path, *, strict: bool) -> ActionPayload | None:
         return None
     try:
         payload = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeError, json.JSONDecodeError):
         if strict:
             raise
         return None
@@ -308,7 +308,7 @@ def _load_advice_state(config: MediaforceConfig, prefix: str) -> ActionPayload |
 def _load_advice_state_for_queue(config: MediaforceConfig, prefix: str) -> ActionPayload | None:
     try:
         return _read_advice_state(_advice_file(config, prefix), strict=True)
-    except (OSError, json.JSONDecodeError, ValueError) as exc:
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
         raise HTTPException(
             status_code=409,
             detail=(
@@ -336,13 +336,32 @@ def _merge_quality_risk_records(existing: Any, incoming: Any) -> list[ActionPayl
     binding_keys = ("kind", "verdict", "sample_job_id", "policy_hash", "source_id", "prefix")
     for raw_record in object_list(incoming):
         record = object_dict(raw_record)
+        matching = [
+            current
+            for current in records
+            if all(current.get(key) == record.get(key) for key in binding_keys)
+        ]
         records = [
             current
             for current in records
             if not all(current.get(key) == record.get(key) for key in binding_keys)
         ]
-        records.append(record)
+        records.append(
+            max(
+                [*matching, record],
+                key=lambda current: _advice_record_timestamp(current.get("created_at")),
+            )
+        )
     return records[-100:]
+
+
+def _advice_record_timestamp(value: Any) -> datetime:
+    text = str(value or "").strip()
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.min.replace(tzinfo=UTC)
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
 
 
 def _merge_advice_state(config: MediaforceConfig, prefix: str, patch: ActionPayload) -> ActionPayload:
@@ -940,7 +959,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             tuning_advice_payload=_tuning_advice_payload,
             load_pending_proposal=_load_pending_proposal,
             apply_policy_fragment=_apply_policy_fragment,
-            load_advice_state=_load_advice_state_for_queue,
+            load_advice_state=_load_advice_state,
             save_advice_state=_save_advice_state,
             advisor_routing=advisor_routing,
             save_job_state=_save_job_state,
@@ -1005,7 +1024,8 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 deps=_encode_queue_runtime_deps(),
             ),
             save_encode_job=save_encode_job,
-            load_advice_state=_load_advice_state,
+            load_advice_state=_load_advice_state_for_queue,
+            load_latest_failed_target_size_job_state=_load_latest_failed_target_size_job_state,
         )
 
     def _approve_measured_encode_recovery_action(normalized_prefix: str) -> ActionPayload:
@@ -2561,7 +2581,14 @@ def _review_pair_key(timestamp_seconds: float) -> int:
 
 def _save_advice_state(config: MediaforceConfig, prefix: str, advice: ActionPayload) -> None:
     with _locked_advice_state(config, prefix) as path:
-        save_advice_state(path, advice)
+        existing = _read_advice_state(path, strict=True) or {}
+        payload = dict(advice)
+        if existing.get("quality_risk_records") or payload.get("quality_risk_records"):
+            payload["quality_risk_records"] = _merge_quality_risk_records(
+                existing.get("quality_risk_records"),
+                payload.get("quality_risk_records"),
+            )
+        save_advice_state(path, payload)
 
 
 def _load_pending_proposal(config: MediaforceConfig, prefix: str) -> dict[str, Any] | None:
@@ -2710,6 +2737,14 @@ def _load_latest_failed_sample_job_state(
         prefix: str,
 ) -> dict[str, Any] | None:
     return load_latest_failed_sample_job_state(connection, config, prefix, _job_runtime_deps())
+
+
+def _load_latest_failed_target_size_job_state(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+) -> dict[str, Any] | None:
+    return load_latest_failed_target_size_job_state(connection, config, prefix, _job_runtime_deps())
 
 
 def _save_job_state(

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -950,6 +950,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 deps=_encode_queue_runtime_deps(),
             ),
             save_encode_job=save_encode_job,
+            load_advice_state=_load_advice_state,
         )
 
     def _approve_measured_encode_recovery_action(normalized_prefix: str) -> ActionPayload:
@@ -1001,7 +1002,6 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             record_visual_approval_artifact=record_visual_approval_artifact,
             merge_advice_state=_merge_advice_state,
             upsert_override=_upsert_override,
-            auto_queue_folder_encode=_queue_folder_encode_action,
             confirm_high_impact=confirm_high_impact,
             confirm_size_tradeoff=confirm_size_tradeoff,
             reviewed_draft_hash=reviewed_draft_hash,

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -285,21 +285,76 @@ _operator_requested_experiment = runtime_operator_requested_experiment
 _apply_policy_fragment = runtime_apply_policy_fragment
 
 
-def _load_advice_state(config: MediaforceConfig, prefix: str) -> ActionPayload | None:
-    path = _advice_file(config, prefix)
+def _read_advice_state(path: Path, *, strict: bool) -> ActionPayload | None:
     if not path.exists():
         return None
     try:
         payload = json.loads(path.read_text())
     except (OSError, json.JSONDecodeError):
+        if strict:
+            raise
         return None
-    return payload if isinstance(payload, dict) else None
+    if isinstance(payload, dict):
+        return payload
+    if strict:
+        raise ValueError(f"Advice state at {path} must be a JSON object")
+    return None
+
+
+def _load_advice_state(config: MediaforceConfig, prefix: str) -> ActionPayload | None:
+    return _read_advice_state(_advice_file(config, prefix), strict=False)
+
+
+def _load_advice_state_for_queue(config: MediaforceConfig, prefix: str) -> ActionPayload | None:
+    try:
+        return _read_advice_state(_advice_file(config, prefix), strict=True)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Mediaforce could not read the current review evidence safely. "
+                "Repair or rerun the representative test before starting production."
+            ),
+        ) from exc
+
+
+@contextmanager
+def _locked_advice_state(config: MediaforceConfig, prefix: str) -> Iterator[Path]:
+    path = _advice_file(config, prefix)
+    lock_path = path.with_name(f".{path.name}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield path
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _merge_quality_risk_records(existing: Any, incoming: Any) -> list[ActionPayload]:
+    records = [object_dict(record) for record in object_list(existing)]
+    binding_keys = ("kind", "verdict", "sample_job_id", "policy_hash", "source_id", "prefix")
+    for raw_record in object_list(incoming):
+        record = object_dict(raw_record)
+        records = [
+            current
+            for current in records
+            if not all(current.get(key) == record.get(key) for key in binding_keys)
+        ]
+        records.append(record)
+    return records[-100:]
 
 
 def _merge_advice_state(config: MediaforceConfig, prefix: str, patch: ActionPayload) -> ActionPayload:
-    existing = _load_advice_state(config, prefix) or {}
-    merged = {**existing, **patch}
-    _save_advice_state(config, prefix, merged)
+    with _locked_advice_state(config, prefix) as path:
+        existing = _read_advice_state(path, strict=True) or {}
+        merged = {**existing, **patch}
+        if "quality_risk_records" in patch:
+            merged["quality_risk_records"] = _merge_quality_risk_records(
+                existing.get("quality_risk_records"),
+                patch.get("quality_risk_records"),
+            )
+        save_advice_state(path, merged)
     return merged
 
 
@@ -885,7 +940,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             tuning_advice_payload=_tuning_advice_payload,
             load_pending_proposal=_load_pending_proposal,
             apply_policy_fragment=_apply_policy_fragment,
-            load_advice_state=_load_advice_state,
+            load_advice_state=_load_advice_state_for_queue,
             save_advice_state=_save_advice_state,
             advisor_routing=advisor_routing,
             save_job_state=_save_job_state,
@@ -2505,7 +2560,8 @@ def _review_pair_key(timestamp_seconds: float) -> int:
 
 
 def _save_advice_state(config: MediaforceConfig, prefix: str, advice: ActionPayload) -> None:
-    save_advice_state(_advice_file(config, prefix), advice)
+    with _locked_advice_state(config, prefix) as path:
+        save_advice_state(path, advice)
 
 
 def _load_pending_proposal(config: MediaforceConfig, prefix: str) -> dict[str, Any] | None:

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -2581,7 +2581,10 @@ def _review_pair_key(timestamp_seconds: float) -> int:
 
 def _save_advice_state(config: MediaforceConfig, prefix: str, advice: ActionPayload) -> None:
     with _locked_advice_state(config, prefix) as path:
-        existing = _read_advice_state(path, strict=True) or {}
+        try:
+            existing = _read_advice_state(path, strict=True) or {}
+        except (OSError, UnicodeError, json.JSONDecodeError, ValueError):
+            existing = {}
         payload = dict(advice)
         if existing.get("quality_risk_records") or payload.get("quality_risk_records"):
             payload["quality_risk_records"] = _merge_quality_risk_records(

--- a/mediaforce/web/runtime/__init__.py
+++ b/mediaforce/web/runtime/__init__.py
@@ -26,8 +26,8 @@ from mediaforce.web.runtime.host_runtime import default_sample_host_key, default
 from mediaforce.web.runtime.host_status import refresh_host_status_cache, safe_collect_host_statuses
 from mediaforce.web.runtime.job_runtime import JobRuntimeDeps, active_scan_from_db, \
     calibration_job_belongs_to_current_process, expire_calibration_job, latest_scan_completed_at, \
-    load_job_state, load_latest_failed_sample_job_state, load_retryable_sample_job_state, maybe_schedule_scan, \
-    load_scan_job_state as load_scan_job_state_runtime, \
+    load_job_state, load_latest_failed_sample_job_state, load_latest_failed_target_size_job_state, \
+    load_retryable_sample_job_state, maybe_schedule_scan, load_scan_job_state as load_scan_job_state_runtime, \
     save_job_state, save_scan_job_state as save_scan_job_state_runtime, scan_is_stale, \
     scan_job_belongs_to_current_process, scan_process_is_alive
 from mediaforce.web.runtime.queue_actions import pause_encode_queue_action, resume_encode_queue_action, \
@@ -71,6 +71,7 @@ __all__ = [
     "load_calibration_state",
     "load_job_state",
     "load_latest_failed_sample_job_state",
+    "load_latest_failed_target_size_job_state",
     "load_retryable_sample_job_state",
     "load_json_object",
     "list_library_structure_cards",

--- a/mediaforce/web/runtime/calibration_runtime.py
+++ b/mediaforce/web/runtime/calibration_runtime.py
@@ -17,6 +17,7 @@ from mediaforce.core.type_defs import float_value, int_value, object_dict, objec
 from mediaforce.encoding.quality import quality_error_message, resolve_local_quality_temp_root
 from mediaforce.encoding.video_filters import build_video_filter
 from mediaforce.state_cleanup import purge_transient_artifacts
+from mediaforce.tuning.target_size_search import TargetSizeSearchError
 
 
 @dataclass(slots=True)
@@ -264,6 +265,24 @@ def run_calibration_job(
                     "status": "stopped",
                     "finished_at": deps.now_iso(),
                     "error": "Calibration queue job was stopped and cleaned up.",
+                },
+            )
+    except TargetSizeSearchError as exc:
+        with open_db(config.paths.db_path) as connection:
+            deps.save_job_state(
+                connection,
+                config,
+                prefix,
+                {
+                    **job,
+                    "job_id": job_id,
+                    "status": "failed",
+                    "finished_at": deps.now_iso(),
+                    "error": quality_error_message(exc),
+                    "result": {
+                        "target_size_status": exc.status,
+                        "target_size_trace": exc.trace,
+                    },
                 },
             )
     except Exception as exc:

--- a/mediaforce/web/runtime/folder_actions.py
+++ b/mediaforce/web/runtime/folder_actions.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import math
 from collections.abc import Callable
+from datetime import UTC, datetime
 import uuid
 from pathlib import Path
 from typing import Any, Protocol, TypeAlias
@@ -170,6 +171,7 @@ def queue_folder_encode_action(
         prepare_terminal_encode_job_for_requeue_fn: PrepareTerminalEncodeJobForRequeueFn,
         save_encode_job: SaveEncodeJobFn,
         load_advice_state: LoadAdviceStateFn | None = None,
+        load_latest_failed_target_size_job_state: LoadJobStateFn | None = None,
 ) -> ActionPayload:
     with open_db(config.paths.db_path) as connection:
         existing_job = load_job_state(connection, config, normalized_prefix)
@@ -182,7 +184,15 @@ def queue_folder_encode_action(
         if calibration is None:
             raise HTTPException(status_code=400, detail="Run a sampled calibration first.")
         calibration_payload = object_dict(calibration)
-        failed_target_reason = _failed_target_size_job_blocking_reason(existing_job, calibration_payload)
+        latest_failed_sample_job = (
+            load_latest_failed_target_size_job_state(connection, config, normalized_prefix)
+            if load_latest_failed_target_size_job_state is not None
+            else existing_job
+        )
+        failed_target_reason = _failed_target_size_job_blocking_reason(
+            latest_failed_sample_job,
+            calibration_payload,
+        )
         if failed_target_reason is not None:
             raise HTTPException(status_code=409, detail=failed_target_reason)
         if load_advice_state is not None:
@@ -195,7 +205,7 @@ def queue_folder_encode_action(
                 operator_request=object_dict(advice_state.get("operator_request")) or None,
                 calibration=calibration_payload,
                 advice_state=advice_state,
-                latest_failed_sample_job=existing_job,
+                latest_failed_sample_job=latest_failed_sample_job,
             )
             blocking_reason = _quality_risk_blocking_reason(quality_risk_contract)
             if blocking_reason is not None:
@@ -1005,14 +1015,13 @@ def _failed_target_size_job_blocking_reason(
     target_status = str(result.get("target_size_status") or trace.get("status") or "").strip().lower()
     if target_status not in {"infeasible", "quality_conflict"}:
         return None
-    accepted_at = str(calibration.get("accepted_at") or "").strip()
-    failed_at = str(
+    accepted_at = _parse_state_timestamp(calibration.get("accepted_at"))
+    failed_at = _parse_state_timestamp(
         job_payload.get("finished_at")
         or job_payload.get("updated_at")
         or job_payload.get("created_at")
-        or ""
-    ).strip()
-    if accepted_at and failed_at and failed_at <= accepted_at:
+    )
+    if accepted_at and failed_at and failed_at < accepted_at:
         return None
     if target_status == "infeasible":
         return (
@@ -1023,3 +1032,14 @@ def _failed_target_size_job_blocking_reason(
         "The latest size-directed test could not reach this target without crossing the quality floor. "
         "Choose a different size or revise the quality decision, then approve a fresh test before starting production."
     )
+
+
+def _parse_state_timestamp(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)

--- a/mediaforce/web/runtime/folder_actions.py
+++ b/mediaforce/web/runtime/folder_actions.py
@@ -182,6 +182,9 @@ def queue_folder_encode_action(
         if calibration is None:
             raise HTTPException(status_code=400, detail="Run a sampled calibration first.")
         calibration_payload = object_dict(calibration)
+        failed_target_reason = _failed_target_size_job_blocking_reason(existing_job, calibration_payload)
+        if failed_target_reason is not None:
+            raise HTTPException(status_code=409, detail=failed_target_reason)
         if load_advice_state is not None:
             advice_state = object_dict(load_advice_state(config, normalized_prefix))
             quality_risk_contract = build_quality_risk_contract(
@@ -192,6 +195,7 @@ def queue_folder_encode_action(
                 operator_request=object_dict(advice_state.get("operator_request")) or None,
                 calibration=calibration_payload,
                 advice_state=advice_state,
+                latest_failed_sample_job=existing_job,
             )
             blocking_reason = _quality_risk_blocking_reason(quality_risk_contract)
             if blocking_reason is not None:
@@ -987,3 +991,35 @@ def _quality_risk_blocking_reason(contract: ActionPayload) -> str | None:
         if str(reason).strip()
     ]
     return blocking_reasons[0] if blocking_reasons else "Measured review facts still block this action."
+
+
+def _failed_target_size_job_blocking_reason(
+        job: JobPayload | None,
+        calibration: ActionPayload,
+) -> str | None:
+    job_payload = object_dict(job)
+    if str(job_payload.get("status") or "") not in {"failed", "stopped"}:
+        return None
+    result = object_dict(job_payload.get("result"))
+    trace = object_dict(result.get("target_size_trace"))
+    target_status = str(result.get("target_size_status") or trace.get("status") or "").strip().lower()
+    if target_status not in {"infeasible", "quality_conflict"}:
+        return None
+    accepted_at = str(calibration.get("accepted_at") or "").strip()
+    failed_at = str(
+        job_payload.get("finished_at")
+        or job_payload.get("updated_at")
+        or job_payload.get("created_at")
+        or ""
+    ).strip()
+    if accepted_at and failed_at and failed_at <= accepted_at:
+        return None
+    if target_status == "infeasible":
+        return (
+            "The latest size-directed test found that this target cannot fit the required streams. "
+            "Choose a different size and approve a fresh test before starting production."
+        )
+    return (
+        "The latest size-directed test could not reach this target without crossing the quality floor. "
+        "Choose a different size or revise the quality decision, then approve a fresh test before starting production."
+    )

--- a/mediaforce/web/runtime/folder_actions.py
+++ b/mediaforce/web/runtime/folder_actions.py
@@ -47,7 +47,6 @@ CalibrationDraftHashFn: TypeAlias = Callable[[ActionPayload], str]
 SaveCalibrationStateFn: TypeAlias = Callable[[MediaforceConfig, str, ActionPayload], None]
 LoadAdviceStateFn: TypeAlias = Callable[[MediaforceConfig, str], ActionPayload | None]
 MergeAdviceStateFn: TypeAlias = Callable[[MediaforceConfig, str, ActionPayload], ActionPayload]
-AutoQueueApprovedFolderEncodeFn: TypeAlias = Callable[[str, str, bool], ActionPayload]
 LoadSampleItemFn: TypeAlias = Callable[[DBClient, MediaforceConfig, str], FolderItem | None]
 QueueFolderEncodeActionFn: TypeAlias = Callable[[str, str, bool], ActionPayload]
 
@@ -170,6 +169,7 @@ def queue_folder_encode_action(
         clear_terminal_encode_jobs_for_prefix_fn: ClearTerminalEncodeJobsFn,
         prepare_terminal_encode_job_for_requeue_fn: PrepareTerminalEncodeJobForRequeueFn,
         save_encode_job: SaveEncodeJobFn,
+        load_advice_state: LoadAdviceStateFn | None = None,
 ) -> ActionPayload:
     with open_db(config.paths.db_path) as connection:
         existing_job = load_job_state(connection, config, normalized_prefix)
@@ -181,8 +181,33 @@ def queue_folder_encode_action(
             raise HTTPException(status_code=400, detail=str(gate["message"]))
         if calibration is None:
             raise HTTPException(status_code=400, detail="Run a sampled calibration first.")
-        saved_profile_path = config.paths.runtime_settings_path
         calibration_payload = object_dict(calibration)
+        if load_advice_state is not None:
+            advice_state = object_dict(load_advice_state(config, normalized_prefix))
+            quality_risk_contract = build_quality_risk_contract(
+                prefix=normalized_prefix,
+                sample_item=object_dict(calibration_payload.get("sample_item")),
+                current_policy=object_dict(calibration_payload.get("policy")),
+                preview_policy=object_dict(calibration_payload.get("policy")),
+                operator_request=object_dict(advice_state.get("operator_request")) or None,
+                calibration=calibration_payload,
+                advice_state=advice_state,
+            )
+            blocking_reason = _quality_risk_blocking_reason(quality_risk_contract)
+            if blocking_reason is not None:
+                raise HTTPException(status_code=409, detail=blocking_reason)
+            operator_status = str(
+                object_dict(quality_risk_contract.get("operator_decision")).get("status") or ""
+            ).strip().lower()
+            if operator_status == "rejected":
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        "The current review evidence was rejected after approval. "
+                        "Make and approve a revised test before starting the season."
+                    ),
+                )
+        saved_profile_path = config.paths.runtime_settings_path
         calibration_policy = object_dict(calibration_payload.get("policy"))
         calibration_video = object_dict(calibration_policy.get("video"))
         if {"target_size_mb", "target_size_bytes", "size_goal_mode"} & calibration_video.keys():
@@ -773,7 +798,6 @@ def save_profile_action(
         record_visual_approval_artifact: RecordVisualApprovalArtifactFn,
         merge_advice_state: MergeAdviceStateFn,
         upsert_override: UpsertOverrideFn,
-        auto_queue_folder_encode: AutoQueueApprovedFolderEncodeFn | None = None,
         confirm_high_impact: bool = False,
         confirm_size_tradeoff: bool = False,
         reviewed_draft_hash: str = "",
@@ -868,15 +892,11 @@ def save_profile_action(
         calibration=calibration_payload,
         advice_state=advice_state,
     )
-    if bool(object_dict(quality_risk_contract.get("deterministic_gates")).get("blocked")):
-        blocking_reasons = [
-            str(reason)
-            for reason in object_list(object_dict(quality_risk_contract.get("deterministic_gates")).get("blocking_reasons"))
-            if str(reason).strip()
-        ]
+    blocking_reason = _quality_risk_blocking_reason(quality_risk_contract)
+    if blocking_reason is not None:
         raise HTTPException(
             status_code=409,
-            detail=blocking_reasons[0] if blocking_reasons else "Measured review facts still block approval for this sample.",
+            detail=blocking_reason,
         )
     if str(calibration_payload.get("mode") or "sample") == "sample":
         if not calibration_payload.get("review_media_ready"):
@@ -946,76 +966,24 @@ def save_profile_action(
         normalized_prefix,
         calibration_payload["policy"],
     )
-    response: ActionPayload = {
+    return {
         "ok": True,
         "queued": False,
-        "auto_queue_status": "not_requested",
-        "message": "Approved the current draft and saved it as the folder profile.",
+        "auto_queue_status": "approval_only",
+        "message": (
+            "Approved the current test and saved it as the folder profile. "
+            "Choose Make the season when you are ready to start production."
+        ),
     }
-    if auto_queue_folder_encode is None:
-        return response
 
-    try:
-        queue_result = auto_queue_folder_encode(normalized_prefix, "", False)
-    except HTTPException as exc:
-        detail = str(exc.detail)
-        if detail == "No pending items were found to enqueue for this folder." or detail.startswith(
-                "No encode candidates were found for this folder."
-        ):
-            response["auto_queue_status"] = "no_pending"
-            response["message"] = (
-                "Approved the current draft and saved it as the folder profile. "
-                "There were no encode candidates left to queue for this folder."
-            )
-            response["queue_message"] = detail
-            return response
-        response["auto_queue_status"] = "blocked"
-        response["queue_message"] = detail
-        response["message"] = (
-            "Approved the current draft and saved it as the folder profile. "
-            f"Mediaforce could not auto-queue the folder encode: {detail}"
-        )
-        return response
 
-    queue_message = str(queue_result.get("message") or "").strip()
-    if queue_result.get("ok"):
-        response.update(
-            {
-                "queued": True,
-                "auto_queue_status": "queued",
-                "message": "Approved the current draft, saved it as the folder profile, and queued the full folder encode.",
-            }
-        )
-        if queue_message:
-            response["queue_message"] = queue_message
-        if queue_result.get("job") is not None:
-            response["job"] = queue_result["job"]
-        if queue_result.get("action") is not None:
-            response["action"] = queue_result["action"]
-        return response
-
-    if queue_message.startswith("A folder encode is already "):
-        response.update(
-            {
-                "queued": True,
-                "auto_queue_status": "already_active",
-                "queue_message": queue_message,
-                "message": (
-                    "Approved the current draft and saved it as the folder profile. "
-                    f"{queue_message}"
-                ),
-            }
-        )
-        return response
-
-    response.update(
-        {
-            "auto_queue_status": "blocked",
-            "queue_message": queue_message,
-            "message": (
-                "Approved the current draft and saved it as the folder profile. "
-                f"Mediaforce could not auto-queue the folder encode: {queue_message or 'unknown queue error'}"
-            ),
-        }
-    )
-    return response
+def _quality_risk_blocking_reason(contract: ActionPayload) -> str | None:
+    gates = object_dict(contract.get("deterministic_gates"))
+    if not bool(gates.get("blocked")):
+        return None
+    blocking_reasons = [
+        str(reason)
+        for reason in object_list(gates.get("blocking_reasons"))
+        if str(reason).strip()
+    ]
+    return blocking_reasons[0] if blocking_reasons else "Measured review facts still block this action."

--- a/mediaforce/web/runtime/folder_state.py
+++ b/mediaforce/web/runtime/folder_state.py
@@ -1,6 +1,8 @@
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
+import tempfile
 from typing import Any
 
 from mediaforce.core.config import MediaforceConfig
@@ -215,7 +217,26 @@ def review_pair_key(timestamp_seconds: float) -> int:
 
 
 def save_advice_state(advice_file: Path, advice: dict[str, Any]) -> None:
-    advice_file.write_text(json.dumps(dict(advice), indent=2) + "\n")
+    advice_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=advice_file.parent,
+                prefix=f".{advice_file.name}.",
+                suffix=".tmp",
+                delete=False,
+        ) as tmp_file:
+            tmp_path = Path(tmp_file.name)
+            tmp_file.write(json.dumps(dict(advice), indent=2))
+            tmp_file.write("\n")
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+        os.replace(tmp_path, advice_file)
+    finally:
+        if tmp_path is not None and tmp_path.exists():
+            tmp_path.unlink()
 
 
 def load_pending_proposal(proposal_file: Path) -> dict[str, Any] | None:

--- a/mediaforce/web/runtime/folder_tuning_advice.py
+++ b/mediaforce/web/runtime/folder_tuning_advice.py
@@ -802,7 +802,7 @@ def operator_request_from_intent(
         "applied_policy": intent.resolution.policy_fragment(),
         "request_text": note,
     }
-    return {
+    request = {
         "source": "guided_workflow",
         "operator_note_parse": parsed_note,
         "honor_mode": "combined_experiment",
@@ -832,6 +832,20 @@ def operator_request_from_intent(
         "scale_request": scale_request,
         "applied_policy": intent.policy_fragment(item_runtime_seconds=duration_seconds),
     }
+    feedback_tags = [
+        str(tag).strip()[:64]
+        for tag in object_list(intent_payload.get("quality_risk_tags"))[:7]
+        if str(tag).strip()
+    ]
+    if feedback_tags:
+        request["quality_risk_tags"] = feedback_tags
+    feedback_details = str(intent_payload.get("quality_risk_details") or "").strip()
+    if feedback_details:
+        request["quality_risk_details"] = feedback_details[:2000]
+    evidence_authority = str(intent_payload.get("evidence_authority") or "").strip().lower()
+    if evidence_authority in _EVIDENCE_AUTHORITY_VALUES:
+        request["evidence_authority"] = evidence_authority
+    return request
 
 
 def _positive_float_value(value: Any) -> float | None:
@@ -1363,10 +1377,10 @@ def review_gate(calibration: dict[str, Any] | None) -> dict[str, Any]:
     if can_confirm_full:
         return {
             "can_confirm_full": True,
-            "message": f"Approved sample draft saved at {accepted_at}. Mediaforce queues the folder encode automatically after approval.",
+            "message": f"Approved sample draft saved at {accepted_at}. Production starts only when you choose Make the season.",
             "status": "accepted",
             "accepted_at": accepted_at,
-            "next_action_label": "Auto-queued after approval",
+            "next_action_label": "Make the season",
         }
 
     if not review_media_ready:
@@ -1379,7 +1393,7 @@ def review_gate(calibration: dict[str, Any] | None) -> dict[str, Any]:
 
     return {
         "can_confirm_full": False,
-        "message": "Review the sample clips, then approve this draft to save the folder policy and queue the folder encode.",
+        "message": "Review the sample clips, then approve this draft to save the folder policy. Production remains separate until you choose Make the season.",
         "status": "needs_approval",
         "next_action_label": "Review clips and approve",
     }

--- a/mediaforce/web/runtime/job_runtime.py
+++ b/mediaforce/web/runtime/job_runtime.py
@@ -18,8 +18,8 @@ from sqlalchemy import true
 from sqlalchemy import update
 
 from mediaforce.tuning.calibration_jobs import claim_next_queued_calibration_job, load_latest_failed_sample_job, \
-    load_latest_job, load_latest_overlapping_job, load_latest_retryable_sample_job, load_latest_sample_job, \
-    queue_position, save_job
+    load_latest_failed_target_size_sample_job, load_latest_job, load_latest_overlapping_job, \
+    load_latest_retryable_sample_job, load_latest_sample_job, queue_position, save_job
 from mediaforce.core.config import MediaforceConfig, load_config
 from mediaforce.core.db import DBClient, DBRow, open_db
 from mediaforce.core.db_tables import calibration_jobs
@@ -161,6 +161,16 @@ def load_latest_failed_sample_job_state(
 ) -> dict[str, Any] | None:
     _ = config, deps
     return load_latest_failed_sample_job(connection, prefix)
+
+
+def load_latest_failed_target_size_job_state(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+        deps: JobRuntimeDeps,
+) -> dict[str, Any] | None:
+    _ = config, deps
+    return load_latest_failed_target_size_sample_job(connection, prefix)
 
 
 def save_job_state(

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -19,6 +19,9 @@ from mediaforce.core.db_tables import (
     library_items,
     staged_artifacts,
 )
+from mediaforce.core.evidence import stable_policy_hash, stable_source_id
+from mediaforce.library.planner import build_manifest_item
+from mediaforce.tuning.size_goals import operator_intent_from_policy
 from mediaforce.web.runtime.folder_tuning_advice import (
     calibration_draft_hash,
     calibration_policy_hash,
@@ -32,10 +35,17 @@ RETRY_PREFIX = "tv/Retry Show/Season 1"
 COMPLETED_PREFIX = "movies/Archive Ready"
 BLOCKED_COMPLETED_PREFIX = "movies/Blocked Cleanup"
 REVIEW_READY_PREFIX = "tv/Review Ready/Season 1"
+ABSOLUTE_TARGET_PREFIX = "tv/Absolute Goal/Season 1"
 APPROVED_PREFIX = "tv/Approved Show/Season 1"
 MISSED_TARGET_PREFIX = "tv/Overshoot Show/Season 1"
+UNDER_TARGET_PREFIX = "tv/Undershoot Show/Season 1"
+INFEASIBLE_PREFIX = "tv/Infeasible Goal/Season 1"
+QUALITY_CONFLICT_PREFIX = "tv/Quality Conflict/Season 1"
 ENCODE_RUNNING_PREFIX = "tv/Encoding Show/Season 1"
 ENCODE_RETRY_PREFIX = "tv/Failed Encode/Season 1"
+VALIDATION_PREFIX = "tv/Validation Ready/Season 1"
+PROMOTION_PREFIX = "tv/Promotion Ready/Season 1"
+FINISHED_PREFIX = "tv/Finished Show/Season 1"
 ENCODE_WAITING_PREFIX = "movies/Waiting Encode"
 FIXTURE_PREFIXES = (
     FOLDER_PREFIX,
@@ -44,10 +54,17 @@ FIXTURE_PREFIXES = (
     COMPLETED_PREFIX,
     BLOCKED_COMPLETED_PREFIX,
     REVIEW_READY_PREFIX,
+    ABSOLUTE_TARGET_PREFIX,
     APPROVED_PREFIX,
     MISSED_TARGET_PREFIX,
+    UNDER_TARGET_PREFIX,
+    INFEASIBLE_PREFIX,
+    QUALITY_CONFLICT_PREFIX,
     ENCODE_RUNNING_PREFIX,
     ENCODE_RETRY_PREFIX,
+    VALIDATION_PREFIX,
+    PROMOTION_PREFIX,
+    FINISHED_PREFIX,
     ENCODE_WAITING_PREFIX,
 )
 
@@ -91,6 +108,92 @@ def _library_item(
         "size_bytes": size_bytes,
         "mtime_ns": 1_700_000_000_000_000_000,
         "fingerprint": f"fixture:{rel_path}",
+        "cadence_summary_json": json.dumps(
+            {
+                "schema_version": 1,
+                "probe": {
+                    "field_order": "progressive",
+                    "average_frame_rate": "24000/1001",
+                },
+                "analysis": {
+                    "tff_frames": 0,
+                    "bff_frames": 0,
+                    "progressive_frames": 200,
+                    "undetermined_frames": 0,
+                    "repeated_neither": 200,
+                    "repeated_top": 0,
+                    "repeated_bottom": 0,
+                    "sampled_frames": 200,
+                    "coverage": 1.0,
+                    "ranges": [
+                        {
+                            "start_seconds": 0.0,
+                            "frame_limit": 200,
+                            "sampled_frames": 200,
+                            "status": "measured",
+                        }
+                    ],
+                    "tool": {
+                        "name": "mediaforce.ffmpeg_idet",
+                        "version": "1",
+                        "ffmpeg_version": "web-smoke",
+                    },
+                },
+            },
+            sort_keys=True,
+        ),
+        "media_fingerprint_json": json.dumps(
+            {
+                "schema_version": 1,
+                "analysis": {
+                    "sampled_frames": 120,
+                    "coverage": 1.0,
+                    "aggregate": {
+                        "dark_frame_fraction": 0.05,
+                        "gradient_frame_fraction": 0.02,
+                        "banding_risk_score": 0.02,
+                        "high_motion_frame_fraction": 0.04,
+                        "ydif_p90": 3.0,
+                        "high_texture_frame_fraction": 0.04,
+                        "edge_density_p90": 0.035,
+                        "duplicate_like_frame_fraction": 0.05,
+                        "temporal_noise_proxy": 0.5,
+                        "chroma_instability": 0.2,
+                        "smooth_temporal_noise_fraction": 0.02,
+                        "audio_loudness_range_lu_max": 0.0,
+                    },
+                    "audio_probe": {
+                        "track_count": 1,
+                        "max_channels": 6,
+                        "max_bitrate_bps": 768_000,
+                    },
+                    "ranges": [
+                        {
+                            "start_seconds": 0.0,
+                            "frame_limit": 120,
+                            "sampled_frames": 120,
+                            "status": "measured",
+                            "measurements": {
+                                "dark_frame_fraction": 0.05,
+                                "gradient_frame_fraction": 0.02,
+                                "high_motion_frame_fraction": 0.04,
+                                "ydif_p90": 3.0,
+                                "high_texture_frame_fraction": 0.04,
+                                "edge_density_p90": 0.035,
+                                "duplicate_like_frame_fraction": 0.05,
+                                "temporal_noise_proxy": 0.5,
+                            },
+                        }
+                    ],
+                    "tool": {
+                        "name": "mediaforce.media_fingerprint",
+                        "version": "1",
+                        "ffmpeg_version": "web-smoke",
+                    },
+                },
+            },
+            sort_keys=True,
+        ),
         "duration_seconds": duration_seconds,
         "video_codec": video_codec,
         "video_bitrate": 8_000_000 if video_codec == "h264" else 4_500_000,
@@ -135,6 +238,7 @@ def _job(
     status: str,
     sample_item: dict[str, Any],
     error: str | None = None,
+    result: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     timestamp = _now()
     return {
@@ -147,6 +251,7 @@ def _job(
         "notes": "Seeded browser QA fixture.",
         "policy_json": json.dumps(sample_item["resolved_policy"], sort_keys=True),
         "sample_item_json": json.dumps(sample_item, sort_keys=True),
+        "result_json": json.dumps(result, sort_keys=True) if result is not None else None,
         "error": error,
         "created_at": timestamp,
         "started_at": timestamp if status in {"running", "failed", "stopped"} else None,
@@ -154,6 +259,24 @@ def _job(
         if status in {"failed", "stopped", "completed"}
         else None,
         "updated_at": timestamp,
+    }
+
+
+def _target_search_failure(status: str, selection_reason: str) -> dict[str, Any]:
+    return {
+        "target_size_status": status,
+        "target_size_trace": {
+            "schema_version": 1,
+            "status": status,
+            "selection_reason": selection_reason,
+            "target": {
+                "total_target_bytes": 300_000_000,
+                "sample_lower_bound_bytes": 270_000_000,
+                "sample_upper_bound_bytes": 330_000_000,
+            },
+            "quality_floor": {"metric": "vmaf", "minimum": 93.0},
+            "curve": {"shape": "monotonic", "candidate_count": 3, "max_candidates": 6},
+        },
     }
 
 
@@ -256,10 +379,39 @@ def _write_review_sample_state(
     quality_score: float,
     outcome: str = "good_fit",
     accepted: bool = False,
-    size_target: bool = False,
+    target_mode: str | None = None,
+    target_megabytes: float | None = None,
 ) -> None:
     row = rows_by_prefix[prefix]
-    policy = config.resolve_policy(row["rel_path"])
+    policy = json.loads(json.dumps(config.resolve_policy(row["rel_path"])))
+    if target_megabytes is not None:
+        mode = target_mode or "absolute"
+        target_bytes = int(round(target_megabytes * 1_000_000))
+        policy.setdefault("video", {}).update(
+            {
+                "size_goal_schema_version": 1,
+                "size_goal_mode": mode,
+                "size_goal_source": "web_smoke_fixture",
+                "target_size_mb": target_megabytes,
+                "target_size_bytes": target_bytes,
+                "target_runtime_minutes": (
+                    45 if mode == "normalized" else round(float(row["duration_seconds"]) / 60.0, 3)
+                ),
+                "sample_projection_tolerance_percent": 10,
+                "final_output_tolerance_percent": 5,
+                "resolution_intent_mode": "source",
+                "resolution_intent_source": "web_smoke_fixture",
+                "max_height": 0,
+            }
+        )
+    operator_intent = operator_intent_from_policy(
+        policy.get("video", {}),
+        default_video_policy=config.video,
+        audio_policy=policy.get("audio", {}),
+        subtitle_policy=policy.get("subtitle", {}),
+    )
+    resolved_goal = operator_intent.size_goal.resolve(float(row["duration_seconds"]))
+    target_bytes = int(resolved_goal.target_size_bytes or 0)
     review_dir = config.paths.review_dir / review_slug
     review_dir.mkdir(parents=True, exist_ok=True)
     source_clip = review_dir / "source.mov"
@@ -269,19 +421,26 @@ def _write_review_sample_state(
     preview_clip.write_bytes(b"mediaforce smoke preview clip\n")
     artifact_image.write_bytes(b"mediaforce smoke contact sheet\n")
 
-    sample_item = {
-        **row,
-        "source_size_bytes": row["size_bytes"],
-        "resolved_policy": policy,
+    sample_item = build_manifest_item(row, config)
+    sample_item["resolved_policy"] = policy
+    source_id = stable_source_id(sample_item)
+    sample_item["representative_source_id"] = source_id
+    evidence_ids = [
+        str(sample_item["cadence_decision"]["evidence_id"]),
+        str(sample_item["media_fingerprint_decision"]["evidence_id"]),
+    ]
+    policy_hash = stable_policy_hash(policy)
+    operator_request = {
+        "source": "guided_workflow",
+        "request_type": "combined_experiment",
+        "operator_confirmed": True,
+        "evidence_authority": "none",
+        "budget_bytes": target_bytes,
+        "budget_label": f"{target_bytes / 1_000_000:.0f} MB per episode",
+        "sample_projection_tolerance_percent": 10,
+        "final_output_tolerance_percent": 5,
+        "size_goal": resolved_goal.to_payload(),
     }
-    operator_request = (
-        {
-            "budget_bytes": 314_572_800,
-            "budget_label": "300 MB per episode",
-        }
-        if size_target
-        else None
-    )
     run_verdict = {"outcome": outcome}
     calibration_payload = {
         "job_id": job_id,
@@ -291,38 +450,69 @@ def _write_review_sample_state(
         "policy": policy,
         "sample_result": {
             "predicted_total_size_bytes": predicted_total_size_bytes,
+            "sampled_clip_bytes": 12_000_000,
             "quality_metric": "vmaf",
             "quality_score": quality_score,
+            "cadence_evidence_id": evidence_ids[0],
+            "media_fingerprint_evidence_id": evidence_ids[1],
         },
         "advice": {"run_verdict": run_verdict},
+        "review_moments": [
+            {
+                "moment": 1,
+                "timestamp_seconds": 60,
+                "role": "representative",
+                "risk_tags": ["softness_detail_loss", "audio_quality_layout"],
+                "evidence_id": evidence_ids[1],
+                "rationale": "Fixture moment for picture and sound review.",
+            }
+        ],
         "review_pairs": [
             {
                 "timestamp_seconds": 60,
                 "duration_seconds": 12,
                 "source_clip": {
-                    "path": f"/review-media/{review_slug}/source.mov"
+                    "path": f"/review-media/{review_slug}/source.mov",
+                    "timestamp_seconds": 60,
+                    "duration_seconds": 12,
+                    "size_bytes": 96_000_000,
                 },
                 "preview_clip": {
-                    "path": f"/review-media/{review_slug}/preview.mov"
+                    "path": f"/review-media/{review_slug}/preview.mov",
+                    "timestamp_seconds": 60,
+                    "duration_seconds": 12,
+                    "size_bytes": 12_000_000,
                 },
             }
         ],
         "review_media_ready": True,
         "browser_review_ready": True,
     }
-    if accepted:
-        calibration_payload["accepted_at"] = _now()
-        calibration_payload["accepted_sample_job_id"] = job_id
-        calibration_payload["accepted_policy_hash"] = calibration_policy_hash(
-            calibration_payload
-        )
-        calibration_payload["accepted_draft_hash"] = calibration_draft_hash(
-            calibration_payload
-        )
     advice_payload = {
         "summary": "Fixture review pack is ready for operator inspection.",
         "confidence": "high",
         "run_verdict": run_verdict,
+        "operator_request": operator_request,
+        "quality_risk_interpretation": {
+            "summary": "Picture detail and surround layout need an operator comparison.",
+            "verdict": "request_comparison",
+            "confidence": "medium",
+            "risks": [
+                {
+                    "tag": "softness_detail_loss",
+                    "label": "Picture detail",
+                    "level": "medium",
+                    "rationale": "Inspect faces and moving texture in the representative moment.",
+                },
+                {
+                    "tag": "audio_quality_layout",
+                    "label": "Surround layout",
+                    "level": "medium",
+                    "rationale": "Confirm that dialogue and channel layout remain natural.",
+                },
+            ],
+            "suggested_actions": ["Compare the current picture and sound evidence."],
+        },
         "multimodal_review_pack": {
             "artifacts": [
                 {
@@ -339,9 +529,31 @@ def _write_review_sample_state(
             ]
         },
     }
-    if operator_request:
-        calibration_payload["advice"]["operator_request"] = operator_request
-        advice_payload["operator_request"] = operator_request
+    calibration_payload["advice"]["operator_request"] = operator_request
+    if accepted:
+        calibration_payload["accepted_at"] = _now()
+        calibration_payload["accepted_sample_job_id"] = job_id
+        calibration_payload["accepted_policy_hash"] = calibration_policy_hash(
+            calibration_payload
+        )
+        calibration_payload["accepted_draft_hash"] = calibration_draft_hash(
+            calibration_payload
+        )
+        advice_payload["quality_risk_records"] = [
+            {
+                "kind": "post_test",
+                "created_at": calibration_payload["accepted_at"],
+                "verdict": "approved",
+                "tags": ["softness_detail_loss", "audio_quality_layout"],
+                "details": "Fixture operator approved the current picture and sound evidence.",
+                "evidence_ids": evidence_ids,
+                "moment_indexes": [1],
+                "sample_job_id": job_id,
+                "policy_hash": policy_hash,
+                "source_id": source_id,
+                "prefix": prefix,
+            }
+        ]
     web_dir = config.paths.web_state_dir
     web_dir.mkdir(parents=True, exist_ok=True)
     slug = _slug(prefix)
@@ -360,8 +572,19 @@ def _write_review_states(config: Any, rows_by_prefix: dict[str, dict[str, Any]])
         prefix=REVIEW_READY_PREFIX,
         job_id="web-smoke-review-ready",
         review_slug="web-smoke-review-ready",
-        predicted_total_size_bytes=int(rows_by_prefix[REVIEW_READY_PREFIX]["size_bytes"] * 0.58),
+        predicted_total_size_bytes=398_000_000,
         quality_score=96.2,
+    )
+    _write_review_sample_state(
+        config,
+        rows_by_prefix,
+        prefix=ABSOLUTE_TARGET_PREFIX,
+        job_id="web-smoke-absolute-target",
+        review_slug="web-smoke-absolute-target",
+        predicted_total_size_bytes=224_000_000,
+        quality_score=95.1,
+        target_mode="absolute",
+        target_megabytes=225,
     )
     _write_review_sample_state(
         config,
@@ -369,7 +592,7 @@ def _write_review_states(config: Any, rows_by_prefix: dict[str, dict[str, Any]])
         prefix=APPROVED_PREFIX,
         job_id="web-smoke-approved",
         review_slug="web-smoke-approved",
-        predicted_total_size_bytes=int(rows_by_prefix[APPROVED_PREFIX]["size_bytes"] * 0.52),
+        predicted_total_size_bytes=396_000_000,
         quality_score=94.8,
         accepted=True,
     )
@@ -379,10 +602,19 @@ def _write_review_states(config: Any, rows_by_prefix: dict[str, dict[str, Any]])
         prefix=MISSED_TARGET_PREFIX,
         job_id="web-smoke-overshoot",
         review_slug="web-smoke-overshoot",
-        predicted_total_size_bytes=803_322_876,
+        predicted_total_size_bytes=560_000_000,
         quality_score=92.0,
         outcome="poor_fit",
-        size_target=True,
+    )
+    _write_review_sample_state(
+        config,
+        rows_by_prefix,
+        prefix=UNDER_TARGET_PREFIX,
+        job_id="web-smoke-undershoot",
+        review_slug="web-smoke-undershoot",
+        predicted_total_size_bytes=300_000_000,
+        quality_score=90.5,
+        outcome="needs_revision",
     )
 
 
@@ -553,9 +785,21 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
             _library_item(
                 project_root=project_root,
                 media_root="tv",
+                rel_path="tv/Absolute Goal/Season 1/Episode 01.mkv",
+                size_bytes=7 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=84,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture absolute 225 MB goal state for browser QA.",
+                duration_seconds=88 * 60,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
                 rel_path="tv/Approved Show/Season 1/Episode 01.mkv",
                 size_bytes=7 * 1024**3,
-                status="approved",
+                status="discovered",
                 video_codec="h264",
                 priority_score=83,
                 recommendation="priority_encode",
@@ -571,6 +815,39 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 priority_score=82,
                 recommendation="priority_encode",
                 recommendation_reason="Fixture target-missed review state for browser QA.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
+                rel_path="tv/Undershoot Show/Season 1/Episode 01.mkv",
+                size_bytes=7 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=81,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture under-target review state for browser QA.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
+                rel_path="tv/Infeasible Goal/Season 1/Episode 01.mkv",
+                size_bytes=7 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=81,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture arithmetic infeasibility state for browser QA.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
+                rel_path="tv/Quality Conflict/Season 1/Episode 01.mkv",
+                size_bytes=7 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=81,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture quality-floor conflict state for browser QA.",
             ),
             _library_item(
                 project_root=project_root,
@@ -605,12 +882,51 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 recommendation="priority_encode",
                 recommendation_reason="Fixture queued encode with unavailable host state.",
             ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
+                rel_path="tv/Validation Ready/Season 1/Episode 01.mkv",
+                size_bytes=5 * 1024**3,
+                status="encoded",
+                video_codec="av1",
+                priority_score=20,
+                recommendation="already_optimized",
+                recommendation_reason="Fixture output waiting for validation.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
+                rel_path="tv/Promotion Ready/Season 1/Episode 01.mkv",
+                size_bytes=5 * 1024**3,
+                status="validated",
+                video_codec="av1",
+                priority_score=19,
+                recommendation="already_optimized",
+                recommendation_reason="Fixture validated output waiting for promotion.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
+                rel_path="tv/Finished Show/Season 1/Episode 01.mkv",
+                size_bytes=5 * 1024**3,
+                status="promoted",
+                video_codec="av1",
+                priority_score=18,
+                recommendation="already_optimized",
+                recommendation_reason="Fixture completed season state for browser QA.",
+            ),
         ]
         inserted_ids: list[int] = []
         for row in rows:
             result = connection.execute(library_items.insert().values(**row))
             inserted_ids.append(int(result.inserted_primary_key[0]))
+        for row, item_id in zip(rows, inserted_ids, strict=True):
+            row["id"] = item_id
         rows_by_prefix = {str(row["parent_dir"]): row for row in rows}
+        ids_by_rel_path = {
+            str(row["rel_path"]): item_id
+            for row, item_id in zip(rows, inserted_ids, strict=True)
+        }
 
         completed_id = inserted_ids[3]
         blocked_completed_id = inserted_ids[6]
@@ -710,6 +1026,32 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 )
             )
 
+        for prefix, validated_at in (
+            (VALIDATION_PREFIX, None),
+            (PROMOTION_PREFIX, timestamp),
+        ):
+            row = rows_by_prefix[prefix]
+            item_id = ids_by_rel_path[str(row["rel_path"])]
+            staging_path = (
+                staging_root / Path(str(row["rel_path"])).with_suffix(".av1.mkv")
+            )
+            staging_path.parent.mkdir(parents=True, exist_ok=True)
+            staging_path.write_bytes(b"mediaforce smoke staged output\n")
+            connection.execute(
+                staged_artifacts.insert().values(
+                    library_item_id=item_id,
+                    source_rel_path=row["rel_path"],
+                    source_size_bytes=row["size_bytes"],
+                    staging_path=str(staging_path),
+                    staging_size_bytes=max(1, int(row["size_bytes"]) // 2),
+                    bytes_saved=max(1, int(row["size_bytes"]) // 2),
+                    size_ratio=0.5,
+                    staged_at=timestamp,
+                    validated_at=validated_at,
+                    updated_at=timestamp,
+                )
+            )
+
         policy = config.resolve_policy(rows[0]["rel_path"])
         for item_id, row, job in (
             (
@@ -718,7 +1060,7 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 _job(
                     job_id="web-smoke-sampling",
                     prefix=SAMPLING_PREFIX,
-                    status="queued",
+                    status="starting",
                     sample_item={
                         "library_item_id": inserted_ids[4],
                         **rows[4],
@@ -741,6 +1083,50 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                         "resolved_policy": policy,
                     },
                     error="Fixture sample failed so retry state is inspectable.",
+                ),
+            ),
+            (
+                ids_by_rel_path["tv/Infeasible Goal/Season 1/Episode 01.mkv"],
+                rows_by_prefix[INFEASIBLE_PREFIX],
+                _job(
+                    job_id="web-smoke-infeasible",
+                    prefix=INFEASIBLE_PREFIX,
+                    status="failed",
+                    sample_item={
+                        "library_item_id": ids_by_rel_path[
+                            "tv/Infeasible Goal/Season 1/Episode 01.mkv"
+                        ],
+                        **rows_by_prefix[INFEASIBLE_PREFIX],
+                        "source_size_bytes": rows_by_prefix[INFEASIBLE_PREFIX]["size_bytes"],
+                        "resolved_policy": policy,
+                    },
+                    error="The resolved stream budget leaves no positive video budget.",
+                    result=_target_search_failure(
+                        "infeasible",
+                        "arithmetically_infeasible_stream_budget",
+                    ),
+                ),
+            ),
+            (
+                ids_by_rel_path["tv/Quality Conflict/Season 1/Episode 01.mkv"],
+                rows_by_prefix[QUALITY_CONFLICT_PREFIX],
+                _job(
+                    job_id="web-smoke-quality-conflict",
+                    prefix=QUALITY_CONFLICT_PREFIX,
+                    status="failed",
+                    sample_item={
+                        "library_item_id": ids_by_rel_path[
+                            "tv/Quality Conflict/Season 1/Episode 01.mkv"
+                        ],
+                        **rows_by_prefix[QUALITY_CONFLICT_PREFIX],
+                        "source_size_bytes": rows_by_prefix[QUALITY_CONFLICT_PREFIX]["size_bytes"],
+                        "resolved_policy": policy,
+                    },
+                    error="No measured candidate met both the size target and quality floor.",
+                    result=_target_search_failure(
+                        "quality_conflict",
+                        "all_candidates_violate_quality_floor",
+                    ),
                 ),
             ),
         ):
@@ -814,16 +1200,19 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 "label": "Folder Studio waiting fixture",
                 "route": "/folders/tv/Example%20Show/Season%201",
                 "marker": "Example Show",
+                "stageMarker": "Choose a size for Season 1",
             },
             {
                 "label": "Folder Studio sampling fixture",
                 "route": "/folders/tv/Sampling%20Show/Season%201",
                 "marker": "Sampling Show",
+                "stageMarker": "Making your test",
             },
             {
                 "label": "Folder Studio retry fixture",
                 "route": "/folders/tv/Retry%20Show/Season%201",
                 "marker": "Retry Show",
+                "stageMarker": "The test stopped",
             },
             {
                 "label": "Completed cleanup fixture",
@@ -839,26 +1228,73 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 "label": "Folder Studio review-ready fixture",
                 "route": "/folders/tv/Review%20Ready/Season%201",
                 "marker": "Review Ready",
+                "stageMarker": "Looks good",
+            },
+            {
+                "label": "Folder Studio absolute-target fixture",
+                "route": "/folders/tv/Absolute%20Goal/Season%201",
+                "marker": "Absolute Goal",
+                "stageMarker": "225 MB",
             },
             {
                 "label": "Folder Studio approved fixture",
                 "route": "/folders/tv/Approved%20Show/Season%201",
                 "marker": "Approved Show",
+                "stageMarker": "Ready to make the season",
             },
             {
                 "label": "Folder Studio missed-target fixture",
                 "route": "/folders/tv/Overshoot%20Show/Season%201",
                 "marker": "Overshoot Show",
+                "stageMarker": "Size goal not met",
+            },
+            {
+                "label": "Folder Studio under-target fixture",
+                "route": "/folders/tv/Undershoot%20Show/Season%201",
+                "marker": "Undershoot Show",
+                "stageMarker": "Below the representative band",
+            },
+            {
+                "label": "Folder Studio infeasible fixture",
+                "route": "/folders/tv/Infeasible%20Goal/Season%201",
+                "marker": "Infeasible Goal",
+                "stageMarker": "This size cannot fit the required streams",
+            },
+            {
+                "label": "Folder Studio quality-conflict fixture",
+                "route": "/folders/tv/Quality%20Conflict/Season%201",
+                "marker": "Quality Conflict",
+                "stageMarker": "This size conflicts with the quality floor",
             },
             {
                 "label": "Folder Studio active processing fixture",
                 "route": "/folders/tv/Encoding%20Show/Season%201",
                 "marker": "Encoding Show",
+                "stageMarker": "Making Season 1",
             },
             {
                 "label": "Folder Studio retryable processing fixture",
                 "route": "/folders/tv/Failed%20Encode/Season%201",
                 "marker": "Failed Encode",
+                "stageMarker": "The season stopped",
+            },
+            {
+                "label": "Folder Studio validation fixture",
+                "route": "/folders/tv/Validation%20Ready/Season%201",
+                "marker": "Validation Ready",
+                "stageMarker": "Let’s check every new file",
+            },
+            {
+                "label": "Folder Studio promotion fixture",
+                "route": "/folders/tv/Promotion%20Ready/Season%201",
+                "marker": "Promotion Ready",
+                "stageMarker": "Ready to finish",
+            },
+            {
+                "label": "Folder Studio finished fixture",
+                "route": "/folders/tv/Finished%20Show/Season%201",
+                "marker": "Finished Show",
+                "stageMarker": "Season 1 is ready",
             },
         ],
         "completedPrefix": COMPLETED_PREFIX,

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -26,6 +26,7 @@ const APP_ROOT_SELECTOR = ".app-shell";
  * @property {string} label
  * @property {string} route
  * @property {string} marker
+ * @property {string=} stageMarker
  */
 
 /**
@@ -308,7 +309,12 @@ async function checkRoutes(baseUrl, routeChecksForBrowser, timeoutMs) {
     });
     const pageErrors = [];
     page.on("pageerror", (error) => pageErrors.push(error.message));
-    for (const [label, route, marker] of routeChecksForBrowser) {
+    for (const [
+      label,
+      route,
+      marker,
+      stageMarker = "",
+    ] of routeChecksForBrowser) {
       pageErrors.length = 0;
       const started = performance.now();
       const requireFolderReadyMarker = route.startsWith("/folders/");
@@ -326,8 +332,13 @@ async function checkRoutes(baseUrl, routeChecksForBrowser, timeoutMs) {
       });
       await page
         .waitForFunction(
-          ({ expectedMarker, requireFolderReady }) => {
+          ({ expectedMarker, expectedStageMarker, requireFolderReady }) => {
             if (!document.body.innerText.includes(expectedMarker)) return false;
+            if (
+              expectedStageMarker &&
+              !document.body.innerText.includes(expectedStageMarker)
+            )
+              return false;
             if (!requireFolderReady) return true;
             const readyMarker = document
               .querySelector("[data-folder-ready-marker]")
@@ -336,6 +347,7 @@ async function checkRoutes(baseUrl, routeChecksForBrowser, timeoutMs) {
           },
           {
             expectedMarker: marker,
+            expectedStageMarker: stageMarker,
             requireFolderReady: requireFolderReadyMarker,
           },
           { timeout: timeoutMs },
@@ -345,27 +357,35 @@ async function checkRoutes(baseUrl, routeChecksForBrowser, timeoutMs) {
             `${label} did not show marker ${JSON.stringify(marker)} within ${timeoutMs}ms: ${error.message}`,
           );
         });
-      const state = await page.evaluate(({ expectedMarker, requireFolderReady }) => {
-        const bodyText = document.body.innerText.trim();
-        const readyMarker = document
-          .querySelector("[data-folder-ready-marker]")
-          ?.getAttribute("data-folder-ready-marker");
-        return {
-          bodyLength: bodyText.length,
-          hasMain: document.querySelector("main") !== null,
-          hasAppRoot: document.querySelector(".app-shell") !== null,
-          hasMarker: bodyText.includes(expectedMarker),
-          hasReadyMarker:
-            !requireFolderReady || Boolean(readyMarker?.includes(expectedMarker)),
-        };
-      }, {
-        expectedMarker: marker,
-        requireFolderReady: requireFolderReadyMarker,
-      });
+      const state = await page.evaluate(
+        ({ expectedMarker, expectedStageMarker, requireFolderReady }) => {
+          const bodyText = document.body.innerText.trim();
+          const readyMarker = document
+            .querySelector("[data-folder-ready-marker]")
+            ?.getAttribute("data-folder-ready-marker");
+          return {
+            bodyLength: bodyText.length,
+            hasMain: document.querySelector("main") !== null,
+            hasAppRoot: document.querySelector(".app-shell") !== null,
+            hasMarker: bodyText.includes(expectedMarker),
+            hasStageMarker:
+              !expectedStageMarker || bodyText.includes(expectedStageMarker),
+            hasReadyMarker:
+              !requireFolderReady ||
+              Boolean(readyMarker?.includes(expectedMarker)),
+          };
+        },
+        {
+          expectedMarker: marker,
+          expectedStageMarker: stageMarker,
+          requireFolderReady: requireFolderReadyMarker,
+        },
+      );
       if (
         !state.hasAppRoot ||
         !state.hasMain ||
         !state.hasMarker ||
+        !state.hasStageMarker ||
         !state.hasReadyMarker ||
         state.bodyLength < 80
       ) {
@@ -462,7 +482,12 @@ async function checkNarrowRoutes(baseUrl, routeChecksForNarrow, timeoutMs) {
     });
     const pageErrors = [];
     page.on("pageerror", (error) => pageErrors.push(error.message));
-    for (const [label, route, marker] of routeChecksForNarrow) {
+    for (const [
+      label,
+      route,
+      marker,
+      stageMarker = "",
+    ] of routeChecksForNarrow) {
       pageErrors.length = 0;
       const started = performance.now();
       const requireFolderReadyMarker = route.startsWith("/folders/");
@@ -480,8 +505,13 @@ async function checkNarrowRoutes(baseUrl, routeChecksForNarrow, timeoutMs) {
       });
       await page
         .waitForFunction(
-          ({ expectedMarker, requireFolderReady }) => {
+          ({ expectedMarker, expectedStageMarker, requireFolderReady }) => {
             if (!document.body.innerText.includes(expectedMarker)) return false;
+            if (
+              expectedStageMarker &&
+              !document.body.innerText.includes(expectedStageMarker)
+            )
+              return false;
             if (!requireFolderReady) return true;
             const readyMarker = document
               .querySelector("[data-folder-ready-marker]")
@@ -490,6 +520,7 @@ async function checkNarrowRoutes(baseUrl, routeChecksForNarrow, timeoutMs) {
           },
           {
             expectedMarker: marker,
+            expectedStageMarker: stageMarker,
             requireFolderReady: requireFolderReadyMarker,
           },
           { timeout: timeoutMs },
@@ -499,44 +530,54 @@ async function checkNarrowRoutes(baseUrl, routeChecksForNarrow, timeoutMs) {
             `${label} narrow route did not show marker ${JSON.stringify(marker)} within ${timeoutMs}ms: ${error.message}`,
           );
         });
-      const state = await page.evaluate(({ expectedMarker, requireFolderReady }) => {
-        const bodyText = document.body.innerText.trim();
-        const readyMarker = document
-          .querySelector("[data-folder-ready-marker]")
-          ?.getAttribute("data-folder-ready-marker");
-        const visibleWideTables = Array.from(document.querySelectorAll("table"))
-          .map((el) => {
-            const rect = el.getBoundingClientRect();
-            return {
-              text: String(el.textContent ?? "")
-                .trim()
-                .replace(/\s+/g, " ")
-                .slice(0, 80),
-              width: Math.round(rect.width),
-              height: Math.round(rect.height),
-              display: getComputedStyle(el).display,
-            };
-          })
-          .filter(
-            (item) => item.width > window.innerWidth + 2 && item.height > 0,
-          );
-        return {
-          bodyLength: bodyText.length,
-          hasMarker: bodyText.includes(expectedMarker),
-          hasReadyMarker:
-            !requireFolderReady || Boolean(readyMarker?.includes(expectedMarker)),
-          pageOverflow:
-            document.documentElement.scrollWidth > window.innerWidth + 2,
-          scrollWidth: document.documentElement.scrollWidth,
-          visibleWideTables,
-        };
-      }, {
-        expectedMarker: marker,
-        requireFolderReady: requireFolderReadyMarker,
-      });
+      const state = await page.evaluate(
+        ({ expectedMarker, expectedStageMarker, requireFolderReady }) => {
+          const bodyText = document.body.innerText.trim();
+          const readyMarker = document
+            .querySelector("[data-folder-ready-marker]")
+            ?.getAttribute("data-folder-ready-marker");
+          const visibleWideTables = Array.from(
+            document.querySelectorAll("table"),
+          )
+            .map((el) => {
+              const rect = el.getBoundingClientRect();
+              return {
+                text: String(el.textContent ?? "")
+                  .trim()
+                  .replace(/\s+/g, " ")
+                  .slice(0, 80),
+                width: Math.round(rect.width),
+                height: Math.round(rect.height),
+                display: getComputedStyle(el).display,
+              };
+            })
+            .filter(
+              (item) => item.width > window.innerWidth + 2 && item.height > 0,
+            );
+          return {
+            bodyLength: bodyText.length,
+            hasMarker: bodyText.includes(expectedMarker),
+            hasStageMarker:
+              !expectedStageMarker || bodyText.includes(expectedStageMarker),
+            hasReadyMarker:
+              !requireFolderReady ||
+              Boolean(readyMarker?.includes(expectedMarker)),
+            pageOverflow:
+              document.documentElement.scrollWidth > window.innerWidth + 2,
+            scrollWidth: document.documentElement.scrollWidth,
+            visibleWideTables,
+          };
+        },
+        {
+          expectedMarker: marker,
+          expectedStageMarker: stageMarker,
+          requireFolderReady: requireFolderReadyMarker,
+        },
+      );
       if (
         state.bodyLength < 80 ||
         !state.hasMarker ||
+        !state.hasStageMarker ||
         !state.hasReadyMarker ||
         state.pageOverflow ||
         state.visibleWideTables.length
@@ -593,6 +634,7 @@ async function main() {
         fixtureRoute.label,
         fixtureRoute.route,
         fixtureRoute.marker,
+        fixtureRoute.stageMarker ?? "",
       ]);
     }
     await checkEndpoints(targetUrl, args.endpointTimeoutMs);

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -13530,7 +13530,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 "",
                 False,
                 now_iso=web_app._now_iso,
-                load_job_state=lambda *_args, **_kwargs: failed_job,
+                load_job_state=self._noop_load_job_state,
                 load_calibration_state=lambda *_args, **_kwargs: calibration,
                 review_gate=self._accepted_review_gate,
                 upsert_override=self._noop_upsert_override,
@@ -13538,6 +13538,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 clear_terminal_encode_jobs_for_prefix_fn=clear_terminal_encode_jobs_for_prefix,
                 prepare_terminal_encode_job_for_requeue_fn=self._prepare_terminal_encode_job_for_requeue,
                 save_encode_job=save_encode_job,
+                load_latest_failed_target_size_job_state=lambda *_args, **_kwargs: failed_job,
             )
 
         self.assertEqual(raised.exception.status_code, 409)
@@ -13547,7 +13548,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         reason = folder_actions_runtime._failed_target_size_job_blocking_reason(
             {
                 "status": "failed",
-                "finished_at": "2026-07-11T23:59:00+00:00",
+                "finished_at": "2026-07-11T19:59:00-04:00",
                 "result": {"target_size_status": "quality_conflict"},
             },
             {"accepted_at": "2026-07-12T00:00:00+00:00"},
@@ -13583,6 +13584,57 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             {str(object_dict(record).get("verdict")) for record in object_list(merged["quality_risk_records"])},
             {"approved", "rejected"},
         )
+
+    def test_advice_save_preserves_existing_quality_risk_records(self) -> None:
+        prefix = "tv/show/Season 1"
+        rejected = {
+            "kind": "post_test",
+            "verdict": "rejected",
+            "sample_job_id": "sample-1",
+            "policy_hash": "policy-1",
+            "source_id": "source-1",
+            "prefix": prefix,
+            "created_at": "2026-07-12T00:01:00+00:00",
+        }
+        web_app._save_advice_state(self.config, prefix, {"quality_risk_records": [rejected]})
+
+        web_app._save_advice_state(self.config, prefix, {"summary": "Fresh tuning advice."})
+
+        saved = web_app._load_advice_state(self.config, prefix)
+        self.assertEqual(object_dict(saved).get("summary"), "Fresh tuning advice.")
+        self.assertEqual(
+            [object_dict(record).get("verdict") for record in object_list(object_dict(saved).get("quality_risk_records"))],
+            ["rejected"],
+        )
+
+    def test_advice_merge_keeps_newer_same_verdict_record(self) -> None:
+        prefix = "tv/show/Season 1"
+        newer = {
+            "kind": "post_test",
+            "verdict": "rejected",
+            "sample_job_id": "sample-1",
+            "policy_hash": "policy-1",
+            "source_id": "source-1",
+            "prefix": prefix,
+            "created_at": "2026-07-12T00:02:00+00:00",
+            "details": "Newer rejection evidence.",
+        }
+        stale = {
+            **newer,
+            "created_at": "2026-07-12T00:01:00+00:00",
+            "details": "Stale rejection evidence.",
+        }
+        web_app._save_advice_state(self.config, prefix, {"quality_risk_records": [newer]})
+
+        merged = web_app._merge_advice_state(
+            self.config,
+            prefix,
+            {"quality_risk_records": [stale]},
+        )
+
+        records = object_list(merged["quality_risk_records"])
+        self.assertEqual(len(records), 1)
+        self.assertEqual(object_dict(records[0]).get("details"), "Newer rejection evidence.")
 
     def test_queue_advice_loader_fails_closed_on_corrupt_state(self) -> None:
         prefix = "tv/show/Season 1"

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -32,7 +32,7 @@ from mediaforce.core.db_tables import item_events
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.db_tables import scan_runs
 from mediaforce.core.db_tables import staged_artifacts
-from mediaforce.core.evidence import stable_policy_hash
+from mediaforce.core.evidence import stable_policy_hash, stable_source_id
 from mediaforce.core.models import ProbeSummary
 from mediaforce.core.process_control import ProcessCancelledError
 from mediaforce.core.type_defs import object_dict, object_list
@@ -132,7 +132,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             "can_confirm_full": True,
             "message": None,
             "status": "accepted",
-            "next_action_label": "Auto-queued after approval",
+            "next_action_label": "Make the season",
         }
 
     @staticmethod
@@ -5181,7 +5181,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
         self.assertEqual(accepted_gate["status"], "accepted")
         self.assertTrue(accepted_gate["can_confirm_full"])
-        self.assertEqual(accepted_gate["next_action_label"], "Auto-queued after approval")
+        self.assertEqual(accepted_gate["next_action_label"], "Make the season")
 
     def test_review_gate_preserves_legacy_approval_for_same_sample_when_hash_drifts(self) -> None:
         payload = {
@@ -5219,8 +5219,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(review_gate["status"], "needs_approval")
         self.assertFalse(review_gate["can_confirm_full"])
 
-    def test_save_profile_action_auto_queues_folder_encode(self) -> None:
-        manifest_path = self._write_manifest("manifest-approved-queue.json", [{"library_item_id": 1}])
+    def test_save_profile_action_approves_without_queueing_production(self) -> None:
         calibration_state: dict[str, folder_actions_runtime.ActionPayload] = {
             "tv/show": {
                 "mode": "sample",
@@ -5245,124 +5244,33 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         ) -> None:
             calibration_state[prefix] = dict(payload)
 
-        with patch("mediaforce.web.runtime.folder_actions.load_config", return_value=self.config), patch(
-                "mediaforce.web.runtime.folder_actions.create_folder_manifest",
-                return_value=({"items": [{"library_item_id": 1}]}, manifest_path),
-        ):
-            result = folder_actions_runtime.save_profile_action(
-                self.config,
-                "tv/show",
-                now_iso=web_app._now_iso,
-                load_sample_item=lambda *_args, **_kwargs: {"resolved_policy": {"video": {"target_vmaf": 95.0}}},
-                load_calibration_state=load_calibration_state,
-                calibration_draft_hash=web_app._calibration_draft_hash,
-                save_calibration_state=save_calibration_state,
-                load_advice_state=lambda *_args, **_kwargs: None,
-                record_visual_approval_artifact=lambda *_args, **_kwargs: None,
-                merge_advice_state=lambda *_args, **_kwargs: {},
-                upsert_override=web_app._upsert_override,
-                auto_queue_folder_encode=lambda prefix, notes,
-                                                bypass_schedule: folder_actions_runtime.queue_folder_encode_action(
-                    self.config,
-                    prefix,
-                    notes,
-                    bypass_schedule,
-                    now_iso=web_app._now_iso,
-                    load_job_state=self._noop_load_job_state,
-                    load_calibration_state=load_calibration_state,
-                    review_gate=web_app._review_gate,
-                    upsert_override=web_app._upsert_override,
-                    load_active_encode_job_for_prefix_fn=load_active_encode_job_for_prefix,
-                    clear_terminal_encode_jobs_for_prefix_fn=clear_terminal_encode_jobs_for_prefix,
-                    prepare_terminal_encode_job_for_requeue_fn=self._prepare_terminal_encode_job_for_requeue,
-                    save_encode_job=save_encode_job,
-                ),
-            )
+        result = folder_actions_runtime.save_profile_action(
+            self.config,
+            "tv/show",
+            now_iso=web_app._now_iso,
+            load_sample_item=lambda *_args, **_kwargs: {"resolved_policy": {"video": {"target_vmaf": 95.0}}},
+            load_calibration_state=load_calibration_state,
+            calibration_draft_hash=web_app._calibration_draft_hash,
+            save_calibration_state=save_calibration_state,
+            load_advice_state=lambda *_args, **_kwargs: None,
+            record_visual_approval_artifact=lambda *_args, **_kwargs: None,
+            merge_advice_state=lambda *_args, **_kwargs: {},
+            upsert_override=web_app._upsert_override,
+        )
 
         self.assertTrue(result["ok"])
-        self.assertTrue(result["queued"])
-        self.assertEqual(result["auto_queue_status"], "queued")
-        self.assertIn("queued the full folder encode", result["message"])
+        self.assertFalse(result["queued"])
+        self.assertEqual(result["auto_queue_status"], "approval_only")
+        self.assertIn("Choose Make the season", result["message"])
         calibration = load_calibration_state(self.config, "tv/show")
         assert calibration is not None
         self.assertTrue(calibration.get("accepted_at"))
         self.assertTrue(calibration.get("accepted_policy_hash"))
         with open_db(self.config.paths.db_path) as connection:
-            rows = connection.execute(
-                select(encode_jobs.c.job_kind, encode_jobs.c.status)
-                .where(encode_jobs.c.prefix == "tv/show")
-                .order_by(encode_jobs.c.created_at.asc(), encode_jobs.c.job_id.asc())
-            ).mappings().fetchall()
-        self.assertCountEqual(
-            [(str(row["job_kind"]), str(row["status"])) for row in rows],
-            [("folder", "queued"), ("shard", "queued")],
-        )
-
-    def test_save_profile_action_reports_when_nothing_is_left_to_queue(self) -> None:
-        manifest_path = self._write_manifest("manifest-approved-empty.json", [])
-        calibration_state: dict[str, folder_actions_runtime.ActionPayload] = {
-            "tv/show": {
-                "mode": "sample",
-                "job_id": "sample-1",
-                "review_media_ready": True,
-                "policy": {"video": {"target_vmaf": 95.0}},
-                "sample_item": {"library_item_id": 1},
-            }
-        }
-
-        def load_calibration_state(
-                _config: MediaforceConfig,
-                prefix: str,
-        ) -> folder_actions_runtime.ActionPayload | None:
-            payload = calibration_state.get(prefix)
-            return dict(payload) if payload is not None else None
-
-        def save_calibration_state(
-                _config: MediaforceConfig,
-                prefix: str,
-                payload: folder_actions_runtime.ActionPayload,
-        ) -> None:
-            calibration_state[prefix] = dict(payload)
-
-        with patch("mediaforce.web.runtime.folder_actions.load_config", return_value=self.config), patch(
-                "mediaforce.web.runtime.folder_actions.create_folder_manifest",
-                return_value=({"items": []}, manifest_path),
-        ):
-            result = folder_actions_runtime.save_profile_action(
-                self.config,
-                "tv/show",
-                now_iso=web_app._now_iso,
-                load_sample_item=lambda *_args, **_kwargs: {"resolved_policy": {"video": {"target_vmaf": 95.0}}},
-                load_calibration_state=load_calibration_state,
-                calibration_draft_hash=web_app._calibration_draft_hash,
-                save_calibration_state=save_calibration_state,
-                load_advice_state=lambda *_args, **_kwargs: None,
-                record_visual_approval_artifact=lambda *_args, **_kwargs: None,
-                merge_advice_state=lambda *_args, **_kwargs: {},
-                upsert_override=web_app._upsert_override,
-                auto_queue_folder_encode=lambda prefix, notes,
-                                                bypass_schedule: folder_actions_runtime.queue_folder_encode_action(
-                    self.config,
-                    prefix,
-                    notes,
-                    bypass_schedule,
-                    now_iso=web_app._now_iso,
-                    load_job_state=self._noop_load_job_state,
-                    load_calibration_state=load_calibration_state,
-                    review_gate=web_app._review_gate,
-                    upsert_override=web_app._upsert_override,
-                    load_active_encode_job_for_prefix_fn=load_active_encode_job_for_prefix,
-                    clear_terminal_encode_jobs_for_prefix_fn=clear_terminal_encode_jobs_for_prefix,
-                    prepare_terminal_encode_job_for_requeue_fn=self._prepare_terminal_encode_job_for_requeue,
-                    save_encode_job=save_encode_job,
-                ),
+            queued_count = connection.scalar(
+                select(func.count()).select_from(encode_jobs).where(encode_jobs.c.prefix == "tv/show")
             )
-
-        self.assertTrue(result["ok"])
-        self.assertFalse(result["queued"])
-        self.assertEqual(result["auto_queue_status"], "no_pending")
-        self.assertIn("no encode candidates left to queue", result["message"])
-        self.assertIn("Next action:", result["queue_message"])
+        self.assertEqual(queued_count, 0)
 
     def test_retry_failed_encode_queue_action_retries_latest_approved_failures_only(self) -> None:
         with open_db(self.config.paths.db_path) as connection:
@@ -5782,13 +5690,12 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             record_visual_approval_artifact=lambda *_args, **_kwargs: {"artifact_id": "approval-1"},
             merge_advice_state=lambda _config, _prefix, payload: merged_advice.append(dict(payload)),
             upsert_override=lambda *_args, **_kwargs: None,
-            auto_queue_folder_encode=lambda *_args, **_kwargs: {"ok": True, "message": "Queued folder encode."},
             confirm_size_tradeoff=True,
             reviewed_draft_hash=web_app._calibration_draft_hash(calibration_payload),
         )
 
         self.assertTrue(result["ok"])
-        self.assertTrue(result["queued"])
+        self.assertFalse(result["queued"])
         self.assertEqual(saved_payloads[0]["accepted_at"], "2026-05-24T04:40:00+00:00")
         self.assertTrue(merged_advice[0]["operator_approved_size_tradeoff"])
         quality_record = merged_advice[0]["quality_risk_records"][-1]
@@ -5812,8 +5719,6 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             "sample_result": {"predicted_total_size_bytes": 376 * 1024 * 1024},
         }
         saved_payloads: list[folder_actions_runtime.ActionPayload] = []
-        queued_prefixes: list[str] = []
-
         with self.assertRaises(HTTPException) as exc:
             folder_actions_runtime.save_profile_action(
                 self.config,
@@ -5836,9 +5741,6 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 record_visual_approval_artifact=lambda *_args, **_kwargs: None,
                 merge_advice_state=lambda *_args, **_kwargs: {},
                 upsert_override=lambda *_args, **_kwargs: None,
-                auto_queue_folder_encode=lambda prefix, *_args, **_kwargs: queued_prefixes.append(prefix) or {
-                    "ok": True
-                },
                 confirm_size_tradeoff=True,
                 reviewed_draft_hash="draft-old",
             )
@@ -5846,7 +5748,6 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(exc.exception.status_code, 409)
         self.assertIn("changed after the size tradeoff review", str(exc.exception.detail))
         self.assertEqual(saved_payloads, [])
-        self.assertEqual(queued_prefixes, [])
 
     def test_save_profile_action_does_not_override_missing_size_prediction(self) -> None:
         calibration_payload: folder_actions_runtime.ActionPayload = {
@@ -5927,13 +5828,12 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             record_visual_approval_artifact=lambda *_args, **_kwargs: {"artifact_id": "approval-1"},
             merge_advice_state=lambda _config, _prefix, payload: merged_advice.append(dict(payload)),
             upsert_override=lambda *_args, **_kwargs: None,
-            auto_queue_folder_encode=lambda *_args, **_kwargs: {"ok": True, "message": "Queued folder encode."},
             confirm_high_impact=True,
             reviewed_draft_hash=web_app._calibration_draft_hash(calibration_payload),
         )
 
         self.assertTrue(result["ok"])
-        self.assertTrue(result["queued"])
+        self.assertFalse(result["queued"])
         self.assertEqual(saved_payloads[0]["accepted_at"], "2026-05-24T04:40:00+00:00")
         self.assertFalse(merged_advice[0]["operator_approved_size_tradeoff"])
 
@@ -5974,13 +5874,12 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             record_visual_approval_artifact=lambda *_args, **_kwargs: {"artifact_id": "approval-1"},
             merge_advice_state=lambda _config, _prefix, payload: merged_advice.append(dict(payload)),
             upsert_override=lambda *_args, **_kwargs: None,
-            auto_queue_folder_encode=lambda *_args, **_kwargs: {"ok": True, "message": "Queued folder encode."},
             confirm_high_impact=True,
             reviewed_draft_hash=web_app._calibration_draft_hash(calibration_payload),
         )
 
         self.assertTrue(result["ok"])
-        self.assertTrue(result["queued"])
+        self.assertFalse(result["queued"])
         self.assertEqual(saved_payloads[0]["accepted_at"], "2026-05-24T04:40:00+00:00")
         self.assertFalse(merged_advice[0]["operator_approved_size_tradeoff"])
 
@@ -13535,6 +13434,79 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             raised.exception.detail,
             "No encode candidates were found for this folder. Next action: Validate outputs.",
         )
+
+    def test_queue_folder_encode_rejects_current_review_rejection(self) -> None:
+        policy = {"video": {"target_vmaf": 95.0}}
+        sample_item = {
+            "rel_path": "tv/show/Season 1/Episode 01.mkv",
+            "source_size_bytes": 8_000_000_000,
+            "duration_seconds": 3600.0,
+            "resolved_policy": policy,
+        }
+        source_id = stable_source_id(sample_item)
+        policy_hash = stable_policy_hash(policy)
+        calibration = {
+            "mode": "sample",
+            "job_id": "sample-1",
+            "review_media_ready": True,
+            "policy": policy,
+            "sample_item": sample_item,
+            "sample_result": {"cadence_evidence_id": "ev1_current"},
+            "accepted_at": "2026-07-12T00:00:00+00:00",
+            "accepted_draft_hash": "draft-1",
+            "accepted_policy_hash": folder_actions_runtime._calibration_policy_hash({"policy": policy}),
+            "accepted_sample_job_id": "sample-1",
+            "draft_hash": "draft-1",
+        }
+        records = [
+            {
+                "kind": "post_test",
+                "created_at": "2026-07-12T00:00:00+00:00",
+                "verdict": "approved",
+                "tags": ["other"],
+                "details": "Approved current evidence.",
+                "evidence_ids": ["ev1_current"],
+                "moment_indexes": [],
+                "sample_job_id": "sample-1",
+                "policy_hash": policy_hash,
+                "source_id": source_id,
+                "prefix": "tv/show/Season 1",
+            },
+            {
+                "kind": "post_test",
+                "created_at": "2026-07-12T00:01:00+00:00",
+                "verdict": "rejected",
+                "tags": ["motion_breakup"],
+                "details": "Current motion evidence was rejected.",
+                "evidence_ids": ["ev1_current"],
+                "moment_indexes": [],
+                "sample_job_id": "sample-1",
+                "policy_hash": policy_hash,
+                "source_id": source_id,
+                "prefix": "tv/show/Season 1",
+            },
+        ]
+
+        with self.assertRaises(HTTPException) as raised:
+            folder_actions_runtime.queue_folder_encode_action(
+                self.config,
+                "tv/show/Season 1",
+                "",
+                False,
+                now_iso=web_app._now_iso,
+                load_job_state=self._noop_load_job_state,
+                load_calibration_state=lambda *_args, **_kwargs: calibration,
+                review_gate=self._accepted_review_gate,
+                upsert_override=self._noop_upsert_override,
+                load_active_encode_job_for_prefix_fn=load_active_encode_job_for_prefix,
+                clear_terminal_encode_jobs_for_prefix_fn=clear_terminal_encode_jobs_for_prefix,
+                prepare_terminal_encode_job_for_requeue_fn=self._prepare_terminal_encode_job_for_requeue,
+                save_encode_job=save_encode_job,
+                load_advice_state=lambda *_args, **_kwargs: {"quality_risk_records": records},
+            )
+
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertIn("rejected after approval", str(raised.exception.detail))
 
     def test_build_manifest_shards_creates_one_file_per_shard(self) -> None:
         manifest: folder_actions_runtime.ManifestPayload = {

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -13508,6 +13508,92 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(raised.exception.status_code, 409)
         self.assertIn("rejected after approval", str(raised.exception.detail))
 
+    def test_queue_folder_encode_rejects_newer_failed_target_search(self) -> None:
+        calibration = {
+            "policy": {"video": {"target_size_mb": 300, "target_size_bytes": 300_000_000, "size_goal_mode": "absolute"}},
+            "accepted_at": "2026-07-12T00:00:00+00:00",
+        }
+        failed_job = {
+            "job_id": "sample-2",
+            "status": "failed",
+            "finished_at": "2026-07-12T00:05:00+00:00",
+            "result": {
+                "target_size_status": "infeasible",
+                "target_size_trace": {"status": "infeasible"},
+            },
+        }
+
+        with self.assertRaises(HTTPException) as raised:
+            folder_actions_runtime.queue_folder_encode_action(
+                self.config,
+                "tv/show/Season 1",
+                "",
+                False,
+                now_iso=web_app._now_iso,
+                load_job_state=lambda *_args, **_kwargs: failed_job,
+                load_calibration_state=lambda *_args, **_kwargs: calibration,
+                review_gate=self._accepted_review_gate,
+                upsert_override=self._noop_upsert_override,
+                load_active_encode_job_for_prefix_fn=load_active_encode_job_for_prefix,
+                clear_terminal_encode_jobs_for_prefix_fn=clear_terminal_encode_jobs_for_prefix,
+                prepare_terminal_encode_job_for_requeue_fn=self._prepare_terminal_encode_job_for_requeue,
+                save_encode_job=save_encode_job,
+            )
+
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertIn("cannot fit the required streams", str(raised.exception.detail))
+
+    def test_target_search_failure_before_approval_does_not_block_production(self) -> None:
+        reason = folder_actions_runtime._failed_target_size_job_blocking_reason(
+            {
+                "status": "failed",
+                "finished_at": "2026-07-11T23:59:00+00:00",
+                "result": {"target_size_status": "quality_conflict"},
+            },
+            {"accepted_at": "2026-07-12T00:00:00+00:00"},
+        )
+
+        self.assertIsNone(reason)
+
+    def test_advice_merge_preserves_concurrent_rejection(self) -> None:
+        prefix = "tv/show/Season 1"
+        rejected = {
+            "kind": "post_test",
+            "verdict": "rejected",
+            "sample_job_id": "sample-1",
+            "policy_hash": "policy-1",
+            "source_id": "source-1",
+            "prefix": prefix,
+            "created_at": "2026-07-12T00:01:00+00:00",
+        }
+        approved = {
+            **rejected,
+            "verdict": "approved",
+            "created_at": "2026-07-12T00:00:00+00:00",
+        }
+        web_app._save_advice_state(self.config, prefix, {"quality_risk_records": [rejected]})
+
+        merged = web_app._merge_advice_state(
+            self.config,
+            prefix,
+            {"quality_risk_records": [approved]},
+        )
+
+        self.assertEqual(
+            {str(object_dict(record).get("verdict")) for record in object_list(merged["quality_risk_records"])},
+            {"approved", "rejected"},
+        )
+
+    def test_queue_advice_loader_fails_closed_on_corrupt_state(self) -> None:
+        prefix = "tv/show/Season 1"
+        web_app._advice_file(self.config, prefix).write_text("{not-json")
+
+        with self.assertRaises(HTTPException) as raised:
+            web_app._load_advice_state_for_queue(self.config, prefix)
+
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertIn("could not read the current review evidence safely", str(raised.exception.detail))
+
     def test_build_manifest_shards_creates_one_file_per_shard(self) -> None:
         manifest: folder_actions_runtime.ManifestPayload = {
             "items": [

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -13646,6 +13646,15 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(raised.exception.status_code, 409)
         self.assertIn("could not read the current review evidence safely", str(raised.exception.detail))
 
+    def test_advice_save_repairs_corrupt_state(self) -> None:
+        prefix = "tv/show/Season 1"
+        web_app._advice_file(self.config, prefix).write_text("{not-json")
+
+        web_app._save_advice_state(self.config, prefix, {"summary": "Fresh representative-test advice."})
+
+        saved = web_app._load_advice_state_for_queue(self.config, prefix)
+        self.assertEqual(object_dict(saved).get("summary"), "Fresh representative-test advice.")
+
     def test_build_manifest_shards_creates_one_file_per_shard(self) -> None:
         manifest: folder_actions_runtime.ManifestPayload = {
             "items": [

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -60,6 +60,7 @@ from mediaforce.tuning.tuning_memory import (
 )
 from mediaforce.tuning.quality_risk import build_quality_risk_contract, quality_risk_public_view, \
     with_quality_risk_intent
+from mediaforce.tuning.calibration_jobs import load_latest_failed_target_size_sample_job
 from mediaforce.tuning.target_size_search import TargetSizeSearchError
 from mediaforce.web.app import (
     _advice_file,
@@ -7774,6 +7775,50 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIsNotNone(inferred_request)
         self.assertEqual(inferred_request["quality_risk_tags"], ["motion_breakup"])
         self.assertEqual(len(inferred_request["quality_risk_details"]), 2000)
+        details_only_request = with_quality_risk_intent(
+            {"quality_risk_details": "x" * 3000},
+            note="Make another test.",
+        )
+        self.assertIsNotNone(details_only_request)
+        self.assertEqual(details_only_request["quality_risk_tags"], ["other"])
+        self.assertEqual(len(details_only_request["quality_risk_details"]), 2000)
+
+    def test_latest_failed_target_size_job_ignores_newer_unrelated_failure(self) -> None:
+        prefix = "tv/show/Season 1"
+        with open_db(self.config.paths.db_path) as connection:
+            for job_id, created_at, result in (
+                (
+                    "target-failed",
+                    "2026-07-12T00:00:00+00:00",
+                    {"target_size_status": "quality_conflict"},
+                ),
+                (
+                    "unrelated-failed",
+                    "2026-07-12T00:01:00+00:00",
+                    {"failure_kind": "host_unavailable"},
+                ),
+            ):
+                connection.execute(
+                    calibration_jobs.insert().values(
+                        job_id=job_id,
+                        prefix=prefix,
+                        status="failed",
+                        lane="sample",
+                        action="ai_tune",
+                        host_json="{}",
+                        notes="note",
+                        policy_json="{}",
+                        sample_item_json="{}",
+                        result_json=json.dumps(result),
+                        created_at=created_at,
+                        updated_at=created_at,
+                    )
+                )
+
+            job = load_latest_failed_target_size_sample_job(connection, prefix)
+
+        self.assertIsNotNone(job)
+        self.assertEqual(job["job_id"], "target-failed")
 
     def test_run_calibration_job_marks_cancelled_run_stopped(self) -> None:
         saved_statuses: list[str] = []

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -59,6 +59,7 @@ from mediaforce.tuning.tuning_memory import (
     sibling_approved_season_memory,
 )
 from mediaforce.tuning.quality_risk import build_quality_risk_contract, quality_risk_public_view
+from mediaforce.tuning.target_size_search import TargetSizeSearchError
 from mediaforce.web.app import (
     _advice_file,
     _backfill_multimodal_review_pack,
@@ -105,7 +106,11 @@ from mediaforce.web.runtime.folder_ai_tuning import (
     folder_ai_tune_confirm_action,
     folder_ai_tune_preview_action,
 )
-from mediaforce.web.runtime.folder_tuning_advice import audio_tradeoff_hint, operator_request_signature
+from mediaforce.web.runtime.folder_tuning_advice import (
+    audio_tradeoff_hint,
+    operator_request_from_intent,
+    operator_request_signature,
+)
 from mediaforce.web.runtime.folder_tuning_helpers import (
     measured_size_budget_policy_fragment,
     proposal_alignment_issue,
@@ -7703,6 +7708,50 @@ class TuningRuntimeTests(unittest.TestCase):
 
         self.assertEqual(smart_signature, auto_signature)
 
+    def test_guided_review_feedback_preserves_target_and_current_rejection(self) -> None:
+        request = operator_request_from_intent(
+            {
+                "schema_version": 1,
+                "size_goal": {
+                    "mode": "normalized",
+                    "value_mb": 300,
+                    "reference_runtime_minutes": 45,
+                    "sample_projection_tolerance_percent": 10,
+                    "final_output_tolerance_percent": 5,
+                },
+                "resolution": {"mode": "source", "max_height": None},
+                "quality_risk_tags": ["motion_breakup", "audio_quality_layout"],
+                "quality_risk_details": "Moment 2 loses texture and the center channel sounds thin.",
+                "evidence_authority": "rejected_visual_result",
+            },
+            note="Keep the target and revise the picture and sound.",
+            sample_item={
+                "rel_path": "tv/show/season-1/episode.mkv",
+                "source_size_bytes": 8_000_000_000,
+                "duration_seconds": 88 * 60,
+                "video_bitrate": 8_000_000,
+                "audio_summary": [],
+                "subtitle_summary": [],
+            },
+            current_policy={
+                "video": {"max_height": 0},
+                "audio": {},
+                "subtitle": {},
+            },
+        )
+
+        self.assertEqual(request["request_type"], "combined_experiment")
+        self.assertEqual(request["budget_bytes"], 586_666_667)
+        self.assertEqual(
+            request["quality_risk_tags"],
+            ["motion_breakup", "audio_quality_layout"],
+        )
+        self.assertEqual(request["evidence_authority"], "rejected_visual_result")
+        self.assertEqual(
+            request["quality_risk_details"],
+            "Moment 2 loses texture and the center channel sounds thin.",
+        )
+
     def test_run_calibration_job_marks_cancelled_run_stopped(self) -> None:
         saved_statuses: list[str] = []
 
@@ -7764,6 +7813,92 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIn("running", saved_statuses)
         self.assertIn("stopped", saved_statuses)
         self.assertNotIn("failed", saved_statuses)
+
+    def test_run_calibration_job_preserves_failed_target_search_evidence(self) -> None:
+        saved_payloads: list[dict[str, object]] = []
+        trace = {
+            "schema_version": 1,
+            "status": "quality_conflict",
+            "selection_reason": "all_candidates_violate_quality_floor",
+            "target": {
+                "total_target_bytes": 300_000_000,
+                "sample_lower_bound_bytes": 270_000_000,
+                "sample_upper_bound_bytes": 330_000_000,
+            },
+            "quality_floor": {"metric": "vmaf", "minimum": 93.0},
+            "curve": {"shape": "monotonic", "candidate_count": 3, "max_candidates": 6},
+        }
+
+        deps = CalibrationRunDeps(
+            now_iso=lambda: "2026-04-11T00:00:00+00:00",
+            load_job_state=lambda *_args, **_kwargs: {"job_id": "job-1", "status": "queued"},
+            sample_item=lambda *_args, **_kwargs: {
+                "rel_path": "tv/show/season-1/episode.mkv",
+                "source_path": str(self.root / "target-search-episode.mkv"),
+                "source_size_bytes": 8_000_000_000,
+                "video_codec": "h264",
+                "video_bitrate": 8_000_000,
+                "duration_seconds": 5280.0,
+                "audio_summary": [],
+                "subtitle_summary": [],
+            },
+            save_job_state=lambda _connection, _config, _prefix, payload: saved_payloads.append(dict(payload)),
+            save_calibration_state=lambda *_args, **_kwargs: None,
+            record_run_verdict=lambda *_args, **_kwargs: None,
+            summarize_calibration_result=lambda payload: payload,
+            calibration_mode_for_action=lambda _action: "sample",
+            effective_video_preset=lambda *_args, **_kwargs: 4,
+            search_quality_for_source=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                TargetSizeSearchError(
+                    "No candidate met both the target band and quality floor.",
+                    status="quality_conflict",
+                    trace=trace,
+                )
+            ),
+            run_sample_encode=lambda *_args, **_kwargs: None,
+            detect_video_crop=lambda *_args, **_kwargs: None,
+            recommend_review_timestamps=lambda *_args, **_kwargs: [],
+            encode_preview_clips=lambda *_args, **_kwargs: [],
+            render_source_review_clips=lambda *_args, **_kwargs: [],
+            generate_compare_clips_from_previews=lambda *_args, **_kwargs: [],
+            resolve_stream_budget_ledger=resolve_stream_budget_ledger,
+            build_svt_params=lambda *_args, **_kwargs: {},
+            review_url=lambda *_args, **_kwargs: "",
+            encode_manifest_items=lambda *_args, **_kwargs: None,
+            validate_manifest_items=lambda *_args, **_kwargs: None,
+            generate_compare_clips=lambda *_args, **_kwargs: [],
+            staged_artifact_columns=("library_item_id",),
+        )
+
+        (self.root / "target-search-episode.mkv").write_text("episode")
+        with patch("mediaforce.web.runtime.calibration_runtime.load_config", return_value=self.config), patch(
+                "mediaforce.web.runtime.calibration_runtime.purge_transient_artifacts"
+        ):
+            run_calibration_job(
+                config_path=self.config.paths.config_path,
+                prefix="tv/show/season-1",
+                action="ai_tune",
+                host_data={"key": "localhost", "label": "Local worker"},
+                notes="Keep the target.",
+                policy={
+                    "video": {
+                        "pixel_format": "yuv420p10le",
+                        "sample_every": "8m",
+                        "sample_duration": "20s",
+                        "encoder": "libsvtav1",
+                    }
+                },
+                job_id="job-1",
+                seed_metadata=None,
+                process_controller=type("Controller", (), {"throw_if_cancelled": lambda _self: None})(),
+                deps=deps,
+            )
+
+        failed = next(payload for payload in saved_payloads if payload.get("status") == "failed")
+        self.assertEqual(
+            failed["result"],
+            {"target_size_status": "quality_conflict", "target_size_trace": trace},
+        )
 
     def test_run_calibration_job_uses_saved_job_sample_item_before_reselecting(self) -> None:
         saved_statuses: list[str] = []

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -58,7 +58,8 @@ from mediaforce.tuning.tuning_memory import (
     retrieve_learning_context,
     sibling_approved_season_memory,
 )
-from mediaforce.tuning.quality_risk import build_quality_risk_contract, quality_risk_public_view
+from mediaforce.tuning.quality_risk import build_quality_risk_contract, quality_risk_public_view, \
+    with_quality_risk_intent
 from mediaforce.tuning.target_size_search import TargetSizeSearchError
 from mediaforce.web.app import (
     _advice_file,
@@ -7751,6 +7752,28 @@ class TuningRuntimeTests(unittest.TestCase):
             request["quality_risk_details"],
             "Moment 2 loses texture and the center channel sounds thin.",
         )
+
+        normalized_request = with_quality_risk_intent(
+            request,
+            note="Keep the target because motion breakup and thin sound need another test. " + ("x" * 3000),
+        )
+
+        self.assertIsNotNone(normalized_request)
+        self.assertEqual(
+            normalized_request["quality_risk_tags"],
+            ["motion_breakup", "audio_quality_layout"],
+        )
+        self.assertEqual(
+            normalized_request["quality_risk_details"],
+            "Moment 2 loses texture and the center channel sounds thin.",
+        )
+        inferred_request = with_quality_risk_intent(
+            None,
+            note="Motion breakup needs another test. " + ("x" * 3000),
+        )
+        self.assertIsNotNone(inferred_request)
+        self.assertEqual(inferred_request["quality_risk_tags"], ["motion_breakup"])
+        self.assertEqual(len(inferred_request["quality_risk_details"]), 2000)
 
     def test_run_calibration_job_marks_cancelled_run_stopped(self) -> None:
         saved_statuses: list[str] = []


### PR DESCRIPTION
## Summary
- guide operators through runtime-correct recommended, smaller, and roomier episode-size goals with optional plain-language priorities
- make comparison honest about target bands, predicted whole-episode size, actual review-clip bytes, picture/sound risk, measured retries, and explicit production start
- preserve structured review authority across failures and concurrent state updates; approval no longer auto-queues production
- add complete desktop/narrow browser fixtures for inside, over, under, infeasible, conflict, approved, processing, delivery, and recovery states

## Validation
- `bash scripts/pre-commit-check.sh`
  - 776 backend tests passed
  - 185 frontend unit tests passed
  - Svelte check and frontend lint passed
  - frontend and package build passed
  - CLI smoke passed
  - complete desktop and 390px web-route smoke passed, including empty-state routes
- browser interaction acceptance: keyboard goal selection, optional priorities, structured concerns, approval-only tradeoff dialog, visible focus, no horizontal overflow
- safe real-media acceptance on a copied runtime database: an 88-minute representative resolved to 587 MB at desktop and 390px without path leakage
- independent backend, frontend, and live-browser reviews completed; all actionable findings were fixed and re-reviewed

## Notes
- PyCharm headless inspection was attempted, but the installed `inspect.sh` could not run while the existing PyCharm instance was active.

Closes #164