### PR TITLE
Request external GUIDs from Plex show inventory

### DIFF
--- a/mediaforce/library/external_metadata.py
+++ b/mediaforce/library/external_metadata.py
@@ -146,7 +146,7 @@ class PlexClient:
                     )
 
     def shows(self) -> Iterator[PlexShow]:
-        for metadata in self._metadata(2):
+        for metadata in self._metadata(2, include_guids=True):
             rating_key = str(metadata.get("ratingKey") or "").strip()
             if not rating_key:
                 raise ProviderHttpError("Plex show metadata did not include ratingKey")
@@ -162,13 +162,16 @@ class PlexClient:
             }))
             yield PlexShow(rating_key=rating_key, guids=guids)
 
-    def _metadata(self, metadata_type: int) -> Iterator[JSONPayload]:
+    def _metadata(self, metadata_type: int, *, include_guids: bool = False) -> Iterator[JSONPayload]:
         page_size = 500
         offset = 0
         while True:
+            query: dict[str, object] = {"type": metadata_type, "includeElements": "Guid,Media"}
+            if include_guids:
+                query["includeGuids"] = 1
             payload, response_headers = self._get(
                 "library/all",
-                query={"type": metadata_type, "includeElements": "Guid,Media"},
+                query=query,
                 headers={
                     "X-Plex-Container-Start": str(offset),
                     "X-Plex-Container-Size": str(page_size),

--- a/tests/test_external_metadata.py
+++ b/tests/test_external_metadata.py
@@ -57,10 +57,14 @@ class ExternalMetadataTests(unittest.TestCase):
         def fake_fetch(url: str, headers, _timeout: float):
             requests.append((url, dict(headers)))
             if "type=2" in url:
+                query = parse_qs(urlsplit(url).query)
                 return {
                     "MediaContainer": {
                         "totalSize": 1,
-                        "Metadata": [{"ratingKey": "show-1", "Guid": [{"id": "tmdb://42"}]}],
+                        "Metadata": [{
+                            "ratingKey": "show-1",
+                            "Guid": ([{"id": "tmdb://42"}] if query.get("includeGuids") == ["1"] else []),
+                        }],
                     }
                 }, {}
             if "type=4" in url:
@@ -99,6 +103,7 @@ class ExternalMetadataTests(unittest.TestCase):
         self.assertEqual(show.guids, ("tmdb://42",))
         self.assertEqual(item.season_index, 0)
         self.assertEqual(series.status, "Returning Series")
+        self.assertEqual(parse_qs(urlsplit(requests[0][0]).query).get("includeGuids"), ["1"])
         self.assertEqual(requests[0][1]["X-Plex-Token"], "plex-secret")
         self.assertEqual(requests[-1][1]["Authorization"], "Bearer tmdb-secret")
         self.assertTrue(all("secret" not in url for url, _ in requests))

--- a/tests/test_external_metadata.py
+++ b/tests/test_external_metadata.py
@@ -67,6 +67,17 @@ class ExternalMetadataTests(unittest.TestCase):
                         }],
                     }
                 }, {}
+            if "type=1" in url:
+                return {
+                    "MediaContainer": {
+                        "totalSize": 1,
+                        "Metadata": [{
+                            "ratingKey": "movie-1",
+                            "addedAt": 1_700_000_000,
+                            "Media": [{"Part": [{"id": "part-1", "file": "/plex/movies/Movie.mkv"}]}],
+                        }],
+                    }
+                }, {}
             if "type=4" in url:
                 return {
                     "MediaContainer": {
@@ -97,13 +108,19 @@ class ExternalMetadataTests(unittest.TestCase):
         )
 
         show = list(plex.shows())[0]
+        movie = list(plex.items(1))[0]
         item = list(plex.items(4))[0]
         series = tmdb.series(42)
 
         self.assertEqual(show.guids, ("tmdb://42",))
+        self.assertEqual(movie.part_path, "/plex/movies/Movie.mkv")
         self.assertEqual(item.season_index, 0)
         self.assertEqual(series.status, "Returning Series")
-        self.assertEqual(parse_qs(urlsplit(requests[0][0]).query).get("includeGuids"), ["1"])
+        plex_queries = [parse_qs(urlsplit(url).query) for url, _headers in requests if url.startswith("http://plex")]
+        self.assertEqual([query.get("type") for query in plex_queries], [["2"], ["1"], ["4"]])
+        self.assertEqual(plex_queries[0].get("includeGuids"), ["1"])
+        self.assertNotIn("includeGuids", plex_queries[1])
+        self.assertNotIn("includeGuids", plex_queries[2])
         self.assertEqual(requests[0][1]["X-Plex-Token"], "plex-secret")
         self.assertEqual(requests[-1][1]["Authorization"], "Bearer tmdb-secret")
         self.assertTrue(all("secret" not in url for url, _ in requests))


### PR DESCRIPTION
## Summary

- request `includeGuids=1` only for Plex show inventory pages
- preserve existing movie/episode payload size, pagination, and malformed-response handling
- add a regression test that models modern Plex returning external GUIDs only when explicitly requested

## Live Verification

- configured the documented direct Plex endpoint and exact `movies`/`tv` path mappings in local Mediaforce runtime settings
- installed the existing Plex owner token through the gitignored local environment file without exposing it
- matched 10,411 local catalog items and populated Plex age for 492 movie items and 9,919 TV items
- corrected refresh populated TMDB IDs for all 189 matched series; TMDB status refresh remains pending a separately owned TMDB API credential

## Validation

- focused metadata tests: 10 passed
- `bash scripts/pre-commit-check.sh`
  - 833 backend tests
  - frontend checks, lint, 188 tests, and build
  - desktop, narrow, and empty-library route smoke
- PyCharm changed-files inspection: clean
- independent focused review: PASS
