### PR TITLE
Add typed media scopes and exact-file actions

### DIFF
--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -160,6 +160,9 @@ Guidance:
   - ffprobe-based media inspection and audio, subtitle, attachment track summaries
 - `scanner.py`
   - library scan orchestration and catalog updates
+- `media_scopes.py`
+  - canonical operator grouping for TV, movie, and generic media roots
+  - exact-item versus descendant matching, SQL-safe boundaries, and API scope payloads
 - `folder_profiles.py`
   - folder inspection and suggested override shaping
 - `run_manifests.py`
@@ -173,6 +176,12 @@ Guidance:
 - Keep scan, probe, planning, and manifest orchestration logic under
   `mediaforce/library/` instead of spreading it back across the top-level
   package.
+- Resolve operator paths through `MediaScope` before selecting items, loading
+  staged artifacts, or comparing queue jobs. File scopes match one exact
+  `rel_path`; folder scopes match case-sensitive, `/`-bounded descendants.
+- TV item grouping remains series/season oriented, while an explicitly
+  requested nested TV path retains its own bounded folder scope instead of
+  widening to the season.
 
 ### `mediaforce/tuning/`
 

--- a/frontend/src/lib/api/placeholders.ts
+++ b/frontend/src/lib/api/placeholders.ts
@@ -5,6 +5,7 @@ import type {
 	FolderPayload,
 	FolderStatusPayload,
 	HostsPayload,
+	MediaScopePayload,
 	QueueLane
 } from './types';
 
@@ -48,9 +49,25 @@ export const initialFoldersPayload: DashboardFoldersPayload = {
 
 export const initialHosts: HostsPayload = { compact: true, hosts: [] };
 
+function loadingMediaScope(prefix: string): MediaScopePayload {
+	return {
+		schema_version: 1,
+		prefix,
+		root: prefix.split('/')[0] ?? '',
+		domain: 'other',
+		kind: 'media_folder',
+		match: 'descendants',
+		title: prefix.split('/').at(-1) || 'Library',
+		subtitle: 'Library',
+		scope_label: 'Folder',
+		parent: null
+	};
+}
+
 export function initialFolderPayload(prefix: string): FolderPayload {
 	return {
 		prefix,
+		media_scope: loadingMediaScope(prefix),
 		pending: true,
 		metric_support: { vmaf: false, xpsnr: false, ssim: false },
 		metric_status_copy: 'loading',
@@ -78,6 +95,7 @@ export function initialFolderPayload(prefix: string): FolderPayload {
 export function initialFolderStatusPayload(prefix: string): FolderStatusPayload {
 	return {
 		prefix,
+		media_scope: loadingMediaScope(prefix),
 		polling_active: false,
 		calibration_status: 'loading',
 		folder_scan_status: 'loading',

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -86,6 +86,30 @@ export interface LifecycleState {
 	seasons: SeasonLifecycleState[];
 }
 
+export type MediaScopeDomain = 'tv' | 'movie' | 'other';
+export type MediaScopeKind =
+	| 'library_root'
+	| 'tv_series'
+	| 'tv_season'
+	| 'movie_title'
+	| 'movie_file'
+	| 'media_folder'
+	| 'media_file';
+export type MediaScopeMatch = 'exact_item' | 'descendants';
+
+export interface MediaScopePayload {
+	schema_version: number;
+	prefix: string;
+	root: string;
+	domain: MediaScopeDomain;
+	kind: MediaScopeKind;
+	match: MediaScopeMatch;
+	title: string;
+	subtitle: string;
+	scope_label: string;
+	parent?: { prefix: string; title: string } | null;
+}
+
 export interface FolderCard {
 	prefix: string;
 	title: string;
@@ -106,6 +130,7 @@ export interface FolderCard {
 	review_badge_detail?: string | null;
 	workflow_state?: FolderWorkflowState | null;
 	lifecycle?: LifecycleState | null;
+	media_scope?: MediaScopePayload | null;
 	details_loading: boolean;
 }
 
@@ -764,6 +789,7 @@ export interface QualityRiskPayload {
 
 export interface FolderPayload {
 	prefix: string;
+	media_scope: MediaScopePayload;
 	pending: boolean;
 	summary?: FolderSummary;
 	sample_item?: Record<string, unknown>;
@@ -816,6 +842,7 @@ export interface FolderBenchConfirmResponse {
 
 export interface FolderStatusPayload {
 	prefix: string;
+	media_scope: MediaScopePayload;
 	polling_active: boolean;
 	calibration_status: string;
 	folder_scan_status: string;

--- a/frontend/src/lib/components/workstation/folder-studio-view.test.ts
+++ b/frontend/src/lib/components/workstation/folder-studio-view.test.ts
@@ -39,6 +39,18 @@ import type { FolderCalibrationState, PendingSampleProposal } from '$lib/folders
 function folderPayload(overrides: Partial<FolderPayload> = {}): FolderPayload {
 	return {
 		prefix: 'tv/Example/Season 1',
+		media_scope: {
+			schema_version: 1,
+			prefix: 'tv/Example/Season 1',
+			root: 'tv',
+			domain: 'tv',
+			kind: 'tv_season',
+			match: 'descendants',
+			title: 'Example · Season 1',
+			subtitle: 'Example',
+			scope_label: 'Season',
+			parent: { prefix: 'tv/Example', title: 'Example' }
+		},
 		pending: true,
 		summary: {
 			prefix: 'tv/Example/Season 1',
@@ -59,6 +71,18 @@ function folderPayload(overrides: Partial<FolderPayload> = {}): FolderPayload {
 function folderStatusPayload(overrides: Partial<FolderStatusPayload> = {}): FolderStatusPayload {
 	return {
 		prefix: 'tv/Example/Season 1',
+		media_scope: {
+			schema_version: 1,
+			prefix: 'tv/Example/Season 1',
+			root: 'tv',
+			domain: 'tv',
+			kind: 'tv_season',
+			match: 'descendants',
+			title: 'Example · Season 1',
+			subtitle: 'Example',
+			scope_label: 'Season',
+			parent: { prefix: 'tv/Example', title: 'Example' }
+		},
 		polling_active: false,
 		calibration_status: 'idle',
 		folder_scan_status: 'idle',

--- a/frontend/src/lib/season/experience.test.ts
+++ b/frontend/src/lib/season/experience.test.ts
@@ -92,6 +92,18 @@ const dashboard = {
 
 const status = {
 	prefix: card.prefix,
+	media_scope: {
+		schema_version: 1,
+		prefix: card.prefix,
+		root: 'tv',
+		domain: 'tv',
+		kind: 'tv_season',
+		match: 'descendants',
+		title: card.title,
+		subtitle: card.subtitle,
+		scope_label: card.scope_label,
+		parent: { prefix: 'tv/Big Brother (US)', title: 'Big Brother (US)' }
+	},
 	polling_active: false,
 	calibration_status: 'idle',
 	folder_scan_status: 'idle',
@@ -102,6 +114,7 @@ const status = {
 function folder(overrides: Partial<FolderPayload> = {}): FolderPayload {
 	return {
 		prefix: card.prefix,
+		media_scope: status.media_scope,
 		pending: false,
 		metric_support: dashboard.metric_support,
 		metric_status_copy: '',

--- a/mediaforce/encoding/encode_queue.py
+++ b/mediaforce/encoding/encode_queue.py
@@ -3,11 +3,9 @@ from typing import Any
 
 from sqlalchemy import delete
 from sqlalchemy import func
-from sqlalchemy import literal
 from sqlalchemy import literal_column
 from sqlalchemy import or_
 from sqlalchemy import select
-from sqlalchemy import true
 from sqlalchemy import update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
@@ -16,6 +14,7 @@ from mediaforce.core.db import DBRow
 from mediaforce.core.db_tables import encode_jobs
 from mediaforce.core.db_tables import encode_queue_state
 from mediaforce.core.type_defs import int_value
+from mediaforce.library.media_scopes import MediaScope, resolve_media_scope, scope_prefix_overlap_filter
 
 DEFAULT_QUEUE_NAME = "heavy"
 DEFAULT_SCHEDULER_POLICY = {
@@ -215,10 +214,10 @@ def load_encode_job(connection: DBClient, job_id: str) -> dict[str, Any] | None:
 
 
 def load_latest_encode_job(connection: DBClient, prefix: str) -> dict[str, Any] | None:
-    normalized_prefix = _normalize_prefix(prefix)
+    scope = resolve_media_scope(connection, prefix)
     row = connection.execute(
         _encode_job_select()
-        .where(_prefix_overlap_filter(normalized_prefix))
+        .where(_prefix_overlap_filter(scope))
         .where(encode_jobs.c.job_kind.in_(DISPLAY_ENCODE_JOB_KINDS))
         .order_by(encode_jobs.c.created_at.desc(), _rowid_column().desc())
         .limit(1)
@@ -227,10 +226,10 @@ def load_latest_encode_job(connection: DBClient, prefix: str) -> dict[str, Any] 
 
 
 def load_active_encode_job_for_prefix(connection: DBClient, prefix: str) -> dict[str, Any] | None:
-    normalized_prefix = _normalize_prefix(prefix)
+    scope = resolve_media_scope(connection, prefix)
     row = connection.execute(
         _encode_job_select()
-        .where(_prefix_overlap_filter(normalized_prefix))
+        .where(_prefix_overlap_filter(scope))
         .where(encode_jobs.c.job_kind.in_(DISPLAY_ENCODE_JOB_KINDS))
         .where(encode_jobs.c.status.in_(ACTIVE_ENCODE_JOB_STATUSES))
         .order_by(encode_jobs.c.created_at.desc(), _rowid_column().desc())
@@ -239,27 +238,8 @@ def load_active_encode_job_for_prefix(connection: DBClient, prefix: str) -> dict
     return _hydrate_job(row) if row is not None else None
 
 
-def _normalize_prefix(prefix: str) -> str:
-    return prefix.strip().strip("/")
-
-
-def _prefix_overlap_filter(prefix: str) -> Any:
-    if not prefix:
-        return true()
-    return or_(
-        encode_jobs.c.prefix == prefix,
-        encode_jobs.c.prefix.like(f"{_sql_like_escape(prefix)}/%", escape="\\"),
-        literal(prefix).like(_escaped_prefix_column(encode_jobs.c.prefix) + "/%", escape="\\"),
-    )
-
-
-def _escaped_prefix_column(column: Any) -> Any:
-    return func.replace(func.replace(func.replace(column, "\\", "\\\\"), "%", "\\%"), "_", "\\_")
-
-
-def _sql_like_escape(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
+def _prefix_overlap_filter(scope: MediaScope) -> Any:
+    return scope_prefix_overlap_filter(encode_jobs.c.prefix, scope)
 
 def clear_terminal_encode_jobs_for_prefix(connection: DBClient, prefix: str) -> None:
     connection.execute(

--- a/mediaforce/library/candidate_selection.py
+++ b/mediaforce/library/candidate_selection.py
@@ -11,6 +11,8 @@ from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items, plex_item_metadata, series_metadata, staged_artifacts
 from mediaforce.core.type_defs import object_dict
+from mediaforce.library.media_scopes import is_tv_season_prefix, normalize_scope_prefix, path_matches_scope, \
+    resolve_media_scopes
 from mediaforce.library.workflow_state import ENCODE_CANDIDATE_STATUSES, derive_item_workflow_state
 
 LifecycleMode = Literal["auto", "on", "off"]
@@ -152,15 +154,15 @@ def project_candidates(
         season_prefix: _newest_age_evidence(_media_age(row) for row in grouped_rows)
         for season_prefix, grouped_rows in season_rows.items()
     }
-    normalized_prefixes = [prefix.strip().strip("/") for prefix in prefixes or []]
-    normalized_override = str(manual_override_prefix or "").strip().strip("/")
+    resolved_scopes = resolve_media_scopes(connection, prefixes or [])
+    normalized_override = normalize_scope_prefix(manual_override_prefix or "")
     decisions: list[CandidateDecision] = []
 
     for row in rows:
         if statuses is not None and str(row["status"] or "") not in statuses:
             continue
         rel_path = str(row["rel_path"] or "")
-        if normalized_prefixes and not any(_path_matches_prefix(rel_path, prefix) for prefix in normalized_prefixes):
+        if resolved_scopes and not any(scope.includes(rel_path) for scope in resolved_scopes):
             continue
         workflow_lane = derive_item_workflow_state(row).lane
         season = season_by_item[int(row["item_id"])]
@@ -285,7 +287,7 @@ def scope_lifecycle_payload_from_decisions(
     decisions = [
         decision
         for decision in decisions
-        if _path_matches_prefix(str(decision.row["rel_path"] or ""), normalized_prefix)
+        if path_matches_scope(str(decision.row["rel_path"] or ""), normalized_prefix)
     ]
     if not decisions:
         return {
@@ -582,14 +584,8 @@ def _lifecycle_mode(value: object) -> LifecycleMode:
     return "auto"
 
 
-def _path_matches_prefix(path: str, prefix: str) -> bool:
-    normalized_path = path.strip().strip("/")
-    return not prefix or normalized_path == prefix or normalized_path.startswith(f"{prefix}/")
-
-
 def _is_season_prefix(prefix: str) -> bool:
-    parts = Path(prefix).parts
-    return len(parts) == 3 and parts[0].lower() == "tv"
+    return is_tv_season_prefix(prefix)
 
 
 def _latest_timestamp(values: Any) -> datetime | None:

--- a/mediaforce/library/folder_profiles.py
+++ b/mediaforce/library/folder_profiles.py
@@ -4,21 +4,21 @@ from pathlib import Path
 from typing import Any
 
 from sqlalchemy import select
-from sqlalchemy import or_
-from sqlalchemy import true
 
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.type_defs import mapping_dict
+from mediaforce.library.media_scopes import resolve_media_scope, scope_rel_path_filter
 
 
 def inspect_prefix(connection: DBClient, config: MediaforceConfig, prefix: str) -> dict[str, Any]:
+    scope = resolve_media_scope(connection, prefix)
     rows = [
         mapping_dict(row)
         for row in connection.execute(
             select(library_items)
-            .where(_prefix_filter(prefix))
+            .where(scope_rel_path_filter(library_items.c.rel_path, scope))
             .order_by(library_items.c.rel_path)
         ).mappings().fetchall()
     ]
@@ -54,21 +54,6 @@ def inspect_prefix(connection: DBClient, config: MediaforceConfig, prefix: str) 
         "resolved_policy": policy,
         "suggested_override": recommendation,
     }
-
-
-def _prefix_filter(prefix: str) -> Any:
-    normalized_prefix = prefix.strip().strip("/")
-    if not normalized_prefix:
-        return true()
-    return or_(
-        library_items.c.rel_path == normalized_prefix,
-        library_items.c.rel_path.like(f"{_sql_like_escape(normalized_prefix)}/%", escape="\\"),
-    )
-
-
-def _sql_like_escape(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
 
 def recommend_folder_profile(prefix: str, rows: list[dict[str, Any]], resolved_policy: dict[str, Any]) -> dict[
     str, Any]:

--- a/mediaforce/library/media_scopes.py
+++ b/mediaforce/library/media_scopes.py
@@ -1,0 +1,334 @@
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Literal
+
+from sqlalchemy import and_, exists, literal, or_, select, true, union_all
+
+from mediaforce.core.db import DBClient
+from mediaforce.core.db_tables import library_items
+
+ScopeDomain = Literal["tv", "movie", "other"]
+ScopeKind = Literal[
+    "library_root",
+    "tv_series",
+    "tv_season",
+    "movie_title",
+    "movie_file",
+    "media_folder",
+    "media_file",
+]
+ScopeMatch = Literal["exact_item", "descendants"]
+ScopeGroup = tuple[str, str, str, str]
+
+
+class MediaScopeConflict(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class MediaScope:
+    prefix: str
+    root: str
+    domain: ScopeDomain
+    kind: ScopeKind
+    match: ScopeMatch
+    title: str
+    subtitle: str
+    scope_label: str
+    parent_prefix: str | None = None
+    parent_title: str | None = None
+
+    def includes(self, rel_path: str) -> bool:
+        return path_matches_scope(rel_path, self)
+
+    def group_tuple(self) -> ScopeGroup:
+        return self.prefix, self.title, self.subtitle, self.scope_label
+
+    def to_payload(self) -> dict[str, object]:
+        parent = None
+        if self.parent_prefix is not None:
+            parent = {
+                "prefix": self.parent_prefix,
+                "title": self.parent_title or self.parent_prefix,
+            }
+        return {
+            "schema_version": 1,
+            "prefix": self.prefix,
+            "root": self.root,
+            "domain": self.domain,
+            "kind": self.kind,
+            "match": self.match,
+            "title": self.title,
+            "subtitle": self.subtitle,
+            "scope_label": self.scope_label,
+            "parent": parent,
+        }
+
+
+def normalize_scope_prefix(prefix: str) -> str:
+    return str(prefix or "").strip().strip("/")
+
+
+def media_group_scope_for_rel_path(rel_path: str) -> MediaScope | None:
+    normalized = normalize_scope_prefix(rel_path)
+    parts = PurePosixPath(normalized).parts
+    if len(parts) < 2:
+        return None
+    if parts[0].lower() == "tv" and len(parts) >= 4:
+        return media_scope_from_prefix("/".join(parts[:3]), match="descendants")
+    if parts[0].lower() == "tv" and len(parts) == 3:
+        return media_scope_from_prefix(normalized, match="exact_item")
+    if len(parts) == 2:
+        return media_scope_from_prefix(normalized, match="exact_item")
+    return media_scope_from_prefix("/".join(parts[:2]), match="descendants")
+
+
+def tv_series_scope_for_rel_path(rel_path: str) -> MediaScope | None:
+    normalized = normalize_scope_prefix(rel_path)
+    parts = PurePosixPath(normalized).parts
+    if len(parts) < 3 or parts[0].lower() != "tv":
+        return None
+    return media_scope_from_prefix("/".join(parts[:2]), match="descendants")
+
+
+def media_scope_from_prefix(prefix: str, *, match: ScopeMatch) -> MediaScope:
+    normalized = normalize_scope_prefix(prefix)
+    parts = PurePosixPath(normalized).parts
+    root = parts[0] if parts else ""
+    domain = _scope_domain(root)
+    root_title = _root_title(root)
+    title = root_title if root else "Library"
+    subtitle = "Library"
+    scope_label = "Library"
+    kind: ScopeKind = "library_root"
+    parent_prefix: str | None = None
+    parent_title: str | None = None
+
+    if match == "exact_item":
+        item_name = parts[-1] if parts else normalized
+        title = PurePosixPath(item_name).stem or item_name
+        subtitle = root_title if root else "Library"
+        scope_label = "Title" if domain == "movie" and len(parts) == 2 else "File"
+        kind = "movie_file" if domain == "movie" and len(parts) == 2 else "media_file"
+        if len(parts) > 1:
+            parent_prefix = "/".join(parts[:-1])
+            parent_title = parts[-2].title() if len(parts) == 2 else parts[-2]
+    elif domain == "tv" and len(parts) == 3:
+        title = f"{parts[1]} · {parts[2]}"
+        subtitle = parts[1]
+        scope_label = "Season"
+        kind = "tv_season"
+        parent_prefix = "/".join(parts[:2])
+        parent_title = parts[1]
+    elif domain == "tv" and len(parts) > 3:
+        title = parts[-1]
+        subtitle = parts[-2]
+        scope_label = "Folder"
+        kind = "media_folder"
+        parent_prefix = "/".join(parts[:-1])
+        parent_title = parts[-2]
+    elif domain == "tv" and len(parts) >= 2:
+        normalized = "/".join(parts[:2])
+        title = parts[1]
+        subtitle = "TV series"
+        scope_label = "Series"
+        kind = "tv_series"
+        parent_prefix = root
+        parent_title = root_title
+    elif len(parts) >= 2:
+        title = parts[-1]
+        subtitle = root_title
+        scope_label = "Title" if domain == "movie" and len(parts) == 2 else "Folder"
+        kind = "movie_title" if domain == "movie" and len(parts) == 2 else "media_folder"
+        parent_prefix = "/".join(parts[:-1])
+        parent_title = parts[-2].title() if len(parts) == 2 else parts[-2]
+
+    return MediaScope(
+        prefix=normalized,
+        root=root,
+        domain=domain,
+        kind=kind,
+        match=match,
+        title=title,
+        subtitle=subtitle,
+        scope_label=scope_label,
+        parent_prefix=parent_prefix,
+        parent_title=parent_title,
+    )
+
+
+def resolve_media_scope(connection: DBClient, prefix: str) -> MediaScope:
+    return resolve_media_scopes(connection, [prefix])[0]
+
+
+def resolve_media_scopes(connection: DBClient, prefixes: list[str]) -> list[MediaScope]:
+    normalized_prefixes = [normalize_scope_prefix(prefix) for prefix in prefixes]
+    if not normalized_prefixes:
+        return []
+    unique_prefixes = list(dict.fromkeys(normalized_prefixes))
+    nonempty_prefixes = [prefix for prefix in unique_prefixes if prefix]
+    exact_statuses: dict[str, list[str]] = {prefix: [] for prefix in nonempty_prefixes}
+    for prefix_batch in _chunks(nonempty_prefixes, 200):
+        exact_rows = connection.execute(
+            select(library_items.c.rel_path, library_items.c.status)
+            .where(library_items.c.rel_path.in_(prefix_batch))
+        ).fetchall()
+        for rel_path, status in exact_rows:
+            exact_statuses[str(rel_path)].append(str(status or ""))
+    active_descendant_prefixes: set[str] = set()
+    exact_prefixes = [prefix for prefix, statuses in exact_statuses.items() if statuses]
+    for prefix_batch in _chunks(exact_prefixes, 200):
+        prefix_queries = [select(literal(prefix).label("prefix")) for prefix in prefix_batch]
+        prefix_table = union_all(*prefix_queries).cte("scope_prefixes")
+        active_descendant_prefixes.update(
+            str(prefix)
+            for prefix in connection.execute(
+                select(prefix_table.c.prefix).where(
+                    exists(
+                        select(library_items.c.id).where(
+                            library_items.c.status != "missing",
+                            scope_descendant_filter(library_items.c.rel_path, prefix_table.c.prefix),
+                        )
+                    )
+                )
+            ).scalars().all()
+        )
+    scopes_by_prefix: dict[str, MediaScope] = {}
+    for prefix in unique_prefixes:
+        exact_rows = exact_statuses.get(prefix, [])
+        active_exact_count = sum(status != "missing" for status in exact_rows)
+        active_descendant_match = prefix in active_descendant_prefixes
+        if active_exact_count > 1:
+            raise MediaScopeConflict(
+                f"Media scope {prefix!r} is ambiguous because multiple active items share that path."
+            )
+        if active_exact_count and active_descendant_match:
+            raise MediaScopeConflict(
+                f"Media scope {prefix!r} is ambiguous because it is both an item and a folder prefix."
+            )
+        exact_match = bool(active_exact_count or (exact_rows and not active_descendant_match))
+        scopes_by_prefix[prefix] = media_scope_from_prefix(
+            prefix,
+            match="exact_item" if exact_match else "descendants",
+        )
+    return [scopes_by_prefix[prefix] for prefix in normalized_prefixes]
+
+
+def scope_rel_path_filter(column: Any, scope: MediaScope | str) -> Any:
+    legacy_prefix = isinstance(scope, str)
+    resolved = _legacy_scope(scope)
+    if not resolved.prefix:
+        return true()
+    if resolved.match == "exact_item":
+        return column == resolved.prefix
+    descendant_filter = scope_descendant_filter(column, resolved.prefix)
+    if legacy_prefix:
+        return or_(column == resolved.prefix, descendant_filter)
+    return descendant_filter
+
+
+def scope_descendant_filter(column: Any, prefix: Any) -> Any:
+    if isinstance(prefix, str):
+        normalized = normalize_scope_prefix(prefix)
+        if not normalized:
+            return true()
+        lower_bound = f"{normalized}/"
+        upper_bound = f"{normalized}0"
+    else:
+        lower_bound = prefix + "/"
+        upper_bound = prefix + "0"
+    binary_column = column.collate("BINARY")
+    return and_(binary_column >= lower_bound, binary_column < upper_bound)
+
+
+def scope_ancestor_prefixes(prefix: str) -> list[str]:
+    normalized = normalize_scope_prefix(prefix)
+    parts = PurePosixPath(normalized).parts
+    return ["/".join(parts[:index]) for index in range(1, len(parts))]
+
+
+def scope_prefix_overlap_filter(column: Any, scope: MediaScope) -> Any:
+    if not scope.prefix:
+        return true()
+    filters = [column == scope.prefix]
+    ancestors = scope_ancestor_prefixes(scope.prefix)
+    if ancestors:
+        filters.append(column.in_(ancestors))
+    if scope.match == "descendants":
+        filters.append(scope_descendant_filter(column, scope.prefix))
+    return or_(*filters)
+
+
+def path_matches_scope(rel_path: str, scope: MediaScope | str) -> bool:
+    normalized_path = normalize_scope_prefix(rel_path)
+    legacy_prefix = isinstance(scope, str)
+    resolved = _legacy_scope(scope)
+    if not resolved.prefix:
+        return True
+    if resolved.match == "exact_item":
+        return normalized_path == resolved.prefix
+    return (
+        (legacy_prefix and normalized_path == resolved.prefix)
+        or normalized_path.startswith(f"{resolved.prefix}/")
+    )
+
+
+def scopes_overlap(left: MediaScope | str, right: MediaScope | str) -> bool:
+    left_scope = _legacy_scope(left)
+    right_scope = _legacy_scope(right)
+    if not left_scope.prefix or not right_scope.prefix:
+        return True
+    if left_scope.prefix == right_scope.prefix:
+        return True
+    if left_scope.match == "exact_item":
+        return (
+            right_scope.match == "descendants"
+            and left_scope.prefix.startswith(f"{right_scope.prefix}/")
+        )
+    if right_scope.match == "exact_item":
+        return right_scope.prefix.startswith(f"{left_scope.prefix}/")
+    return (
+        left_scope.prefix.startswith(f"{right_scope.prefix}/")
+        or right_scope.prefix.startswith(f"{left_scope.prefix}/")
+    )
+
+
+def is_tv_season_prefix(prefix: str) -> bool:
+    parts = PurePosixPath(normalize_scope_prefix(prefix)).parts
+    return len(parts) == 3 and parts[0].lower() == "tv"
+
+
+def is_tv_series_prefix(prefix: str) -> bool:
+    parts = PurePosixPath(normalize_scope_prefix(prefix)).parts
+    return len(parts) == 2 and parts[0].lower() == "tv"
+
+
+def series_context_for_prefix(prefix: str) -> dict[str, str] | None:
+    normalized = normalize_scope_prefix(prefix)
+    if not is_tv_season_prefix(normalized):
+        return None
+    parts = PurePosixPath(normalized).parts
+    return {"prefix": "/".join(parts[:2]), "title": parts[1]}
+
+
+def _legacy_scope(scope: MediaScope | str) -> MediaScope:
+    if isinstance(scope, MediaScope):
+        return scope
+    return media_scope_from_prefix(scope, match="descendants")
+
+
+def _scope_domain(root: str) -> ScopeDomain:
+    normalized = root.lower()
+    if normalized == "tv":
+        return "tv"
+    if normalized == "movies":
+        return "movie"
+    return "other"
+
+
+def _root_title(root: str) -> str:
+    return "TV" if root.lower() == "tv" else root.title()
+
+
+def _chunks(values: list[str], size: int) -> list[list[str]]:
+    return [values[index:index + size] for index in range(0, len(values), size)]

--- a/mediaforce/library/representatives.py
+++ b/mediaforce/library/representatives.py
@@ -7,13 +7,14 @@ from dataclasses import dataclass
 from statistics import median, quantiles
 from typing import Any
 
-from sqlalchemy import or_, select
+from sqlalchemy import select
 
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.evidence import build_evidence_envelope, stable_policy_hash, stable_source_id
 from mediaforce.core.type_defs import mapping_dict, object_dict, object_list
+from mediaforce.library.media_scopes import resolve_media_scope, scope_rel_path_filter
 from mediaforce.library.planner import build_manifest_item
 
 REPRESENTATIVE_SELECTION_TOOL = "mediaforce.representative_selection"
@@ -120,15 +121,10 @@ def load_representative_selection(
         config: MediaforceConfig,
         prefix: str,
 ) -> RepresentativeSelection | None:
-    normalized_prefix = prefix.strip().strip("/")
+    scope = resolve_media_scope(connection, prefix)
     rows = connection.execute(
         select(library_items)
-        .where(
-            or_(
-                library_items.c.rel_path == normalized_prefix,
-                library_items.c.rel_path.like(_prefix_descendant_pattern(normalized_prefix), escape="\\"),
-            )
-        )
+        .where(scope_rel_path_filter(library_items.c.rel_path, scope))
         .order_by(library_items.c.rel_path.asc())
     ).mappings().fetchall()
     if not rows:
@@ -146,8 +142,8 @@ def load_representative_selection(
         items.append(item)
     return select_representatives(
         items,
-        prefix=normalized_prefix,
-        policy=config.resolve_policy(normalized_prefix),
+        prefix=scope.prefix,
+        policy=config.resolve_policy(scope.prefix),
     )
 
 
@@ -825,8 +821,3 @@ def _fraction(numerator: int | float, denominator: int | float) -> float:
     if denominator <= 0:
         return 1.0
     return round(float(numerator) / float(denominator), 4)
-
-
-def _prefix_descendant_pattern(prefix: str) -> str:
-    escaped_prefix = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    return f"{escaped_prefix}/%"

--- a/mediaforce/library/run_manifests.py
+++ b/mediaforce/library/run_manifests.py
@@ -8,7 +8,6 @@ from sqlalchemy import bindparam
 from sqlalchemy import or_
 from sqlalchemy import outerjoin
 from sqlalchemy import select
-from sqlalchemy import true
 from sqlalchemy import update
 
 from mediaforce.core.config import MediaforceConfig
@@ -20,6 +19,7 @@ from mediaforce.library.workflow_state import ENCODE_CANDIDATE_STATUSES
 from mediaforce.library.workflow_state import derive_item_workflow_state
 from mediaforce.core.type_defs import object_dict
 from mediaforce.library.candidate_selection import candidate_rank_key, project_candidates
+from mediaforce.library.media_scopes import resolve_media_scope, resolve_media_scopes, scope_rel_path_filter
 from mediaforce.library.planner import build_manifest_item, recommend_item
 from mediaforce.library.scanner import scan_library
 
@@ -118,7 +118,8 @@ def select_candidates(
         .where(library_items.c.status.in_(statuses))
     )
     if prefixes:
-        query = query.where(or_(*(_prefix_filter(prefix) for prefix in prefixes)))
+        scopes = resolve_media_scopes(connection, prefixes)
+        query = query.where(or_(*(scope_rel_path_filter(library_items.c.rel_path, scope) for scope in scopes)))
     query = query.order_by(library_items.c.priority_score.desc(), library_items.c.size_bytes.desc())
     if limit is not None:
         query = query.limit(limit)
@@ -126,20 +127,6 @@ def select_candidates(
     if buckets:
         rows = [row for row in rows if recommend_item(row, config).bucket in buckets]
     return rows
-
-
-def _prefix_filter(prefix: str) -> Any:
-    normalized_prefix = prefix.strip().strip("/")
-    if not normalized_prefix:
-        return true()
-    return or_(
-        library_items.c.rel_path == normalized_prefix,
-        library_items.c.rel_path.like(f"{_sql_like_escape(normalized_prefix)}/%", escape="\\"),
-    )
-
-
-def _sql_like_escape(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def select_encode_candidates(
@@ -256,6 +243,7 @@ def create_folder_manifest(
 ) -> tuple[dict[str, Any], Path]:
     if scan_first:
         scan_library(connection, config, prefixes=[prefix])
+    scope = resolve_media_scope(connection, prefix)
     rows = select_encode_candidates(
         connection,
         config,
@@ -264,5 +252,6 @@ def create_folder_manifest(
         manual_override_prefix=manual_override_prefix,
     )
     manifest = build_run_manifest(rows, config)
+    manifest["selection"]["media_scope"] = scope.to_payload()
     manifest_path = write_manifest(connection, config, manifest)
     return manifest, manifest_path

--- a/mediaforce/library/scanner.py
+++ b/mediaforce/library/scanner.py
@@ -29,6 +29,7 @@ from mediaforce.encoding.fingerprint import (
     MEDIA_FINGERPRINT_TOOL_VERSION,
     unavailable_media_fingerprint_summary,
 )
+from mediaforce.library.media_scopes import path_matches_scope
 from mediaforce.library.planner import recommend_item
 from mediaforce.library.probe import probe_media
 from mediaforce.core.type_defs import int_value, object_list
@@ -373,7 +374,7 @@ def _iter_media_files(
             if file_path.suffix.lower() not in VIDEO_EXTENSIONS:
                 continue
             rel_path = str(file_path.relative_to(root_path.parent))
-            if prefixes and not any(rel_path.startswith(prefix) for prefix in prefixes):
+            if prefixes and not any(path_matches_scope(rel_path, prefix) for prefix in prefixes):
                 continue
             yield file_path
             matched += 1

--- a/mediaforce/library/workflow_state.py
+++ b/mediaforce/library/workflow_state.py
@@ -2,13 +2,15 @@ from collections import Counter
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from sqlalchemy import or_, select, true
+from sqlalchemy import or_, select
 
 from mediaforce.core.db import DBClient
 from mediaforce.core.db import DBRow
 from mediaforce.core.db_tables import encode_jobs
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.db_tables import staged_artifacts
+from mediaforce.library.media_scopes import MediaScope, normalize_scope_prefix, path_matches_scope, \
+    resolve_media_scope, resolve_media_scopes, scope_rel_path_filter, scopes_overlap
 
 WorkflowItemState = Literal[
     "missing",
@@ -126,17 +128,17 @@ def build_folder_workflow_state(
         *,
         candidate_eligibility: dict[int, tuple[bool, str | None]] | None = None,
 ) -> FolderWorkflowState:
-    normalized_prefix = normalize_prefix(prefix)
+    scope = resolve_media_scope(connection, prefix)
     item_states = tuple(
         derive_item_workflow_state(
             row,
             encode_eligible=(candidate_eligibility or {}).get(int(row["item_id"]), (True, None))[0],
             policy_blocker=(candidate_eligibility or {}).get(int(row["item_id"]), (True, None))[1],
         )
-        for row in _load_item_rows(connection, normalized_prefix)
+        for row in _load_item_rows(connection, scope)
     )
-    job_state = _load_encode_job_state(connection, normalized_prefix)
-    return _build_folder_state(normalized_prefix, item_states, job_state=job_state)
+    job_state = _load_encode_job_state(connection, scope)
+    return _build_folder_state(scope.prefix, item_states, job_state=job_state)
 
 
 def build_folder_workflow_states(
@@ -145,14 +147,14 @@ def build_folder_workflow_states(
         *,
         candidate_eligibility: dict[int, tuple[bool, str | None]] | None = None,
 ) -> dict[str, FolderWorkflowState]:
-    normalized_prefixes = [normalize_prefix(prefix) for prefix in prefixes]
-    unique_prefixes = list(dict.fromkeys(normalized_prefixes))
-    if not unique_prefixes:
+    normalized_prefixes = list(dict.fromkeys(normalize_prefix(prefix) for prefix in prefixes))
+    if not normalized_prefixes:
         return {}
-    rows = _load_item_rows_for_prefixes(connection, unique_prefixes)
-    job_states = _load_encode_job_states(connection, unique_prefixes)
+    scopes = resolve_media_scopes(connection, normalized_prefixes)
+    rows = _load_item_rows_for_scopes(connection, scopes)
+    job_states = _load_encode_job_states(connection, scopes)
     result: dict[str, FolderWorkflowState] = {}
-    for prefix in unique_prefixes:
+    for scope in scopes:
         item_states = tuple(
             derive_item_workflow_state(
                 row,
@@ -160,14 +162,18 @@ def build_folder_workflow_states(
                 policy_blocker=(candidate_eligibility or {}).get(int(row["item_id"]), (True, None))[1],
             )
             for row in rows
-            if _path_matches_prefix(str(row["rel_path"]), prefix)
+            if path_matches_scope(str(row["rel_path"]), scope)
         )
-        result[prefix] = _build_folder_state(prefix, item_states, job_state=job_states.get(prefix))
+        result[scope.prefix] = _build_folder_state(
+            scope.prefix,
+            item_states,
+            job_state=job_states.get(scope.prefix),
+        )
     return result
 
 
 def normalize_prefix(prefix: str) -> str:
-    return prefix.strip().strip("/")
+    return normalize_scope_prefix(prefix)
 
 
 def derive_item_workflow_state(
@@ -225,7 +231,7 @@ def derive_item_workflow_state(
     )
 
 
-def _load_item_rows(connection: DBClient, prefix: str) -> list[DBRow]:
+def _load_item_rows(connection: DBClient, scope: MediaScope) -> list[DBRow]:
     query = (
         select(
             library_items.c.id.label("item_id"),
@@ -242,15 +248,15 @@ def _load_item_rows(connection: DBClient, prefix: str) -> list[DBRow]:
                 staged_artifacts.c.library_item_id == library_items.c.id,
             )
         )
-        .where(_prefix_filter(library_items.c.rel_path, prefix))
+        .where(scope_rel_path_filter(library_items.c.rel_path, scope))
         .order_by(library_items.c.rel_path)
     )
     return connection.execute(query).mappings().fetchall()
 
 
-def _load_item_rows_for_prefixes(connection: DBClient, prefixes: list[str]) -> list[DBRow]:
+def _load_item_rows_for_scopes(connection: DBClient, scopes: list[MediaScope]) -> list[DBRow]:
     rows_by_key: dict[tuple[int, str | None], DBRow] = {}
-    for prefix_batch in _chunks(prefixes, PREFIX_QUERY_BATCH_SIZE):
+    for scope_batch in _chunks(scopes, PREFIX_QUERY_BATCH_SIZE):
         query = (
             select(
                 library_items.c.id.label("item_id"),
@@ -267,7 +273,7 @@ def _load_item_rows_for_prefixes(connection: DBClient, prefixes: list[str]) -> l
                     staged_artifacts.c.library_item_id == library_items.c.id,
                 )
             )
-            .where(or_(*(_prefix_filter(library_items.c.rel_path, prefix) for prefix in prefix_batch)))
+            .where(or_(*(scope_rel_path_filter(library_items.c.rel_path, scope) for scope in scope_batch)))
             .order_by(library_items.c.rel_path)
         )
         for row in connection.execute(query).mappings().fetchall():
@@ -275,7 +281,7 @@ def _load_item_rows_for_prefixes(connection: DBClient, prefixes: list[str]) -> l
     return sorted(rows_by_key.values(), key=lambda row: str(row["rel_path"]))
 
 
-def _chunks(values: list[str], size: int) -> list[list[str]]:
+def _chunks(values: list[Any], size: int) -> list[list[Any]]:
     return [values[index:index + size] for index in range(0, len(values), size)]
 
 
@@ -461,13 +467,13 @@ def _mixed_next_action(prefix: str, lane: WorkflowLane) -> WorkflowNextAction:
     return WorkflowNextAction("review_scope", "Review scope", True, prefix)
 
 
-def _load_encode_job_state(connection: DBClient, prefix: str) -> tuple[WorkflowLane, str] | None:
+def _load_encode_job_state(connection: DBClient, scope: MediaScope) -> tuple[WorkflowLane, str] | None:
     rows = connection.execute(
         select(encode_jobs.c.prefix, encode_jobs.c.status, encode_jobs.c.error)
         .where(encode_jobs.c.status.in_(JOB_STATUSES_FOR_WORKFLOW))
         .order_by(encode_jobs.c.updated_at.desc(), encode_jobs.c.created_at.desc())
     ).mappings().fetchall()
-    overlapping_rows = [row for row in rows if _prefixes_overlap(prefix, str(row["prefix"] or ""))]
+    overlapping_rows = [row for row in rows if scopes_overlap(scope, str(row["prefix"] or ""))]
     active = next((row for row in overlapping_rows if row["status"] in PROCESSING_JOB_STATUSES), None)
     if active is not None:
         return "processing", f"Encode job is {active['status']} for {active['prefix']}."
@@ -478,51 +484,23 @@ def _load_encode_job_state(connection: DBClient, prefix: str) -> tuple[WorkflowL
     return None
 
 
-def _load_encode_job_states(connection: DBClient, prefixes: list[str]) -> dict[str, tuple[WorkflowLane, str] | None]:
+def _load_encode_job_states(connection: DBClient, scopes: list[MediaScope]) -> dict[str, tuple[WorkflowLane, str] | None]:
     rows = connection.execute(
         select(encode_jobs.c.prefix, encode_jobs.c.status, encode_jobs.c.error)
         .where(encode_jobs.c.status.in_(JOB_STATUSES_FOR_WORKFLOW))
         .order_by(encode_jobs.c.updated_at.desc(), encode_jobs.c.created_at.desc())
     ).mappings().fetchall()
     result: dict[str, tuple[WorkflowLane, str] | None] = {}
-    for prefix in prefixes:
-        overlapping_rows = [row for row in rows if _prefixes_overlap(prefix, str(row["prefix"] or ""))]
+    for scope in scopes:
+        overlapping_rows = [row for row in rows if scopes_overlap(scope, str(row["prefix"] or ""))]
         active = next((row for row in overlapping_rows if row["status"] in PROCESSING_JOB_STATUSES), None)
         if active is not None:
-            result[prefix] = "processing", f"Encode job is {active['status']} for {active['prefix']}."
+            result[scope.prefix] = "processing", f"Encode job is {active['status']} for {active['prefix']}."
             continue
         latest = overlapping_rows[0] if overlapping_rows else None
         if latest is not None and latest["status"] in ATTENTION_JOB_STATUSES:
             error = str(latest["error"] or "Encode job needs operator attention.")
-            result[prefix] = "attention", f"Encode job is {latest['status']} for {latest['prefix']}: {error}"
+            result[scope.prefix] = "attention", f"Encode job is {latest['status']} for {latest['prefix']}: {error}"
             continue
-        result[prefix] = None
+        result[scope.prefix] = None
     return result
-
-
-def _prefix_filter(column: Any, prefix: str) -> Any:
-    if not prefix:
-        return true()
-    return or_(column == prefix, column.like(f"{_sql_like_escape(prefix)}/%", escape="\\"))
-
-
-def _sql_like_escape(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
-
-def _path_matches_prefix(path: str, prefix: str) -> bool:
-    normalized_path = normalize_prefix(path)
-    normalized_prefix = normalize_prefix(prefix)
-    return not normalized_prefix or normalized_path == normalized_prefix or normalized_path.startswith(f"{normalized_prefix}/")
-
-
-def _prefixes_overlap(left: str, right: str) -> bool:
-    normalized_left = normalize_prefix(left)
-    normalized_right = normalize_prefix(right)
-    if not normalized_left or not normalized_right:
-        return True
-    return (
-        normalized_left == normalized_right
-        or normalized_left.startswith(f"{normalized_right}/")
-        or normalized_right.startswith(f"{normalized_left}/")
-    )

--- a/mediaforce/tuning/calibration_jobs.py
+++ b/mediaforce/tuning/calibration_jobs.py
@@ -3,11 +3,8 @@ from typing import Any
 from typing import TypeVar
 
 from sqlalchemy import func
-from sqlalchemy import literal
 from sqlalchemy import literal_column
-from sqlalchemy import or_
 from sqlalchemy import select
-from sqlalchemy import true
 from sqlalchemy import update
 from sqlalchemy import distinct
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -16,6 +13,7 @@ from mediaforce.core.db import DBClient
 from mediaforce.core.db import DBRow
 from mediaforce.core.db_tables import calibration_jobs
 from mediaforce.core.type_defs import JSONValue
+from mediaforce.library.media_scopes import resolve_media_scope, scope_prefix_overlap_filter
 
 T = TypeVar("T")
 
@@ -33,10 +31,10 @@ def load_latest_job(connection: DBClient, prefix: str) -> dict[str, Any] | None:
 
 
 def load_latest_overlapping_job(connection: DBClient, prefix: str) -> dict[str, Any] | None:
-    normalized_prefix = _normalize_prefix(prefix)
+    scope = resolve_media_scope(connection, prefix)
     row = connection.execute(
         _calibration_job_select()
-        .where(_prefix_overlap_filter(normalized_prefix))
+        .where(scope_prefix_overlap_filter(calibration_jobs.c.prefix, scope))
         .order_by(calibration_jobs.c.created_at.desc(), _rowid_column().desc())
         .limit(1)
     ).mappings().fetchone()
@@ -110,37 +108,15 @@ def load_active_job(connection: DBClient, prefix: str) -> dict[str, Any] | None:
 
 
 def load_active_overlapping_job(connection: DBClient, prefix: str) -> dict[str, Any] | None:
-    normalized_prefix = _normalize_prefix(prefix)
+    scope = resolve_media_scope(connection, prefix)
     row = connection.execute(
         _calibration_job_select()
-        .where(_prefix_overlap_filter(normalized_prefix))
+        .where(scope_prefix_overlap_filter(calibration_jobs.c.prefix, scope))
         .where(calibration_jobs.c.status.in_(tuple(ACTIVE_JOB_STATUSES)))
         .order_by(calibration_jobs.c.created_at.desc(), _rowid_column().desc())
         .limit(1)
     ).mappings().fetchone()
     return _hydrate_job(row) if row is not None else None
-
-
-def _normalize_prefix(prefix: str) -> str:
-    return prefix.strip().strip("/")
-
-
-def _prefix_overlap_filter(prefix: str) -> Any:
-    if not prefix:
-        return true()
-    return or_(
-        calibration_jobs.c.prefix == prefix,
-        calibration_jobs.c.prefix.like(f"{_sql_like_escape(prefix)}/%", escape="\\"),
-        literal(prefix).like(_escaped_prefix_column(calibration_jobs.c.prefix) + "/%", escape="\\"),
-    )
-
-
-def _escaped_prefix_column(column: Any) -> Any:
-    return func.replace(func.replace(func.replace(column, "\\", "\\\\"), "%", "\\%"), "_", "\\_")
-
-
-def _sql_like_escape(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def list_queued_jobs(connection: DBClient) -> list[dict[str, Any]]:

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -60,6 +60,8 @@ from mediaforce.execution import (
     validate_manifest_items,
 )
 from mediaforce.library.folder_profiles import inspect_prefix
+from mediaforce.library.media_scopes import is_tv_series_prefix, media_group_scope_for_rel_path, resolve_media_scope, \
+    resolve_media_scopes, scope_rel_path_filter, series_context_for_prefix, tv_series_scope_for_rel_path
 from mediaforce.library.planner import build_manifest_item
 from mediaforce.library.representatives import RepresentativeSelection, load_representative_selection, \
     public_representative_item
@@ -662,6 +664,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     def _folder_content_payload(normalized_prefix: str) -> tuple[dict[str, Any], int]:
         latest_failed_sample_job_payload: dict[str, Any] | None = None
         with open_db(config.paths.db_path) as connection:
+            media_scope = resolve_media_scope(connection, normalized_prefix)
             calibration_job = _load_job_state(connection, config, normalized_prefix)
             if calibration_job and calibration_job.get("status") in {"queued", "running"}:
                 existing_scan_job = _load_scan_job_state(config, normalized_prefix)
@@ -675,6 +678,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             metric_support = _metric_support()
             base_context: dict[str, Any] = {
                 "prefix": normalized_prefix,
+                "media_scope": media_scope.to_payload(),
                 "calibration_job": calibration_job,
                 "folder_scan_job": folder_scan_job,
                 "metric_support": metric_support,
@@ -1171,9 +1175,8 @@ def create_app(config_path: Path | None = None) -> FastAPI:
 
     def _save_series_lifecycle_action(normalized_prefix: str, mode: str) -> dict[str, Any]:
         nonlocal config
-        parts = Path(normalized_prefix).parts
         normalized_mode = mode.strip().lower()
-        if len(parts) != 2 or parts[0].lower() != "tv":
+        if not is_tv_series_prefix(normalized_prefix):
             raise HTTPException(status_code=400, detail="Lifecycle mode can only be set for one TV series.")
         if normalized_mode not in {"auto", "on", "off"}:
             raise HTTPException(status_code=400, detail="Lifecycle mode must be auto, on, or off.")
@@ -1769,7 +1772,7 @@ def _reset_folder_card_cache() -> None:
 def _list_library_structure_cards(config: MediaforceConfig, connection: DBClient) -> list[FolderCard]:
     needs_attention_badges = _folder_needs_attention_badges(connection)
     calibration_job_badges = _folder_calibration_job_badges(connection)
-    return list_library_structure_cards(
+    cards = list_library_structure_cards(
         connection,
         config=config,
         folder_group=_folder_group,
@@ -1780,6 +1783,7 @@ def _list_library_structure_cards(config: MediaforceConfig, connection: DBClient
             calibration_job_badges=calibration_job_badges,
         ),
     )
+    return _attach_media_scopes(connection, cards)
 
 
 def _list_library_detail_cards(config: MediaforceConfig, connection: DBClient) -> list[FolderCard]:
@@ -1809,7 +1813,7 @@ def _list_folder_cards(config: MediaforceConfig, connection: DBClient) -> list[F
             calibration_job_badges=calibration_job_badges,
         )
 
-    return cached_folder_cards(
+    cards = cached_folder_cards(
         config,
         connection,
         minimum_recommended_savings_bytes=MIN_RECOMMENDED_SAVINGS_BYTES,
@@ -1818,6 +1822,7 @@ def _list_folder_cards(config: MediaforceConfig, connection: DBClient) -> list[F
         estimate_savings_bytes=_estimate_savings_bytes,
         review_badge_for_prefix=review_badge_for_prefix,
     )
+    return _attach_media_scopes(connection, cards)
 
 
 def _list_series_folder_cards(config: MediaforceConfig, connection: DBClient) -> list[FolderCard]:
@@ -1863,7 +1868,7 @@ def _folder_cards_for_group(
             calibration_job_badges=calibration_job_badges,
         )
 
-    return list_folder_cards(
+    cards = list_folder_cards(
         connection,
         config=config,
         minimum_recommended_savings_bytes=minimum_recommended_savings_bytes,
@@ -1873,12 +1878,13 @@ def _folder_cards_for_group(
         review_badge_for_prefix=review_badge_for_prefix,
         rel_path_root=rel_path_root,
     )
+    return _attach_media_scopes(connection, cards)
 
 
 def _preview_folder_cards(config: MediaforceConfig, connection: DBClient) -> list[FolderCard]:
     needs_attention_badges = _folder_needs_attention_badges(connection)
     calibration_job_badges = _folder_calibration_job_badges(connection)
-    return preview_folder_cards(
+    cards = preview_folder_cards(
         connection,
         config=config,
         minimum_recommended_savings_bytes=MIN_RECOMMENDED_SAVINGS_BYTES,
@@ -1891,6 +1897,14 @@ def _preview_folder_cards(config: MediaforceConfig, connection: DBClient) -> lis
             calibration_job_badges=calibration_job_badges,
         ),
     )
+    return _attach_media_scopes(connection, cards)
+
+
+def _attach_media_scopes(connection: DBClient, cards: list[FolderCard]) -> list[FolderCard]:
+    scopes = resolve_media_scopes(connection, [card.prefix for card in cards])
+    for card, scope in zip(cards, scopes, strict=True):
+        card.media_scope = scope.to_payload()
+    return cards
 
 
 def _host_runtime_rows(
@@ -2239,11 +2253,6 @@ def _representative_selection(
     return load_representative_selection(connection, config, prefix)
 
 
-def _prefix_descendant_like_pattern(prefix: str) -> str:
-    escaped_prefix = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    return f"{escaped_prefix}/%"
-
-
 def _load_folder_staged_items(
         connection: DBClient,
         config: MediaforceConfig,
@@ -2254,16 +2263,11 @@ def _load_folder_staged_items(
     normalized_prefix = normalized_prefix.strip().strip("/")
     if not normalized_prefix or not statuses:
         return []
-    descendant_pattern = _prefix_descendant_like_pattern(normalized_prefix)
+    scope = resolve_media_scope(connection, normalized_prefix)
     rows = connection.execute(
         select(library_items)
         .join(staged_artifacts, staged_artifacts.c.library_item_id == library_items.c.id)
-        .where(
-            or_(
-                library_items.c.parent_dir == normalized_prefix,
-                library_items.c.parent_dir.like(descendant_pattern, escape="\\"),
-            )
-        )
+        .where(scope_rel_path_filter(library_items.c.rel_path, scope))
         .where(library_items.c.status.in_(tuple(sorted(statuses))))
         .where(staged_artifacts.c.staging_path.is_not(None))
         .where(staged_artifacts.c.promoted_at.is_(None))
@@ -2891,36 +2895,24 @@ def _preview_hotspots(sample_item: dict[str, Any], calibration: dict[str, Any] |
 
 
 def _folder_group(rel_path: str) -> tuple[str, str, str, str] | None:
-    parts = Path(rel_path).parts
-    if len(parts) < 2:
-        return None
-    if parts[0] == "tv" and len(parts) >= 3:
-        return "/".join(parts[:3]), f"{parts[1]} · {parts[2]}", parts[1], "Season"
-    return "/".join(parts[:2]), parts[1], parts[0].title(), "Folder"
+    scope = media_group_scope_for_rel_path(rel_path)
+    return scope.group_tuple() if scope is not None else None
 
 
 def _tv_series_folder_group(rel_path: str) -> tuple[str, str, str, str] | None:
-    parts = Path(rel_path).parts
-    if len(parts) < 3 or parts[0] != "tv":
-        return None
-    return "/".join(parts[:2]), parts[1], "TV series", "Series"
+    scope = tv_series_scope_for_rel_path(rel_path)
+    return scope.group_tuple() if scope is not None else None
 
 
 def _tv_season_folder_group(rel_path: str) -> tuple[str, str, str, str] | None:
-    group = _folder_group(rel_path)
-    if group is None or group[3] != "Season":
+    scope = media_group_scope_for_rel_path(rel_path)
+    if scope is None or scope.kind != "tv_season":
         return None
-    return group
+    return scope.group_tuple()
 
 
 def _folder_series_context(prefix: str) -> dict[str, str] | None:
-    parts = Path(prefix).parts
-    if len(parts) < 3 or parts[0] != "tv":
-        return None
-    series_prefix = "/".join(parts[:2])
-    if series_prefix == prefix:
-        return None
-    return {"prefix": series_prefix, "title": parts[1]}
+    return series_context_for_prefix(prefix)
 
 
 def _folder_encode_candidate_count(connection: DBClient, config: MediaforceConfig, prefix: str) -> int:

--- a/mediaforce/web/runtime/completed_runtime.py
+++ b/mediaforce/web/runtime/completed_runtime.py
@@ -11,6 +11,7 @@ from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import item_events, library_items, staged_artifacts
 from mediaforce.encoding.staging import safe_unlink
+from mediaforce.library.media_scopes import path_matches_scope
 FolderGroup = tuple[str, str, str, str]
 ORIGINALS_REMOVED_EVENT = "originals_removed_confirmed"
 HISTORY_DETAIL_MAX_CHARS = 320
@@ -443,10 +444,7 @@ def _normalized_prefixes(prefixes: list[str] | None) -> set[str] | None:
 
 
 def _path_matches_prefixes(rel_path: str, prefixes: set[str]) -> bool:
-    for prefix in prefixes:
-        if rel_path == prefix or rel_path.startswith(f"{prefix}/"):
-            return True
-    return False
+    return any(path_matches_scope(rel_path, prefix) for prefix in prefixes)
 
 
 def _configured_archive_root(config: MediaforceConfig) -> Path | None:

--- a/mediaforce/web/runtime/dashboard_payloads.py
+++ b/mediaforce/web/runtime/dashboard_payloads.py
@@ -8,6 +8,7 @@ from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import open_db
 from mediaforce.core.db_tables import library_items
 from mediaforce.encoding.encode_queue import summarize_encode_queue
+from mediaforce.library.media_scopes import resolve_media_scope
 from mediaforce.library.workflow_state import build_folder_workflow_state
 from mediaforce.library.candidate_selection import encode_candidate_decisions, workflow_eligibility
 
@@ -104,6 +105,7 @@ def folder_status_payload(
         load_active_encode_job_for_prefix: Any,
 ) -> dict[str, Any]:
     with open_db(config.paths.db_path) as connection:
+        media_scope = resolve_media_scope(connection, normalized_prefix)
         calibration_job = load_job_state(connection, config, normalized_prefix)
         retryable_sample_job = load_retryable_sample_job_state(connection, config, normalized_prefix)
         active_encode_job = load_active_encode_job_for_prefix(connection, normalized_prefix)
@@ -125,6 +127,7 @@ def folder_status_payload(
     )
     return {
         "prefix": normalized_prefix,
+        "media_scope": media_scope.to_payload(),
         "polling_active": polling_active,
         "calibration_status": calibration_job.get("status") if calibration_job else "idle",
         "folder_scan_status": folder_scan_job.get("status") if folder_scan_job else "idle",

--- a/mediaforce/web/runtime/folder_actions.py
+++ b/mediaforce/web/runtime/folder_actions.py
@@ -17,6 +17,8 @@ from mediaforce.core.type_defs import float_value, object_dict, object_list
 from mediaforce.encoding.encode_queue import ACTIVE_ENCODE_JOB_STATUSES, list_child_encode_jobs, \
     load_latest_terminal_encode_job_for_prefix
 from mediaforce.encoding.staging import safe_unlink
+from mediaforce.library.media_scopes import MediaScope, path_matches_scope, resolve_media_scope, \
+    scope_descendant_filter, scope_rel_path_filter
 from mediaforce.library.workflow_state import build_folder_workflow_state
 from mediaforce.library.run_manifests import create_folder_manifest
 from mediaforce.library.candidate_selection import encode_candidate_decisions, scope_lifecycle_payload_from_decisions, \
@@ -176,9 +178,10 @@ def queue_folder_encode_action(
         load_advice_state: LoadAdviceStateFn | None = None,
         load_latest_failed_target_size_job_state: LoadJobStateFn | None = None,
 ) -> ActionPayload:
-    if override_policy_holds and len(Path(normalized_prefix).parts) != 3:
-        raise HTTPException(status_code=400, detail="Lifecycle holds can only be overridden for one season at a time.")
     with open_db(config.paths.db_path) as connection:
+        scope = resolve_media_scope(connection, normalized_prefix)
+        if override_policy_holds and scope.kind != "tv_season":
+            raise HTTPException(status_code=400, detail="Lifecycle holds can only be overridden for one season at a time.")
         existing_job = load_job_state(connection, config, normalized_prefix)
         if existing_job and existing_job.get("status") in {"queued", "running", "pending_review"}:
             return {"ok": False, "message": "A calibration job is already active for this folder."}
@@ -753,16 +756,11 @@ def _reset_stale_prefix_encoding_items_for_requeue(
     normalized_prefix = str(prefix).strip().strip("/")
     if not normalized_prefix:
         return
-    descendant_pattern = _prefix_descendant_path_pattern(normalized_prefix)
-    protected_prefixes = _active_descendant_encode_prefixes(connection, normalized_prefix)
+    scope = resolve_media_scope(connection, normalized_prefix)
+    protected_prefixes = _active_descendant_encode_prefixes(connection, scope)
     rows = connection.execute(
         select(library_items.c.id, library_items.c.rel_path)
-        .where(
-            or_(
-                library_items.c.parent_dir == normalized_prefix,
-                library_items.c.parent_dir.like(descendant_pattern, escape="\\"),
-            )
-        )
+        .where(scope_rel_path_filter(library_items.c.rel_path, scope))
         .where(library_items.c.status == "encoding")
     ).mappings().fetchall()
     if not rows:
@@ -794,40 +792,28 @@ def _reset_stale_prefix_encoding_items_for_requeue(
         )
 
 
-def _prefix_descendant_path_pattern(prefix: str) -> str:
-    if not prefix:
-        return "%"
-    escaped_prefix = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-    return f"{escaped_prefix}/%"
-
-
-def _active_descendant_encode_prefixes(connection: DBClient, prefix: str) -> set[str]:
-    if not prefix:
+def _active_descendant_encode_prefixes(connection: DBClient, scope: MediaScope) -> set[str]:
+    if not scope.prefix or scope.match == "exact_item":
         return set()
-    descendant_pattern = _prefix_descendant_path_pattern(prefix)
     rows = connection.execute(
         select(encode_jobs.c.prefix)
         .where(encode_jobs.c.status.in_(("queued", "retry_backoff", "running")))
         .where(
             or_(
-                encode_jobs.c.prefix == prefix,
-                encode_jobs.c.prefix.like(descendant_pattern, escape="\\"),
+                encode_jobs.c.prefix == scope.prefix,
+                scope_descendant_filter(encode_jobs.c.prefix, scope.prefix),
             )
         )
     ).fetchall()
     return {
         str(row[0]).strip().strip("/")
         for row in rows
-        if str(row[0] or "").strip().strip("/") and str(row[0]).strip().strip("/") != prefix
+        if str(row[0] or "").strip().strip("/") and str(row[0]).strip().strip("/") != scope.prefix
     }
 
 
 def _rel_path_is_within_any_prefix(rel_path: str, prefixes: set[str]) -> bool:
-    normalized_rel_path = str(rel_path).strip().strip("/")
-    for prefix in prefixes:
-        if normalized_rel_path == prefix or normalized_rel_path.startswith(f"{prefix}/"):
-            return True
-    return False
+    return any(path_matches_scope(rel_path, prefix) for prefix in prefixes)
 
 
 def save_profile_action(

--- a/mediaforce/web/runtime/folder_cards.py
+++ b/mediaforce/web/runtime/folder_cards.py
@@ -42,6 +42,7 @@ class FolderCard:
     review_badge_detail: str | None = None
     workflow_state: WorkflowPayload | None = None
     lifecycle: dict[str, object] | None = None
+    media_scope: dict[str, object] | None = None
     details_loading: bool = False
 
 

--- a/mediaforce/web/runtime/job_runtime.py
+++ b/mediaforce/web/runtime/job_runtime.py
@@ -12,9 +12,7 @@ from typing import Any
 
 from sqlalchemy import func
 from sqlalchemy import literal_column
-from sqlalchemy import or_
 from sqlalchemy import select
-from sqlalchemy import true
 from sqlalchemy import update
 
 from mediaforce.tuning.calibration_jobs import claim_next_queued_calibration_job, load_latest_failed_sample_job, \
@@ -26,8 +24,9 @@ from mediaforce.core.db_tables import calibration_jobs
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.db_tables import scan_runs
 from mediaforce.core.process_control import ManagedProcessController
-from mediaforce.library.scanner import scan_library
+from mediaforce.library.media_scopes import path_matches_scope, resolve_media_scope, scope_rel_path_filter
 from mediaforce.library.metadata_sync import sync_external_metadata
+from mediaforce.library.scanner import scan_library
 from mediaforce.state_cleanup import purge_transient_artifacts
 from mediaforce.core.type_defs import JSONValue, object_dict
 from mediaforce.web.runtime.worker_supervision import run_supervised_worker_loop
@@ -484,11 +483,12 @@ def scan_is_stale(
             return True
         return datetime.now(tz=UTC) - latest > deps.full_scan_stale_after
 
+    scope = resolve_media_scope(connection, prefix)
     item_count = int(
         connection.execute(
             select(func.count())
             .select_from(library_items)
-            .where(_prefix_filter(prefix))
+            .where(scope_rel_path_filter(library_items.c.rel_path, scope))
         ).scalar_one()
     )
     if item_count == 0:
@@ -497,21 +497,6 @@ def scan_is_stale(
     if latest is None:
         return True
     return datetime.now(tz=UTC) - latest > deps.prefix_scan_stale_after
-
-
-def _prefix_filter(prefix: str) -> Any:
-    normalized_prefix = prefix.strip().strip("/")
-    if not normalized_prefix:
-        return true()
-    return or_(
-        library_items.c.rel_path == normalized_prefix,
-        library_items.c.rel_path.like(f"{_sql_like_escape(normalized_prefix)}/%", escape="\\"),
-    )
-
-
-def _sql_like_escape(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
 
 def latest_scan_completed_at(connection: DBClient, prefix: str | None) -> datetime | None:
     rows = connection.execute(
@@ -544,7 +529,7 @@ def latest_scan_completed_at(connection: DBClient, prefix: str | None) -> dateti
             prefixes = []
         for candidate in prefixes:
             normalized = str(candidate).strip("/")
-            if normalized and prefix.startswith(normalized):
+            if normalized and path_matches_scope(prefix, normalized):
                 return completed
     return None
 
@@ -680,7 +665,7 @@ def _scan_run_matches_prefix(row: DBRow, prefix: str | None) -> str | None | obj
         prefixes = []
     for candidate in prefixes:
         normalized = str(candidate).strip("/")
-        if normalized and prefix.startswith(normalized):
+        if normalized and path_matches_scope(prefix, normalized):
             return normalized
     return _MISSING
 

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -4359,6 +4359,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertIsNone(first_cards[0].review_badge_label)
         self.assertEqual(second_cards[0].review_badge_label, "Encode failed")
         self.assertEqual(second_cards[0].review_badge_tone, "danger")
+        self.assertEqual(second_cards[0].media_scope["kind"], "tv_season")
+        self.assertEqual(second_cards[0].media_scope["match"], "descendants")
         folder_cards_runtime.reset_folder_card_cache()
 
     def test_folder_cards_show_delivery_badge_after_approved_draft_validates(self) -> None:
@@ -12488,6 +12490,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertFalse(payload["pending"])
         self.assertEqual(payload["prefix"], "tv/House/Season 5")
+        self.assertEqual(payload["media_scope"]["kind"], "tv_season")
+        self.assertEqual(payload["media_scope"]["parent"]["prefix"], "tv/House")
         self.assertEqual(payload["sample_item"]["rel_path"], "tv/House/Season 5/episode-promoted-folder.mp4")
         self.assertEqual(payload["summary"]["statuses"]["promoted"], 1)
 
@@ -14251,6 +14255,158 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
         self.assertEqual([item["library_item_id"] for item in items], [encoded_id, validated_id])
 
+    def test_load_folder_staged_items_exact_file_excludes_similarly_named_sibling(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            exact_id, sibling_id = self._insert_exact_root_staged_items(connection, status="encoded")
+
+            with patch(
+                    "mediaforce.web.app.build_manifest_item",
+                    side_effect=lambda row, _config: {"library_item_id": row["id"]},
+            ):
+                items = web_app._load_folder_staged_items(
+                    connection,
+                    self.config,
+                    "other/Foo.mkv",
+                    statuses={"encoded"},
+                )
+
+        self.assertEqual([item["library_item_id"] for item in items], [exact_id])
+        self.assertNotIn(sibling_id, [item["library_item_id"] for item in items])
+
+    def test_validate_exact_file_uses_only_matching_staged_item(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            exact_id, sibling_id = self._insert_exact_root_staged_items(connection, status="encoded")
+
+        validated_item_ids: list[int] = []
+
+        class _ValidateManifestItems(folder_actions_runtime.ValidateManifestItemsFn):
+            def __call__(
+                    self,
+                    _connection: DBClient,
+                    _config: MediaforceConfig,
+                    manifest: folder_actions_runtime.ManifestPayload,
+                    indexes: list[int],
+            ) -> list[folder_actions_runtime.ActionPayload]:
+                validated_item_ids.extend(
+                    int(manifest["items"][index]["library_item_id"])
+                    for index in indexes
+                )
+                return [{"passed": True}]
+
+        with patch(
+                "mediaforce.web.app.build_manifest_item",
+                side_effect=lambda row, _config: {"library_item_id": row["id"]},
+        ):
+            result = folder_actions_runtime.validate_folder_outputs_action(
+                self.config,
+                "other/Foo.mkv",
+                load_folder_staged_items_fn=web_app._load_folder_staged_items,
+                validate_manifest_items_fn=_ValidateManifestItems(),
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(validated_item_ids, [exact_id])
+        self.assertNotIn(sibling_id, validated_item_ids)
+
+    def test_promote_exact_file_uses_only_matching_staged_item(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            exact_id, sibling_id = self._insert_exact_root_staged_items(connection, status="validated")
+
+        promoted_item_ids: list[int] = []
+
+        class _PromoteManifestItems(folder_actions_runtime.PromoteManifestItemsFn):
+            def __call__(
+                    self,
+                    _connection: DBClient,
+                    _config: MediaforceConfig,
+                    manifest: folder_actions_runtime.ManifestPayload,
+                    indexes: list[int],
+                    *,
+                    force: bool,
+            ) -> list[Path]:
+                self_test.assertFalse(force)
+                promoted_item_ids.extend(
+                    int(manifest["items"][index]["library_item_id"])
+                    for index in indexes
+                )
+                return [self_test.root / "promoted" / "Foo.mkv"]
+
+        self_test = self
+        with patch(
+                "mediaforce.web.app.build_manifest_item",
+                side_effect=lambda row, _config: {"library_item_id": row["id"]},
+        ):
+            result = folder_actions_runtime.promote_folder_outputs_action(
+                self.config,
+                "other/Foo.mkv",
+                load_folder_staged_items_fn=web_app._load_folder_staged_items,
+                promote_manifest_items_fn=_PromoteManifestItems(),
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(promoted_item_ids, [exact_id])
+        self.assertNotIn(sibling_id, promoted_item_ids)
+
+    def test_stale_requeue_exact_file_does_not_reset_similarly_named_sibling(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            exact_id, sibling_id = self._insert_exact_root_staged_items(connection, status="encoding")
+
+            folder_actions_runtime._reset_stale_prefix_encoding_items_for_requeue(
+                connection,
+                self.config,
+                "other/Foo.mkv",
+                now_iso=web_app._now_iso,
+            )
+
+            rows = connection.execute(
+                select(library_items.c.id, library_items.c.status)
+                .where(library_items.c.id.in_((exact_id, sibling_id)))
+            ).mappings().fetchall()
+            staged_item_ids = set(
+                connection.execute(
+                    select(staged_artifacts.c.library_item_id)
+                    .where(staged_artifacts.c.library_item_id.in_((exact_id, sibling_id)))
+                ).scalars().all()
+            )
+
+        statuses = {int(row["id"]): str(row["status"]) for row in rows}
+        self.assertEqual(statuses[exact_id], "planned")
+        self.assertEqual(statuses[sibling_id], "encoding")
+        self.assertNotIn(exact_id, staged_item_ids)
+        self.assertIn(sibling_id, staged_item_ids)
+
+    def test_lifecycle_override_rejects_non_tv_exact_scope(self) -> None:
+        source = self.root / "source" / "other" / "Foo.mkv"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text("source")
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_library_item(
+                connection,
+                source,
+                rel_path="other/Foo.mkv",
+            )
+
+        with self.assertRaises(HTTPException) as raised:
+            folder_actions_runtime.queue_folder_encode_action(
+                self.config,
+                "other/Foo.mkv",
+                "",
+                False,
+                True,
+                now_iso=web_app._now_iso,
+                load_job_state=Mock(),
+                load_calibration_state=Mock(),
+                review_gate=Mock(),
+                upsert_override=Mock(),
+                load_active_encode_job_for_prefix_fn=Mock(),
+                clear_terminal_encode_jobs_for_prefix_fn=Mock(),
+                prepare_terminal_encode_job_for_requeue_fn=Mock(),
+                save_encode_job=Mock(),
+            )
+
+        self.assertEqual(raised.exception.status_code, 400)
+        self.assertIn("one season at a time", str(raised.exception.detail))
+
     def test_validate_folder_outputs_action_uses_only_validate_lane_outputs(self) -> None:
         encoded_source = self._create_source_file("episode-encoded-validate.mkv")
         validated_source = self._create_source_file("episode-validated-promote.mkv")
@@ -14486,6 +14642,42 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(workflow_state["next_action"]["kind"], "validate_outputs")
         self.assertEqual(workflow_state["counts"]["encode_candidates"], 0)
 
+    def test_folder_status_payload_exposes_exact_file_scope(self) -> None:
+        source = self.root / "source" / "other" / "Foo.mkv"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text("source")
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_library_item(
+                connection,
+                source,
+                rel_path="other/Foo.mkv",
+            )
+
+        payload = dashboard_payloads.folder_status_payload(
+            self.config,
+            "other/Foo.mkv",
+            load_job_state=lambda _connection, _config, _prefix: None,
+            load_retryable_sample_job_state=lambda _connection, _config, _prefix: None,
+            load_scan_job_state=lambda _config, _prefix: None,
+            load_active_encode_job_for_prefix=lambda _connection, _prefix: None,
+        )
+
+        self.assertEqual(
+            payload["media_scope"],
+            {
+                "schema_version": 1,
+                "prefix": "other/Foo.mkv",
+                "root": "other",
+                "domain": "other",
+                "kind": "media_file",
+                "match": "exact_item",
+                "title": "Foo",
+                "subtitle": "Other",
+                "scope_label": "File",
+                "parent": {"prefix": "other", "title": "Other"},
+            },
+        )
+
     def test_active_encode_job_lookup_matches_overlapping_series_and_season_scopes(self) -> None:
         def save_active_job(connection: DBClient, *, job_id: str, prefix: str, offset_seconds: int) -> None:
             timestamp = (datetime.now(tz=UTC) + timedelta(seconds=offset_seconds)).isoformat(timespec="seconds")
@@ -14536,6 +14728,58 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(child_match["job_id"], "series-active")
         self.assertIsNone(sibling_miss)
         self.assertEqual(parent_match["job_id"], "season-active")
+
+    def test_active_encode_job_lookup_does_not_treat_exact_file_as_parent_scope(self) -> None:
+        source = self.root / "source" / "other" / "Foo.mkv"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text("source")
+        now = web_app._now_iso()
+        manifest_path = self._write_manifest("exact-file-descendant-job.json", [{"library_item_id": 1}])
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_library_item(
+                connection,
+                source,
+                rel_path="other/Foo.mkv",
+            )
+            save_encode_job(
+                connection,
+                {
+                    "job_id": "impossible-descendant",
+                    "prefix": "other/Foo.mkv/descendant",
+                    "job_kind": "folder",
+                    "parent_job_id": None,
+                    "status": "running",
+                    "manifest_path": str(manifest_path),
+                    "manifest_indexes": None,
+                    "item_count": 1,
+                    "saved_profile_path": None,
+                    "host": {},
+                    "last_host": {},
+                    "notes": "",
+                    "bypass_schedule": False,
+                    "attempt_count": 1,
+                    "process_pid": None,
+                    "error": None,
+                    "leased_at": None,
+                    "lease_expires_at": None,
+                    "heartbeat_at": None,
+                    "worker_id": None,
+                    "retry_not_before": None,
+                    "waiting_reason": None,
+                    "terminal_reason": None,
+                    "last_failure_kind": None,
+                    "last_failure_at": None,
+                    "host_cooldown_until": None,
+                    "created_at": now,
+                    "started_at": now,
+                    "finished_at": None,
+                    "updated_at": now,
+                },
+            )
+
+            match = load_active_encode_job_for_prefix(connection, "other/Foo.mkv")
+
+        self.assertIsNone(match)
 
     def test_latest_encode_job_lookup_matches_overlapping_series_and_season_scopes(self) -> None:
         def save_display_job(connection: DBClient, *, job_id: str, prefix: str, offset_seconds: int) -> None:
@@ -16608,17 +16852,51 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
     def _staging_path(self, name: str) -> Path:
         return self.root / "staging" / "tv" / "show" / name
 
+    def _insert_exact_root_staged_items(self, connection: DBClient, *, status: str) -> tuple[int, int]:
+        exact_source = self.root / "source" / "other" / "Foo.mkv"
+        sibling_source = self.root / "source" / "other" / "Foo.mkv.backup.mkv"
+        exact_source.parent.mkdir(parents=True, exist_ok=True)
+        exact_source.write_text("exact")
+        sibling_source.write_text("sibling")
+        exact_stage = self.root / "staging" / "other" / "Foo.mkv"
+        sibling_stage = self.root / "staging" / "other" / "Foo.mkv.backup.mkv"
+        exact_stage.parent.mkdir(parents=True, exist_ok=True)
+        exact_stage.write_text("exact staged")
+        sibling_stage.write_text("sibling staged")
+        exact_id = self._insert_library_item(
+            connection,
+            exact_source,
+            status=status,
+            rel_path="other/Foo.mkv",
+        )
+        sibling_id = self._insert_library_item(
+            connection,
+            sibling_source,
+            status=status,
+            rel_path="other/Foo.mkv.backup.mkv",
+        )
+        self._insert_staged_artifact(connection, exact_id, exact_stage)
+        self._insert_staged_artifact(connection, sibling_id, sibling_stage)
+        return exact_id, sibling_id
+
     @staticmethod
-    def _insert_library_item(connection: DBClient, source_path: Path, *,
-                             status: str = "planned") -> int:
+    def _insert_library_item(
+            connection: DBClient,
+            source_path: Path,
+            *,
+            status: str = "planned",
+            rel_path: str | None = None,
+    ) -> int:
         now = web_app._now_iso()
+        normalized_rel_path = rel_path or f"tv/show/{source_path.name}"
+        path = Path(normalized_rel_path)
         result = connection.execute(
             library_items.insert().values(
                 source_path=str(source_path),
-                rel_path=f"tv/show/{source_path.name}",
-                media_root="tv",
-                parent_dir="tv/show",
-                file_name=source_path.name,
+                rel_path=normalized_rel_path,
+                media_root=path.parts[0],
+                parent_dir=str(path.parent),
+                file_name=path.name,
                 container=".mkv",
                 size_bytes=1024,
                 mtime_ns=1,

--- a/tests/test_library_lifecycle.py
+++ b/tests/test_library_lifecycle.py
@@ -6,10 +6,10 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from mediaforce.core.config import ConfigPaths, DEFAULT_CONFIG_PATH, MediaforceConfig
-from mediaforce.core.db import open_db, reset_engine_cache
+from mediaforce.core.db import DBClient, open_db, reset_engine_cache
 from mediaforce.core.db_tables import library_items, plex_item_metadata, series_metadata
 from mediaforce.library.candidate_selection import project_candidates, season_identity
-from mediaforce.library.run_manifests import build_run_manifest, select_encode_candidates
+from mediaforce.library.run_manifests import build_run_manifest, create_folder_manifest, select_encode_candidates
 from mediaforce.library.workflow_state import build_folder_workflow_state, derive_item_workflow_state
 from mediaforce.web.routes.folders import _request_flag
 from mediaforce.web.runtime.folder_cards import list_folder_cards
@@ -259,6 +259,22 @@ class LibraryLifecycleTests(unittest.TestCase):
         )
         self.assertTrue(provenance["override_applied"])
 
+    def test_manifest_exact_root_movie_excludes_similarly_named_sibling(self) -> None:
+        config = self._config(mode="off")
+        with open_db(config.paths.db_path) as connection:
+            exact_id = self._insert_item(connection, "movies/Foo.mkv", age_days=100)
+            self._insert_item(connection, "movies/Foo.mkv.backup.mkv", age_days=100)
+
+            manifest, _ = create_folder_manifest(
+                connection,
+                config,
+                prefix="movies/Foo.mkv",
+            )
+
+        self.assertEqual([item["library_item_id"] for item in manifest["items"]], [exact_id])
+        self.assertEqual(manifest["selection"]["media_scope"]["kind"], "movie_file")
+        self.assertEqual(manifest["selection"]["media_scope"]["match"], "exact_item")
+
     def test_manual_override_does_not_bypass_unknown_content_age(self) -> None:
         config = self._config(mode="off")
         with open_db(config.paths.db_path) as connection:
@@ -360,7 +376,11 @@ class LibraryLifecycleTests(unittest.TestCase):
     def _config(self, *, mode: str | None = None) -> MediaforceConfig:
         with DEFAULT_CONFIG_PATH.open("rb") as handle:
             raw = copy.deepcopy(tomllib.load(handle))
-        raw["media"]["source_roots"] = {"tv": str(self.root / "source" / "tv")}
+        raw["media"]["source_roots"] = {
+            "movies": str(self.root / "source" / "movies"),
+            "other": str(self.root / "source" / "other"),
+            "tv": str(self.root / "source" / "tv"),
+        }
         raw["media"]["staging_root"] = str(self.root / "staging")
         raw["media"]["archive_root"] = str(self.root / "archive")
         if mode is not None:
@@ -381,7 +401,7 @@ class LibraryLifecycleTests(unittest.TestCase):
         )
         return MediaforceConfig(raw=raw, paths=paths)
 
-    def _insert_item(self, connection, rel_path: str, *, age_days: int) -> int:
+    def _insert_item(self, connection: DBClient, rel_path: str, *, age_days: int) -> int:
         timestamp = NOW - timedelta(days=age_days)
         timestamp_text = timestamp.isoformat(timespec="seconds")
         source_path = self.root / "source" / rel_path
@@ -389,7 +409,7 @@ class LibraryLifecycleTests(unittest.TestCase):
             library_items.insert().values(
                 source_path=str(source_path),
                 rel_path=rel_path,
-                media_root="tv",
+                media_root=Path(rel_path).parts[0],
                 parent_dir=str(Path(rel_path).parent),
                 file_name=Path(rel_path).name,
                 container="mkv",
@@ -419,7 +439,7 @@ class LibraryLifecycleTests(unittest.TestCase):
 
     @staticmethod
     def _insert_series_metadata(
-            connection,
+            connection: DBClient,
             prefix: str,
             *,
             status: str,
@@ -438,7 +458,13 @@ class LibraryLifecycleTests(unittest.TestCase):
         )
 
     @staticmethod
-    def _insert_plex_metadata(connection, item_id: int, *, added_at: datetime, season_index: int) -> None:
+    def _insert_plex_metadata(
+            connection: DBClient,
+            item_id: int,
+            *,
+            added_at: datetime,
+            season_index: int,
+    ) -> None:
         connection.execute(
             plex_item_metadata.insert().values(
                 library_item_id=item_id,

--- a/tests/test_media_scopes.py
+++ b/tests/test_media_scopes.py
@@ -1,0 +1,247 @@
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+from sqlalchemy import event, select
+
+from mediaforce.core.db import DBClient, open_db, reset_engine_cache
+from mediaforce.core.db_tables import library_items
+from mediaforce.library.media_scopes import MediaScopeConflict, media_group_scope_for_rel_path, \
+    media_scope_from_prefix, path_matches_scope, resolve_media_scope, resolve_media_scopes, \
+    scope_prefix_overlap_filter, scope_rel_path_filter, scopes_overlap, tv_series_scope_for_rel_path
+from mediaforce.web import app as web_app
+
+
+class MediaScopeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.temp_dir.name) / "library.sqlite3"
+
+    def tearDown(self) -> None:
+        reset_engine_cache()
+        self.temp_dir.cleanup()
+
+    def test_classifies_root_files_nested_folders_and_tv_scopes(self) -> None:
+        movie_file = media_group_scope_for_rel_path("movies/Foo.mkv")
+        other_file = media_group_scope_for_rel_path("other/Concert.mkv")
+        movie_title = media_group_scope_for_rel_path("movies/Foo/Foo.mkv")
+        other_folder = media_group_scope_for_rel_path("other/Concert/Night 1.mkv")
+        tv_season = media_group_scope_for_rel_path("tv/Show/Season 2/Episode 1.mkv")
+        tv_series = tv_series_scope_for_rel_path("tv/Show/Season 2/Episode 1.mkv")
+
+        self.assertIsNotNone(movie_file)
+        self.assertEqual((movie_file.kind, movie_file.match, movie_file.prefix), ("movie_file", "exact_item", "movies/Foo.mkv"))
+        self.assertEqual(movie_file.to_payload()["parent"], {"prefix": "movies", "title": "Movies"})
+        self.assertIsNotNone(other_file)
+        self.assertEqual((other_file.kind, other_file.match), ("media_file", "exact_item"))
+        self.assertIsNotNone(movie_title)
+        self.assertEqual((movie_title.kind, movie_title.prefix), ("movie_title", "movies/Foo"))
+        self.assertIsNotNone(other_folder)
+        self.assertEqual((other_folder.kind, other_folder.prefix), ("media_folder", "other/Concert"))
+        self.assertIsNotNone(tv_season)
+        self.assertEqual((tv_season.kind, tv_season.prefix), ("tv_season", "tv/Show/Season 2"))
+        self.assertIsNotNone(tv_series)
+        self.assertEqual((tv_series.kind, tv_series.prefix), ("tv_series", "tv/Show"))
+
+    def test_web_grouping_preserves_tv_and_exposes_exact_root_files(self) -> None:
+        self.assertEqual(
+            web_app._folder_group("tv/Show/Season 2/Episode 1.mkv"),
+            ("tv/Show/Season 2", "Show · Season 2", "Show", "Season"),
+        )
+        self.assertEqual(
+            web_app._tv_series_folder_group("tv/Show/Season 2/Episode 1.mkv"),
+            ("tv/Show", "Show", "TV series", "Series"),
+        )
+        self.assertEqual(
+            web_app._folder_group("movies/Foo.mkv"),
+            ("movies/Foo.mkv", "Foo", "Movies", "Title"),
+        )
+        self.assertEqual(
+            web_app._folder_group("other/Concert.mkv"),
+            ("other/Concert.mkv", "Concert", "Other", "File"),
+        )
+        self.assertEqual(
+            web_app._folder_group("tv/Show/Episode 1.mkv"),
+            ("tv/Show/Episode 1.mkv", "Episode 1", "TV", "File"),
+        )
+        self.assertEqual(
+            web_app._folder_group("tv/Show/Season 2/Extras/Clip.mkv"),
+            ("tv/Show/Season 2", "Show · Season 2", "Show", "Season"),
+        )
+
+    def test_nested_tv_folder_scope_preserves_requested_boundary(self) -> None:
+        with open_db(self.db_path) as connection:
+            child_id = self._insert_item(connection, "tv/Show/Season 2/Extras/Clip.mkv")
+            season_id = self._insert_item(connection, "tv/Show/Season 2/Episode 1.mkv")
+
+            scope = resolve_media_scope(connection, "tv/Show/Season 2/Extras")
+            rows = connection.execute(
+                select(library_items.c.id).where(scope_rel_path_filter(library_items.c.rel_path, scope))
+            ).scalars().all()
+
+        self.assertEqual((scope.kind, scope.prefix), ("media_folder", "tv/Show/Season 2/Extras"))
+        self.assertEqual(rows, [child_id])
+        self.assertNotIn(season_id, rows)
+
+    def test_exact_and_descendant_filters_exclude_similarly_named_siblings(self) -> None:
+        with open_db(self.db_path) as connection:
+            exact_id = self._insert_item(connection, "movies/Foo.mkv")
+            sibling_id = self._insert_item(connection, "movies/Foo.mkv.backup.mkv")
+            folder_id = self._insert_item(connection, "movies/Foo/Foo.mkv")
+            folder_sibling_id = self._insert_item(connection, "movies/Foo 2/Foo.mkv")
+
+            exact_scope = resolve_media_scope(connection, "movies/Foo.mkv")
+            folder_scope = resolve_media_scope(connection, "movies/Foo")
+            exact_rows = connection.execute(
+                select(library_items.c.id).where(scope_rel_path_filter(library_items.c.rel_path, exact_scope))
+            ).scalars().all()
+            folder_rows = connection.execute(
+                select(library_items.c.id).where(scope_rel_path_filter(library_items.c.rel_path, folder_scope))
+            ).scalars().all()
+
+        self.assertEqual(exact_scope.match, "exact_item")
+        self.assertEqual(exact_rows, [exact_id])
+        self.assertNotIn(sibling_id, exact_rows)
+        self.assertEqual(folder_scope.match, "descendants")
+        self.assertEqual(folder_rows, [folder_id])
+        self.assertNotIn(folder_sibling_id, folder_rows)
+
+    def test_missing_exact_item_keeps_file_scope_identity(self) -> None:
+        with open_db(self.db_path) as connection:
+            missing_id = self._insert_item(connection, "other/Offline.mkv", status="missing")
+
+            scope = resolve_media_scope(connection, "other/Offline.mkv")
+            rows = connection.execute(
+                select(library_items.c.id).where(scope_rel_path_filter(library_items.c.rel_path, scope))
+            ).scalars().all()
+
+        self.assertEqual((scope.kind, scope.match), ("media_file", "exact_item"))
+        self.assertEqual(rows, [missing_id])
+
+    def test_active_folder_topology_supersedes_missing_exact_tombstone(self) -> None:
+        with open_db(self.db_path) as connection:
+            missing_id = self._insert_item(connection, "other/Foo", status="missing")
+            child_id = self._insert_item(connection, "other/Foo/Bar.mkv")
+
+            scope = resolve_media_scope(connection, "other/Foo")
+            rows = connection.execute(
+                select(library_items.c.id).where(scope_rel_path_filter(library_items.c.rel_path, scope))
+            ).scalars().all()
+
+        self.assertEqual((scope.kind, scope.match), ("media_folder", "descendants"))
+        self.assertEqual(rows, [child_id])
+        self.assertNotIn(missing_id, rows)
+
+    def test_missing_descendant_does_not_override_active_exact_item(self) -> None:
+        with open_db(self.db_path) as connection:
+            exact_id = self._insert_item(connection, "other/Foo")
+            self._insert_item(connection, "other/Foo/Bar.mkv", status="missing")
+
+            scope = resolve_media_scope(connection, "other/Foo")
+            rows = connection.execute(
+                select(library_items.c.id).where(scope_rel_path_filter(library_items.c.rel_path, scope))
+            ).scalars().all()
+
+        self.assertEqual(scope.match, "exact_item")
+        self.assertEqual(rows, [exact_id])
+
+    def test_multiple_active_exact_items_fail_closed(self) -> None:
+        with open_db(self.db_path) as connection:
+            self._insert_item(connection, "other/Foo.mkv", source_path="/media-a/other/Foo.mkv")
+            self._insert_item(connection, "other/Foo.mkv", source_path="/media-b/other/Foo.mkv")
+
+            with self.assertRaisesRegex(MediaScopeConflict, "multiple active items"):
+                resolve_media_scope(connection, "other/Foo.mkv")
+
+    def test_descendant_matching_is_case_sensitive(self) -> None:
+        with open_db(self.db_path) as connection:
+            upper_id = self._insert_item(connection, "movies/Foo/A.mkv")
+            lower_id = self._insert_item(connection, "movies/foo/B.mkv")
+
+            scope = resolve_media_scope(connection, "movies/Foo")
+            rows = connection.execute(
+                select(library_items.c.id).where(scope_rel_path_filter(library_items.c.rel_path, scope))
+            ).scalars().all()
+            overlap_rows = connection.execute(
+                select(library_items.c.id).where(
+                    scope_prefix_overlap_filter(
+                        library_items.c.rel_path,
+                        media_scope_from_prefix("movies/Foo", match="descendants"),
+                    )
+                )
+            ).scalars().all()
+
+        self.assertEqual(rows, [upper_id])
+        self.assertNotIn(lower_id, rows)
+        self.assertEqual(overlap_rows, [upper_id])
+
+    def test_bulk_exact_resolution_uses_bounded_query_count(self) -> None:
+        with open_db(self.db_path) as connection:
+            prefixes = [f"movies/Movie {index}.mkv" for index in range(401)]
+            for prefix in prefixes:
+                self._insert_item(connection, prefix)
+            query_count = 0
+
+            def count_query(*_args: object) -> None:
+                nonlocal query_count
+                query_count += 1
+
+            event.listen(connection.engine, "before_cursor_execute", count_query)
+            try:
+                bulk_scopes = resolve_media_scopes(connection, prefixes)
+            finally:
+                event.remove(connection.engine, "before_cursor_execute", count_query)
+
+        self.assertTrue(all(scope.match == "exact_item" for scope in bulk_scopes))
+        self.assertLessEqual(query_count, 6)
+
+    def test_ambiguous_active_item_and_descendants_fail_closed(self) -> None:
+        with open_db(self.db_path) as connection:
+            self._insert_item(connection, "other/Foo")
+            self._insert_item(connection, "other/Foo/Bar.mkv")
+
+            with self.assertRaisesRegex(MediaScopeConflict, "both an item and a folder prefix"):
+                resolve_media_scope(connection, "other/Foo")
+
+    def test_exact_scope_does_not_overlap_descendant_jobs(self) -> None:
+        with open_db(self.db_path) as connection:
+            self._insert_item(connection, "movies/Foo.mkv")
+            exact_scope = resolve_media_scope(connection, "movies/Foo.mkv")
+
+        self.assertTrue(path_matches_scope("movies/Foo.mkv", exact_scope))
+        self.assertFalse(path_matches_scope("movies/Foo.mkv/descendant.mkv", exact_scope))
+        self.assertTrue(scopes_overlap(exact_scope, "movies"))
+        self.assertFalse(scopes_overlap(exact_scope, "movies/Foo.mkv/descendant"))
+
+    @staticmethod
+    def _insert_item(
+            connection: DBClient,
+            rel_path: str,
+            *,
+            status: str = "discovered",
+            source_path: str | None = None,
+    ) -> int:
+        now = datetime.now(tz=UTC).isoformat(timespec="seconds")
+        path = Path(rel_path)
+        result = connection.execute(
+            library_items.insert().values(
+                source_path=source_path or f"/media/{rel_path}",
+                rel_path=rel_path,
+                media_root=path.parts[0],
+                parent_dir=str(path.parent),
+                file_name=path.name,
+                container=path.suffix or ".mkv",
+                size_bytes=1024,
+                mtime_ns=1,
+                fingerprint=f"fingerprint-{rel_path}",
+                audio_summary_json="[]",
+                subtitle_summary_json="[]",
+                status=status,
+                last_scan_id="scan-1",
+                discovered_at=now,
+                last_seen_at=now,
+                updated_at=now,
+            )
+        )
+        return int(result.inserted_primary_key[0])


### PR DESCRIPTION
## Summary
- add a canonical typed media-scope boundary for TV, movies, and generic libraries
- distinguish exact files from case-sensitive, slash-bounded descendant folders across preview, manifests, queues, requeue, validation, and promotion
- expose media-scope contracts in folder cards, detail/status APIs, manifests, and frontend types
- preserve TV series/season grouping and restrict lifecycle overrides to explicit TV season scopes

## Safety and compatibility
- missing standalone files retain exact-file identity, while stale file tombstones yield to active folder topology
- duplicate active exact paths and active file/folder ambiguity fail closed
- nested requested TV paths retain their own bounded folder scope; normal TV item grouping remains season-oriented
- 3D/VR-specific production enablement remains parked under #188; this change adds no spatial-media policy

## Validation
- `bash scripts/pre-commit-check.sh`
- `uv build`
- 853 backend tests and 6 subtests
- 188 frontend tests
- desktop and 390px browser review of Library and Folder Studio
- folder API media-scope payload verified in the live browser
- PyCharm changed-files inspection: GREEN
- independent agent review completed; resolver performance, tombstone topology, case sensitivity, and TV boundary findings addressed

Closes #186