### PR TITLE
Auto-mount remote macOS SMB shares

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,8 +423,15 @@ Mediaforce can install this Mac's SSH public key, then let the prep step
 create remote paths and install `ffmpeg-full` plus `ab-av1` for
 `sample_calibration` hosts when possible. Those sample hosts now verify
 `libvmaf`/`xpsnr` metric support and `libsvtav1` before they show as ready.
-Shared media mounts still need to exist on the remote host before it will show
-as ready.
+For mounted-media macOS hosts, Mediaforce can reconnect an SMB volume over SSH
+when the same `/Volumes/...` root is mounted on the controller. Recovery runs
+before preparation, sampling, or encode dispatch. The configured SSH account
+must be the active signed-in console user, and the remote Finder session uses
+that account's saved login-Keychain credentials; Mediaforce never reads or
+transports the password. If another account is active, the action identifies the
+account that must sign in. If Finder cannot use a saved credential, the action
+identifies the host and share that need one manual Finder connection with the
+password saved to Keychain before retrying.
 
 Sampled calibration and AI note tuning can now run on any configured host with
 the `sample_calibration` capability. The folder page uses one AI-guided sample

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -99,6 +99,9 @@ Guidance:
   - host probe scripts, capability checks, status parsing
 - `lifecycle.py`
   - wake/start/stop commands, cooldown behavior
+- `mount_runtime.py`
+  - controller SMB mount discovery and password-free remote Finder mount recovery
+  - bounded transient LaunchAgent execution, cleanup, and Keychain recovery messages
 - `setup.py`
   - prepare/reset trust/bootstrap flows
 - `models.py`

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -286,7 +286,9 @@ export interface HostRuntime {
 	probe_message?: string;
 	media_access?: string;
 	source_roots?: Record<string, string>;
+	storage_recovery_available?: boolean;
 	missing_paths: string[];
+	missing_mounts?: string[];
 	issues: string[];
 	probe_issues?: string[];
 	detail: string | null;

--- a/frontend/src/lib/components/workstation/FolderStudioView.svelte
+++ b/frontend/src/lib/components/workstation/FolderStudioView.svelte
@@ -1273,7 +1273,13 @@
 							<div class="host-row">
 								<StateBadge
 									compact
-									tone={host.available ? (host.scheduleOpen === false ? 'wait' : 'ready') : 'fail'}
+									tone={host.state === 'Reconnects for sample'
+										? 'wait'
+										: host.available
+											? host.scheduleOpen === false
+												? 'wait'
+												: 'ready'
+											: 'fail'}
 									label={host.state}
 								/>
 								<span>{host.label}{host.detail ? ` · ${host.detail}` : ''}</span>

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -203,6 +203,25 @@ describe('Folder Studio review request mapping', () => {
 		});
 	});
 
+	it('shows storage-recoverable workers as reconnecting rather than already ready', () => {
+		const options = buildBenchHostOptions([
+			{
+				key: 'm2',
+				label: 'M2',
+				available: true,
+				storage_recovery_available: true,
+				detail: 'Storage will reconnect when the test starts.'
+			}
+		]);
+
+		expect(options[0]).toMatchObject({
+			available: true,
+			state: 'Reconnects for sample',
+			detail: 'Storage will reconnect when the test starts.'
+		});
+		expect(resolveBenchRequestState('try 300MB', 'm2', options, null, false).disabled).toBe(false);
+	});
+
 	it('maps worker states for output processing capacity', () => {
 		const options = buildProcessingHostOptions({
 			compact: true,
@@ -290,6 +309,40 @@ describe('Folder Studio review request mapping', () => {
 				detail: 'ssh failed'
 			}
 		]);
+	});
+
+	it('shows storage-recoverable processing workers as reconnecting capacity', () => {
+		const options = buildProcessingHostOptions({
+			compact: true,
+			hosts: [
+				{
+					key: 'm2',
+					label: 'M2',
+					available: false,
+					message: 'Storage will reconnect when work starts',
+					storage_recovery_available: true,
+					missing_paths: ['/Volumes/media/tv'],
+					issues: [],
+					detail: null,
+					capabilities: ['encode_queue'],
+					priority: 1,
+					max_parallel_encodes: 1,
+					active_encode_count: 0,
+					schedule_profile_label: 'always',
+					schedule_detail: 'always',
+					schedule_open: true,
+					active_flag: 'idle',
+					active_reason: 'shared storage will reconnect when work starts',
+					queue_active: false
+				}
+			]
+		});
+
+		expect(options[0]).toMatchObject({
+			state: 'Reconnects storage',
+			tone: 'wait',
+			detail: 'Storage will reconnect when work starts'
+		});
 	});
 
 	it('enables send only for a note, available host, and inactive sample job', () => {

--- a/frontend/src/lib/components/workstation/folder-studio-view.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.ts
@@ -340,6 +340,7 @@ export function buildBenchHostOptions(
 		.map((host) => {
 			const key = compactText(host.key);
 			const available = host.available !== false;
+			const storageRecovery = host.storage_recovery_available === true;
 			const scheduleOpen = typeof host.schedule_open === 'boolean' ? host.schedule_open : null;
 			return {
 				key,
@@ -347,11 +348,13 @@ export function buildBenchHostOptions(
 				detail: compactText(host.detail) || compactText(host.message),
 				available,
 				scheduleOpen,
-				state: !available
-					? 'Unavailable'
-					: scheduleOpen === false
-						? 'Sample ok, encode later'
-						: 'Ready for samples'
+				state: storageRecovery
+					? 'Reconnects for sample'
+					: !available
+						? 'Unavailable'
+						: scheduleOpen === false
+							? 'Sample ok, encode later'
+							: 'Ready for samples'
 			};
 		})
 		.filter((host) => host.key);
@@ -383,6 +386,13 @@ function processingHostState(
 		: active
 			? `${active} encoding`
 			: '';
+	if (host.storage_recovery_available === true) {
+		return {
+			state: 'Reconnects storage',
+			tone: 'wait',
+			detail: compactText(host.message) || compactText(host.detail) || host.active_reason
+		};
+	}
 	if (!host.available) {
 		return {
 			state: 'Unavailable',

--- a/frontend/src/lib/components/workstation/ops-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.test.ts
@@ -354,6 +354,31 @@ describe('Ops workstation mapping', () => {
 		expect(hostStateCopy(unavailable)).toBe('Unavailable');
 	});
 
+	it('treats storage-recoverable workers as reconnecting capacity', () => {
+		const dashboard = dashboardFixture();
+		dashboard.encode_queue.needs_attention_count = 0;
+		dashboard.encode_queue.recent = [];
+		const recoverable = {
+			...hostsFixture().hosts[0],
+			available: false,
+			queue_active: false,
+			active_encode_count: 0,
+			storage_recovery_available: true,
+			message: 'Storage will reconnect when work starts'
+		};
+		const hosts = { compact: true, hosts: [recoverable] };
+
+		expect(buildOpsBlockers(dashboard, hosts, null).map((blocker) => blocker.key)).not.toContain(
+			'no-hosts-ready'
+		);
+		expect(buildOpsStatusTiles(dashboard, hosts, null).at(-1)).toMatchObject({
+			label: 'Workers',
+			value: '1 can encode / 1'
+		});
+		expect(hostTone(recoverable)).toBe('wait');
+		expect(hostStateCopy(recoverable)).toBe('Reconnects storage');
+	});
+
 	it('shows running encode telemetry instead of stale restart errors', () => {
 		const dashboard = dashboardFixture();
 		dashboard.encode_queue.running[0] = {

--- a/frontend/src/lib/components/workstation/ops-workstation.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.ts
@@ -73,23 +73,33 @@ function activeJobStatus(status: unknown): boolean {
 }
 
 function hostEncodeReady(host: HostRuntime): boolean {
+	const storageRecovery = host.storage_recovery_available === true;
 	return (
-		host.available &&
+		(host.available || storageRecovery) &&
 		host.schedule_open !== false &&
-		host.queue_active !== false &&
+		(storageRecovery || host.queue_active !== false) &&
 		numberValue(host.active_encode_count) < numberValue(host.max_parallel_encodes)
 	);
 }
 
 function hostCapacityCounts(hosts: HostsPayload | null | undefined) {
 	const rows = hosts?.hosts ?? [];
-	const available = rows.filter((host) => host.available).length;
+	const available = rows.filter(
+		(host) => host.available || host.storage_recovery_available === true
+	).length;
 	return {
 		available,
 		activeEncodes: rows.reduce((total, host) => total + numberValue(host.active_encode_count), 0),
 		encodeReady: rows.filter(hostEncodeReady).length,
-		busy: rows.filter((host) => host.available && numberValue(host.active_encode_count) > 0).length,
-		scheduledOff: rows.filter((host) => host.available && host.schedule_open === false).length,
+		busy: rows.filter(
+			(host) =>
+				(host.available || host.storage_recovery_available === true) &&
+				numberValue(host.active_encode_count) > 0
+		).length,
+		scheduledOff: rows.filter(
+			(host) =>
+				(host.available || host.storage_recovery_available === true) && host.schedule_open === false
+		).length,
 		unavailable: Math.max(rows.length - available, 0),
 		total: rows.length
 	};
@@ -810,12 +820,13 @@ export function buildOpsFooterSignals(
 		},
 		{
 			label: 'Workers',
-			value: `${hosts?.hosts.filter((host) => host.available).length ?? 0}/${hosts?.hosts.length ?? 0}`
+			value: `${hosts?.hosts.filter((host) => host.available || host.storage_recovery_available === true).length ?? 0}/${hosts?.hosts.length ?? 0}`
 		}
 	];
 }
 
 export function hostTone(host: HostRuntime, fleetHasReadyCapacity = false): ShellTone {
+	if (host.storage_recovery_available === true) return 'wait';
 	if (!host.available) return fleetHasReadyCapacity ? 'wait' : 'fail';
 	if (host.active_encode_count > 0) return 'active';
 	if (host.schedule_open === false) return 'wait';
@@ -824,6 +835,7 @@ export function hostTone(host: HostRuntime, fleetHasReadyCapacity = false): Shel
 }
 
 export function hostStateCopy(host: HostRuntime): string {
+	if (host.storage_recovery_available === true) return 'Reconnects storage';
 	if (!host.available) return 'Unavailable';
 	if (host.active_encode_count > 0) return 'Busy';
 	if (host.schedule_open === false) return 'Window closed';

--- a/mediaforce/hosts/__init__.py
+++ b/mediaforce/hosts/__init__.py
@@ -19,7 +19,7 @@ from mediaforce.hosts.wake_helpers import _broadcast_addresses_for_interface, _i
     _persist_remote_wake_mac, _resolve_host_to_ip, _resolved_ssh_network_host, _tcp_port_is_open, \
     _wake_broadcast_destinations
 from mediaforce.hosts.types import AB_AV1_MISSING_ISSUE, DEFAULT_HOST_CAPABILITIES, DEFAULT_HOST_MEDIA_ACCESS, \
-    DEFAULT_WAKE_WAIT_SECONDS, FFMPEG_MISSING_ISSUE, HostSetupResult, HostStatus, \
+    DEFAULT_WAKE_WAIT_SECONDS, FFMPEG_MISSING_ISSUE, HostReadinessError, HostSetupResult, HostStatus, \
     LINUX_SAMPLE_CALIBRATION_UNSUPPORTED_ISSUE, REMOTE_SHELL_PATH, REMOTE_STATUS_RETRY_DELAY_SECONDS, \
     SAMPLE_AV1_ENCODER_MISSING_ISSUE, SAMPLE_METRIC_MISSING_ISSUE
 
@@ -31,6 +31,7 @@ __all__ = [
     "FFMPEG_MISSING_ISSUE",
     "HostSetupResult",
     "HostStatus",
+    "HostReadinessError",
     "LINUX_SAMPLE_CALIBRATION_UNSUPPORTED_ISSUE",
     "REMOTE_SHELL_PATH",
     "REMOTE_STATUS_RETRY_DELAY_SECONDS",

--- a/mediaforce/hosts/mount_runtime.py
+++ b/mediaforce/hosts/mount_runtime.py
@@ -1,0 +1,409 @@
+import base64
+import hashlib
+import os
+import re
+import shlex
+import subprocess
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import quote, unquote
+
+from mediaforce.hosts.types import HostSetupResult
+
+
+REMOTE_MOUNT_ATTEMPT_SECONDS = 30
+
+_NO_GUI_SESSION_EXIT = 41
+_MOUNT_TIMEOUT_EXIT = 42
+_MOUNT_BUSY_EXIT = 43
+_MOUNT_HELPER_EXIT = 44
+_MOUNT_ESCAPE_RE = re.compile(r"\\([0-7]{3})")
+_SMB_SERVER_RE = re.compile(r"^[A-Za-z0-9._\-\[\]:]+$")
+
+
+@dataclass(frozen=True, slots=True)
+class ControllerSmbMount:
+    source: str
+    mount_point: Path
+
+
+@dataclass(frozen=True, slots=True)
+class RemoteSmbMount:
+    mount_point: Path
+    share_name: str
+    url: str
+
+
+def controller_smb_mounts_from_output(raw_output: str) -> list[ControllerSmbMount]:
+    mounts: list[ControllerSmbMount] = []
+    for raw_line in raw_output.splitlines():
+        line = raw_line.strip()
+        prefix, marker, raw_options = line.rpartition(" (")
+        if not marker or not raw_options.endswith(")"):
+            continue
+        options = raw_options[:-1].split(",", 1)[0].strip().lower()
+        if options != "smbfs":
+            continue
+        source, separator, mount_point = prefix.partition(" on ")
+        if not separator or not source.startswith("//"):
+            continue
+        decoded_source = _decode_mount_field(source)
+        decoded_mount_point = _decode_mount_field(mount_point)
+        path = Path(decoded_mount_point)
+        if not path.is_absolute():
+            continue
+        mounts.append(ControllerSmbMount(source=decoded_source, mount_point=path))
+    return sorted(mounts, key=lambda mount: len(mount.mount_point.parts), reverse=True)
+
+
+def remote_smb_mounts_for_paths(
+        paths: list[str],
+        controller_mounts: list[ControllerSmbMount],
+        *,
+        remote_user: str | None,
+) -> list[RemoteSmbMount] | None:
+    resolved: dict[Path, RemoteSmbMount] = {}
+    for raw_path in paths:
+        path = Path(os.path.normpath(str(Path(raw_path).expanduser())))
+        if not path.is_absolute():
+            return None
+        controller_mount = next(
+            (mount for mount in controller_mounts if _path_is_within(path, mount.mount_point)),
+            None,
+        )
+        if controller_mount is None or not _finder_mount_point_supported(controller_mount.mount_point):
+            return None
+        remote_mount = _remote_smb_mount(controller_mount, remote_user=remote_user)
+        if remote_mount is None:
+            return None
+        resolved[remote_mount.mount_point] = remote_mount
+    return list(resolved.values())
+
+
+def finder_mount_roots_for_paths(paths: list[str | Path]) -> list[Path]:
+    roots: dict[Path, None] = {}
+    for raw_path in paths:
+        path = Path(os.path.normpath(str(Path(raw_path).expanduser())))
+        parts = path.parts
+        if len(parts) < 3 or parts[0] != "/" or parts[1] != "Volumes":
+            continue
+        roots[Path("/Volumes") / parts[2]] = None
+    return list(roots)
+
+
+def mount_remote_smb_shares(
+        host: dict[str, Any],
+        mounts: list[RemoteSmbMount],
+        *,
+        run_remote_ssh: Callable[..., subprocess.CompletedProcess[str]],
+        attempt_seconds: int = REMOTE_MOUNT_ATTEMPT_SECONDS,
+) -> HostSetupResult:
+    label = str(host.get("label") or host.get("host") or "Remote host").strip() or "Remote host"
+    remote_account = _remote_login_account(host)
+    mounted_names: list[str] = []
+    for mount in mounts:
+        token = uuid.uuid4().hex
+        script = _remote_mount_script(mount, token=token, attempt_seconds=attempt_seconds)
+        try:
+            result = run_remote_ssh(
+                host,
+                "sh",
+                "-s",
+                input_text=script,
+                timeout=attempt_seconds + 15,
+            )
+        except subprocess.TimeoutExpired:
+            return HostSetupResult(
+                ok=False,
+                message=f"{label} did not finish the shared-storage connection request.",
+                detail="The SSH request timed out. Retry after the remote host connection is stable.",
+                failure_kind="ssh_transport",
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return HostSetupResult(
+                ok=False,
+                message=f"{label} could not run the shared-storage connection request.",
+                detail=f"The remote request failed with {exc.__class__.__name__}. Retry after SSH is stable.",
+                failure_kind="ssh_transport",
+            )
+        if result.returncode == 0:
+            mounted_names.append(mount.share_name)
+            continue
+        if result.returncode == _NO_GUI_SESSION_EXIT:
+            return HostSetupResult(
+                ok=False,
+                message=f"{label} needs a signed-in macOS desktop session to connect shared storage.",
+                detail=f"Sign in to {label} as {remote_account}, then retry Prepare or the workload.",
+                failure_kind="host_unavailable",
+            )
+        if result.returncode == _MOUNT_BUSY_EXIT:
+            return HostSetupResult(
+                ok=False,
+                message=f"{label} is already connecting the {mount.share_name} share.",
+                detail="Retry after the existing shared-storage connection attempt finishes.",
+                failure_kind="host_unavailable",
+            )
+        if result.returncode == _MOUNT_TIMEOUT_EXIT:
+            return _finder_recovery_result(label, mount)
+        return HostSetupResult(
+            ok=False,
+            message=f"{label} could not start the Finder storage helper.",
+            detail=(
+                "The temporary macOS launch service failed before Finder could connect shared storage. "
+                "Retry the request; if it keeps failing, inspect the remote macOS launch service."
+            ),
+            failure_kind="host_configuration",
+        )
+    names = ", ".join(mounted_names)
+    return HostSetupResult(
+        ok=True,
+        message=f"Connected shared storage on {label}.",
+        performed_steps=[f"Connected {names} using the remote Finder Keychain."],
+    )
+
+
+def _remote_mount_script(mount: RemoteSmbMount, *, token: str, attempt_seconds: int) -> str:
+    if not re.fullmatch(r"[a-f0-9]{32}", token):
+        raise ValueError("Remote mount token must be a lowercase UUID hex value.")
+    expected = str(mount.mount_point)
+    if not _finder_mount_point_supported(mount.mount_point):
+        raise ValueError("Finder SMB mounts must target one direct child of /Volumes.")
+    applescript = "\n".join([
+        "use scripting additions",
+        "on run argv",
+        "    set share_url to item 1 of argv",
+        "    mount volume share_url",
+        "end run",
+        "",
+    ])
+    runner = "\n".join(
+        [
+            "#!/bin/sh",
+            "set -u",
+            'script="$1"',
+            'mount_url="$2"',
+            'stdout_path="$3"',
+            'stderr_path="$4"',
+            'timeout_seconds="$5"',
+            'lock_path="$6"',
+            'service_label="$7"',
+            'uid="$(/usr/bin/id -u)"',
+            'runner_dir="${0%/*}"',
+            '/usr/bin/osascript "$script" "$mount_url" >"$stdout_path" 2>"$stderr_path" &',
+            "child_pid=$!",
+            "(",
+            '  /bin/sleep "$timeout_seconds"',
+            '  /bin/kill "$child_pid" >/dev/null 2>&1 || true',
+            ") &",
+            "watchdog_pid=$!",
+            "child_status=0",
+            'wait "$child_pid" || child_status=$?',
+            '/bin/kill "$watchdog_pid" >/dev/null 2>&1 || true',
+            'wait "$watchdog_pid" >/dev/null 2>&1 || true',
+            '/bin/rm -rf "$runner_dir"',
+            '/bin/rmdir "$lock_path" >/dev/null 2>&1 || true',
+            '/bin/launchctl bootout "gui/$uid/$service_label" >/dev/null 2>&1 || true',
+            'exit "$child_status"',
+            "",
+        ]
+    )
+    applescript_payload = base64.b64encode(applescript.encode()).decode()
+    runner_payload = base64.b64encode(runner.encode()).decode()
+    mount_url_payload = base64.b64encode(mount.url.encode()).decode()
+    lock_hash = hashlib.sha256(expected.encode()).hexdigest()[:24]
+    label = f"com.mediaforce.mount.{token}"
+    q_expected = shlex.quote(expected)
+    q_mount_output_path = shlex.quote(mount_output_field(expected))
+    q_label = shlex.quote(label)
+    q_applescript_payload = shlex.quote(applescript_payload)
+    q_runner_payload = shlex.quote(runner_payload)
+    q_mount_url_payload = shlex.quote(mount_url_payload)
+    return f"""set -u
+expected={q_expected}
+mount_output_path={q_mount_output_path}
+label={q_label}
+attempt_seconds={int(attempt_seconds)}
+mount_present() {{
+  mount_output="$(/sbin/mount 2>/dev/null || true)"
+  if printf '%s\\n' "$mount_output" | /usr/bin/grep -F -- " on $expected (smbfs," >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ "$mount_output_path" != "$expected" ]; then
+    printf '%s\\n' "$mount_output" | /usr/bin/grep -F -- " on $mount_output_path (smbfs," >/dev/null 2>&1
+    return $?
+  fi
+  return 1
+}}
+if mount_present; then
+  printf 'MEDIAFORCE_MOUNT=already-mounted\\n'
+  exit 0
+fi
+uid="$(/usr/bin/id -u)"
+console_uid="$(/usr/bin/stat -f '%u' /dev/console 2>/dev/null || true)"
+if [ "$console_uid" != "$uid" ] || ! /bin/launchctl print "gui/$uid" >/dev/null 2>&1; then
+  printf 'MEDIAFORCE_MOUNT=no-gui-session\\n'
+  exit {_NO_GUI_SESSION_EXIT}
+fi
+lock_root="$HOME/Library/Caches/mediaforce"
+/bin/mkdir -p "$lock_root" || exit {_MOUNT_HELPER_EXIT}
+/bin/chmod 700 "$lock_root" >/dev/null 2>&1 || true
+lock_path="$lock_root/mount-{lock_hash}.lock"
+if [ -d "$lock_path" ] && [ -n "$(/usr/bin/find "$lock_path" -prune -mmin +2 -print 2>/dev/null)" ]; then
+  /bin/rm -rf "$lock_path"
+fi
+if ! /bin/mkdir "$lock_path" 2>/dev/null; then
+  waited=0
+  while [ "$waited" -lt "$attempt_seconds" ]; do
+    if mount_present; then
+      printf 'MEDIAFORCE_MOUNT=joined-existing\\n'
+      exit 0
+    fi
+    waited=$((waited + 1))
+    /bin/sleep 1
+  done
+  printf 'MEDIAFORCE_MOUNT=busy-timeout\\n'
+  exit {_MOUNT_BUSY_EXIT}
+fi
+tmp_dir=""
+cleanup() {{
+  /bin/launchctl bootout "gui/$uid/$label" >/dev/null 2>&1 || true
+  if [ -n "$tmp_dir" ]; then /bin/rm -rf "$tmp_dir"; fi
+  /bin/rmdir "$lock_path" >/dev/null 2>&1 || true
+}}
+trap cleanup EXIT HUP INT TERM
+tmp_dir="$(/usr/bin/mktemp -d /tmp/mediaforce-mount.XXXXXX)" || exit {_MOUNT_HELPER_EXIT}
+/bin/chmod 700 "$tmp_dir" >/dev/null 2>&1 || true
+source_path="$tmp_dir/mount.applescript"
+script_path="$tmp_dir/mount.scpt"
+runner_path="$tmp_dir/run-mount.sh"
+plist_path="$tmp_dir/$label.plist"
+stdout_path="$tmp_dir/mount.out"
+stderr_path="$tmp_dir/mount.err"
+mount_url="$(/usr/bin/printf '%s' {q_mount_url_payload} | /usr/bin/base64 -D)" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/printf '%s' {q_applescript_payload} | /usr/bin/base64 -D >"$source_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/printf '%s' {q_runner_payload} | /usr/bin/base64 -D >"$runner_path" || exit {_MOUNT_HELPER_EXIT}
+/bin/chmod 700 "$runner_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/osacompile -o "$script_path" "$source_path" >/dev/null 2>&1 || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -create xml1 "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert Label -string "$label" "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert ProgramArguments -json '[]' "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert ProgramArguments.0 -string /bin/sh "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert ProgramArguments.1 -string "$runner_path" "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert ProgramArguments.2 -string "$script_path" "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert ProgramArguments.3 -string "$mount_url" "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert ProgramArguments.4 -string "$stdout_path" "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert ProgramArguments.5 -string "$stderr_path" "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert ProgramArguments.6 -string "$((attempt_seconds + 5))" "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert ProgramArguments.7 -string "$lock_path" "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert ProgramArguments.8 -string "$label" "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert RunAtLoad -bool YES "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert StandardOutPath -string "$stdout_path" "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+/usr/bin/plutil -insert StandardErrorPath -string "$stderr_path" "$plist_path" || exit {_MOUNT_HELPER_EXIT}
+if ! /bin/launchctl bootstrap "gui/$uid" "$plist_path" >/dev/null 2>&1; then
+  printf 'MEDIAFORCE_MOUNT=bootstrap-failed\\n'
+  exit {_MOUNT_HELPER_EXIT}
+fi
+waited=0
+while [ "$waited" -lt "$attempt_seconds" ]; do
+  if mount_present; then
+    printf 'MEDIAFORCE_MOUNT=mounted\\n'
+    exit 0
+  fi
+  waited=$((waited + 1))
+  /bin/sleep 1
+done
+printf 'MEDIAFORCE_MOUNT=timeout\\n'
+exit {_MOUNT_TIMEOUT_EXIT}
+"""
+
+
+def _remote_smb_mount(
+        controller_mount: ControllerSmbMount,
+        *,
+        remote_user: str | None,
+) -> RemoteSmbMount | None:
+    source = controller_mount.source
+    if not source.startswith("//"):
+        return None
+    authority, separator, raw_share_path = source[2:].partition("/")
+    if not separator or not raw_share_path:
+        return None
+    raw_source_user = authority.rsplit("@", 1)[0] if "@" in authority else ""
+    server = authority.rsplit("@", 1)[-1]
+    if not server or not _SMB_SERVER_RE.fullmatch(server):
+        return None
+    source_user = unquote(raw_source_user).split(":", 1)[0]
+    selected_user = source_user or unquote(remote_user or "")
+    if any(ord(char) < 32 for char in selected_user):
+        return None
+    user_prefix = f"{quote(selected_user, safe='-._~')}@" if selected_user else ""
+    decoded_share_path = unquote(raw_share_path)
+    if not decoded_share_path or any(ord(char) < 32 for char in decoded_share_path):
+        return None
+    share_path = quote(decoded_share_path, safe="/:@-._~")
+    share_name = decoded_share_path.rstrip("/").rsplit("/", 1)[-1] or controller_mount.mount_point.name
+    return RemoteSmbMount(
+        mount_point=controller_mount.mount_point,
+        share_name=share_name,
+        url=f"smb://{user_prefix}{server}/{share_path}",
+    )
+
+
+def _finder_recovery_result(label: str, mount: RemoteSmbMount) -> HostSetupResult:
+    return HostSetupResult(
+        ok=False,
+        message=f"{label} could not connect the {mount.share_name} share with Finder.",
+        detail=(
+            f"On {label}, connect to {mount.share_name} once in Finder, "
+            "save the password to Keychain, then retry."
+        ),
+        failure_kind="host_configuration",
+    )
+
+
+def _remote_login_account(host: dict[str, Any]) -> str:
+    target = str(host.get("host") or host.get("key") or "").strip()
+    if "@" in target:
+        account = target.rsplit("@", 1)[0].strip()
+        if account:
+            return account
+    return "the configured SSH account"
+
+
+def _finder_mount_point_supported(path: Path) -> bool:
+    return (
+        path.is_absolute()
+        and path.parent == Path("/Volumes")
+        and bool(path.name)
+        and not any(ord(char) < 32 for char in str(path))
+    )
+
+
+def _path_is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _decode_mount_field(value: str) -> str:
+    return _MOUNT_ESCAPE_RE.sub(lambda match: chr(int(match.group(1), 8)), value)
+
+
+def mount_output_field(value: str) -> str:
+    return value.replace("\\", "\\134").replace("\t", "\\011").replace("\n", "\\012").replace(" ", "\\040")
+
+
+__all__ = [
+    "ControllerSmbMount",
+    "REMOTE_MOUNT_ATTEMPT_SECONDS",
+    "RemoteSmbMount",
+    "controller_smb_mounts_from_output",
+    "finder_mount_roots_for_paths",
+    "mount_output_field",
+    "mount_remote_smb_shares",
+    "remote_smb_mounts_for_paths",
+]

--- a/mediaforce/hosts/setup_runtime.py
+++ b/mediaforce/hosts/setup_runtime.py
@@ -181,6 +181,7 @@ def prepare_remote_host_with_password(
         ssh_access_must_be_fixed_first: Callable[[HostStatus], bool],
         request_remote_xcode_install: Callable[[dict[str, Any]], HostSetupResult],
         bootstrap_remote_macos: Callable[[dict[str, Any], str, list[str]], HostSetupResult],
+        recover_remote_host_mounts: Callable[[MediaforceConfig, dict[str, Any], HostStatus], HostSetupResult],
         finish_remote_host_prepare: Callable[[MediaforceConfig, dict[str, Any], list[str]], HostSetupResult],
 ) -> HostSetupResult:
     host = _find_remote_host(config, host_key)
@@ -220,6 +221,13 @@ def prepare_remote_host_with_password(
             key_install.performed_steps = prep_steps
             if not key_install.ok:
                 return key_install
+            continue
+        if status.missing_mounts and status.platform == "macos":
+            mount_result = recover_remote_host_mounts(config, host, status)
+            prep_steps.extend(mount_result.performed_steps)
+            mount_result.performed_steps = prep_steps
+            if not mount_result.ok:
+                return mount_result
             continue
         if ssh_access_must_be_fixed_first(status):
             return HostSetupResult(

--- a/mediaforce/hosts/status_helpers.py
+++ b/mediaforce/hosts/status_helpers.py
@@ -11,6 +11,7 @@ from mediaforce.encoding.ffmpeg import SVT_AV1_REQUIRED_ISSUE, VIDEOTOOLBOX_REQU
     normalize_execution_platform
 from mediaforce.hosts.config import _host_supports_capability, host_media_access_for_host, \
     _parse_utc_offset_minutes, remote_shell_path_export_line, stream_host_has_remote_source_roots
+from mediaforce.hosts.mount_runtime import mount_output_field
 from mediaforce.hosts.types import AB_AV1_MISSING_ISSUE, FFMPEG_MISSING_ISSUE, HostStatus, \
     LINUX_SAMPLE_CALIBRATION_UNSUPPORTED_ISSUE, SAMPLE_AV1_ENCODER_MISSING_ISSUE, SAMPLE_METRIC_MISSING_ISSUE, \
     SOURCE_ROOT_READ_MISSING_ISSUE, STAGING_ROOT_WRITE_MISSING_ISSUE
@@ -188,13 +189,20 @@ def _status_from_paths(
         videotoolbox_available: bool | None = None,
         utc_offset_minutes: int | None = None,
         issues: list[str] | None = None,
+        missing_mounts: list[str] | None = None,
         setup_supported: bool = False,
         setup_requires_password: bool = False,
         require_paths: bool = True,
 ) -> HostStatus:
     missing_paths = [path for path, mounted in mounted_paths.items() if not mounted]
+    missing_mount_list = list(missing_mounts or [])
     issue_list = [str(issue) for issue in object_list(issues)]
-    available = (len(mounted_paths) > 0 or not require_paths) and not missing_paths and not issue_list
+    available = (
+        (len(mounted_paths) > 0 or not require_paths)
+        and not missing_paths
+        and not missing_mount_list
+        and not issue_list
+    )
     return HostStatus(
         key=key,
         label=label,
@@ -202,7 +210,12 @@ def _status_from_paths(
         priority=priority,
         capabilities=capabilities,
         available=available,
-        message=_host_message(available=available, missing_paths=missing_paths, issues=issue_list),
+        message=_host_message(
+            available=available,
+            missing_paths=missing_paths,
+            missing_mounts=missing_mount_list,
+            issues=issue_list,
+        ),
         missing_paths=missing_paths,
         repo_path=repo_path,
         ffmpeg_path=ffmpeg_path,
@@ -210,15 +223,24 @@ def _status_from_paths(
         videotoolbox_available=videotoolbox_available,
         utc_offset_minutes=utc_offset_minutes,
         issues=issue_list,
+        missing_mounts=missing_mount_list,
         setup_supported=setup_supported,
         setup_requires_password=setup_requires_password,
     )
 
 
-def _host_message(*, available: bool, missing_paths: list[str], issues: list[str]) -> str:
+def _host_message(
+        *,
+        available: bool,
+        missing_paths: list[str],
+        missing_mounts: list[str],
+        issues: list[str],
+) -> str:
     _ = missing_paths
     if available:
         return "Mounted and ready"
+    if missing_mounts:
+        return "Shared storage disconnected"
     if any(issue == LINUX_SAMPLE_CALIBRATION_UNSUPPORTED_ISSUE for issue in issues):
         return "Linux sample unsupported"
     if any(issue == "Xcode Command Line Tools are not installed on the remote Mac." for issue in issues):
@@ -380,6 +402,7 @@ def _remote_status_script(
         paths: list[str],
         repo_path: str,
         include_expensive_tools: bool = True,
+        mount_paths: list[str] | None = None,
         writable_paths: list[str] | None = None,
 ) -> str:
     quoted_paths = " ".join(shlex.quote(path) for path in paths)
@@ -424,8 +447,20 @@ def _remote_status_script(
         'printf "meta|platform|%s\\n" "$PLATFORM_NAME"',
         'printf "time|utc_offset|%s\\n" "$(date +%z)"',
     ])
+    if mount_paths:
+        lines.append('MOUNT_OUTPUT="$(/sbin/mount 2>/dev/null || true)"')
+        for mount_path in mount_paths:
+            lines.extend([
+                f"mount_path={shlex.quote(mount_path)}",
+                f"mount_output_path={shlex.quote(mount_output_field(mount_path))}",
+                'if printf "%s\\n" "$MOUNT_OUTPUT" | /usr/bin/grep -F -- " on $mount_path (" >/dev/null 2>&1 || printf "%s\\n" "$MOUNT_OUTPUT" | /usr/bin/grep -F -- " on $mount_output_path (" >/dev/null 2>&1; then',
+                '  printf "mount|%s|1\\n" "$mount_path"',
+                'else',
+                '  printf "mount|%s|0\\n" "$mount_path"',
+                'fi',
+            ])
     if paths:
-        lines[16:16] = [
+        lines.extend([
             f"for path in {quoted_paths}; do",
             '  exists=0',
             '  readable=0',
@@ -452,7 +487,7 @@ def _remote_status_script(
             '  printf "pathread|%s|%s\\n" "$path" "$readable"',
             '  printf "pathwrite|%s|%s\\n" "$path" "$writable"',
             "done",
-        ]
+        ])
     if repo_path:
         lines.append(
             f'if [ -e {shlex.quote(repo_path)} ]; then printf "repo|exists|1\\n"; else printf "repo|exists|0\\n"; fi'
@@ -469,6 +504,7 @@ def _parse_remote_status_output(stdout: str) -> dict[str, Any]:
         "tool_paths": {},
         "tool_meta": {},
         "path_access": {},
+        "mounts": {},
         "repo_path_exists": True,
         "utc_offset": None,
         "platform": "unknown",
@@ -492,6 +528,8 @@ def _parse_remote_status_output(stdout: str) -> dict[str, Any]:
         elif kind == "pathwrite":
             access = payload["path_access"].setdefault(key, {})
             access["write"] = value == "1"
+        elif kind == "mount":
+            payload["mounts"][key] = value == "1"
         elif kind == "tool":
             payload["tools"][key] = value == "1"
         elif kind == "toolpath":

--- a/mediaforce/hosts/status_runtime.py
+++ b/mediaforce/hosts/status_runtime.py
@@ -8,6 +8,7 @@ from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.type_defs import object_dict
 from mediaforce.hosts.config import _host_capabilities, _host_priority, _parse_utc_offset_minutes, \
     host_media_access_for_host, host_targets_current_machine, stream_host_has_remote_source_roots
+from mediaforce.hosts.mount_runtime import finder_mount_roots_for_paths
 from mediaforce.hosts.status_helpers import _classify_ssh_failure, _find_local_tool, _host_capability_issues, \
     _host_setup_supported, _local_platform_name, _local_utc_offset_minutes, _parse_remote_status_output, \
     _remote_setup_needs_password, _remote_status_script, _status_from_paths, _status_platform
@@ -197,6 +198,7 @@ def _remote_host_status(
         paths=paths,
         repo_path=repo_check_path,
         include_expensive_tools=cached_tools is None,
+        mount_paths=[str(path) for path in finder_mount_roots_for_paths(paths)],
         writable_paths=writable_paths,
     )
     try:
@@ -329,6 +331,11 @@ def _remote_host_status(
     tools = object_dict(payload.get("tools"))
     tool_paths = object_dict(payload.get("tool_paths"))
     platform_name = _status_platform(payload.get("platform"), tools=tools)
+    missing_mounts = [
+        str(path_text)
+        for path_text, mounted in object_dict(payload.get("mounts")).items()
+        if platform_name == "macos" and not bool(mounted)
+    ]
     learn_remote_wake_mac(config, host, ssh_host)
     capability_issues = _host_capability_issues(
         host,
@@ -357,6 +364,7 @@ def _remote_host_status(
         videotoolbox_available=bool(tools.get("ffmpeg_videotoolbox")),
         utc_offset_minutes=_parse_utc_offset_minutes(payload.get("utc_offset")),
         issues=capability_issues,
+        missing_mounts=missing_mounts,
         setup_supported=_host_setup_supported(platform_name),
         setup_requires_password=_remote_setup_needs_password(capability_issues),
         require_paths=require_paths,
@@ -386,10 +394,16 @@ def _current_machine_host_status(
     else:
         status_paths = [Path(str(path).strip()).expanduser() for path in explicit_source_roots.values() if str(path).strip()]
         require_paths = bool(status_paths)
+    platform_name = _local_platform_name()
     mounted_paths = {
         str(path): path.exists()
         for path in status_paths
     }
+    missing_mounts = [
+        str(path)
+        for path in finder_mount_roots_for_paths(status_paths)
+        if platform_name == "macos" and not _local_mount_present(path)
+    ]
     source_path_map = explicit_source_roots if media_access == "stream" else merged_source_roots
     source_paths = [str(path) for path in source_path_map.values()]
     staging_path = str(config.staging_root_for_host(host)) if require_paths and media_access != "stream" else None
@@ -403,7 +417,6 @@ def _current_machine_host_status(
     }
     tools = local_tool_status_snapshot()
     ffmpeg_bin = _find_local_tool("ffmpeg", fallback_paths=["/opt/homebrew/opt/ffmpeg-full/bin/ffmpeg"])
-    platform_name = _local_platform_name()
     capability_issues = _host_capability_issues(
         host,
         tools=tools,
@@ -428,6 +441,7 @@ def _current_machine_host_status(
         videotoolbox_available=bool(tools.get("ffmpeg_videotoolbox")),
         utc_offset_minutes=_local_utc_offset_minutes(),
         issues=capability_issues,
+        missing_mounts=missing_mounts,
         setup_supported=_host_setup_supported(platform_name),
         require_paths=require_paths,
     )
@@ -460,3 +474,10 @@ def _local_path_writable(path: Path) -> bool:
         except OSError:
             pass
     return True
+
+
+def _local_mount_present(path: Path) -> bool:
+    try:
+        return path.is_mount()
+    except OSError:
+        return False

--- a/mediaforce/hosts/types.py
+++ b/mediaforce/hosts/types.py
@@ -30,6 +30,7 @@ class HostStatus:
     videotoolbox_available: bool | None = None
     utc_offset_minutes: int | None = None
     issues: list[str] = field(default_factory=list)
+    missing_mounts: list[str] = field(default_factory=list)
     detail: str | None = None
     setup_supported: bool = False
     setup_requires_password: bool = False
@@ -43,6 +44,13 @@ class HostSetupResult:
     detail: str | None = None
     performed_steps: list[str] = field(default_factory=list)
     requires_password: bool = False
+    failure_kind: str | None = None
+
+
+class HostReadinessError(RuntimeError):
+    def __init__(self, message: str, *, failure_kind: str) -> None:
+        super().__init__(message)
+        self.failure_kind = failure_kind
 
 
 __all__ = [
@@ -53,6 +61,7 @@ __all__ = [
     "FFMPEG_MISSING_ISSUE",
     "HostSetupResult",
     "HostStatus",
+    "HostReadinessError",
     "LINUX_SAMPLE_CALIBRATION_UNSUPPORTED_ISSUE",
     "REMOTE_SHELL_PATH",
     "REMOTE_STATUS_RETRY_DELAY_SECONDS",

--- a/mediaforce/remote.py
+++ b/mediaforce/remote.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -7,8 +8,10 @@ from typing import Any
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.encoding.ffmpeg import SVT_AV1_REQUIRED_ISSUE, VIDEOTOOLBOX_REQUIRED_ISSUE
 from mediaforce.hosts.config import execution_mode_for_host, host_media_access_for_host, \
-    host_status_targets_current_machine, normalize_host_media_access, remote_shell_path_export_line, \
-    ssh_target_for_host
+    host_status_targets_current_machine, host_targets_current_machine, normalize_host_media_access, \
+    remote_shell_path_export_line, ssh_target_for_host
+from mediaforce.hosts.mount_runtime import ControllerSmbMount, RemoteSmbMount, controller_smb_mounts_from_output, \
+    mount_remote_smb_shares, remote_smb_mounts_for_paths
 from mediaforce.hosts.status_runtime import _current_machine_host_status as _current_machine_host_status_impl, \
     _remote_host_status as _remote_host_status_impl, _run_remote_status_probe as _run_remote_status_probe_impl
 from mediaforce.hosts.setup_runtime import _finish_remote_host_prepare as _finish_remote_host_prepare_impl, \
@@ -30,7 +33,7 @@ from mediaforce.hosts.wake_runtime import _ensure_remote_awake_for_ssh as _ensur
     _learn_remote_wake_mac as _learn_remote_wake_mac_impl, \
     _wake_remote_host_if_configured as _wake_remote_host_if_configured_impl
 from mediaforce.hosts.types import AB_AV1_MISSING_ISSUE, DEFAULT_HOST_CAPABILITIES, DEFAULT_HOST_MEDIA_ACCESS, \
-    DEFAULT_WAKE_WAIT_SECONDS, HostSetupResult, HostStatus, \
+    DEFAULT_WAKE_WAIT_SECONDS, HostReadinessError, HostSetupResult, HostStatus, \
     FFMPEG_MISSING_ISSUE, LINUX_SAMPLE_CALIBRATION_UNSUPPORTED_ISSUE, \
     REMOTE_STATUS_RETRY_DELAY_SECONDS, SAMPLE_AV1_ENCODER_MISSING_ISSUE, SAMPLE_METRIC_MISSING_ISSUE
 
@@ -42,6 +45,7 @@ __all__ = [
     "FFMPEG_MISSING_ISSUE",
     "HostSetupResult",
     "HostStatus",
+    "HostReadinessError",
     "LINUX_SAMPLE_CALIBRATION_UNSUPPORTED_ISSUE",
     "REMOTE_STATUS_RETRY_DELAY_SECONDS",
     "SAMPLE_AV1_ENCODER_MISSING_ISSUE",
@@ -56,6 +60,8 @@ __all__ = [
     "host_status_targets_current_machine",
     "normalize_host_media_access",
     "prepare_remote_host_with_password",
+    "recover_remote_host_mounts",
+    "remote_mount_recovery_supported",
     "remote_shell_path_export_line",
     "reset_remote_host_trust",
     "run_host_lifecycle_command",
@@ -71,6 +77,91 @@ def run_host_lifecycle_command(host: dict[str, object], command: str, *, timeout
     if not command_text:
         raise RuntimeError("Lifecycle command cannot be empty.")
     return _run_subprocess_text(["sh", "-lc", command_text], timeout=timeout)
+
+
+def remote_mount_recovery_supported(
+        config: MediaforceConfig,
+        host: dict[str, Any],
+        status: HostStatus,
+) -> bool:
+    if status.issues or not _missing_paths_covered_by_mounts(status.missing_paths, status.missing_mounts):
+        return False
+    return bool(_remote_smb_mounts_for_status(config, host, status))
+
+
+def recover_remote_host_mounts(
+        config: MediaforceConfig,
+        host: dict[str, Any],
+        status: HostStatus,
+) -> HostSetupResult:
+    mounts = _remote_smb_mounts_for_status(config, host, status)
+    label = str(host.get("label") or status.label or host.get("host") or "Remote host").strip() or "Remote host"
+    if not mounts:
+        return HostSetupResult(
+            ok=False,
+            message=f"{label} needs shared storage connected before it can run Mediaforce work.",
+            detail=(
+                "Mediaforce could not match the disconnected storage to an SMB volume mounted on this Mac."
+            ),
+            failure_kind="controller_storage_unavailable",
+        )
+    return mount_remote_smb_shares(host, mounts, run_remote_ssh=_run_remote_ssh)
+
+
+def _remote_smb_mounts_for_status(
+        config: MediaforceConfig,
+        host: dict[str, Any],
+        status: HostStatus,
+) -> list[RemoteSmbMount] | None:
+    _ = config
+    if (
+            status.available
+            or status.mode != "ssh"
+            or status.platform != "macos"
+            or not status.missing_mounts
+            or host_media_access_for_host(host) != "mounted"
+            or host_targets_current_machine(host)
+    ):
+        return None
+    controller_mounts: list[ControllerSmbMount] = controller_smb_mounts_from_output(_controller_smb_mount_output())
+    return remote_smb_mounts_for_paths(
+        status.missing_mounts,
+        controller_mounts,
+        remote_user=_ssh_user_for_host(host),
+    )
+
+
+def _controller_smb_mount_output() -> str:
+    try:
+        result = _run_subprocess_text(["/sbin/mount"], timeout=5)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _ssh_user_for_host(host: dict[str, Any]) -> str | None:
+    target = ssh_target_for_host(host)
+    if "@" not in target:
+        return None
+    user = target.rsplit("@", 1)[0].strip()
+    return user or None
+
+
+def _missing_paths_covered_by_mounts(missing_paths: list[str], missing_mounts: list[str]) -> bool:
+    mount_points = [Path(os.path.normpath(path)) for path in missing_mounts]
+    for raw_path in missing_paths:
+        path = Path(os.path.normpath(raw_path))
+        if not any(_path_is_within(path, mount_point) for mount_point in mount_points):
+            return False
+    return True
+
+
+def _path_is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
 
 
 def _run_subprocess_text(
@@ -196,6 +287,7 @@ def prepare_remote_host_with_password(
         ssh_access_must_be_fixed_first=_ssh_access_must_be_fixed_first,
         request_remote_xcode_install=_request_remote_xcode_install,
         bootstrap_remote_macos=lambda host, pwd, issues: _bootstrap_remote_macos(host, pwd, issues=issues),
+        recover_remote_host_mounts=recover_remote_host_mounts,
         finish_remote_host_prepare=_finish_remote_host_prepare,
     )
 

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -7,7 +7,6 @@ import re
 import shutil
 import subprocess
 import threading
-import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
@@ -74,6 +73,7 @@ from mediaforce.remote import (
     HostStatus,
     collect_host_statuses,
     prepare_remote_host_with_password,
+    remote_mount_recovery_supported,
     reset_remote_host_trust,
     run_remote_command,
     run_host_lifecycle_command,
@@ -105,7 +105,7 @@ from mediaforce.web.runtime import FolderCard, cached_folder_cards, dashboard_fo
     archive_cleanup_summary, clear_archive_cleanup_action, \
     clear_completed_backups_action, completed_page_payload, confirm_originals_removed_action, \
     list_completed_folders, \
-    ensure_encode_host_ready, \
+    ensure_encode_host_ready, ensure_sample_host_ready, \
     folder_ai_tune_action, folder_ai_tune_confirm_action, folder_ai_tune_preview_action, \
     folder_card_cache_key, folder_status_payload, host_config_for_key, host_lifecycle_start_command, \
     host_lifecycle_start_timeout_seconds, host_lifecycle_stop_command, host_runtime_rows, \
@@ -133,8 +133,7 @@ from mediaforce.web.runtime.calibration_runtime import CalibrationRunDeps, \
     run_full_calibration as runtime_run_full_calibration, \
     run_sampled_calibration as runtime_run_sampled_calibration, \
     remove_path as runtime_remove_path, snapshot_staged_artifact as runtime_snapshot_staged_artifact
-from mediaforce.web.runtime.host_runtime import lifecycle_command_error_detail as runtime_lifecycle_command_error_detail, \
-    unavailable_host_error_message as runtime_unavailable_host_error_message
+from mediaforce.web.runtime.host_runtime import lifecycle_command_error_detail as runtime_lifecycle_command_error_detail
 from mediaforce.web.runtime.worker_leadership import WorkerLeadershipLease
 from mediaforce.web.runtime.encode_runtime import EncodeQueueRuntimeDeps, \
     clear_stale_encoding_items_when_idle as runtime_clear_stale_encoding_items_when_idle, \
@@ -598,7 +597,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         if started:
             message = f"{label} accepted the start command and is reachable now."
         else:
-            message = f"{label} was already reachable."
+            message = f"{label} is reachable now."
         return _host_action_result(HostSetupResult(ok=True, message=message))
 
     def _reset_host_trust_action(host_key: str) -> dict[str, Any]:
@@ -793,8 +792,11 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         )
         resolved_metric, _ = select_quality_metric(str(video_policy.get("quality_metric", "auto")))
         sample_host_statuses = _sample_calibration_host_statuses(config)
-        sample_host_key = _default_sample_host_key_from_statuses(sample_host_statuses)
         sample_host_choices = _sample_host_options_from_statuses(config, sample_host_statuses)
+        sample_host_key = _sample_host_key_from_choices(
+            _default_sample_host_key_from_statuses(sample_host_statuses),
+            sample_host_choices,
+        )
         return (
             {
                 **base_context,
@@ -1875,31 +1877,12 @@ def _fresh_host_status_for_key(config: MediaforceConfig, host_key: str) -> HostS
 
 
 def _ensure_encode_host_ready(config: MediaforceConfig, host_payload: dict[str, Any] | None) -> bool:
-    host = object_dict(host_payload)
-    host_key = str(host.get("key") or host.get("host") or host.get("label") or "").strip()
-    if not host_key:
-        return False
-    status = _fresh_host_status_for_key(config, host_key)
-    if status is not None and status.available:
-        return False
-    start_command = _host_lifecycle_start_command(host)
-    if not start_command:
-        raise RuntimeError(runtime_unavailable_host_error_message(status))
-    result = run_host_lifecycle_command(host, start_command, timeout=HOST_LIFECYCLE_COMMAND_TIMEOUT_SECONDS)
-    if result.returncode != 0:
-        raise RuntimeError(runtime_lifecycle_command_error_detail(result, "host start command failed"))
-    deadline = time.monotonic() + _host_lifecycle_start_timeout_seconds(host)
-    while time.monotonic() < deadline:
-        refreshed = _fresh_host_status_for_key(config, host_key)
-        if refreshed is not None and refreshed.available:
-            return True
-        time.sleep(HOST_LIFECYCLE_POLL_SECONDS)
-    refreshed = _fresh_host_status_for_key(config, host_key)
-    if refreshed is not None and refreshed.available:
-        return True
-    detail = refreshed.detail if refreshed is not None else None
-    message = refreshed.message if refreshed is not None else f"Timed out waiting for {host_key}"
-    raise RuntimeError(detail or message or f"Timed out waiting for {host_key}")
+    return ensure_encode_host_ready(
+        config,
+        host_payload,
+        lifecycle_command_timeout_seconds=HOST_LIFECYCLE_COMMAND_TIMEOUT_SECONDS,
+        lifecycle_poll_seconds=HOST_LIFECYCLE_POLL_SECONDS,
+    )
 
 
 def _stop_encode_host_if_configured(config: MediaforceConfig, host_payload: dict[str, Any] | None) -> None:
@@ -1944,7 +1927,8 @@ def _sample_host_options_from_statuses(
 
 
 def _sample_host_schedule_fields(config: MediaforceConfig, status: HostStatus) -> dict[str, Any]:
-    host_payload = {**_host_config_for_key(config, status.key), **asdict(status)}
+    host_config = _host_config_for_key(config, status.key)
+    host_payload = {**host_config, **asdict(status)}
     policy = _schedule_profile_policy_for_host(config, host_payload)
     schedule_open = _scheduler_allows_encode_run(policy, host_payload=host_payload)
     summary = str(policy.get("summary") or "").strip()
@@ -1952,6 +1936,7 @@ def _sample_host_schedule_fields(config: MediaforceConfig, status: HostStatus) -
         "schedule_open": schedule_open,
         "schedule_detail": summary,
         "schedule_profile_label": str(policy.get("label") or "Always"),
+        "storage_recovery_available": remote_mount_recovery_supported(config, host_config, status),
     }
 
 
@@ -1962,6 +1947,15 @@ def _sample_host_help_text(sample_host_choices: list[dict[str, Any]], selected_k
         detail = str(option.get("detail") or "").strip()
         return detail or "Choose where sampled calibration should run."
     return "Choose where sampled calibration should run."
+
+
+def _sample_host_key_from_choices(default_key: str, sample_host_choices: list[dict[str, Any]]) -> str:
+    if default_key:
+        return default_key
+    for option in sample_host_choices:
+        if bool(option.get("available")):
+            return str(option.get("key") or "").strip()
+    return ""
 
 
 def _resolve_sample_host(config: MediaforceConfig, host_key: str) -> HostStatus:
@@ -1977,7 +1971,7 @@ def _resolve_sample_host(config: MediaforceConfig, host_key: str) -> HostStatus:
     host = statuses.get(requested_key)
     if host is None:
         raise HTTPException(status_code=400, detail="Unknown sampled calibration host")
-    if not host.available:
+    if not host.available and not remote_mount_recovery_supported(config, _host_config_for_key(config, host.key), host):
         raise HTTPException(status_code=400, detail=host.message)
     return host
 
@@ -2695,6 +2689,7 @@ def _encode_queue_runtime_deps() -> EncodeQueueRuntimeDeps:
 def _calibration_run_deps() -> CalibrationRunDeps:
     return CalibrationRunDeps(
         now_iso=_now_iso,
+        ensure_sample_host_ready=ensure_sample_host_ready,
         load_job_state=_load_job_state,
         sample_item=_sample_item,
         save_job_state=_save_job_state,

--- a/mediaforce/web/runtime/__init__.py
+++ b/mediaforce/web/runtime/__init__.py
@@ -19,7 +19,8 @@ from mediaforce.web.runtime.folder_tuning_runtime import FolderTuningRuntimeDeps
     build_tuning_runtime_toolbelt, multimodal_review_pack_public_view, planned_audio_review_context, \
     proposal_context_snapshot, review_pack_dir
 from mediaforce.web.runtime.host_runtime import default_sample_host_key, default_sample_host_key_from_statuses, \
-    ensure_encode_host_ready, fresh_host_status_for_key, host_config_for_key, host_lifecycle_start_command, \
+    ensure_encode_host_ready, ensure_sample_host_ready, fresh_host_status_for_key, host_config_for_key, \
+    host_lifecycle_start_command, \
     host_lifecycle_start_timeout_seconds, host_lifecycle_stop_command, host_runtime_rows, \
     sample_calibration_host_statuses, sample_host_options, sample_host_options_from_statuses, \
     stop_encode_host_if_configured
@@ -50,6 +51,7 @@ __all__ = [
     "default_sample_host_key",
     "default_sample_host_key_from_statuses",
     "ensure_encode_host_ready",
+    "ensure_sample_host_ready",
     "FolderAiTuneDeps",
     "FolderStateDeps",
     "FolderTuningRuntimeDeps",

--- a/mediaforce/web/runtime/calibration_runtime.py
+++ b/mediaforce/web/runtime/calibration_runtime.py
@@ -1,7 +1,7 @@
 import json
 import shutil
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +23,7 @@ from mediaforce.tuning.target_size_search import TargetSizeSearchError
 @dataclass(slots=True)
 class CalibrationRunDeps:
     now_iso: Any
+    ensure_sample_host_ready: Any
     load_job_state: Any
     sample_item: Any
     save_job_state: Any
@@ -178,6 +179,8 @@ def run_calibration_job(
     staged_artifact_snapshot: dict[str, Any] | None = None
 
     try:
+        ready_host = deps.ensure_sample_host_ready(config, host_data)
+        host_data = {**host_data, **asdict(ready_host)}
         with open_db(config.paths.db_path) as connection:
             sample_item = _job_sample_item(job)
             if sample_item is None:

--- a/mediaforce/web/runtime/encode_runtime.py
+++ b/mediaforce/web/runtime/encode_runtime.py
@@ -31,7 +31,7 @@ from mediaforce.core.type_defs import float_value, int_value, object_dict, objec
 from mediaforce.encoding.quality import QualitySearchError, QualityTempCleanupError, QualityTempSetupError, \
     analyze_quality_policy_failure, quality_error_message
 from mediaforce.encoding.staging import safe_unlink
-from mediaforce.remote import execution_mode_for_host, host_media_access_for_host, run_remote_command
+from mediaforce.remote import HostReadinessError, execution_mode_for_host, host_media_access_for_host, run_remote_command
 from mediaforce.web.runtime.host_runtime import host_config_for_key
 from mediaforce.web.runtime.worker_supervision import run_supervised_worker_loop
 
@@ -948,7 +948,10 @@ def select_encode_host(
         if not bool(host.get("available"))
         and not _probe_available(host)
         and not object_list(host.get("issues"))
-        and bool(deps.host_lifecycle_start_command(host))
+        and (
+            bool(deps.host_lifecycle_start_command(host))
+            or bool(host.get("storage_recovery_available"))
+        )
         and "encode_queue" in {str(capability).lower() for capability in host.get("capabilities") or []}
         and int(host.get("active_encode_count") or 0) < int(host.get("max_parallel_encodes") or 1)
         and _schedule_open(host)
@@ -1598,7 +1601,7 @@ def _finalize_encode_job_progress(
 
 
 def _encode_failure_is_host_related(failure_kind: str, error_message: str, host_payload: dict[str, Any]) -> bool:
-    if failure_kind in {"host_unavailable", "ssh_transport"}:
+    if failure_kind in {"controller_storage_unavailable", "host_unavailable", "ssh_transport"}:
         return True
     return _encode_failure_is_ssh_transport(error_message, host_payload)
 
@@ -1657,7 +1660,13 @@ def _quality_temp_setup_is_host_related(message: str) -> bool:
 
 
 def _encode_failure_is_retryable(failure_kind: str, error_message: str, host_payload: dict[str, Any]) -> bool:
-    if failure_kind in {"worker_restart", "stale_lease", "host_unavailable", "ssh_transport"}:
+    if failure_kind in {
+        "controller_storage_unavailable",
+        "worker_restart",
+        "stale_lease",
+        "host_unavailable",
+        "ssh_transport",
+    }:
         return True
     if failure_kind in {"stopped", "deterministic"}:
         return False
@@ -1669,6 +1678,8 @@ def _encode_failure_retries_after_attempt_cap(
         error_message: str,
         host_payload: dict[str, Any],
 ) -> bool:
+    if failure_kind == "controller_storage_unavailable":
+        return False
     if not _encode_failure_is_host_related(failure_kind, error_message, host_payload):
         return False
     lowered = error_message.lower()
@@ -1681,6 +1692,7 @@ def _encode_retry_waiting_reason(*, failure_kind: str, retry_not_before: str) ->
         "worker_restart": "worker restart",
         "stale_lease": "stale worker lease",
         "host_unavailable": "host availability issue",
+        "controller_storage_unavailable": "controller storage issue",
         "ssh_transport": "SSH transport failure",
     }.get(failure_kind, "retryable failure")
     return f"retrying after {reason} at {retry_not_before}"
@@ -1764,6 +1776,8 @@ def _cleanup_encode_retry_artifacts(
 def _classify_encode_failure(exc: Exception, job: dict[str, Any]) -> str:
     message = str(exc).lower()
     host_payload = object_dict(job.get("host"))
+    if isinstance(exc, HostReadinessError):
+        return exc.failure_kind
     if isinstance(exc, PermissionError):
         return "controller_media_access"
     if isinstance(exc, QualityTempSetupError) and _quality_temp_setup_is_host_related(message):

--- a/mediaforce/web/runtime/host_runtime.py
+++ b/mediaforce/web/runtime/host_runtime.py
@@ -13,8 +13,9 @@ from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import encode_jobs
 from mediaforce.core.type_defs import float_value, object_dict
 from mediaforce.encoding.encode_queue import RUNNABLE_ENCODE_JOB_KINDS
-from mediaforce.remote import HostStatus, collect_host_statuses, host_status_targets_current_machine, \
-    normalize_host_media_access, run_host_lifecycle_command
+from mediaforce.remote import HostReadinessError, HostStatus, collect_host_statuses, host_status_targets_current_machine, \
+    normalize_host_media_access, recover_remote_host_mounts, remote_mount_recovery_supported, \
+    run_host_lifecycle_command
 
 
 def _progress_float(job: dict[str, Any], key: str) -> float:
@@ -56,6 +57,7 @@ def host_runtime_rows(
     current_time = now or datetime.now(UTC)
     for status in statuses:
         host_config = host_config_for_key(config, status.key)
+        storage_recovery_available = remote_mount_recovery_supported(config, host_config, status)
         capabilities = {capability.lower() for capability in status.capabilities}
         raw_allowed_libraries = host_config.get("allowed_libraries")
         allowed_libraries = [
@@ -79,6 +81,7 @@ def host_runtime_rows(
             "allowed_libraries": allowed_libraries,
             "source_roots": merged_source_roots,
             "staging_root": str(host_config.get("staging_root") or "").strip() or None,
+            "storage_recovery_available": storage_recovery_available,
         }
         max_parallel_encodes = host_max_parallel_encodes(host_config)
         schedule_profile = host_schedule_profile_key(host_config)
@@ -93,7 +96,11 @@ def host_runtime_rows(
         if active_probe_degraded:
             active_reason = "status check deferred while encode is running"
         elif not status.available:
-            active_reason = status.message
+            active_reason = (
+                "shared storage will reconnect when work starts"
+                if storage_recovery_available
+                else status.message
+            )
         elif not encode_capable:
             active_reason = "encode queue capability disabled"
         elif str(policy.get("mode") or "anytime") == "never":
@@ -129,6 +136,8 @@ def host_runtime_rows(
                 "probe_message": status.message,
                 "probe_issues": list(status.issues),
             }
+            if storage_recovery_available:
+                status_payload["message"] = "Storage will reconnect when work starts"
         rows.append(
             {
                 **status_payload,
@@ -355,6 +364,10 @@ def ensure_encode_host_ready(
     status = fresh_host_status_for_key(config, host_key)
     if status is not None and status.available:
         return False
+    if status is not None:
+        status = _recover_host_mounts(config, host, status)
+        if status is not None and status.available:
+            return False
     start_command = host_lifecycle_start_command(host)
     if not start_command:
         raise RuntimeError(unavailable_host_error_message(status))
@@ -364,15 +377,54 @@ def ensure_encode_host_ready(
     deadline = time.monotonic() + host_lifecycle_start_timeout_seconds(host)
     while time.monotonic() < deadline:
         refreshed = fresh_host_status_for_key(config, host_key)
-        if refreshed is not None and refreshed.available:
-            return True
+        if refreshed is not None:
+            refreshed = _recover_host_mounts(config, host, refreshed)
+            if refreshed.available:
+                return True
         time.sleep(lifecycle_poll_seconds)
     refreshed = fresh_host_status_for_key(config, host_key)
-    if refreshed is not None and refreshed.available:
-        return True
+    if refreshed is not None:
+        refreshed = _recover_host_mounts(config, host, refreshed)
+        if refreshed.available:
+            return True
     detail = refreshed.detail if refreshed is not None else None
     message = refreshed.message if refreshed is not None else f"Timed out waiting for {host_key}"
     raise RuntimeError(detail or message or f"Timed out waiting for {host_key}")
+
+
+def ensure_sample_host_ready(config: MediaforceConfig, host_payload: dict[str, Any] | None) -> HostStatus:
+    host = object_dict(host_payload)
+    host_key = str(host.get("key") or host.get("host") or host.get("label") or "").strip()
+    if not host_key:
+        raise HostReadinessError("Sample host is not configured.", failure_kind="host_configuration")
+    status = fresh_host_status_for_key(config, host_key)
+    if status is None:
+        raise HostReadinessError("Sample host is not available.", failure_kind="host_unavailable")
+    status = _recover_host_mounts(config, host, status)
+    if not status.available:
+        raise HostReadinessError(
+            status.detail or status.message or "Sample host is not available.",
+            failure_kind="host_unavailable",
+        )
+    return status
+
+
+def _recover_host_mounts(
+        config: MediaforceConfig,
+        host: dict[str, Any],
+        status: HostStatus,
+) -> HostStatus:
+    if not status.missing_mounts:
+        return status
+    mount_result = recover_remote_host_mounts(config, host, status)
+    if not mount_result.ok:
+        detail = f" Details: {mount_result.detail}" if mount_result.detail else ""
+        raise HostReadinessError(
+            f"{mount_result.message}{detail}",
+            failure_kind=mount_result.failure_kind or "host_unavailable",
+        )
+    host_key = str(host.get("key") or host.get("host") or host.get("label") or status.key).strip()
+    return fresh_host_status_for_key(config, host_key) or status
 
 
 def stop_encode_host_if_configured(host_payload: dict[str, Any] | None, *,
@@ -387,8 +439,15 @@ def stop_encode_host_if_configured(host_payload: dict[str, Any] | None, *,
 
 
 def default_sample_host_key(config: MediaforceConfig, *, safe_collect_statuses: Any) -> str:
-    return default_sample_host_key_from_statuses(
-        sample_calibration_host_statuses(config, safe_collect_statuses=safe_collect_statuses))
+    statuses = sample_calibration_host_statuses(config, safe_collect_statuses=safe_collect_statuses)
+    ready_key = default_sample_host_key_from_statuses(statuses)
+    if ready_key:
+        return ready_key
+    for status in statuses:
+        host = host_config_for_key(config, status.key)
+        if remote_mount_recovery_supported(config, host, status):
+            return status.key
+    return ""
 
 
 def default_sample_host_key_from_statuses(statuses: list[HostStatus]) -> str:
@@ -430,13 +489,19 @@ def sample_host_options_from_statuses(
     options: list[dict[str, Any]] = []
     for status in statuses:
         schedule_fields = object_dict(schedule_fields_for_host(status)) if schedule_fields_for_host else {}
+        storage_recovery_available = bool(schedule_fields.get("storage_recovery_available"))
         options.append(
             {
                 "key": status.key,
                 "label": status.label,
-                "detail": status.message if not status.available else (
-                    "This machine" if host_status_targets_current_machine(status) else "Remote host"),
-                "available": status.available,
+                "detail": (
+                    "Storage will reconnect when the test starts."
+                    if storage_recovery_available
+                    else status.message if not status.available else (
+                        "This machine" if host_status_targets_current_machine(status) else "Remote host"
+                    )
+                ),
+                "available": status.available or storage_recovery_available,
                 **schedule_fields,
             }
         )

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -1793,6 +1793,41 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
         self.assertEqual(encode_runtime._classify_encode_failure(exc, job), "deterministic")
 
+    def test_mount_recovery_failure_preserves_host_retry_classification(self) -> None:
+        job = {"host": {"key": "remote-a", "label": "Remote A", "mode": "ssh"}}
+        exc = remote.HostReadinessError(
+            "Remote A could not connect shared storage.",
+            failure_kind="host_unavailable",
+        )
+
+        self.assertEqual(encode_runtime._classify_encode_failure(exc, job), "host_unavailable")
+        self.assertTrue(encode_runtime._encode_failure_is_retryable("host_unavailable", str(exc), job["host"]))
+
+    def test_mount_configuration_failure_is_not_retryable(self) -> None:
+        job = {"host": {"key": "remote-a", "label": "Remote A", "mode": "ssh"}}
+        exc = remote.HostReadinessError(
+            "Mediaforce could not identify the SMB share.",
+            failure_kind="host_configuration",
+        )
+
+        failure_kind = encode_runtime._classify_encode_failure(exc, job)
+        self.assertEqual(failure_kind, "host_configuration")
+        self.assertFalse(encode_runtime._encode_failure_is_retryable(failure_kind, str(exc), job["host"]))
+
+    def test_controller_storage_failure_retries_other_hosts_within_attempt_cap(self) -> None:
+        job = {"host": {"key": "remote-a", "label": "Remote A", "mode": "ssh"}}
+        exc = remote.HostReadinessError(
+            "The controller SMB volume is not mounted.",
+            failure_kind="controller_storage_unavailable",
+        )
+
+        failure_kind = encode_runtime._classify_encode_failure(exc, job)
+        self.assertEqual(failure_kind, "controller_storage_unavailable")
+        self.assertTrue(encode_runtime._encode_failure_is_retryable(failure_kind, str(exc), job["host"]))
+        self.assertFalse(
+            encode_runtime._encode_failure_retries_after_attempt_cap(failure_kind, str(exc), job["host"])
+        )
+
     def test_transient_ssh_failure_stays_in_retry_backoff_after_attempt_cap(self) -> None:
         source_path = self._create_source_file("episode-host-retry.mkv")
         staging_path = self._staging_path("episode-host-retry.mkv")
@@ -2619,6 +2654,39 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertFalse(rows[0]["queue_active"])
         self.assertEqual(rows[0]["active_reason"], "encode queue disabled by schedule")
 
+    def test_host_runtime_rows_marks_missing_storage_as_automatically_recoverable(self) -> None:
+        self.config.raw["remote_hosts"] = [
+            {
+                "host": "remote@mac",
+                "label": "Remote Mac",
+                "capabilities": ["encode_queue"],
+            }
+        ]
+        status = HostStatus(
+            key="remote@mac",
+            label="Remote Mac",
+            mode="ssh",
+            priority=20,
+            capabilities=["encode_queue"],
+            available=False,
+            message="Missing required paths",
+            missing_paths=["/Volumes/media/tv"],
+            missing_mounts=["/Volumes/media"],
+            platform="macos",
+            setup_supported=True,
+        )
+
+        with open_db(self.config.paths.db_path) as connection, patch(
+                "mediaforce.web.app._safe_collect_host_statuses", return_value=[status]
+        ), patch(
+            "mediaforce.web.runtime.host_runtime.remote_mount_recovery_supported", return_value=True
+        ):
+            rows = web_app._host_runtime_rows(connection, self.config)
+
+        self.assertTrue(rows[0]["storage_recovery_available"])
+        self.assertEqual(rows[0]["message"], "Storage will reconnect when work starts")
+        self.assertEqual(rows[0]["active_reason"], "shared storage will reconnect when work starts")
+
     def test_select_encode_host_can_choose_startable_unavailable_host(self) -> None:
         host = {
             "key": "ct103",
@@ -2638,6 +2706,30 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertIsNotNone(selected_host)
         assert selected_host is not None
         self.assertEqual(selected_host["key"], "ct103")
+        self.assertIsNone(waiting_reason)
+
+    def test_select_encode_host_can_choose_storage_recoverable_host(self) -> None:
+        host = {
+            "key": "remote-mac",
+            "host": "remote@mac",
+            "label": "Remote Mac",
+            "available": False,
+            "probe_available": False,
+            "priority": 50,
+            "capabilities": ["encode_queue"],
+            "active_encode_count": 0,
+            "max_parallel_encodes": 1,
+            "storage_recovery_available": True,
+            "schedule_profile": "always",
+            "issues": [],
+        }
+
+        with patch("mediaforce.web.app._host_runtime_rows", return_value=[host]):
+            selected_host, waiting_reason = web_app._select_encode_host(
+                cast(Any, None), self.config, {"job_id": "job-1", "bypass_schedule": False}
+            )
+
+        self.assertEqual(selected_host, host)
         self.assertIsNone(waiting_reason)
 
     def test_select_encode_host_does_not_choose_startable_host_with_capability_issues(self) -> None:
@@ -2878,16 +2970,97 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             missing_paths=[],
         )
         with patch(
-                "mediaforce.web.app.collect_host_statuses",
+                "mediaforce.web.runtime.host_runtime.collect_host_statuses",
                 side_effect=[[unavailable], [available]],
         ), patch(
-            "mediaforce.web.app.run_host_lifecycle_command",
+            "mediaforce.web.runtime.host_runtime.run_host_lifecycle_command",
             return_value=subprocess.CompletedProcess(args=["sh"], returncode=0, stdout="", stderr=""),
-        ) as lifecycle_mock, patch("mediaforce.web.app.time.sleep") as sleep_mock:
+        ) as lifecycle_mock, patch("mediaforce.web.runtime.host_runtime.time.sleep") as sleep_mock:
             started = web_app._ensure_encode_host_ready(self.config, host)
         lifecycle_mock.assert_called_once_with(host, "ssh prox-main.shiny pct start 103",
                                                timeout=web_app.HOST_LIFECYCLE_COMMAND_TIMEOUT_SECONDS)
         self.assertTrue(started)
+        sleep_mock.assert_not_called()
+
+    def test_ensure_encode_host_ready_recovers_missing_storage_without_marking_host_started(self) -> None:
+        host = {"key": "remote@mac", "host": "remote@mac", "label": "Remote Mac"}
+        missing = HostStatus(
+            key="remote@mac",
+            label="Remote Mac",
+            mode="ssh",
+            priority=50,
+            capabilities=["encode_queue"],
+            available=False,
+            message="Missing required paths",
+            missing_paths=["/Volumes/media/tv"],
+            missing_mounts=["/Volumes/media"],
+            platform="macos",
+        )
+        available = replace(missing, available=True, message="Mounted and ready", missing_paths=[])
+        mount_result = remote.HostSetupResult(
+            ok=True,
+            message="Connected shared storage on Remote Mac.",
+            performed_steps=["Connected media using the remote Finder Keychain."],
+        )
+
+        with patch(
+                "mediaforce.web.runtime.host_runtime.collect_host_statuses",
+                side_effect=[[missing], [available]],
+        ), patch(
+            "mediaforce.web.runtime.host_runtime.recover_remote_host_mounts",
+            return_value=mount_result,
+        ) as mount_mock, patch(
+            "mediaforce.web.runtime.host_runtime.run_host_lifecycle_command"
+        ) as lifecycle_mock:
+            started = web_app._ensure_encode_host_ready(self.config, host)
+
+        self.assertFalse(started)
+        mount_mock.assert_called_once_with(self.config, host, missing)
+        lifecycle_mock.assert_not_called()
+
+    def test_ensure_encode_host_ready_recovers_storage_after_host_wakes(self) -> None:
+        host = {
+            "key": "remote@mac",
+            "host": "remote@mac",
+            "label": "Remote Mac",
+            "start_command": "wake-remote-mac",
+            "start_timeout_seconds": 5,
+        }
+        sleeping = HostStatus(
+            key="remote@mac",
+            label="Remote Mac",
+            mode="ssh",
+            priority=50,
+            capabilities=["encode_queue"],
+            available=False,
+            message="SSH unavailable",
+            missing_paths=[],
+        )
+        missing = replace(
+            sleeping,
+            message="Shared storage disconnected",
+            missing_paths=["/Volumes/media/tv"],
+            missing_mounts=["/Volumes/media"],
+            platform="macos",
+        )
+        available = replace(missing, available=True, message="Mounted and ready", missing_paths=[], missing_mounts=[])
+        mount_result = remote.HostSetupResult(ok=True, message="Connected shared storage on Remote Mac.")
+
+        with patch(
+                "mediaforce.web.runtime.host_runtime.collect_host_statuses",
+                side_effect=[[sleeping], [missing], [available]],
+        ), patch(
+            "mediaforce.web.runtime.host_runtime.run_host_lifecycle_command",
+            return_value=subprocess.CompletedProcess(args=["sh"], returncode=0, stdout="", stderr=""),
+        ) as lifecycle_mock, patch(
+            "mediaforce.web.runtime.host_runtime.recover_remote_host_mounts",
+            return_value=mount_result,
+        ) as mount_mock, patch("mediaforce.web.runtime.host_runtime.time.sleep") as sleep_mock:
+            started = web_app._ensure_encode_host_ready(self.config, host)
+
+        self.assertTrue(started)
+        lifecycle_mock.assert_called_once()
+        mount_mock.assert_called_once_with(self.config, host, missing)
         sleep_mock.assert_not_called()
 
     def test_ensure_encode_host_ready_returns_false_when_host_already_available(self) -> None:
@@ -2907,8 +3080,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             message="Mounted and ready",
             missing_paths=[],
         )
-        with patch("mediaforce.web.app.collect_host_statuses", return_value=[available]), patch(
-                "mediaforce.web.app.run_host_lifecycle_command"
+        with patch("mediaforce.web.runtime.host_runtime.collect_host_statuses", return_value=[available]), patch(
+                "mediaforce.web.runtime.host_runtime.run_host_lifecycle_command"
         ) as lifecycle_mock:
             started = web_app._ensure_encode_host_ready(self.config, host)
         self.assertFalse(started)
@@ -6358,6 +6531,91 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             host = web_app._resolve_sample_host(self.config, "cbusillo@m1-mini")
         self.assertEqual(host.key, "cbusillo@m1-mini")
 
+    def test_sample_host_option_remains_selectable_when_storage_can_reconnect(self) -> None:
+        status = HostStatus(
+            key="cbusillo@m1-mini",
+            label="M1 mini",
+            mode="ssh",
+            priority=80,
+            capabilities=["sample_calibration"],
+            available=False,
+            message="Missing required paths",
+            missing_paths=["/Volumes/media/tv"],
+            missing_mounts=["/Volumes/media"],
+            platform="macos",
+        )
+
+        with patch("mediaforce.web.app.remote_mount_recovery_supported", return_value=True):
+            options = web_app._sample_host_options_from_statuses(self.config, [status])
+
+        self.assertTrue(options[0]["available"])
+        self.assertTrue(options[0]["storage_recovery_available"])
+        self.assertEqual(options[0]["detail"], "Storage will reconnect when the test starts.")
+
+    def test_default_sample_host_uses_storage_recoverable_host_when_none_are_ready(self) -> None:
+        host_config = {
+            "host": "cbusillo@m1-mini",
+            "label": "M1 mini",
+            "capabilities": ["sample_calibration"],
+        }
+        self.config.raw["remote_hosts"] = [host_config]
+        status = HostStatus(
+            key="cbusillo@m1-mini",
+            label="M1 mini",
+            mode="ssh",
+            priority=80,
+            capabilities=["sample_calibration"],
+            available=False,
+            message="Shared storage disconnected",
+            missing_paths=["/Volumes/media/tv"],
+            missing_mounts=["/Volumes/media"],
+            platform="macos",
+        )
+
+        with patch("mediaforce.web.app._safe_collect_host_statuses", return_value=[status]), patch(
+                "mediaforce.web.runtime.host_runtime.remote_mount_recovery_supported", return_value=True
+        ) as recovery_supported:
+            selected_key = web_app._default_sample_host_key(self.config)
+
+        self.assertEqual(selected_key, "cbusillo@m1-mini")
+        recovery_supported.assert_called_once_with(self.config, host_config, status)
+
+    def test_sample_host_choices_fall_back_past_offline_host_to_recoverable_host(self) -> None:
+        choices = [
+            {"key": "offline", "available": False},
+            {"key": "recoverable", "available": True, "storage_recovery_available": True},
+        ]
+
+        self.assertEqual(web_app._sample_host_key_from_choices("", choices), "recoverable")
+        self.assertEqual(web_app._sample_host_key_from_choices("explicit", choices), "explicit")
+
+    def test_resolve_sample_host_defers_storage_recovery_to_worker(self) -> None:
+        host_config = {
+            "host": "cbusillo@m1-mini",
+            "label": "M1 mini",
+            "capabilities": ["sample_calibration"],
+        }
+        self.config.raw["remote_hosts"] = [host_config]
+        missing = HostStatus(
+            key="cbusillo@m1-mini",
+            label="M1 mini",
+            mode="ssh",
+            priority=80,
+            capabilities=["sample_calibration"],
+            available=False,
+            message="Missing required paths",
+            missing_paths=["/Volumes/media/tv"],
+            missing_mounts=["/Volumes/media"],
+            platform="macos",
+        )
+        with patch("mediaforce.web.app._safe_collect_host_statuses", return_value=[missing]), patch(
+                "mediaforce.web.app.remote_mount_recovery_supported", return_value=True
+        ) as recovery_supported:
+            resolved = web_app._resolve_sample_host(self.config, "cbusillo@m1-mini")
+
+        self.assertEqual(resolved, missing)
+        recovery_supported.assert_called_once_with(self.config, host_config, missing)
+
     def test_resolve_sample_host_allows_closed_encode_schedule_for_manual_samples(self) -> None:
         config = replace(
             self.config,
@@ -7108,24 +7366,25 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertNotIn("for write_path in /srv/media/tv /srv/media/transcode", script)
         self.assertIn('mktemp "$path/.mediaforce-write-test.XXXXXX"', script)
 
-    def test_remote_host_status_keeps_missing_mounts_as_missing_paths(self) -> None:
+    def test_remote_host_status_tracks_disconnected_volume_separately_from_missing_paths(self) -> None:
         host: dict[str, object] = {
             "host": "cbusillo@encode-host",
             "label": "Encode Host",
             "capabilities": ["encode_queue"],
-            "source_roots": {"tv": "/srv/media/tv"},
-            "staging_root": "/srv/media/transcode",
+            "source_roots": {"tv": "/Volumes/My Share/tv"},
+            "staging_root": "/Volumes/My Share/transcode",
         }
         stdout = "\n".join(
             [
-                "path|/srv/media/tv|0",
-                "pathexists|/srv/media/tv|0",
-                "pathread|/srv/media/tv|0",
-                "pathwrite|/srv/media/tv|0",
-                "path|/srv/media/transcode|1",
-                "pathexists|/srv/media/transcode|1",
-                "pathread|/srv/media/transcode|1",
-                "pathwrite|/srv/media/transcode|1",
+                "mount|/Volumes/My Share|0",
+                "path|/Volumes/My Share/tv|0",
+                "pathexists|/Volumes/My Share/tv|0",
+                "pathread|/Volumes/My Share/tv|0",
+                "pathwrite|/Volumes/My Share/tv|0",
+                "path|/Volumes/My Share/transcode|1",
+                "pathexists|/Volumes/My Share/transcode|1",
+                "pathread|/Volumes/My Share/transcode|1",
+                "pathwrite|/Volumes/My Share/transcode|1",
                 "tool|xcode_clt|1",
                 "tool|brew|1",
                 "tool|ffmpeg|1",
@@ -7142,13 +7401,19 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         with patch(
                 "mediaforce.remote._run_remote_ssh",
                 return_value=subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout=stdout, stderr=""),
-        ), patch("mediaforce.remote._learn_remote_wake_mac"):
+        ) as run_remote_ssh_mock, patch("mediaforce.remote._learn_remote_wake_mac"):
             status = remote._remote_host_status(self.config, host)
 
         self.assertFalse(status.available)
-        self.assertEqual(status.message, "Missing required paths")
-        self.assertEqual(status.missing_paths, ["/srv/media/tv"])
+        self.assertEqual(status.message, "Shared storage disconnected")
+        self.assertEqual(status.missing_paths, ["/Volumes/My Share/tv"])
+        self.assertEqual(status.missing_mounts, ["/Volumes/My Share"])
         self.assertEqual(status.issues, [])
+        self.assertIn(
+            "mount_output_path='/Volumes/My\\040Share'",
+            run_remote_ssh_mock.call_args.kwargs["input_text"],
+        )
+        self.assertIn(' on $mount_path (', run_remote_ssh_mock.call_args.kwargs["input_text"])
 
     def test_remote_host_status_rejects_unwritable_staging_root(self) -> None:
         host: dict[str, object] = {
@@ -8012,7 +8277,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         key_install_mock.assert_called_once_with(host, "secret")
         self.assertEqual(status_mock.call_count, 2)
 
-    def test_prepare_remote_host_with_password_routes_missing_paths_to_finish_prepare(self) -> None:
+    def test_prepare_remote_host_with_password_recovers_missing_macos_mounts_then_rechecks(self) -> None:
         host = {"host": "cbusillo@sample-host", "label": "Sample Host"}
         self.config.raw["remote_hosts"] = [host]
         needs_paths = HostStatus(
@@ -8023,15 +8288,55 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             capabilities=["encode_queue"],
             available=False,
             message="Missing required paths",
-            missing_paths=["/srv/media/transcode"],
+            missing_paths=["/Volumes/media/transcode"],
+            missing_mounts=["/Volumes/media"],
             repo_path=None,
+            platform="macos",
+            setup_supported=True,
+        )
+        ready = replace(needs_paths, available=True, message="Mounted and ready", missing_paths=[])
+        mounted = remote.HostSetupResult(
+            ok=True,
+            message="Connected shared storage on Sample Host.",
+            performed_steps=["Connected media using the remote Finder Keychain."],
+        )
+        with patch("mediaforce.remote._remote_host_status", side_effect=[needs_paths, ready]), patch(
+                "mediaforce.remote.recover_remote_host_mounts", return_value=mounted) as mount_mock, patch(
+                "mediaforce.remote._finish_remote_host_prepare") as finish_mock:
+            result = remote.prepare_remote_host_with_password(self.config, "Sample Host", password=None)
+        self.assertTrue(result.ok)
+        self.assertEqual(result.performed_steps, ["Connected media using the remote Finder Keychain."])
+        mount_mock.assert_called_once_with(self.config, host, needs_paths)
+        finish_mock.assert_not_called()
+
+    def test_prepare_remote_host_with_password_creates_missing_child_paths_on_mounted_volume(self) -> None:
+        host = {"host": "cbusillo@sample-host", "label": "Sample Host"}
+        self.config.raw["remote_hosts"] = [host]
+        needs_path = HostStatus(
+            key="cbusillo@sample-host",
+            label="Sample Host",
+            mode="ssh",
+            priority=0,
+            capabilities=["encode_queue"],
+            available=False,
+            message="Missing required paths",
+            missing_paths=["/Volumes/media/transcode"],
+            missing_mounts=[],
+            repo_path=None,
+            platform="macos",
             setup_supported=True,
         )
         finished = remote.HostSetupResult(ok=True, message="Sample Host is mounted and ready.")
-        with patch("mediaforce.remote._remote_host_status", return_value=needs_paths), patch(
-                "mediaforce.remote._finish_remote_host_prepare", return_value=finished) as finish_mock:
+
+        with patch("mediaforce.remote._remote_host_status", return_value=needs_path), patch(
+                "mediaforce.remote.recover_remote_host_mounts"
+        ) as mount_mock, patch(
+            "mediaforce.remote._finish_remote_host_prepare", return_value=finished
+        ) as finish_mock:
             result = remote.prepare_remote_host_with_password(self.config, "Sample Host", password=None)
-        self.assertTrue(result.ok)
+
+        self.assertEqual(result, finished)
+        mount_mock.assert_not_called()
         finish_mock.assert_called_once_with(self.config, host, [])
 
     def test_request_remote_xcode_install_returns_missing_key_message_without_public_key(self) -> None:

--- a/tests/test_remote_mounts.py
+++ b/tests/test_remote_mounts.py
@@ -1,0 +1,228 @@
+import base64
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from mediaforce import remote
+from mediaforce.hosts.mount_runtime import ControllerSmbMount, RemoteSmbMount, _remote_mount_script, \
+    controller_smb_mounts_from_output, mount_remote_smb_shares, remote_smb_mounts_for_paths
+from mediaforce.remote import HostStatus
+
+
+class RemoteMountRuntimeTests(unittest.TestCase):
+    def test_controller_smb_mounts_parse_only_smb_volumes(self) -> None:
+        mounts = controller_smb_mounts_from_output(
+            "\n".join(
+                [
+                    "/dev/disk3s1 on / (apfs, local)",
+                    "//local@NAS.local/media on /Volumes/media (smbfs, nodev, nosuid)",
+                    "//local@NAS.local/My\\040Share on /Volumes/My\\040Share (smbfs, nodev)",
+                    "//local@NAS.local/Raw Share on /Volumes/Raw Share (smbfs, nodev)",
+                ]
+            )
+        )
+
+        self.assertEqual(
+            mounts,
+            [
+                ControllerSmbMount(source="//local@NAS.local/media", mount_point=Path("/Volumes/media")),
+                ControllerSmbMount(source="//local@NAS.local/My Share", mount_point=Path("/Volumes/My Share")),
+                ControllerSmbMount(source="//local@NAS.local/Raw Share", mount_point=Path("/Volumes/Raw Share")),
+            ],
+        )
+
+    def test_remote_mount_plan_deduplicates_paths_and_strips_source_password(self) -> None:
+        mounts = remote_smb_mounts_for_paths(
+            ["/Volumes/media/tv", "/Volumes/media/transcode"],
+            [ControllerSmbMount(source="//local:secret@NAS.local/media", mount_point=Path("/Volumes/media"))],
+            remote_user="remote user",
+        )
+
+        self.assertEqual(
+            mounts,
+            [
+                RemoteSmbMount(
+                    mount_point=Path("/Volumes/media"),
+                    share_name="media",
+                    url="smb://local@NAS.local/media",
+                )
+            ],
+        )
+
+    def test_remote_mount_plan_rejects_unmapped_or_non_finder_paths(self) -> None:
+        controller_mounts = [
+            ControllerSmbMount(source="//local@NAS.local/media", mount_point=Path("/Volumes/media"))
+        ]
+
+        self.assertIsNone(
+            remote_smb_mounts_for_paths(["/srv/media/tv"], controller_mounts, remote_user="remote")
+        )
+        self.assertIsNone(
+            remote_smb_mounts_for_paths(
+                ["/Volumes/media/../other/tv"],
+                controller_mounts,
+                remote_user="remote",
+            )
+        )
+
+    def test_remote_mount_plan_strips_percent_encoded_password(self) -> None:
+        mounts = remote_smb_mounts_for_paths(
+            ["/Volumes/media/tv"],
+            [ControllerSmbMount(source="//local%3Asecret@NAS.local/media", mount_point=Path("/Volumes/media"))],
+            remote_user="remote",
+        )
+
+        self.assertEqual(mounts, [RemoteSmbMount(Path("/Volumes/media"), "media", "smb://local@NAS.local/media")])
+
+    def test_remote_mount_script_hides_url_and_cleans_launchagent(self) -> None:
+        script = _remote_mount_script(
+            RemoteSmbMount(
+                mount_point=Path("/Volumes/media"),
+                share_name="media",
+                url='smb://remote@NAS.local/share%22%20&%20do%20shell%20script%20%22unsafe',
+            ),
+            token="a" * 32,
+            attempt_seconds=30,
+        )
+
+        self.assertNotIn("smb://", script)
+        self.assertIn("launchctl bootout", script)
+        self.assertIn("launchctl bootstrap", script)
+        self.assertIn("/dev/console", script)
+        self.assertIn("trap cleanup EXIT HUP INT TERM", script)
+        self.assertIn('osacompile -o "$script_path" "$source_path"', script)
+        payload_line = next(line for line in script.splitlines() if "base64 -D" in line and "source_path" in line)
+        encoded = payload_line.split("printf '%s' ", 1)[1].split(" |", 1)[0].strip("'")
+        applescript = base64.b64decode(encoded).decode()
+        self.assertIn("set share_url to item 1 of argv", applescript)
+        self.assertIn("mount volume share_url", applescript)
+        self.assertNotIn("smb://", applescript)
+        self.assertNotIn("unsafe", applescript)
+        runner_line = next(line for line in script.splitlines() if "base64 -D" in line and "runner_path" in line)
+        encoded_runner = runner_line.split("printf '%s' ", 1)[1].split(" |", 1)[0].strip("'")
+        runner = base64.b64decode(encoded_runner).decode()
+        self.assertIn('launchctl bootout "gui/$uid/$service_label"', runner)
+
+    def test_remote_mount_script_matches_mount_output_with_escaped_spaces(self) -> None:
+        script = _remote_mount_script(
+            RemoteSmbMount(
+                mount_point=Path("/Volumes/My Share"),
+                share_name="My Share",
+                url="smb://remote@NAS.local/My%20Share",
+            ),
+            token="e" * 32,
+            attempt_seconds=30,
+        )
+
+        self.assertIn("mount_output_path='/Volumes/My\\040Share'", script)
+        self.assertIn(' on $expected (smbfs,', script)
+        self.assertIn(' on $mount_output_path (smbfs,', script)
+
+    def test_mount_remote_smb_shares_returns_success_without_exposing_url(self) -> None:
+        run_remote_ssh = Mock(
+            return_value=subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="MEDIAFORCE_MOUNT=mounted\n", stderr="")
+        )
+        mount = RemoteSmbMount(
+            mount_point=Path("/Volumes/media"),
+            share_name="media",
+            url="smb://remote@NAS.local/media",
+        )
+
+        with patch("mediaforce.hosts.mount_runtime.uuid.uuid4", return_value=Mock(hex="b" * 32)):
+            result = mount_remote_smb_shares(
+                {"host": "remote@worker", "label": "Worker"},
+                [mount],
+                run_remote_ssh=run_remote_ssh,
+            )
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.message, "Connected shared storage on Worker.")
+        self.assertNotIn("smb://", run_remote_ssh.call_args.kwargs["input_text"])
+        self.assertEqual(result.performed_steps, ["Connected media using the remote Finder Keychain."])
+
+    def test_mount_remote_smb_shares_reports_missing_gui_session(self) -> None:
+        result = mount_remote_smb_shares(
+            {"host": "remote@worker", "label": "Worker"},
+            [RemoteSmbMount(Path("/Volumes/media"), "media", "smb://remote@NAS.local/media")],
+            run_remote_ssh=Mock(
+                return_value=subprocess.CompletedProcess(args=["ssh"], returncode=41, stdout="", stderr="")
+            ),
+        )
+
+        self.assertFalse(result.ok)
+        self.assertIn("signed-in macOS desktop session", result.message)
+        self.assertIn("Sign in to Worker as remote", result.detail or "")
+
+    def test_mount_remote_smb_shares_classifies_ssh_timeout_as_transport_failure(self) -> None:
+        result = mount_remote_smb_shares(
+            {"host": "remote@worker", "label": "Worker"},
+            [RemoteSmbMount(Path("/Volumes/media"), "media", "smb://remote@NAS.local/media")],
+            run_remote_ssh=Mock(side_effect=subprocess.TimeoutExpired(cmd=["ssh"], timeout=45)),
+        )
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.failure_kind, "ssh_transport")
+        self.assertIn("SSH request timed out", result.detail or "")
+
+    def test_mount_remote_smb_shares_reports_finder_keychain_recovery(self) -> None:
+        result = mount_remote_smb_shares(
+            {"host": "remote@worker", "label": "Worker"},
+            [RemoteSmbMount(Path("/Volumes/media"), "media", "smb://remote@NAS.local/media")],
+            run_remote_ssh=Mock(
+                return_value=subprocess.CompletedProcess(args=["ssh"], returncode=42, stdout="", stderr="")
+            ),
+        )
+
+        self.assertFalse(result.ok)
+        self.assertIn("could not connect the media share with Finder", result.message)
+        self.assertIn("save the password to Keychain", result.detail or "")
+
+    def test_remote_mount_recovery_support_requires_clean_remote_macos_status(self) -> None:
+        host = {"host": "remote@worker", "label": "Worker", "media_access": "mounted"}
+        status = HostStatus(
+            key="remote@worker",
+            label="Worker",
+            mode="ssh",
+            priority=0,
+            capabilities=["encode_queue"],
+            available=False,
+            message="Missing required paths",
+            missing_paths=["/Volumes/media/tv"],
+            missing_mounts=["/Volumes/media"],
+            platform="macos",
+        )
+        mount_output = "//local@NAS.local/media on /Volumes/media (smbfs, nodev)\n"
+
+        with patch("mediaforce.remote._controller_smb_mount_output", return_value=mount_output):
+            self.assertTrue(remote.remote_mount_recovery_supported(Mock(), host, status))
+            status.missing_paths.append("/srv/transcode")
+            self.assertFalse(remote.remote_mount_recovery_supported(Mock(), host, status))
+            status.missing_paths.pop()
+            status.issues.append("ffmpeg is missing")
+            self.assertFalse(remote.remote_mount_recovery_supported(Mock(), host, status))
+
+    def test_remote_mount_recovery_reports_controller_storage_when_mapping_disappears(self) -> None:
+        host = {"host": "remote@worker", "label": "Worker", "media_access": "mounted"}
+        status = HostStatus(
+            key="remote@worker",
+            label="Worker",
+            mode="ssh",
+            priority=0,
+            capabilities=["encode_queue"],
+            available=False,
+            message="Shared storage disconnected",
+            missing_paths=["/Volumes/media/tv"],
+            missing_mounts=["/Volumes/media"],
+            platform="macos",
+        )
+
+        with patch("mediaforce.remote._controller_smb_mount_output", return_value=""):
+            result = remote.recover_remote_host_mounts(Mock(), host, status)
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.failure_kind, "controller_storage_unavailable")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -10,7 +10,7 @@ import time
 import unittest
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from fastapi.routing import APIRoute
 from sqlalchemy import func
@@ -50,7 +50,7 @@ from mediaforce.core.evidence import stable_policy_hash
 from mediaforce.core.process_control import ProcessCancelledError
 from mediaforce.core.type_defs import object_dict
 from mediaforce.execution import resolve_stream_budget_ledger
-from mediaforce.hosts.types import HostStatus
+from mediaforce.hosts.types import HostReadinessError, HostStatus
 from mediaforce.tuning.tuning_memory import (
     promote_learning_artifact,
     record_tuning_session,
@@ -298,6 +298,19 @@ def _fake_operator_note_parse(
         "crop": crop,
         "reasoning_note": "test parser",
     }
+
+
+def _ready_calibration_host(host_data: dict[str, Any]) -> HostStatus:
+    return HostStatus(
+        key=str(host_data.get("key") or host_data.get("host") or "local"),
+        label=str(host_data.get("label") or "Test host"),
+        mode="ssh",
+        priority=0,
+        capabilities=["sample_calibration"],
+        available=True,
+        message="Mounted and ready",
+        missing_paths=[],
+    )
 
 
 class TuningRuntimeTests(unittest.TestCase):
@@ -7820,8 +7833,65 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIsNotNone(job)
         self.assertEqual(job["job_id"], "target-failed")
 
+    def test_run_calibration_job_records_storage_recovery_failure_before_sampling(self) -> None:
+        saved_payloads: list[dict[str, object]] = []
+        sample_item = Mock()
+
+        deps = CalibrationRunDeps(
+            now_iso=lambda: "2026-04-11T00:00:00+00:00",
+            ensure_sample_host_ready=Mock(
+                side_effect=HostReadinessError(
+                    "M2 MBP could not connect the media share with Finder.",
+                    failure_kind="host_configuration",
+                )
+            ),
+            load_job_state=lambda *_args, **_kwargs: {"job_id": "job-1", "status": "queued"},
+            sample_item=sample_item,
+            save_job_state=lambda _connection, _config, _prefix, payload: saved_payloads.append(dict(payload)),
+            save_calibration_state=lambda *_args, **_kwargs: None,
+            record_run_verdict=lambda *_args, **_kwargs: None,
+            summarize_calibration_result=lambda payload: payload,
+            calibration_mode_for_action=lambda _action: "sample",
+            effective_video_preset=lambda *_args, **_kwargs: 4,
+            search_quality_for_source=lambda *_args, **_kwargs: None,
+            run_sample_encode=lambda *_args, **_kwargs: None,
+            detect_video_crop=lambda *_args, **_kwargs: None,
+            recommend_review_timestamps=lambda *_args, **_kwargs: [],
+            encode_preview_clips=lambda *_args, **_kwargs: [],
+            render_source_review_clips=lambda *_args, **_kwargs: [],
+            generate_compare_clips_from_previews=lambda *_args, **_kwargs: [],
+            resolve_stream_budget_ledger=resolve_stream_budget_ledger,
+            build_svt_params=lambda *_args, **_kwargs: {},
+            review_url=lambda *_args, **_kwargs: "",
+            encode_manifest_items=lambda *_args, **_kwargs: None,
+            validate_manifest_items=lambda *_args, **_kwargs: None,
+            generate_compare_clips=lambda *_args, **_kwargs: [],
+            staged_artifact_columns=("library_item_id",),
+        )
+
+        with patch("mediaforce.web.runtime.calibration_runtime.load_config", return_value=self.config), patch(
+                "mediaforce.web.runtime.calibration_runtime.purge_transient_artifacts"
+        ):
+            run_calibration_job(
+                config_path=self.config.paths.config_path,
+                prefix="tv/show/season-1",
+                action="ai_tune",
+                host_data={"key": "cbusillo@chris-mbp", "label": "M2 MBP"},
+                notes="retry later",
+                policy={"video": {}},
+                job_id="job-1",
+                seed_metadata=None,
+                process_controller=type("Controller", (), {"throw_if_cancelled": lambda _self: None})(),
+                deps=deps,
+            )
+
+        failed = next(payload for payload in saved_payloads if payload.get("status") == "failed")
+        self.assertIn("could not connect the media share with Finder", str(failed.get("error") or ""))
+        sample_item.assert_not_called()
+
     def test_run_calibration_job_marks_cancelled_run_stopped(self) -> None:
         saved_statuses: list[str] = []
+        readiness = Mock(side_effect=lambda _config, host_data: _ready_calibration_host(host_data))
 
         def _save_job_state(_connection: object, _config: object, _prefix: str, payload: dict[str, object]) -> None:
             status = payload.get("status")
@@ -7829,6 +7899,7 @@ class TuningRuntimeTests(unittest.TestCase):
 
         deps = CalibrationRunDeps(
             now_iso=lambda: "2026-04-11T00:00:00+00:00",
+            ensure_sample_host_ready=readiness,
             load_job_state=lambda *_args, **_kwargs: {"job_id": "job-1", "status": "queued"},
             sample_item=lambda *_args, **_kwargs: {
                 "rel_path": "tv/show/season-1/episode.mkv",
@@ -7881,6 +7952,10 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIn("running", saved_statuses)
         self.assertIn("stopped", saved_statuses)
         self.assertNotIn("failed", saved_statuses)
+        readiness.assert_called_once_with(
+            self.config,
+            {"key": "cbusillo@localhost", "label": "M4 Studio"},
+        )
 
     def test_run_calibration_job_preserves_failed_target_search_evidence(self) -> None:
         saved_payloads: list[dict[str, object]] = []
@@ -7899,6 +7974,7 @@ class TuningRuntimeTests(unittest.TestCase):
 
         deps = CalibrationRunDeps(
             now_iso=lambda: "2026-04-11T00:00:00+00:00",
+            ensure_sample_host_ready=lambda _config, host_data: _ready_calibration_host(host_data),
             load_job_state=lambda *_args, **_kwargs: {"job_id": "job-1", "status": "queued"},
             sample_item=lambda *_args, **_kwargs: {
                 "rel_path": "tv/show/season-1/episode.mkv",
@@ -7990,6 +8066,7 @@ class TuningRuntimeTests(unittest.TestCase):
 
         deps = CalibrationRunDeps(
             now_iso=lambda: "2026-04-11T00:00:00+00:00",
+            ensure_sample_host_ready=lambda _config, host_data: _ready_calibration_host(host_data),
             load_job_state=lambda *_args, **_kwargs: {"job_id": "job-1", "status": "queued", "sample_item": dict(saved_sample_item)},
             sample_item=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not reselect sample item")),
             save_job_state=_save_job_state,


### PR DESCRIPTION
## Summary
- distinguish disconnected `/Volumes` mounts from ordinary missing child paths
- reconnect matching SMB shares over SSH through a transient per-user LaunchAgent, using Finder and the remote login Keychain without reading or transporting passwords
- recover storage during Prepare, sampled calibration, and encode dispatch, including wake-then-mount hosts and bounded retry/failover behavior
- show recoverable workers as reconnecting capacity instead of unavailable
- provide host/account/share-specific recovery guidance when the GUI session or Keychain credential is unavailable

## Safety
- maps only SMB volumes already mounted at the same `/Volumes/...` root on the controller
- strips source passwords, passes the SMB URL as an AppleScript argument, uses randomized service labels and private temporary directories, and self-cleans the LaunchAgent, lock, scripts, and logs
- never mounts during ordinary status polling

## Validation
- `bash scripts/pre-commit-check.sh` — 801 backend tests, CLI smoke, frontend check/lint, 188 frontend tests, production build, desktop and narrow route smoke
- PyCharm changed-files inspection — green, 0 findings
- independent security, architecture, and coverage reviews completed and reconciled
- live M2 MBP proof: disconnected `/Volumes/media`, remounted through this implementation with the saved Finder Keychain credential, verified readable, and confirmed no temporary files, locks, or LaunchAgent service remained
- manual browser review of Activity and Folder Studio at desktop and narrow widths

Closes #166