### PR TITLE
Expose typed library configuration in Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,9 +346,14 @@ that machine can reuse them without mutating the tracked repo defaults. If a
 bench-learned policy should become a shared starting point for everyone, copy it
 into `config/folder-defaults.toml` intentionally.
 
-Use the web Settings page for local libraries, the transcode folder, remote host
-definitions, the Plex server URL, and Plex-to-Mediaforce library path mappings
-so those environment details stay off the checked-in repo.
+Use the web Settings page for ordered typed library roots, the transcode folder,
+remote host definitions, the Plex server URL, and Plex-to-Mediaforce path
+mappings so those environment details stay off the checked-in repo. Library
+labels are editable while root IDs remain stable. TV can run in Production;
+Movies, 3D/VR, and Other can be configured as Browse only until their dedicated
+workflow and safety plans land. Changing an existing type requires an explicit
+compatibility preview and never moves media files. See
+`docs/architecture/typed-library-settings.md` for the durable config contract.
 
 ## Library lifecycle policy
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,8 @@ Use this directory for guidance that should not live in `AGENTS.md`.
   execution, deterministic bypasses, privacy-safe telemetry, and eval operation
 - `docs/architecture/library-lifecycle-policy.md`: current-season protection,
   acquisition guards, Plex/TMDB metadata, age ranking, and manifest provenance
+- `docs/architecture/typed-library-settings.md`: ordered typed roots,
+  availability states, type-change compatibility, and credential boundaries
 
 ## Design briefs
 

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -163,6 +163,9 @@ Guidance:
 - `media_scopes.py`
   - canonical operator grouping for TV, movie, and generic media roots
   - exact-item versus descendant matching, SQL-safe boundaries, and API scope payloads
+- `library_settings.py`
+  - ordered typed-root schema, legacy inference, safe availability defaults,
+    type-specific policies, and profile registries
 - `folder_profiles.py`
   - folder inspection and suggested override shaping
 - `run_manifests.py`

--- a/docs/architecture/typed-library-settings.md
+++ b/docs/architecture/typed-library-settings.md
@@ -1,0 +1,81 @@
+# Typed Library Settings
+
+Mediaforce stores operator-facing library configuration as ordered typed roots.
+The Settings workstation is the authority for root labels, order, type,
+availability, processing profile, Plex path translation, and type-specific
+policy.
+
+## Configuration contract
+
+`media.libraries` is the ordered canonical record. Each row contains:
+
+- `key`: stable root identity used by catalog rows, hosts, manifests, and saved
+  work
+- `label`: editable operator-facing name
+- `path`: the controller's local path
+- `color`: operator color used by Library views
+- `plex_path`: optional path reported by Plex when it differs from `path`
+- `type`: `tv`, `movie`, `spatial`, or `other`
+- `availability`: `production`, `browse_only`, or `disabled`
+- `default_profile`: a profile compatible with the selected type
+- `policy`: only the controls relevant to the selected type
+
+`media.source_roots`, `media.library_colors`, and
+`metadata.plex.library_roots` remain compatibility projections for existing
+runtime consumers. When `media.libraries` exists, its rows define effective
+root membership and order; omitted compatibility-map entries do not resurrect
+roots from checked-in defaults.
+
+Legacy configurations with only `media.source_roots` remain readable. Settings
+projects `tv` as TV, `movies` as Movies, and unknown root IDs as Other. TV
+defaults to Production; other inferred types default to Browse only on the
+first typed save.
+
+## Availability
+
+- `production`: scan, display, select, calibrate, queue, validate, and promote
+- `browse_only`: scan and display, but never select or process
+- `disabled`: neither scan nor process; a full scan marks former catalog rows
+  missing
+
+TV is the only production-enabled type in this phase. Movies remains Browse
+only until the Movies workflow is complete. Other remains Browse only until its
+bounded generic workflow is complete. Spatial media remains safety-blocked
+until the 3D/VR qualification plan proves geometry, stream, metadata, audio,
+and target-device playback invariants.
+
+## Type policies
+
+TV exposes current-season mode, inactivity release days, acquisition hold days,
+and series-status freshness. These values layer above global planning defaults
+and below explicit folder overrides.
+
+Movies records title grouping, separate editions, extras inclusion, and ranking
+intent. Other records a bounded folder or exact-file work unit. Spatial records
+the playback target, stereo layout, projection, source-preserving geometry, and
+an unqualified container state. Controls that do not apply to the selected type
+are structurally absent from Settings.
+
+## Type changes
+
+Changing an existing root type requires a server-produced compatibility
+preview. The acknowledgement is bound to the root ID and exact old/new type.
+Confirmation returns the root to Browse only, schedules a catalog refresh, and
+preserves historical folder overrides with their former library type. Those
+overrides remain recoverable but are ignored while their type is incompatible.
+Media files are never moved or deleted by a type change.
+
+## Credentials
+
+Plex and TMDB tokens remain environment-only. Settings exposes the environment
+variable name and a ready/needed signal, but never accepts, persists, logs, or
+returns a token value. Per-root Plex path translation is configuration, not a
+credential.
+
+## Refresh behavior
+
+Root add/remove, path changes, scan enablement changes, and type changes require
+a catalog scan. Label, color, ordering, profile, and policy changes do not alter
+filesystem membership. Metadata configuration changes continue through the
+metadata refresh performed by the scan runtime. Unrelated host, schedule,
+working-folder, and advanced runtime settings survive typed-library saves.

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -383,11 +383,54 @@ export interface HostsPayload {
 	hosts: HostRuntime[];
 }
 
+export type LibraryType = 'tv' | 'movie' | 'spatial' | 'other';
+export type LibraryAvailability = 'production' | 'browse_only' | 'disabled';
+
+export interface LibraryPolicy {
+	series_lifecycle_mode?: 'auto' | 'on' | 'off';
+	current_season_inactive_days?: number;
+	season_acquisition_hold_days?: number;
+	series_metadata_stale_days?: number;
+	grouping?: 'title' | 'folder' | 'file';
+	editions?: 'separate';
+	extras?: 'exclude' | 'include';
+	ranking?: 'oldest_added_first' | 'largest_first';
+	playback_target?: string;
+	stereo_layout?: 'unknown' | 'side_by_side' | 'top_bottom' | 'frame_sequential';
+	projection?: 'unknown' | 'flat' | 'equirectangular_180' | 'equirectangular_360';
+	geometry_policy?: 'preserve';
+	container_profile?: 'unqualified';
+}
+
+export interface LibraryReadiness {
+	state: 'ready' | 'incomplete' | 'blocked' | 'browse_only' | 'disabled';
+	label: string;
+	detail: string;
+}
+
 export interface SettingsLibrary {
 	index: string;
 	key: string;
+	label: string;
 	path: string;
 	color: string;
+	library_type: LibraryType;
+	availability: LibraryAvailability;
+	default_profile: string;
+	plex_path: string;
+	policy: LibraryPolicy;
+	readiness: LibraryReadiness;
+	type_change_confirmation: string;
+}
+
+export interface LibraryTypeChangePreview {
+	key: string;
+	from_type: LibraryType;
+	to_type: LibraryType;
+	item_count: number;
+	requires_rescan: boolean;
+	clears_saved_profiles: boolean;
+	acknowledgement: string;
 }
 
 export interface SettingsHost {
@@ -423,6 +466,8 @@ export interface SettingsPayload {
 	error: string | null;
 	saved: boolean;
 	libraries: SettingsLibrary[];
+	library_type_options: Array<{ key: LibraryType; label: string }>;
+	library_profile_options: Record<LibraryType, Array<{ key: string; label: string }>>;
 	remote_hosts: SettingsHost[];
 	transcode_root: string;
 	video_defaults: {

--- a/frontend/src/lib/components/settings/LibraryRootsPanel.svelte
+++ b/frontend/src/lib/components/settings/LibraryRootsPanel.svelte
@@ -1,0 +1,721 @@
+<script lang="ts">
+	import type {
+		LibraryAvailability,
+		LibraryPolicy,
+		LibraryType,
+		SettingsLibrary,
+		SettingsPayload
+	} from '$lib/api/types';
+	import { libraryReadiness } from '$lib/settings/editor';
+	import StateBadge from '../workstation/StateBadge.svelte';
+
+	type BadgeTone = 'active' | 'ready' | 'wait' | 'fail' | 'idle';
+
+	let {
+		libraries,
+		typeOptions,
+		profileOptions,
+		plexReady,
+		plexTokenEnv,
+		onLibrariesChange,
+		onAdd,
+		onRemove,
+		onMove,
+		onTypeChange
+	}: {
+		libraries: SettingsLibrary[];
+		typeOptions: SettingsPayload['library_type_options'];
+		profileOptions: SettingsPayload['library_profile_options'];
+		plexReady: boolean;
+		plexTokenEnv: string;
+		onLibrariesChange: (libraries: SettingsLibrary[]) => void;
+		onAdd: () => void;
+		onRemove: (index: number) => void;
+		onMove: (index: number, direction: -1 | 1) => void;
+		onTypeChange: (index: number, libraryType: LibraryType) => void;
+	} = $props();
+
+	let selectedIndex = $state(0);
+	const selected = $derived(libraries[selectedIndex] ?? null);
+
+	$effect(() => {
+		if (libraries.length === 0) selectedIndex = 0;
+		else if (selectedIndex >= libraries.length) selectedIndex = libraries.length - 1;
+	});
+
+	function inputValue(event: Event): string {
+		return (event.currentTarget as HTMLInputElement).value;
+	}
+
+	function selectValue(event: Event): string {
+		return (event.currentTarget as HTMLSelectElement).value;
+	}
+
+	function patchSelected(patch: Partial<SettingsLibrary>) {
+		if (!selected) return;
+		onLibrariesChange(
+			libraries.map((library, index) => {
+				if (index !== selectedIndex) return library;
+				const updated = { ...library, ...patch };
+				return { ...updated, readiness: libraryReadiness(updated) };
+			})
+		);
+	}
+
+	function patchPolicy(patch: Partial<LibraryPolicy>) {
+		if (!selected) return;
+		patchSelected({ policy: { ...selected.policy, ...patch } });
+	}
+
+	function readinessTone(state: SettingsLibrary['readiness']['state']): BadgeTone {
+		if (state === 'ready') return 'ready';
+		if (state === 'incomplete' || state === 'browse_only') return 'wait';
+		if (state === 'blocked') return 'fail';
+		return 'idle';
+	}
+
+	function availabilityLabel(availability: LibraryAvailability): string {
+		if (availability === 'production') return 'Production';
+		if (availability === 'browse_only') return 'Browse only';
+		return 'Disabled';
+	}
+</script>
+
+<div class="library-workstation">
+	<section class="library-master" aria-label="Configured library roots">
+		<header class="library-master__head">
+			<div>
+				<strong>Library roots</strong>
+				<span>{libraries.length.toLocaleString('en-US')} configured</span>
+			</div>
+			<button type="button" class="control" onclick={onAdd}>Add library</button>
+		</header>
+
+		<div class="library-root-list">
+			{#each libraries as library, index (`root-${library.key}-${index}`)}
+				<button
+					type="button"
+					class="library-root-row"
+					class:is-selected={selectedIndex === index}
+					onclick={() => (selectedIndex = index)}
+				>
+					<span class="library-root-row__order mf-mono">{String(index + 1).padStart(2, '0')}</span>
+					<span class="library-root-row__identity">
+						<strong>{library.label || 'Untitled library'}</strong>
+						<small>{library.path || 'Local path needed'}</small>
+					</span>
+					<span class="library-root-row__signals">
+						<small>{typeOptions.find((option) => option.key === library.library_type)?.label}</small
+						>
+						<StateBadge
+							tone={readinessTone(libraryReadiness(library).state)}
+							label={libraryReadiness(library).label}
+						/>
+					</span>
+				</button>
+			{/each}
+		</div>
+	</section>
+
+	<section class="library-inspector" aria-label="Selected library settings">
+		{#if selected}
+			<header class="library-inspector__head">
+				<div>
+					<span class="mf-eyebrow">Selected root</span>
+					<h3>{selected.label || 'New library'}</h3>
+					<p>{libraryReadiness(selected).detail}</p>
+				</div>
+				<StateBadge
+					tone={readinessTone(libraryReadiness(selected).state)}
+					label={libraryReadiness(selected).label}
+				/>
+			</header>
+
+			<div class="library-inspector__actions" aria-label="Library order and removal">
+				<button
+					type="button"
+					class="control control--quiet"
+					disabled={selectedIndex === 0}
+					onclick={() => onMove(selectedIndex, -1)}>Move up</button
+				>
+				<button
+					type="button"
+					class="control control--quiet"
+					disabled={selectedIndex === libraries.length - 1}
+					onclick={() => onMove(selectedIndex, 1)}>Move down</button
+				>
+				<button
+					type="button"
+					class="control control--danger"
+					onclick={() => onRemove(selectedIndex)}
+				>
+					Remove library
+				</button>
+			</div>
+
+			<div class="library-form-grid">
+				<label class="stacked-field">
+					<span>Label</span>
+					<input
+						class="field"
+						value={selected.label}
+						placeholder="Movies"
+						oninput={(event) => patchSelected({ label: inputValue(event) })}
+					/>
+				</label>
+				<label class="stacked-field">
+					<span>Root ID</span>
+					<input class="field mf-mono" value={selected.key} readonly />
+					<small>Stable identity for scans, workers, and saved work.</small>
+				</label>
+				<label class="stacked-field library-form-grid__wide">
+					<span>Local path</span>
+					<input
+						class="field field--path"
+						value={selected.path}
+						placeholder="/Volumes/media/movies"
+						oninput={(event) => patchSelected({ path: inputValue(event) })}
+					/>
+				</label>
+				<label class="stacked-field">
+					<span>Library type</span>
+					<select
+						class="field"
+						value={selected.library_type}
+						onchange={(event) => {
+							const target = event.currentTarget as HTMLSelectElement;
+							onTypeChange(selectedIndex, target.value as LibraryType);
+							target.value = selected.library_type;
+						}}
+					>
+						{#each typeOptions as option (option.key)}
+							<option value={option.key}>{option.label}</option>
+						{/each}
+					</select>
+				</label>
+				<label class="stacked-field">
+					<span>Availability</span>
+					<select
+						class="field"
+						value={selected.availability}
+						onchange={(event) =>
+							patchSelected({ availability: selectValue(event) as LibraryAvailability })}
+					>
+						<option value="production" disabled={selected.library_type !== 'tv'}>Production</option>
+						<option value="browse_only">Browse only</option>
+						<option value="disabled">Disabled</option>
+					</select>
+					<small>{availabilityLabel(selected.availability)}</small>
+				</label>
+				<label class="stacked-field">
+					<span>Default processing profile</span>
+					<select
+						class="field"
+						value={selected.default_profile}
+						disabled={selected.availability !== 'production'}
+						onchange={(event) => patchSelected({ default_profile: selectValue(event) })}
+					>
+						{#each profileOptions[selected.library_type] as option (option.key)}
+							<option value={option.key}>{option.label}</option>
+						{/each}
+					</select>
+					{#if selected.availability !== 'production'}
+						<small>No processing profile is required outside Production.</small>
+					{/if}
+				</label>
+				<label class="stacked-field">
+					<span>Library color</span>
+					<div class="color-field">
+						<input
+							type="color"
+							value={selected.color}
+							oninput={(event) => patchSelected({ color: inputValue(event) })}
+						/>
+						<code>{selected.color}</code>
+					</div>
+				</label>
+			</div>
+
+			<section class="library-policy" aria-label="Library-specific policy">
+				<header>
+					<div>
+						<span class="mf-eyebrow">Type policy</span>
+						<h4>{typeOptions.find((option) => option.key === selected.library_type)?.label}</h4>
+					</div>
+					<small>Only settings relevant to this library type appear here.</small>
+				</header>
+
+				{#if selected.library_type === 'tv'}
+					<div class="policy-grid">
+						<label class="stacked-field">
+							<span>Current-season protection</span>
+							<select
+								class="field"
+								value={selected.policy.series_lifecycle_mode ?? 'auto'}
+								onchange={(event) =>
+									patchPolicy({
+										series_lifecycle_mode: selectValue(event) as 'auto' | 'on' | 'off'
+									})}
+							>
+								<option value="auto">Automatic from TMDB</option>
+								<option value="on">Always protect latest season</option>
+								<option value="off">Off</option>
+							</select>
+						</label>
+						<label class="stacked-field">
+							<span>Release after inactive days</span>
+							<input
+								class="field"
+								type="number"
+								min="1"
+								max="3650"
+								value={selected.policy.current_season_inactive_days ?? 365}
+								oninput={(event) =>
+									patchPolicy({ current_season_inactive_days: Number(inputValue(event)) })}
+							/>
+						</label>
+						<label class="stacked-field">
+							<span>Hold newly acquired seasons</span>
+							<input
+								class="field"
+								type="number"
+								min="0"
+								max="365"
+								value={selected.policy.season_acquisition_hold_days ?? 30}
+								oninput={(event) =>
+									patchPolicy({ season_acquisition_hold_days: Number(inputValue(event)) })}
+							/>
+						</label>
+						<label class="stacked-field">
+							<span>Refresh series status after days</span>
+							<input
+								class="field"
+								type="number"
+								min="1"
+								max="365"
+								value={selected.policy.series_metadata_stale_days ?? 7}
+								oninput={(event) =>
+									patchPolicy({ series_metadata_stale_days: Number(inputValue(event)) })}
+							/>
+						</label>
+					</div>
+				{:else if selected.library_type === 'movie'}
+					<div class="policy-grid">
+						<div class="policy-readout"><span>Grouping</span><strong>Movie title</strong></div>
+						<div class="policy-readout"><span>Editions</span><strong>Keep separate</strong></div>
+						<label class="stacked-field">
+							<span>Extras by default</span>
+							<select
+								class="field"
+								value={selected.policy.extras ?? 'exclude'}
+								onchange={(event) =>
+									patchPolicy({ extras: selectValue(event) as 'exclude' | 'include' })}
+							>
+								<option value="exclude">Exclude</option>
+								<option value="include">Include deliberately</option>
+							</select>
+						</label>
+						<label class="stacked-field">
+							<span>Ranking</span>
+							<select
+								class="field"
+								value={selected.policy.ranking ?? 'oldest_added_first'}
+								onchange={(event) =>
+									patchPolicy({
+										ranking: selectValue(event) as 'oldest_added_first' | 'largest_first'
+									})}
+							>
+								<option value="oldest_added_first">Oldest added first</option>
+								<option value="largest_first">Largest first</option>
+							</select>
+						</label>
+					</div>
+				{:else if selected.library_type === 'spatial'}
+					<div class="policy-grid">
+						<label class="stacked-field library-form-grid__wide">
+							<span>Playback target</span>
+							<input
+								class="field"
+								value={selected.policy.playback_target ?? ''}
+								placeholder="Headset and player application"
+								oninput={(event) => patchPolicy({ playback_target: inputValue(event) })}
+							/>
+						</label>
+						<label class="stacked-field">
+							<span>Stereo layout</span>
+							<select
+								class="field"
+								value={selected.policy.stereo_layout ?? 'unknown'}
+								onchange={(event) =>
+									patchPolicy({
+										stereo_layout: selectValue(event) as LibraryPolicy['stereo_layout']
+									})}
+							>
+								<option value="unknown">Needs classification</option>
+								<option value="side_by_side">Side by side</option>
+								<option value="top_bottom">Top / bottom</option>
+								<option value="frame_sequential">Frame sequential</option>
+							</select>
+						</label>
+						<label class="stacked-field">
+							<span>Projection</span>
+							<select
+								class="field"
+								value={selected.policy.projection ?? 'unknown'}
+								onchange={(event) =>
+									patchPolicy({ projection: selectValue(event) as LibraryPolicy['projection'] })}
+							>
+								<option value="unknown">Needs classification</option>
+								<option value="flat">Flat stereoscopic</option>
+								<option value="equirectangular_180">Equirectangular 180</option>
+								<option value="equirectangular_360">Equirectangular 360</option>
+							</select>
+						</label>
+						<div class="policy-readout"><span>Geometry</span><strong>Preserve source</strong></div>
+						<div class="policy-readout">
+							<span>Container / codec</span><strong>Unqualified</strong>
+						</div>
+					</div>
+					<p class="policy-warning">
+						Production remains blocked until #188 validates geometry, streams, metadata, audio, and
+						target-device playback.
+					</p>
+				{:else}
+					<div class="policy-grid">
+						<label class="stacked-field">
+							<span>Default work unit</span>
+							<select
+								class="field"
+								value={selected.policy.grouping ?? 'folder'}
+								onchange={(event) =>
+									patchPolicy({ grouping: selectValue(event) as 'folder' | 'file' })}
+							>
+								<option value="folder">Bounded folder</option>
+								<option value="file">Exact file</option>
+							</select>
+						</label>
+						<p class="policy-copy">
+							Other libraries never inherit season, edition, or spatial-video behavior.
+						</p>
+					</div>
+				{/if}
+			</section>
+
+			<section class="library-plex" aria-label="Plex mapping">
+				<div>
+					<span class="mf-eyebrow">Plex mapping</span>
+					<h4>{selected.plex_path.trim() ? 'Custom server path' : 'Uses local path'}</h4>
+					<p>Leave blank when Plex reports the same path Mediaforce uses.</p>
+				</div>
+				<label class="stacked-field">
+					<span>Path reported by Plex</span>
+					<input
+						class="field field--path"
+						value={selected.plex_path}
+						placeholder="/mnt/media/movies"
+						oninput={(event) => patchSelected({ plex_path: inputValue(event) })}
+					/>
+				</label>
+				<div class="plex-readiness">
+					<StateBadge
+						tone={plexReady ? 'ready' : 'wait'}
+						label={plexReady ? 'Token ready' : 'Token needed'}
+					/>
+					<code>{plexTokenEnv}</code>
+					<small>Token values are never stored or shown here.</small>
+				</div>
+			</section>
+		{:else}
+			<div class="library-empty">
+				<strong>No library selected</strong>
+				<p>Add a root to configure where Mediaforce scans.</p>
+			</div>
+		{/if}
+	</section>
+</div>
+
+<style>
+	.library-workstation {
+		display: grid;
+		grid-template-columns: minmax(16rem, 0.72fr) minmax(0, 1.7fr);
+		min-height: 34rem;
+		border: 1px solid var(--mf-line);
+		background: color-mix(in srgb, var(--mf-bg-panel) 94%, transparent);
+	}
+
+	.library-master {
+		border-right: 1px solid var(--mf-line);
+		background: color-mix(in srgb, var(--mf-bg-base) 86%, var(--mf-bg-panel));
+	}
+
+	.library-master__head,
+	.library-inspector__head,
+	.library-policy > header,
+	.library-plex {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.library-master__head {
+		padding: 0.85rem;
+		border-bottom: 1px solid var(--mf-line);
+	}
+
+	.library-master__head > div,
+	.library-root-row__identity,
+	.library-root-row__signals,
+	.library-inspector__head > div,
+	.library-policy > header > div,
+	.library-plex > div,
+	.plex-readiness {
+		display: grid;
+		gap: 0.24rem;
+	}
+
+	.library-master__head span,
+	.library-root-row small,
+	.library-inspector__head p,
+	.library-policy header small,
+	.stacked-field small,
+	.library-plex p,
+	.plex-readiness small {
+		color: var(--mf-fg-secondary);
+	}
+
+	.library-root-list {
+		display: grid;
+	}
+
+	.library-root-row {
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr) auto;
+		gap: 0.65rem;
+		align-items: center;
+		width: 100%;
+		padding: 0.72rem 0.8rem;
+		border: 0;
+		border-bottom: 1px solid var(--mf-line);
+		background: transparent;
+		color: inherit;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	.library-root-row:hover,
+	.library-root-row.is-selected {
+		background: color-mix(in srgb, var(--mf-active-fg) 10%, transparent);
+	}
+
+	.library-root-row.is-selected {
+		box-shadow: inset 3px 0 var(--mf-active-fg);
+	}
+
+	.library-root-row__order {
+		color: var(--mf-fg-secondary);
+		font-size: 0.72rem;
+	}
+
+	.library-root-row__identity {
+		min-width: 0;
+	}
+
+	.library-root-row__identity strong,
+	.library-root-row__identity small {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.library-root-row__signals {
+		justify-items: end;
+	}
+
+	.library-inspector {
+		min-width: 0;
+		padding: 1rem;
+	}
+
+	.library-inspector__head {
+		padding-bottom: 0.9rem;
+		border-bottom: 1px solid var(--mf-line);
+	}
+
+	.library-inspector__head h3,
+	.library-policy h4,
+	.library-plex h4 {
+		margin: 0;
+	}
+
+	.library-inspector__head p,
+	.library-plex p {
+		margin: 0;
+	}
+
+	.library-inspector__actions {
+		display: flex;
+		gap: 0.45rem;
+		padding: 0.75rem 0;
+	}
+
+	.library-inspector__actions .control--danger {
+		margin-left: auto;
+	}
+
+	.library-form-grid,
+	.policy-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.75rem;
+	}
+
+	.library-form-grid__wide {
+		grid-column: 1 / -1;
+	}
+
+	.stacked-field {
+		display: grid;
+		gap: 0.34rem;
+	}
+
+	.stacked-field > span,
+	.policy-readout span {
+		font-size: 0.72rem;
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		color: var(--mf-fg-secondary);
+	}
+
+	.color-field {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		min-height: 2.5rem;
+		padding: 0.3rem 0.55rem;
+		border: 1px solid var(--mf-line);
+		background: var(--mf-bg-input);
+	}
+
+	.color-field input {
+		width: 2.5rem;
+		height: 1.7rem;
+		padding: 0;
+		border: 0;
+		background: transparent;
+	}
+
+	.library-policy,
+	.library-plex {
+		margin-top: 1rem;
+		padding: 0.9rem;
+		border: 1px solid var(--mf-line);
+		background: color-mix(in srgb, var(--mf-bg-base) 72%, var(--mf-bg-panel));
+	}
+
+	.library-policy > header {
+		margin-bottom: 0.8rem;
+	}
+
+	.policy-readout {
+		display: grid;
+		gap: 0.3rem;
+		align-content: center;
+		min-height: 4.2rem;
+		padding: 0.7rem;
+		border: 1px solid var(--mf-line);
+		background: color-mix(in srgb, var(--mf-bg-panel) 88%, transparent);
+	}
+
+	.policy-warning,
+	.policy-copy {
+		margin: 0.8rem 0 0;
+		padding: 0.65rem 0.75rem;
+		border-left: 3px solid var(--mf-wait-fg);
+		background: color-mix(in srgb, var(--mf-wait-fg) 10%, transparent);
+		color: var(--mf-fg-secondary);
+	}
+
+	.library-plex {
+		align-items: end;
+		flex-wrap: wrap;
+	}
+
+	.library-plex > div,
+	.library-plex > label {
+		flex: 1 1 14rem;
+	}
+
+	.plex-readiness {
+		flex: 0 1 13rem;
+	}
+
+	.plex-readiness code {
+		font-size: 0.72rem;
+	}
+
+	.library-empty {
+		display: grid;
+		place-content: center;
+		min-height: 30rem;
+		text-align: center;
+		color: var(--mf-fg-secondary);
+	}
+
+	.library-empty p {
+		margin: 0.35rem 0 0;
+	}
+
+	@media (max-width: 900px) {
+		.library-workstation {
+			grid-template-columns: 1fr;
+		}
+
+		.library-master {
+			border-right: 0;
+			border-bottom: 1px solid var(--mf-line);
+		}
+
+		.library-root-list {
+			grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+		}
+
+		.library-root-row {
+			border-right: 1px solid var(--mf-line);
+		}
+	}
+
+	@media (max-width: 620px) {
+		.library-master__head,
+		.library-inspector__head,
+		.library-policy > header,
+		.library-plex {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.library-inspector {
+			padding: 0.75rem;
+		}
+
+		.library-inspector__actions {
+			display: grid;
+			grid-template-columns: 1fr 1fr;
+		}
+
+		.library-inspector__actions .control--danger {
+			grid-column: 1 / -1;
+			margin-left: 0;
+		}
+
+		.library-form-grid,
+		.policy-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.library-form-grid__wide {
+			grid-column: auto;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/settings/SettingsEditor.svelte
+++ b/frontend/src/lib/components/settings/SettingsEditor.svelte
@@ -6,6 +6,8 @@
 		ArchiveCleanupPayload,
 		HostRuntime,
 		HostsPayload,
+		LibraryType,
+		LibraryTypeChangePreview,
 		ScheduleProfile,
 		SettingsHost,
 		SettingsLibrary,
@@ -16,6 +18,7 @@
 		addHostDraft,
 		addLibraryDraft,
 		addScheduleDraft,
+		applyLibraryTypeChange,
 		archiveCleanupTargetDirty,
 		buildArchiveCleanupClearPayload,
 		buildSettingsSavePayload,
@@ -23,6 +26,7 @@
 		hostLibraryAccessChecked,
 		hostLibraryAccessCopy,
 		hostDraftRuntimeKey,
+		moveLibraryDraft,
 		removeAtIndex,
 		scheduleWindowSummaryCopy,
 		settingsDraftIsDirty,
@@ -33,6 +37,7 @@
 		type SettingsDraft
 	} from '$lib/settings/editor';
 	import OperatorShell from '../workstation/OperatorShell.svelte';
+	import LibraryRootsPanel from './LibraryRootsPanel.svelte';
 	import StateBadge from '../workstation/StateBadge.svelte';
 	import WorkstationPanel from '../workstation/WorkstationPanel.svelte';
 	import { workerCapabilityLabel } from '../workstation/ops-workstation';
@@ -46,6 +51,18 @@
 		ok: boolean;
 		message?: string;
 		archive_cleanup?: ArchiveCleanupPayload;
+	};
+	type TypePreviewResponse = {
+		ok: boolean;
+		message?: string;
+		preview?: LibraryTypeChangePreview;
+	};
+	type PendingTypeChange = {
+		index: number;
+		libraryType: LibraryType;
+		loading: boolean;
+		preview: LibraryTypeChangePreview | null;
+		error: string;
 	};
 	type BadgeTone = 'active' | 'ready' | 'wait' | 'fail' | 'idle';
 
@@ -109,6 +126,8 @@
 	let clearArchiveArmed = $state(false);
 	let archiveMessage = $state('');
 	let archiveError = $state('');
+	let pendingTypeChange = $state<PendingTypeChange | null>(null);
+	let pendingRemovalIndex = $state<number | null>(null);
 	let lastSettingsKey = '';
 
 	$effect(() => {
@@ -250,12 +269,6 @@
 		return 'Offline';
 	}
 
-	function updateLibrary(index: number, patch: Partial<SettingsLibrary>) {
-		draft.libraries = draft.libraries.map((library, candidate) =>
-			candidate === index ? { ...library, ...patch } : library
-		);
-	}
-
 	function updateHost(index: number, patch: Partial<SettingsHost>) {
 		draft.remote_hosts = draft.remote_hosts.map((host, candidate) =>
 			candidate === index ? { ...host, ...patch } : host
@@ -286,11 +299,88 @@
 		};
 	}
 
-	function updatePlexLibraryRoot(libraryKey: string, value: string) {
-		const library_roots = { ...draft.metadata.plex.library_roots };
-		if (value.trim()) library_roots[libraryKey] = value;
-		else delete library_roots[libraryKey];
-		updatePlexMetadata({ library_roots });
+	function updateLibraries(libraries: SettingsLibrary[]) {
+		draft.libraries = libraries;
+	}
+
+	function addLibrary() {
+		draft.libraries = addLibraryDraft(draft.libraries);
+	}
+
+	function moveLibrary(index: number, direction: -1 | 1) {
+		draft.libraries = moveLibraryDraft(draft.libraries, index, direction);
+	}
+
+	function requestLibraryRemoval(index: number) {
+		pendingRemovalIndex = index;
+	}
+
+	function confirmLibraryRemoval() {
+		if (pendingRemovalIndex === null) return;
+		draft.libraries = removeAtIndex(draft.libraries, pendingRemovalIndex).map((library, index) => ({
+			...library,
+			index: String(index)
+		}));
+		pendingRemovalIndex = null;
+	}
+
+	async function requestLibraryTypeChange(index: number, libraryType: LibraryType) {
+		const library = draft.libraries[index];
+		if (!library || library.library_type === libraryType || !savedSettings) return;
+		const savedLibrary = savedSettings.libraries.find((candidate) => candidate.key === library.key);
+		if (!savedLibrary) {
+			draft.libraries = applyLibraryTypeChange(
+				draft.libraries,
+				index,
+				libraryType,
+				savedSettings.library_profile_options
+			);
+			return;
+		}
+		pendingTypeChange = { index, libraryType, loading: true, preview: null, error: '' };
+		try {
+			const response = await postJson<TypePreviewResponse>(
+				`${resolve('/')}api/settings/library-type-preview`,
+				{ key: library.key, library_type: libraryType }
+			);
+			if (!response.ok || !response.preview) {
+				pendingTypeChange = {
+					index,
+					libraryType,
+					loading: false,
+					preview: null,
+					error: response.message || 'Compatibility preview could not be loaded.'
+				};
+				return;
+			}
+			pendingTypeChange = {
+				index,
+				libraryType,
+				loading: false,
+				preview: response.preview,
+				error: ''
+			};
+		} catch (error) {
+			pendingTypeChange = {
+				index,
+				libraryType,
+				loading: false,
+				preview: null,
+				error: error instanceof Error ? error.message : 'Compatibility preview could not be loaded.'
+			};
+		}
+	}
+
+	function confirmLibraryTypeChange() {
+		if (!pendingTypeChange?.preview || !savedSettings) return;
+		draft.libraries = applyLibraryTypeChange(
+			draft.libraries,
+			pendingTypeChange.index,
+			pendingTypeChange.libraryType,
+			savedSettings.library_profile_options,
+			pendingTypeChange.preview
+		);
+		pendingTypeChange = null;
 	}
 
 	function metricDefaultsCopy(defaults: SettingsPayload['video_defaults']) {
@@ -299,6 +389,13 @@
 		if (metric === 'xpsnr') return `${target} · XPSNR floor ${defaults.min_target_xpsnr}`;
 		if (metric === 'auto') return `${target} · Auto metric guardrails`;
 		return `${target} · VMAF floor ${defaults.min_target_vmaf}`;
+	}
+
+	function libraryTypeLabel(libraryType: LibraryType): string {
+		return (
+			savedSettings?.library_type_options.find((option) => option.key === libraryType)?.label ??
+			libraryType
+		);
 	}
 
 	function toggleScheduleDay(
@@ -418,7 +515,9 @@
 					<div>
 						<span class="mf-eyebrow">Settings</span>
 						<h1>Settings</h1>
-						<p>Choose where your shows live, where Mediaforce works, and when it may run.</p>
+						<p>
+							Choose where your media lives, how each library behaves, and when Mediaforce may run.
+						</p>
 					</div>
 					<div
 						class="settings-header__actions"
@@ -462,6 +561,84 @@
 					</div>
 				{/if}
 
+				{#if pendingTypeChange}
+					<div class="settings-modal-backdrop" role="presentation">
+						<div
+							class="settings-modal"
+							role="dialog"
+							aria-modal="true"
+							aria-labelledby="library-type-preview-title"
+						>
+							<span class="mf-eyebrow">Compatibility preview</span>
+							<h2 id="library-type-preview-title">Change library type?</h2>
+							{#if pendingTypeChange.loading}
+								<p>Checking scanned items and saved profiles…</p>
+							{:else if pendingTypeChange.error}
+								<div class="notice notice--fail">{pendingTypeChange.error}</div>
+							{:else if pendingTypeChange.preview}
+								<p>
+									Changing
+									<strong>{libraryTypeLabel(pendingTypeChange.preview.from_type)}</strong> to
+									<strong>{libraryTypeLabel(pendingTypeChange.preview.to_type)}</strong> changes
+									grouping for {pendingTypeChange.preview.item_count.toLocaleString('en-US')} scanned
+									items.
+								</p>
+								<ul class="settings-modal__facts">
+									<li>The library returns to Browse only until the new workflow is reviewed.</li>
+									<li>A fresh scan applies the new grouping and metadata rules.</li>
+									<li>Existing profiles are preserved but no longer apply to the new type.</li>
+									<li>No media files move or delete.</li>
+								</ul>
+							{/if}
+							<div class="settings-modal__actions">
+								<button type="button" class="control" onclick={() => (pendingTypeChange = null)}>
+									Keep current type
+								</button>
+								<button
+									type="button"
+									class="control control--ready"
+									disabled={!pendingTypeChange.preview || pendingTypeChange.loading}
+									onclick={confirmLibraryTypeChange}
+								>
+									Apply type and rescan
+								</button>
+							</div>
+						</div>
+					</div>
+				{/if}
+
+				{#if pendingRemovalIndex !== null && draft.libraries[pendingRemovalIndex]}
+					<div class="settings-modal-backdrop" role="presentation">
+						<div
+							class="settings-modal"
+							role="dialog"
+							aria-modal="true"
+							aria-labelledby="library-remove-title"
+						>
+							<span class="mf-eyebrow">Remove library</span>
+							<h2 id="library-remove-title">
+								Remove {draft.libraries[pendingRemovalIndex].label || 'this library'}?
+							</h2>
+							<p>
+								Mediaforce stops scanning this root after Save. Files stay where they are and are
+								never deleted by this action.
+							</p>
+							<div class="settings-modal__actions">
+								<button type="button" class="control" onclick={() => (pendingRemovalIndex = null)}>
+									Keep library
+								</button>
+								<button
+									type="button"
+									class="control control--danger"
+									onclick={confirmLibraryRemoval}
+								>
+									Remove from Mediaforce
+								</button>
+							</div>
+						</div>
+					</div>
+				{/if}
+
 				<div class="settings-overview" aria-label="Settings sections">
 					<a href="#settings-libraries">
 						<span>Library folders</span>
@@ -495,88 +672,29 @@
 							<span class="mf-eyebrow">Basic setup</span>
 							<h2 id="settings-basic-title">Library and working space</h2>
 						</div>
-						<p>These are the only settings most setup sessions need.</p>
+						<p>
+							Configure library behavior first, then choose working space and processing defaults.
+						</p>
 					</header>
 
 					<div id="settings-libraries" class="settings-anchor">
 						<WorkstationPanel
 							eyebrow="Libraries"
-							title="Library folders"
+							title="Library roots"
 							meta={`${configuredLibraries.length.toLocaleString('en-US')} configured`}
 						>
-							<div class="table-wrap">
-								<table class="settings-table settings-table--libraries">
-									<thead>
-										<tr>
-											<th>Library</th>
-											<th>Folder</th>
-											<th>Action</th>
-										</tr>
-									</thead>
-									<tbody>
-										{#each draft.libraries as library, index (`library-${library.index}-${index}`)}
-											<tr>
-												<td>
-													<div class="library-cell">
-														<label
-															class="swatch-field"
-															aria-label={`Color for ${library.key || 'library'}`}
-														>
-															<input
-																type="color"
-																value={library.color}
-																oninput={(event) =>
-																	updateLibrary(index, { color: inputValue(event) })}
-															/>
-															<span class="mf-mono">{library.color || 'unset'}</span>
-														</label>
-														<label class="library-key-field">
-															<span>Library name</span>
-															<input
-																id={`library-key-${index}`}
-																class="field"
-																value={library.key}
-																placeholder="tv"
-																oninput={(event) =>
-																	updateLibrary(index, { key: inputValue(event) })}
-															/>
-														</label>
-													</div>
-												</td>
-												<td>
-													<label class="sr-label" for={`library-path-${index}`}>Folder path</label>
-													<input
-														id={`library-path-${index}`}
-														class="field field--path"
-														value={library.path}
-														placeholder="/Volumes/Media/TV"
-														oninput={(event) => updateLibrary(index, { path: inputValue(event) })}
-													/>
-												</td>
-												<td>
-													<button
-														type="button"
-														class="control control--compact control--danger"
-														onclick={() =>
-															(draft.libraries = removeAtIndex(draft.libraries, index))}
-													>
-														Remove
-													</button>
-												</td>
-											</tr>
-										{/each}
-									</tbody>
-								</table>
-							</div>
-							<div class="panel-actions">
-								<button
-									type="button"
-									class="control"
-									onclick={() => (draft.libraries = addLibraryDraft(draft.libraries))}
-								>
-									Add library
-								</button>
-							</div>
+							<LibraryRootsPanel
+								libraries={draft.libraries}
+								typeOptions={savedSettings.library_type_options}
+								profileOptions={savedSettings.library_profile_options}
+								plexReady={draft.metadata.plex.token_configured}
+								plexTokenEnv={draft.metadata.plex.token_env}
+								onLibrariesChange={updateLibraries}
+								onAdd={addLibrary}
+								onRemove={requestLibraryRemoval}
+								onMove={moveLibrary}
+								onTypeChange={requestLibraryTypeChange}
+							/>
 						</WorkstationPanel>
 					</div>
 
@@ -856,32 +974,10 @@
 									<StateBadge
 										compact
 										tone={draft.metadata.plex.token_configured ? 'ready' : 'wait'}
-										label={draft.metadata.plex.token_configured ? 'Token ready' : 'Token missing'}
+										label={draft.metadata.plex.token_configured ? 'Token ready' : 'Token needed'}
 									/>
 									<code>{draft.metadata.plex.token_env}</code>
 								</div>
-							</div>
-
-							<div class="table-wrap metadata-mappings">
-								<table class="settings-table settings-table--metadata">
-									<thead><tr><th>Library</th><th>Path reported by Plex</th></tr></thead>
-									<tbody>
-										{#each configuredLibraries as library (library.index)}
-											<tr>
-												<td><strong class="mf-mono">{library.key}</strong></td>
-												<td>
-													<input
-														class="field field--path"
-														value={draft.metadata.plex.library_roots[library.key] ?? ''}
-														placeholder={library.path || '/data/media/tv'}
-														oninput={(event) =>
-															updatePlexLibraryRoot(library.key, inputValue(event))}
-													/>
-												</td>
-											</tr>
-										{/each}
-									</tbody>
-								</table>
 							</div>
 
 							<div class="metadata-grid metadata-grid--tmdb">
@@ -900,14 +996,15 @@
 									<StateBadge
 										compact
 										tone={draft.metadata.tmdb.token_configured ? 'ready' : 'wait'}
-										label={draft.metadata.tmdb.token_configured ? 'Token ready' : 'Token missing'}
+										label={draft.metadata.tmdb.token_configured ? 'Token ready' : 'Token needed'}
 									/>
 									<code>{draft.metadata.tmdb.token_env}</code>
 								</div>
 							</div>
 							<p class="metadata-help">
-								Tokens stay outside Mediaforce settings. A full library scan refreshes Plex age and
-								TMDB series status; cached metadata remains available during provider outages.
+								Tokens stay outside Mediaforce settings and are never accepted or shown here. A full
+								library scan refreshes Plex age and TMDB series status; cached metadata remains
+								available during provider outages.
 							</p>
 						</WorkstationPanel>
 					</div>
@@ -1464,6 +1561,49 @@
 		padding: var(--mf-space-5);
 	}
 
+	.settings-modal-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 1000;
+		display: grid;
+		place-items: center;
+		padding: var(--mf-space-5);
+		background: var(--mf-bg-overlay);
+	}
+
+	.settings-modal {
+		display: grid;
+		gap: var(--mf-space-4);
+		width: min(36rem, 100%);
+		max-height: calc(100vh - 2rem);
+		overflow: auto;
+		padding: var(--mf-space-6);
+		border: var(--mf-border-strong);
+		background: var(--mf-bg-panel);
+		box-shadow: var(--mf-shadow-modal);
+	}
+
+	.settings-modal h2,
+	.settings-modal p {
+		margin: 0;
+	}
+
+	.settings-modal__facts {
+		display: grid;
+		gap: var(--mf-space-2);
+		margin: 0;
+		padding-left: 1.2rem;
+		color: var(--mf-fg-secondary);
+	}
+
+	.settings-modal__actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--mf-space-3);
+		padding-top: var(--mf-space-3);
+		border-top: var(--mf-border-muted);
+	}
+
 	.settings-header {
 		align-items: end;
 		border-bottom: var(--mf-border);
@@ -1633,45 +1773,6 @@
 		margin-right: auto;
 	}
 
-	.table-wrap {
-		overflow: auto;
-	}
-
-	table {
-		border-collapse: collapse;
-		min-width: 700px;
-		width: 100%;
-	}
-
-	th,
-	td {
-		border-bottom: var(--mf-border-muted);
-		font-size: var(--mf-text-xs);
-		height: var(--mf-row-default);
-		padding: var(--mf-space-2) var(--mf-space-5);
-		text-align: left;
-		vertical-align: middle;
-	}
-
-	th {
-		background: var(--mf-bg-strip);
-		color: var(--mf-fg-tertiary);
-		font-size: var(--mf-text-2xs);
-		font-weight: var(--mf-weight-semibold);
-		letter-spacing: 0.08em;
-		position: sticky;
-		text-transform: uppercase;
-		top: 0;
-	}
-
-	.settings-table--libraries td:nth-child(1) {
-		min-width: 240px;
-	}
-
-	.settings-table--libraries td:nth-child(2) {
-		min-width: 220px;
-	}
-
 	.field {
 		background: var(--mf-bg-input);
 		border: var(--mf-border);
@@ -1718,15 +1819,6 @@
 		display: grid;
 		gap: var(--mf-space-2);
 		min-width: 0;
-	}
-
-	.swatch-field input {
-		background: transparent;
-		border: var(--mf-border);
-		border-radius: var(--mf-radius-1);
-		height: var(--mf-control-md);
-		padding: 0;
-		width: 36px;
 	}
 
 	.sr-label {
@@ -2222,63 +2314,6 @@
 		.settings-save-dock .control {
 			flex: 1 1 auto;
 		}
-
-		.table-wrap {
-			overflow: visible;
-		}
-
-		.settings-table--libraries {
-			min-width: 0;
-		}
-
-		.settings-table--libraries thead {
-			display: none;
-		}
-
-		.settings-table--libraries tbody,
-		.settings-table--libraries tr,
-		.settings-table--libraries td {
-			display: block;
-			width: 100%;
-		}
-
-		.settings-table--libraries tr {
-			border-bottom: var(--mf-border-muted);
-			display: grid;
-			gap: var(--mf-space-3);
-			grid-template-columns: minmax(0, 1fr);
-			padding: var(--mf-space-4);
-		}
-
-		.settings-table--libraries td {
-			border-bottom: 0;
-			height: auto;
-			min-width: 0;
-			padding: 0;
-		}
-
-		.settings-table--libraries td:nth-child(1),
-		.settings-table--libraries td:nth-child(2) {
-			display: grid;
-			gap: var(--mf-space-2);
-		}
-
-		.settings-table--libraries td:nth-child(1)::before,
-		.settings-table--libraries td:nth-child(2)::before {
-			color: var(--mf-fg-tertiary);
-			font-size: var(--mf-text-2xs);
-			font-weight: var(--mf-weight-semibold);
-			letter-spacing: 0.08em;
-			text-transform: uppercase;
-		}
-
-		.settings-table--libraries td:nth-child(1)::before {
-			content: 'Library';
-		}
-
-		.settings-table--libraries td:nth-child(2)::before {
-			content: 'Folder path';
-		}
 	}
 
 	/* Human settings surface */
@@ -2409,42 +2444,6 @@
 	.settings-anchor {
 		display: block;
 		scroll-margin-top: 18px;
-	}
-
-	.table-wrap {
-		background: var(--mf-bg-panel);
-		border: 0;
-		overflow-x: auto;
-	}
-
-	.settings-table {
-		background: var(--mf-bg-panel);
-		color: var(--mf-fg-primary);
-	}
-
-	.settings-table th {
-		background: var(--mf-bg-panel-2);
-		border-bottom: 1px solid var(--mf-line);
-		color: var(--mf-fg-tertiary);
-		font-family: var(--mf-font-sans);
-		font-size: 11px;
-		letter-spacing: 0.03em;
-		text-transform: none;
-	}
-
-	.settings-table td {
-		border-bottom: 1px solid var(--mf-line-muted);
-		color: var(--mf-fg-secondary);
-		font-family: var(--mf-font-sans);
-		padding: 12px;
-	}
-
-	.library-cell {
-		align-items: end;
-	}
-
-	.swatch-field {
-		display: none;
 	}
 
 	.field,
@@ -2646,60 +2645,6 @@
 
 		.settings-header__actions.has-changes :global(.state-badge) {
 			flex-basis: 100%;
-		}
-
-		.table-wrap {
-			overflow: visible;
-		}
-
-		.settings-table--libraries,
-		.settings-table--metadata {
-			display: block;
-			min-width: 0;
-			width: 100%;
-		}
-
-		.settings-table--metadata thead {
-			display: none;
-		}
-
-		.settings-table--metadata tbody,
-		.settings-table--metadata tr,
-		.settings-table--metadata td {
-			display: block;
-			width: 100%;
-		}
-
-		.settings-table--metadata tr {
-			border-bottom: var(--mf-border-muted);
-			display: grid;
-			gap: var(--mf-space-3);
-			padding: var(--mf-space-4);
-		}
-
-		.settings-table--metadata td {
-			border-bottom: 0;
-			height: auto;
-			min-width: 0;
-			padding: 0;
-		}
-
-		.settings-table--metadata td::before {
-			color: var(--mf-fg-tertiary);
-			display: block;
-			font-size: var(--mf-text-2xs);
-			font-weight: var(--mf-weight-semibold);
-			letter-spacing: 0.06em;
-			margin-bottom: var(--mf-space-2);
-			text-transform: uppercase;
-		}
-
-		.settings-table--metadata td:nth-child(1)::before {
-			content: 'Library';
-		}
-
-		.settings-table--metadata td:nth-child(2)::before {
-			content: 'Path reported by Plex';
 		}
 	}
 </style>

--- a/frontend/src/lib/settings/editor.test.ts
+++ b/frontend/src/lib/settings/editor.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	DEFAULT_SCHEDULE_DAYS,
+	applyLibraryTypeChange,
+	addLibraryDraft,
 	addScheduleDraft,
 	archiveCleanupTargetDirty,
 	buildArchiveCleanupClearPayload,
@@ -10,6 +12,8 @@ import {
 	draftFromSettings,
 	hostLibraryAccessChecked,
 	hostLibraryAccessCopy,
+	libraryReadiness,
+	moveLibraryDraft,
 	scheduleDaysSummaryCopy,
 	scheduleWindowSummaryCopy,
 	settingsDraftIsDirty,
@@ -109,7 +113,39 @@ describe('settings draft helpers', () => {
 	const payload: SettingsPayload = {
 		error: null,
 		saved: false,
-		libraries: [{ index: '0', key: 'tv', path: '/Volumes/TV', color: '#4e6fa6' }],
+		libraries: [
+			{
+				index: '0',
+				key: 'tv',
+				label: 'TV Shows',
+				path: '/Volumes/TV',
+				color: '#4e6fa6',
+				library_type: 'tv',
+				availability: 'production',
+				default_profile: 'inherit_defaults',
+				plex_path: '/data/tv',
+				policy: {
+					series_lifecycle_mode: 'auto',
+					current_season_inactive_days: 365,
+					season_acquisition_hold_days: 30,
+					series_metadata_stale_days: 7
+				},
+				readiness: { state: 'ready', label: 'Ready', detail: 'Ready.' },
+				type_change_confirmation: ''
+			}
+		],
+		library_type_options: [
+			{ key: 'tv', label: 'TV' },
+			{ key: 'movie', label: 'Movies' },
+			{ key: 'spatial', label: '3D / VR' },
+			{ key: 'other', label: 'Other' }
+		],
+		library_profile_options: {
+			tv: [{ key: 'inherit_defaults', label: 'Use assistant defaults' }],
+			movie: [{ key: 'movie_balanced', label: 'Balanced movie' }],
+			spatial: [{ key: 'spatial_preserve', label: 'Preserve source geometry' }],
+			other: [{ key: 'other_conservative', label: 'Conservative' }]
+		},
 		remote_hosts: [
 			{
 				index: '0',
@@ -212,6 +248,52 @@ describe('settings draft helpers', () => {
 
 		draft.libraries[0] = { ...draft.libraries[0], path: '/Volumes/TV2' };
 		expect(settingsDraftIsDirty(draft, payload)).toBe(true);
+	});
+
+	it('creates stable library IDs and preserves order through moves', () => {
+		const libraries = addLibraryDraft(payload.libraries);
+
+		expect(libraries[1]?.key).toBe('library_2');
+		expect(libraries[1]?.availability).toBe('browse_only');
+		expect(moveLibraryDraft(libraries, 1, -1).map((library) => library.key)).toEqual([
+			'library_2',
+			'tv'
+		]);
+	});
+
+	it('resets confirmed type changes to a safe browse-only policy', () => {
+		const preview = {
+			key: 'tv',
+			from_type: 'tv' as const,
+			to_type: 'movie' as const,
+			item_count: 42,
+			requires_rescan: true,
+			clears_saved_profiles: true,
+			acknowledgement: 'tv:tv->movie'
+		};
+
+		const changed = applyLibraryTypeChange(
+			payload.libraries,
+			0,
+			'movie',
+			payload.library_profile_options,
+			preview
+		)[0];
+
+		expect(changed?.availability).toBe('browse_only');
+		expect(changed?.policy.grouping).toBe('title');
+		expect(changed?.type_change_confirmation).toBe('tv:tv->movie');
+	});
+
+	it('keeps spatial roots incomplete until playback facts are supplied', () => {
+		const spatial = applyLibraryTypeChange(
+			payload.libraries,
+			0,
+			'spatial',
+			payload.library_profile_options
+		)[0];
+
+		expect(spatial && libraryReadiness(spatial).state).toBe('incomplete');
 	});
 
 	it('uses the saved transcode root for destructive archive cleanup', () => {

--- a/frontend/src/lib/settings/editor.ts
+++ b/frontend/src/lib/settings/editor.ts
@@ -1,4 +1,8 @@
 import type {
+	LibraryPolicy,
+	LibraryReadiness,
+	LibraryType,
+	LibraryTypeChangePreview,
 	ScheduleProfile,
 	SettingsHost,
 	SettingsLibrary,
@@ -124,7 +128,7 @@ export function draftFromSettings(payload: SettingsPayload) {
 	return {
 		libraries: payload.libraries
 			.filter((library) => library.key || library.path)
-			.map((library) => ({ ...library })),
+			.map((library) => ({ ...library, policy: { ...library.policy } })),
 		remote_hosts: payload.remote_hosts
 			.filter((host) => host.label || host.host)
 			.map((host) => ({
@@ -152,7 +156,7 @@ export function buildSettingsSavePayload(
 	settings: SettingsPayload
 ): SettingsSavePayload {
 	return {
-		libraries: draft.libraries.map((library) => ({ ...library })),
+		libraries: draft.libraries.map((library) => ({ ...library, policy: { ...library.policy } })),
 		remote_hosts: draft.remote_hosts.map((host) => ({
 			...host,
 			capabilities: [...host.capabilities],
@@ -163,7 +167,14 @@ export function buildSettingsSavePayload(
 		encode_queue_scheduler: { ...settings.encode_queue_scheduler },
 		schedule_profiles: draft.schedule_profiles.map((profile) => cloneScheduleProfile(profile)),
 		metadata: {
-			plex: { ...draft.metadata.plex, library_roots: { ...draft.metadata.plex.library_roots } },
+			plex: {
+				...draft.metadata.plex,
+				library_roots: Object.fromEntries(
+					draft.libraries
+						.filter((library) => library.key.trim() && library.plex_path.trim())
+						.map((library) => [library.key.trim(), library.plex_path.trim()])
+				)
+			},
 			tmdb: { ...draft.metadata.tmdb }
 		}
 	};
@@ -194,7 +205,172 @@ export function hostDraftRuntimeKey(host: SettingsHost): string {
 }
 
 export function addLibraryDraft(libraries: SettingsLibrary[]): SettingsLibrary[] {
-	return [...libraries, { index: String(libraries.length), key: '', path: '', color: '#0f766e' }];
+	const key = nextLibraryKey(libraries);
+	return [
+		...libraries,
+		{
+			index: String(libraries.length),
+			key,
+			label: '',
+			path: '',
+			color: '#0f766e',
+			library_type: 'other',
+			availability: 'browse_only',
+			default_profile: 'other_conservative',
+			plex_path: '',
+			policy: libraryPolicyDefaults('other'),
+			readiness: libraryReadiness({
+				key,
+				label: '',
+				path: '',
+				library_type: 'other',
+				availability: 'browse_only',
+				policy: libraryPolicyDefaults('other')
+			}),
+			type_change_confirmation: ''
+		}
+	];
+}
+
+export function moveLibraryDraft(
+	libraries: SettingsLibrary[],
+	index: number,
+	direction: -1 | 1
+): SettingsLibrary[] {
+	const target = index + direction;
+	if (target < 0 || target >= libraries.length) return libraries;
+	const reordered = [...libraries];
+	[reordered[index], reordered[target]] = [reordered[target], reordered[index]];
+	return reordered.map((library, candidate) => ({ ...library, index: String(candidate) }));
+}
+
+export function applyLibraryTypeChange(
+	libraries: SettingsLibrary[],
+	index: number,
+	libraryType: LibraryType,
+	profileOptions: SettingsPayload['library_profile_options'],
+	preview?: LibraryTypeChangePreview
+): SettingsLibrary[] {
+	return libraries.map((library, candidate) => {
+		if (candidate !== index) return library;
+		const policy = libraryPolicyDefaults(libraryType);
+		const updated = {
+			...library,
+			library_type: libraryType,
+			availability: preview
+				? ('browse_only' as const)
+				: libraryType === 'tv'
+					? ('production' as const)
+					: ('browse_only' as const),
+			default_profile: profileOptions[libraryType][0]?.key ?? defaultLibraryProfile(libraryType),
+			policy,
+			type_change_confirmation: preview?.acknowledgement ?? ''
+		};
+		return { ...updated, readiness: libraryReadiness(updated) };
+	});
+}
+
+export function libraryPolicyDefaults(libraryType: LibraryType): LibraryPolicy {
+	if (libraryType === 'tv') {
+		return {
+			series_lifecycle_mode: 'auto',
+			current_season_inactive_days: 365,
+			season_acquisition_hold_days: 30,
+			series_metadata_stale_days: 7
+		};
+	}
+	if (libraryType === 'movie') {
+		return {
+			grouping: 'title',
+			editions: 'separate',
+			extras: 'exclude',
+			ranking: 'oldest_added_first'
+		};
+	}
+	if (libraryType === 'spatial') {
+		return {
+			playback_target: '',
+			stereo_layout: 'unknown',
+			projection: 'unknown',
+			geometry_policy: 'preserve',
+			container_profile: 'unqualified'
+		};
+	}
+	return { grouping: 'folder' };
+}
+
+export function libraryReadiness(
+	library: Pick<
+		SettingsLibrary,
+		'key' | 'label' | 'path' | 'library_type' | 'availability' | 'policy'
+	>
+): LibraryReadiness {
+	if (!library.key.trim() || !library.label.trim() || !library.path.trim()) {
+		return {
+			state: 'incomplete',
+			label: 'Incomplete',
+			detail: 'Add a label, root ID, and local path.'
+		};
+	}
+	if (library.availability === 'disabled') {
+		return {
+			state: 'disabled',
+			label: 'Disabled',
+			detail: 'Mediaforce will not scan or process this library.'
+		};
+	}
+	if (library.library_type === 'spatial') {
+		const missing = [
+			!library.policy.playback_target?.trim() ? 'playback target' : '',
+			library.policy.stereo_layout === 'unknown' ? 'stereo layout' : '',
+			library.policy.projection === 'unknown' ? 'projection' : ''
+		].filter(Boolean);
+		if (missing.length) {
+			return {
+				state: 'incomplete',
+				label: 'Incomplete',
+				detail: `Add ${missing.join(', ')} before playback qualification.`
+			};
+		}
+		return {
+			state: 'blocked',
+			label: 'Safety blocked',
+			detail: 'Browse-only until 3D / VR playback qualification is implemented.'
+		};
+	}
+	if (library.availability === 'browse_only') {
+		return {
+			state: 'browse_only',
+			label: 'Browse only',
+			detail: 'Mediaforce scans and shows this library but never processes it.'
+		};
+	}
+	if (library.library_type !== 'tv') {
+		return {
+			state: 'blocked',
+			label: 'Workflow blocked',
+			detail: 'Production is not available for this library type yet.'
+		};
+	}
+	return {
+		state: 'ready',
+		label: 'Ready',
+		detail: 'Scanning and production processing are enabled.'
+	};
+}
+
+function nextLibraryKey(libraries: SettingsLibrary[]): string {
+	const used = new Set(libraries.map((library) => library.key));
+	let suffix = libraries.length + 1;
+	while (used.has(`library_${suffix}`)) suffix += 1;
+	return `library_${suffix}`;
+}
+
+function defaultLibraryProfile(libraryType: LibraryType): string {
+	if (libraryType === 'tv') return 'inherit_defaults';
+	if (libraryType === 'movie') return 'movie_balanced';
+	if (libraryType === 'spatial') return 'spatial_preserve';
+	return 'other_conservative';
 }
 
 export function addHostDraft(

--- a/mediaforce/core/config.py
+++ b/mediaforce/core/config.py
@@ -10,6 +10,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from mediaforce.library.library_settings import configured_library_definitions, library_definition_map, \
+    library_production_supported
+
 DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "defaults.toml"
 FOLDER_POLICY_OVERRIDES_KEY = "folder_policy_overrides"
 BENCH_SAVED_OVERRIDE_NOTE = "Saved from the calibration bench."
@@ -61,10 +64,48 @@ class MediaforceConfig:
         return value if isinstance(value, dict) else {}
 
     @property
-    def source_root_map(self) -> dict[str, Path]:
+    def configured_source_root_map(self) -> dict[str, Path]:
+        if isinstance(self.media.get("libraries"), list):
+            return {
+                str(definition["key"]): Path(str(definition["path"])).expanduser()
+                for definition in self.library_definitions
+            }
         return {
             key: Path(value).expanduser()
             for key, value in self.media["source_roots"].items()
+        }
+
+    @property
+    def library_definitions(self) -> list[dict[str, Any]]:
+        return configured_library_definitions(self.media)
+
+    @property
+    def library_definition_map(self) -> dict[str, dict[str, Any]]:
+        return library_definition_map(self.media)
+
+    @property
+    def scan_source_root_map(self) -> dict[str, Path]:
+        configured = self.configured_source_root_map
+        if not isinstance(self.media.get("libraries"), list):
+            return configured
+        definitions = self.library_definition_map
+        return {
+            key: path
+            for key, path in configured.items()
+            if definitions.get(key, {}).get("availability") != "disabled"
+        }
+
+    @property
+    def source_root_map(self) -> dict[str, Path]:
+        configured = self.configured_source_root_map
+        if not isinstance(self.media.get("libraries"), list):
+            return configured
+        definitions = self.library_definition_map
+        return {
+            key: path
+            for key, path in configured.items()
+            if definitions.get(key, {}).get("availability") == "production"
+            and library_production_supported(str(definitions.get(key, {}).get("type") or ""))
         }
 
     def source_root_map_for_host(self, host: dict[str, Any] | None = None) -> dict[str, Path]:
@@ -135,10 +176,26 @@ class MediaforceConfig:
         }
 
         normalized_rel_path = rel_path.strip("/")
+        root_key = normalized_rel_path.split("/", 1)[0]
+        library = self.library_definition_map.get(root_key)
+        if library and library.get("type") == "tv":
+            library_policy = library.get("policy")
+            if isinstance(library_policy, dict):
+                for key in (
+                    "series_lifecycle_mode",
+                    "current_season_inactive_days",
+                    "season_acquisition_hold_days",
+                    "series_metadata_stale_days",
+                ):
+                    if key in library_policy:
+                        policy["planning"][key] = copy.deepcopy(library_policy[key])
         matching_overrides: list[tuple[int, int, dict[str, Any]]] = []
         for index, override in enumerate(self.overrides):
             prefix = str(override.get("path_prefix", "")).strip("/")
             if prefix and not _path_prefix_matches(normalized_rel_path, prefix):
+                continue
+            override_library_type = str(override.get("library_type") or "").strip()
+            if override_library_type and library and override_library_type != str(library.get("type") or ""):
                 continue
             matching_overrides.append((len(prefix), index, override))
 
@@ -462,6 +519,9 @@ def _build_folder_policy_override(prefix: str, policy: dict[str, Any]) -> dict[s
         values = policy.get(section)
         if isinstance(values, dict) and values:
             override[section] = copy.deepcopy(values)
+    library_type = str(policy.get("library_type") or "").strip()
+    if library_type:
+        override["library_type"] = library_type
     return override
 
 

--- a/mediaforce/library/candidate_selection.py
+++ b/mediaforce/library/candidate_selection.py
@@ -157,8 +157,11 @@ def project_candidates(
     resolved_scopes = resolve_media_scopes(connection, prefixes or [])
     normalized_override = normalize_scope_prefix(manual_override_prefix or "")
     decisions: list[CandidateDecision] = []
+    production_roots = set(config.source_root_map)
 
     for row in rows:
+        if str(row["media_root"] or "") not in production_roots:
+            continue
         if statuses is not None and str(row["status"] or "") not in statuses:
             continue
         rel_path = str(row["rel_path"] or "")

--- a/mediaforce/library/library_settings.py
+++ b/mediaforce/library/library_settings.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Literal
+
+LibraryType = Literal["tv", "movie", "spatial", "other"]
+LibraryAvailability = Literal["production", "browse_only", "disabled"]
+
+LIBRARY_TYPE_OPTIONS = (
+    {"key": "tv", "label": "TV"},
+    {"key": "movie", "label": "Movies"},
+    {"key": "spatial", "label": "3D / VR"},
+    {"key": "other", "label": "Other"},
+)
+SUPPORTED_LIBRARY_TYPES = frozenset(option["key"] for option in LIBRARY_TYPE_OPTIONS)
+SUPPORTED_LIBRARY_AVAILABILITY = frozenset({"production", "browse_only", "disabled"})
+
+DEFAULT_LIBRARY_PROFILES: dict[LibraryType, str] = {
+    "tv": "inherit_defaults",
+    "movie": "movie_balanced",
+    "spatial": "spatial_preserve",
+    "other": "other_conservative",
+}
+
+LIBRARY_PROFILE_OPTIONS: dict[LibraryType, tuple[dict[str, str], ...]] = {
+    "tv": (
+        {"key": "inherit_defaults", "label": "Use assistant defaults"},
+    ),
+    "movie": (
+        {"key": "movie_balanced", "label": "Balanced movie"},
+        {"key": "movie_quality_first", "label": "Quality first"},
+        {"key": "movie_space_recovery", "label": "Space recovery"},
+    ),
+    "spatial": (
+        {"key": "spatial_preserve", "label": "Preserve source geometry"},
+    ),
+    "other": (
+        {"key": "other_conservative", "label": "Conservative"},
+        {"key": "other_source_preserving", "label": "Source preserving"},
+    ),
+}
+
+
+def infer_library_type(key: str) -> LibraryType:
+    normalized = str(key or "").strip().lower()
+    if normalized == "tv":
+        return "tv"
+    if normalized == "movies":
+        return "movie"
+    return "other"
+
+
+def default_library_availability(library_type: LibraryType) -> LibraryAvailability:
+    return "production" if library_type == "tv" else "browse_only"
+
+
+def default_library_policy(library_type: LibraryType) -> dict[str, Any]:
+    if library_type == "tv":
+        return {
+            "series_lifecycle_mode": "auto",
+            "current_season_inactive_days": 365,
+            "season_acquisition_hold_days": 30,
+            "series_metadata_stale_days": 7,
+        }
+    if library_type == "movie":
+        return {
+            "grouping": "title",
+            "editions": "separate",
+            "extras": "exclude",
+            "ranking": "oldest_added_first",
+        }
+    if library_type == "spatial":
+        return {
+            "playback_target": "",
+            "stereo_layout": "unknown",
+            "projection": "unknown",
+            "geometry_policy": "preserve",
+            "container_profile": "unqualified",
+        }
+    return {
+        "grouping": "folder",
+    }
+
+
+def normalize_library_type(value: Any, *, key: str = "") -> LibraryType:
+    normalized = str(value or "").strip().lower()
+    if normalized in SUPPORTED_LIBRARY_TYPES:
+        return normalized  # type: ignore[return-value]
+    return infer_library_type(key)
+
+
+def normalize_library_availability(value: Any, *, library_type: LibraryType) -> LibraryAvailability:
+    normalized = str(value or "").strip().lower()
+    if normalized in SUPPORTED_LIBRARY_AVAILABILITY:
+        return normalized  # type: ignore[return-value]
+    return default_library_availability(library_type)
+
+
+def normalize_library_policy(library_type: LibraryType, value: Any) -> dict[str, Any]:
+    defaults = default_library_policy(library_type)
+    if not isinstance(value, Mapping):
+        return defaults
+    return {key: value.get(key, default) for key, default in defaults.items()}
+
+
+def normalize_library_definition(value: Any, *, key: str) -> dict[str, Any]:
+    payload = dict(value) if isinstance(value, Mapping) else {}
+    library_type = normalize_library_type(payload.get("type"), key=key)
+    label = str(payload.get("label") or key.replace("_", " ").replace("-", " ").title()).strip()
+    profile_options = {option["key"] for option in LIBRARY_PROFILE_OPTIONS[library_type]}
+    profile = str(payload.get("default_profile") or DEFAULT_LIBRARY_PROFILES[library_type]).strip()
+    if profile not in profile_options:
+        profile = DEFAULT_LIBRARY_PROFILES[library_type]
+    availability = payload.get("availability")
+    if availability is None and not bool(payload.get("enabled", True)):
+        availability = "disabled"
+    if availability is None:
+        availability = payload.get("processing_mode")
+    return {
+        "key": key,
+        "label": label,
+        "path": str(payload.get("path") or "").strip(),
+        "color": str(payload.get("color") or "").strip(),
+        "plex_path": str(payload.get("plex_path") or "").strip(),
+        "type": library_type,
+        "availability": normalize_library_availability(availability, library_type=library_type),
+        "default_profile": profile,
+        "policy": normalize_library_policy(library_type, payload.get("policy")),
+    }
+
+
+def configured_library_definitions(media: Mapping[str, Any]) -> list[dict[str, Any]]:
+    source_roots = media.get("source_roots")
+    configured = media.get("libraries")
+    if isinstance(configured, list):
+        definitions: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for item in configured:
+            if not isinstance(item, Mapping):
+                continue
+            key = str(item.get("key") or "").strip()
+            if not key or key in seen:
+                continue
+            payload = dict(item)
+            if isinstance(source_roots, Mapping):
+                payload.setdefault("path", source_roots.get(key))
+            definitions.append(normalize_library_definition(payload, key=key))
+            seen.add(key)
+        return [definition for definition in definitions if str(definition.get("path") or "").strip()]
+    if not isinstance(source_roots, Mapping):
+        return []
+    return [
+        normalize_library_definition({"path": value}, key=str(key))
+        for key, value in source_roots.items()
+        if str(source_roots.get(key) or "").strip()
+    ]
+
+
+def library_definition_map(media: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    return {definition["key"]: definition for definition in configured_library_definitions(media)}
+
+
+def library_type_label(library_type: str) -> str:
+    return next(
+        (option["label"] for option in LIBRARY_TYPE_OPTIONS if option["key"] == library_type),
+        "Other",
+    )
+
+
+def library_production_supported(library_type: str) -> bool:
+    return library_type == "tv"

--- a/mediaforce/library/metadata_sync.py
+++ b/mediaforce/library/metadata_sync.py
@@ -357,8 +357,11 @@ def _plex_path_mappings(config: MediaforceConfig) -> tuple[PlexPathMapping, ...]
     plex_settings = _mapping(config.metadata.get("plex"))
     library_roots = _mapping(plex_settings.get("library_roots"))
     mappings: list[PlexPathMapping] = []
-    for key, local_root in config.source_root_map.items():
-        configured_root = str(library_roots.get(key) or "").strip()
+    scan_source_roots = getattr(config, "scan_source_root_map", config.source_root_map)
+    library_definitions = getattr(config, "library_definition_map", {})
+    for key, local_root in scan_source_roots.items():
+        definition = library_definitions.get(key, {}) if isinstance(library_definitions, dict) else {}
+        configured_root = str(definition.get("plex_path") or library_roots.get(key) or "").strip()
         mappings.append(
             PlexPathMapping(
                 plex_root=configured_root or str(local_root),

--- a/mediaforce/library/scanner.py
+++ b/mediaforce/library/scanner.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator
 
-from sqlalchemy import case
+from sqlalchemy import and_, case, or_
 from sqlalchemy import insert
 from sqlalchemy import not_
 from sqlalchemy import select
@@ -53,7 +53,8 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
                  limit: int | None = None) -> ScanStats:
     scan_id = uuid.uuid4().hex
     started_at = timestamp()
-    roots_json = json.dumps(sorted(config.source_root_map.keys()))
+    scan_source_roots = getattr(config, "scan_source_root_map", config.source_root_map)
+    roots_json = json.dumps(sorted(scan_source_roots.keys()))
     normalized_prefixes = sorted({prefix.strip("/") for prefix in object_list(prefixes) if str(prefix).strip("/")})
     scope = "prefix" if normalized_prefixes else "full"
     connection.execute(
@@ -73,7 +74,7 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
     seen_paths: set[str] = set()
     pending_writes = 0
 
-    for root_name, root_path in config.source_root_map.items():
+    for root_name, root_path in scan_source_roots.items():
         for file_path in _iter_media_files(root_path, prefixes=normalized_prefixes or None, limit=limit,
                                            seen=stats.total_seen):
             source_path = str(file_path)
@@ -214,14 +215,23 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
             break
 
     full_scan = not normalized_prefixes and limit is None
-    if full_scan and seen_paths:
+    if full_scan:
+        active_roots = tuple(scan_source_roots.keys())
+        stale_filter = library_items.c.status != "missing"
+        if active_roots and seen_paths:
+            stale_filter = and_(
+                stale_filter,
+                or_(
+                    not_(library_items.c.media_root.in_(active_roots)),
+                    and_(
+                        library_items.c.media_root.in_(active_roots),
+                        not_(library_items.c.source_path.in_(tuple(seen_paths))),
+                    ),
+                ),
+            )
         cursor = connection.execute(
             update(library_items)
-            .where(
-                library_items.c.media_root.in_(tuple(config.source_root_map.keys())),
-                not_(library_items.c.source_path.in_(tuple(seen_paths))),
-                library_items.c.status != "missing",
-            )
+            .where(stale_filter)
             .values(status="missing", updated_at=started_at)
         )
         stats.missing = int_value(cursor.rowcount) if cursor.rowcount != -1 else 0

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -180,6 +180,12 @@ from mediaforce.web.runtime.folder_tuning_advice import build_run_verdict_payloa
     tuning_policy_key_paths as runtime_tuning_policy_key_paths, \
     apply_policy_fragment as runtime_apply_policy_fragment
 from mediaforce.web.runtime.folder_tuning_helpers import size_budget_sample_analysis
+from mediaforce.web.runtime.catalog_signature import (
+    catalog_signature_file as _catalog_signature_file,
+    current_catalog_signature as _current_catalog_signature,
+    load_catalog_signature as _load_catalog_signature,
+    save_catalog_signature as _save_catalog_signature,
+)
 from mediaforce.web.runtime.job_runtime import JobRuntimeDeps, active_scan_from_db as runtime_active_scan_from_db, \
     CalibrationQueueRuntimeDeps, calibration_queue_worker_loop as runtime_calibration_queue_worker_loop, \
     calibration_job_belongs_to_current_process as runtime_calibration_job_belongs_to_current_process, \
@@ -2601,17 +2607,6 @@ def _scan_job_file(config: MediaforceConfig, prefix: str | None) -> Path:
     return _state_web_dir(config) / f"scan-{_slug(name)}.job.json"
 
 
-def _catalog_signature_file(config: MediaforceConfig) -> Path:
-    return _state_web_dir(config) / "full-catalog.signature.json"
-
-
-def _current_catalog_signature(config: MediaforceConfig) -> dict[str, Any]:
-    return {
-        "source_roots": {key: str(path) for key, path in config.scan_source_root_map.items()},
-        "libraries": _runtime_library_signature(config.raw),
-    }
-
-
 def _settings_library_rows_for_config(config: MediaforceConfig, *, min_rows: int = 3) -> list[dict[str, Any]]:
     return _settings_library_rows_for_config_runtime(config, min_rows=min_rows)
 
@@ -2626,32 +2621,6 @@ def _settings_transcode_root_value(config: MediaforceConfig) -> str:
 
 def _settings_archive_root(transcode_root: str) -> str:
     return _settings_archive_root_runtime(transcode_root)
-
-
-def _load_catalog_signature(config: MediaforceConfig) -> dict[str, Any] | None:
-    path = _catalog_signature_file(config)
-    if not path.exists():
-        return None
-    try:
-        payload = json.loads(path.read_text())
-    except (OSError, json.JSONDecodeError):
-        return None
-    if not isinstance(payload, dict):
-        return None
-    source_roots = payload.get("source_roots")
-    if not isinstance(source_roots, dict):
-        return None
-    libraries = payload.get("libraries")
-    return {
-        "source_roots": _runtime_source_roots({"media": {"source_roots": source_roots}}),
-        "libraries": _runtime_library_signature(
-            {"media": {"libraries": libraries if isinstance(libraries, list) else []}}
-        ),
-    }
-
-
-def _save_catalog_signature(config: MediaforceConfig) -> None:
-    _catalog_signature_file(config).write_text(json.dumps(_current_catalog_signature(config), indent=2) + "\n")
 
 
 _calibration_draft_hash = runtime_calibration_draft_hash

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -210,6 +210,8 @@ from mediaforce.web.settings_runtime import (
     settings_remote_rows_for_config as _settings_remote_rows_for_config_runtime,
     settings_transcode_root_value as _settings_transcode_root_value_runtime,
     runtime_source_roots as _runtime_source_roots,
+    runtime_library_signature as _runtime_library_signature,
+    bind_runtime_library_overrides as _bind_runtime_library_overrides,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -541,7 +543,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
 
     def _save_settings_action(
             *,
-            libraries: list[dict[str, str]],
+            libraries: list[dict[str, Any]],
             remote_hosts: list[dict[str, Any]],
             transcode_root: str,
             video_defaults: dict[str, Any],
@@ -560,14 +562,40 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             encode_queue_scheduler=encode_queue_scheduler,
             schedule_profiles=schedule_profiles,
             metadata=metadata if metadata is not None else config.metadata,
+            existing_library_types={
+                key: str(definition.get("type") or "")
+                for key, definition in config.library_definition_map.items()
+            },
+            existing_libraries={
+                str(item.get("key") or ""): dict(item)
+                for item in config.media.get("libraries", [])
+                if isinstance(item, dict) and str(item.get("key") or "").strip()
+            } if isinstance(config.media.get("libraries"), list) else {},
+            existing_library_paths={
+                str(key): str(path)
+                for key, path in config.media.get("source_roots", {}).items()
+            } if isinstance(config.media.get("source_roots"), dict) else {},
         )
+        changed_type_roots = {
+            str(definition.get("key") or ""): str(
+                config.library_definition_map[str(definition.get("key") or "")].get("type") or ""
+            )
+            for definition in payload.get("media", {}).get("libraries", [])
+            if isinstance(definition, dict)
+            and str(definition.get("key") or "") in config.library_definition_map
+            and str(config.library_definition_map[str(definition.get("key") or "")].get("type") or "")
+            != str(definition.get("type") or "")
+        }
         catalog_refresh_needed = False
 
         def _apply_runtime_settings(existing_runtime_settings: dict[str, Any]) -> dict[str, Any]:
             nonlocal catalog_refresh_needed
             merged_runtime_settings = _merge_runtime_settings_payload(existing_runtime_settings, payload)
+            merged_runtime_settings = _bind_runtime_library_overrides(merged_runtime_settings, changed_type_roots)
             catalog_refresh_needed = (
                 _runtime_source_roots(existing_runtime_settings) != _runtime_source_roots(merged_runtime_settings)
+                or _runtime_library_signature(existing_runtime_settings)
+                != _runtime_library_signature(merged_runtime_settings)
                 or object_dict(existing_runtime_settings.get("metadata"))
                 != object_dict(merged_runtime_settings.get("metadata"))
             )
@@ -579,9 +607,36 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         if catalog_refresh_needed:
             _reset_folder_card_cache()
             with open_db(config.paths.db_path) as connection:
-                _maybe_schedule_scan(connection, config, prefix=None)
+                _maybe_schedule_scan(connection, config, prefix=None, force=True)
         _refresh_host_status_cache(config)
         return {"ok": True, "message": "Settings saved.", "settings": _settings_page_payload(saved=True)}
+
+    def _library_type_preview_action(key: str, library_type: str) -> dict[str, Any]:
+        definition = config.library_definition_map.get(key)
+        if definition is None:
+            raise ValueError("Unknown library root.")
+        current_type = str(definition.get("type") or "other")
+        supported_types = {"tv", "movie", "spatial", "other"}
+        if library_type not in supported_types:
+            raise ValueError("Unsupported library type.")
+        with open_db(config.paths.db_path) as connection:
+            item_count = int(
+                connection.execute(
+                    select(func.count()).select_from(library_items).where(library_items.c.media_root == key)
+                ).scalar_one()
+            )
+        return {
+            "ok": True,
+            "preview": {
+                "key": key,
+                "from_type": current_type,
+                "to_type": library_type,
+                "item_count": item_count,
+                "requires_rescan": current_type != library_type,
+                "clears_saved_profiles": current_type != library_type,
+                "acknowledgement": f"{key}:{current_type}->{library_type}",
+            },
+        }
 
     def _prepare_host_action(host_key: str, remote_password: str | None = None) -> dict[str, Any]:
         nonlocal config
@@ -638,6 +693,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         app,
         settings_payload=_settings_page_payload,
         save_settings_action=_save_settings_action,
+        library_type_preview_action=_library_type_preview_action,
         archive_cleanup_payload=lambda transcode_root=None: archive_cleanup_summary(
             config,
             transcode_root=transcode_root,
@@ -2550,10 +2606,13 @@ def _catalog_signature_file(config: MediaforceConfig) -> Path:
 
 
 def _current_catalog_signature(config: MediaforceConfig) -> dict[str, Any]:
-    return {"source_roots": _runtime_source_roots(config.raw)}
+    return {
+        "source_roots": {key: str(path) for key, path in config.scan_source_root_map.items()},
+        "libraries": _runtime_library_signature(config.raw),
+    }
 
 
-def _settings_library_rows_for_config(config: MediaforceConfig, *, min_rows: int = 3) -> list[dict[str, str]]:
+def _settings_library_rows_for_config(config: MediaforceConfig, *, min_rows: int = 3) -> list[dict[str, Any]]:
     return _settings_library_rows_for_config_runtime(config, min_rows=min_rows)
 
 
@@ -2582,7 +2641,13 @@ def _load_catalog_signature(config: MediaforceConfig) -> dict[str, Any] | None:
     source_roots = payload.get("source_roots")
     if not isinstance(source_roots, dict):
         return None
-    return {"source_roots": _runtime_source_roots({"media": {"source_roots": source_roots}})}
+    libraries = payload.get("libraries")
+    return {
+        "source_roots": _runtime_source_roots({"media": {"source_roots": source_roots}}),
+        "libraries": _runtime_library_signature(
+            {"media": {"libraries": libraries if isinstance(libraries, list) else []}}
+        ),
+    }
 
 
 def _save_catalog_signature(config: MediaforceConfig) -> None:
@@ -2832,9 +2897,9 @@ def _save_scan_job_state(config: MediaforceConfig, prefix: str | None, payload: 
 
 
 def _maybe_schedule_scan(
-        connection: DBClient, config: MediaforceConfig, prefix: str | None
+        connection: DBClient, config: MediaforceConfig, prefix: str | None, *, force: bool = False
 ) -> dict[str, Any] | None:
-    return runtime_maybe_schedule_scan(connection, config, prefix, _job_runtime_deps())
+    return runtime_maybe_schedule_scan(connection, config, prefix, _job_runtime_deps(), force=force)
 
 
 def _scan_is_stale(connection: DBClient, config: MediaforceConfig, prefix: str | None) -> bool:

--- a/mediaforce/web/routes/settings.py
+++ b/mediaforce/web/routes/settings.py
@@ -4,6 +4,8 @@ from typing import Any
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
+from mediaforce.web.settings_runtime import SettingsValidationError
+
 SETTINGS_SAVE_ERROR_MESSAGE = (
     "Settings could not be saved. Review the submitted values and try again."
 )
@@ -14,6 +16,7 @@ def register_settings_routes(
         *,
         settings_payload: Callable[[bool], dict[str, Any]],
         save_settings_action: Callable[..., dict[str, Any]],
+        library_type_preview_action: Callable[[str, str], dict[str, Any]],
         archive_cleanup_payload: Callable[[str | None], dict[str, Any]],
         clear_archive_cleanup_action: Callable[[str | None], dict[str, Any]],
 ) -> None:
@@ -37,6 +40,20 @@ def register_settings_routes(
                 encode_queue_scheduler=dict(body.get("encode_queue_scheduler", {})),
                 schedule_profiles=[dict(item) for item in body.get("schedule_profiles", [])],
                 metadata=(dict(body["metadata"]) if isinstance(body.get("metadata"), dict) else None),
+            )
+        except SettingsValidationError as exc:
+            return JSONResponse({"ok": False, "message": str(exc)}, status_code=400)
+        except ValueError:
+            return JSONResponse({"ok": False, "message": SETTINGS_SAVE_ERROR_MESSAGE}, status_code=400)
+        return JSONResponse(result)
+
+    @app.post("/api/settings/library-type-preview")
+    async def api_library_type_preview(request: Request) -> JSONResponse:
+        body = await request.json()
+        try:
+            result = library_type_preview_action(
+                str(body.get("key", "")).strip(),
+                str(body.get("library_type", "")).strip(),
             )
         except ValueError:
             return JSONResponse({"ok": False, "message": SETTINGS_SAVE_ERROR_MESSAGE}, status_code=400)

--- a/mediaforce/web/routes/settings.py
+++ b/mediaforce/web/routes/settings.py
@@ -42,7 +42,7 @@ def register_settings_routes(
                 metadata=(dict(body["metadata"]) if isinstance(body.get("metadata"), dict) else None),
             )
         except SettingsValidationError as exc:
-            return JSONResponse({"ok": False, "message": str(exc)}, status_code=400)
+            return JSONResponse({"ok": False, "message": exc.public_message}, status_code=400)
         except ValueError:
             return JSONResponse({"ok": False, "message": SETTINGS_SAVE_ERROR_MESSAGE}, status_code=400)
         return JSONResponse(result)

--- a/mediaforce/web/runtime/catalog_signature.py
+++ b/mediaforce/web/runtime/catalog_signature.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from mediaforce.core.config import MediaforceConfig
+from mediaforce.web.settings_runtime import runtime_library_signature, runtime_source_roots
+
+
+def catalog_signature_file(config: MediaforceConfig) -> Path:
+    config.paths.web_state_dir.mkdir(parents=True, exist_ok=True)
+    return config.paths.web_state_dir / "full-catalog.signature.json"
+
+
+def current_catalog_signature(config: MediaforceConfig) -> dict[str, Any]:
+    return {
+        "source_roots": {key: str(path) for key, path in config.scan_source_root_map.items()},
+        "libraries": runtime_library_signature(config.raw),
+    }
+
+
+def load_catalog_signature(config: MediaforceConfig) -> dict[str, Any] | None:
+    path = catalog_signature_file(config)
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    source_roots = payload.get("source_roots")
+    if not isinstance(source_roots, dict):
+        return None
+    libraries = payload.get("libraries")
+    return {
+        "source_roots": runtime_source_roots({"media": {"source_roots": source_roots}}),
+        "libraries": runtime_library_signature(
+            {"media": {"libraries": libraries if isinstance(libraries, list) else []}}
+        ),
+    }
+
+
+def save_catalog_signature(config: MediaforceConfig) -> None:
+    catalog_signature_file(config).write_text(json.dumps(current_catalog_signature(config), indent=2) + "\n")

--- a/mediaforce/web/runtime/encode_runtime.py
+++ b/mediaforce/web/runtime/encode_runtime.py
@@ -1346,6 +1346,14 @@ def load_next_runnable_encode_job(
         job = load_encode_job(connection, str(row["job_id"]))
         if job is None:
             continue
+        library_key = _encode_job_library_key(job)
+        if library_key and library_key not in config.source_root_map:
+            waiting_reason = "Library is Browse only or Disabled in Settings."
+            if str(job.get("waiting_reason") or "") != waiting_reason:
+                job.update({"waiting_reason": waiting_reason, "updated_at": deps.now_iso()})
+                save_encode_job(connection, job)
+                sync_encode_job_parent(connection, job, deps)
+            continue
         host_payload, waiting_reason = select_encode_host(connection, config, job, deps)
         if host_payload is None:
             if str(job.get("waiting_reason") or "") != str(waiting_reason or ""):
@@ -1374,6 +1382,21 @@ def run_encode_job(
     with open_db(config.paths.db_path) as connection:
         job = load_encode_job(connection, job_id)
         if job is None:
+            return
+        library_key = _encode_job_library_key(job)
+        if library_key and library_key not in config.source_root_map:
+            job.update(
+                {
+                    "status": "queued",
+                    "worker_id": None,
+                    "owner_pid": None,
+                    "process_pid": None,
+                    "waiting_reason": "Library is Browse only or Disabled in Settings.",
+                    "updated_at": deps.now_iso(),
+                }
+            )
+            save_encode_job(connection, job)
+            sync_encode_job_parent(connection, job, deps)
             return
         manifest_path = Path(job["manifest_path"])
         manifest = json.loads(manifest_path.read_text())

--- a/mediaforce/web/runtime/job_runtime.py
+++ b/mediaforce/web/runtime/job_runtime.py
@@ -242,6 +242,8 @@ def maybe_schedule_scan(
         config: MediaforceConfig,
         prefix: str | None,
         deps: JobRuntimeDeps,
+        *,
+        force: bool = False,
 ) -> dict[str, Any] | None:
     active_scan = active_scan_from_db(connection, config, prefix, deps)
     if active_scan is not None:
@@ -263,7 +265,7 @@ def maybe_schedule_scan(
         job = _expire_scan_job(config, prefix, job, deps)
     if job and job.get("status") in {"queued", "running"}:
         return job
-    if not scan_is_stale(connection, config, prefix, deps):
+    if not force and not scan_is_stale(connection, config, prefix, deps):
         return job
     if job and job.get("status") == "failed":
         finished_at = deps.parse_iso(job.get("finished_at") or job.get("started_at"))

--- a/mediaforce/web/runtime/settings_payloads.py
+++ b/mediaforce/web/runtime/settings_payloads.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from mediaforce.core.config import MediaforceConfig
+from mediaforce.library.library_settings import LIBRARY_PROFILE_OPTIONS, LIBRARY_TYPE_OPTIONS
 from mediaforce.library.metadata_sync import metadata_configuration_status
 from mediaforce.web.settings_runtime import HOST_CAPABILITY_OPTIONS, index_schedule_profile_rows, \
     index_settings_library_rows, index_settings_remote_rows, schedule_profile_options, settings_archive_root, \
@@ -43,6 +44,11 @@ def settings_page_payload(
         "host_notice": host_notice,
         "host_notice_kind": host_notice_kind,
         "libraries": index_settings_library_rows(libraries) if libraries is not None else settings_library_rows_for_config(config),
+        "library_type_options": list(LIBRARY_TYPE_OPTIONS),
+        "library_profile_options": {
+            library_type: list(options)
+            for library_type, options in LIBRARY_PROFILE_OPTIONS.items()
+        },
         "remote_hosts": index_settings_remote_rows(remote_hosts) if remote_hosts is not None else settings_remote_rows_for_config(config),
         "transcode_root": resolved_transcode_root,
         "video_defaults": dict(video_defaults) if video_defaults is not None else settings_video_defaults_for_config(config),

--- a/mediaforce/web/settings_runtime.py
+++ b/mediaforce/web/settings_runtime.py
@@ -68,7 +68,9 @@ HOST_CAPABILITY_OPTIONS = (
 
 
 class SettingsValidationError(ValueError):
-    pass
+    def __init__(self, public_message: str) -> None:
+        self.public_message = public_message
+        super().__init__("Settings validation failed.")
 
 
 def settings_library_rows(source_root_map: dict[str, Path], *, min_rows: int = 3) -> list[dict[str, Any]]:
@@ -788,7 +790,7 @@ def build_runtime_settings_payload(
             }
         )
     if not source_roots:
-        raise ValueError("Add at least one library before saving settings.")
+        raise SettingsValidationError("Add at least one library before saving settings.")
     library_colors = library_color_map_from_source_roots(source_roots, library_colors)
     known_library_keys = set(source_roots)
 
@@ -805,12 +807,12 @@ def build_runtime_settings_payload(
         if not label and not host and not repo_path and not wake_mac and not start_command and not stop_command:
             continue
         if not host:
-            raise ValueError("Each remote host row needs an SSH host value.")
+            raise SettingsValidationError("Each remote host row needs an SSH host value.")
         priority_text = _text(row.get("priority", "0"), "0") or "0"
         try:
             priority = int(priority_text)
         except ValueError as exc:
-            raise ValueError(f"Host priority must be a whole number for {label or host}.") from exc
+            raise SettingsValidationError(f"Host priority must be a whole number for {label or host}.") from exc
         max_parallel_text = _text(
             row.get("max_parallel_encodes", str(DEFAULT_HOST_MAX_PARALLEL_ENCODES)),
             str(DEFAULT_HOST_MAX_PARALLEL_ENCODES),
@@ -818,11 +820,11 @@ def build_runtime_settings_payload(
         try:
             max_parallel_encodes = max(1, int(max_parallel_text or str(DEFAULT_HOST_MAX_PARALLEL_ENCODES)))
         except ValueError as exc:
-            raise ValueError(f"Parallel encodes must be a whole number for {label or host}.") from exc
+            raise SettingsValidationError(f"Parallel encodes must be a whole number for {label or host}.") from exc
         try:
             start_timeout_seconds = max(1, int(start_timeout_text))
         except ValueError as exc:
-            raise ValueError(f"Start timeout must be a whole number for {label or host}.") from exc
+            raise SettingsValidationError(f"Start timeout must be a whole number for {label or host}.") from exc
         schedule_profile = canonical_schedule_profile_key(row.get("schedule_profile", DEFAULT_HOST_SCHEDULE_PROFILE))
         payload: dict[str, Any] = {"host": host}
         if label:
@@ -883,13 +885,13 @@ def build_runtime_settings_payload(
         if not any((key_text, label_text, start_hour_text, end_hour_text)):
             continue
         if not key_text:
-            raise ValueError("Each schedule profile needs a key.")
+            raise SettingsValidationError("Each schedule profile needs a key.")
         if key_text in {ALWAYS_SCHEDULE_PROFILE, NEVER_SCHEDULE_PROFILE}:
-            raise ValueError(f"Schedule profile key '{key_text}' is reserved.")
+            raise SettingsValidationError(f"Schedule profile key '{key_text}' is reserved.")
         if key_text in seen_profile_keys:
-            raise ValueError(f"Duplicate schedule profile key: {key_text}")
+            raise SettingsValidationError(f"Duplicate schedule profile key: {key_text}")
         if not days_of_week and not all_day_days_of_week:
-            raise ValueError(f"Select at least one day for schedule profile '{key_text}'.")
+            raise SettingsValidationError(f"Select at least one day for schedule profile '{key_text}'.")
         normalized = normalize_encode_queue_scheduler(
             {
                 "mode": "night",
@@ -922,7 +924,9 @@ def build_runtime_settings_payload(
         }
     )
     if invalid_host_profiles:
-        raise ValueError("Unknown schedule profile for host assignment: " + ", ".join(invalid_host_profiles))
+        raise SettingsValidationError(
+            "Unknown schedule profile for host assignment: " + ", ".join(invalid_host_profiles)
+        )
 
     normalized_video_defaults = normalize_video_defaults(video_defaults)
     metadata_payload = dict(metadata) if isinstance(metadata, dict) else {}
@@ -1009,9 +1013,9 @@ def _normalized_provider_url(value: object, *, allow_http: bool) -> str:
     parsed = urlsplit(text)
     allowed_schemes = {"https"} | ({"http"} if allow_http else set())
     if parsed.scheme not in allowed_schemes or not parsed.netloc or parsed.username or parsed.password:
-        raise ValueError("Provider URLs must use an allowed HTTP scheme and cannot contain credentials.")
+        raise SettingsValidationError("Provider URLs must use an allowed HTTP scheme and cannot contain credentials.")
     if parsed.query or parsed.fragment:
-        raise ValueError("Provider URLs cannot contain query parameters or fragments.")
+        raise SettingsValidationError("Provider URLs cannot contain query parameters or fragments.")
     return text
 
 
@@ -1046,25 +1050,25 @@ def normalize_video_defaults(raw: dict[str, Any] | None) -> dict[str, Any]:
         try:
             value = float(str(payload.get(key, DEFAULT_VIDEO_DEFAULTS[key])))
         except (TypeError, ValueError) as exc:
-            raise ValueError(f"Video default {key} must be a number.") from exc
+            raise SettingsValidationError(f"Video default {key} must be a number.") from exc
         if value < minimum or value > maximum:
-            raise ValueError(f"Video default {key} must be between {minimum:g} and {maximum:g}.")
+            raise SettingsValidationError(f"Video default {key} must be between {minimum:g} and {maximum:g}.")
         return value
 
     def _int_field(key: str, *, minimum: int, maximum: int) -> int:
         value = _float_field(key, minimum=minimum, maximum=maximum)
         if not value.is_integer():
-            raise ValueError(f"Video default {key} must be a whole number.")
+            raise SettingsValidationError(f"Video default {key} must be a whole number.")
         return int(value)
 
     target_vmaf = _float_field("target_vmaf", minimum=1, maximum=100)
     min_target_vmaf = _float_field("min_target_vmaf", minimum=1, maximum=100)
     if min_target_vmaf > target_vmaf:
-        raise ValueError("Video default min_target_vmaf must be less than or equal to target_vmaf.")
+        raise SettingsValidationError("Video default min_target_vmaf must be less than or equal to target_vmaf.")
     target_xpsnr = _float_field("target_xpsnr", minimum=1, maximum=100)
     min_target_xpsnr = _float_field("min_target_xpsnr", minimum=1, maximum=100)
     if min_target_xpsnr > target_xpsnr:
-        raise ValueError("Video default min_target_xpsnr must be less than or equal to target_xpsnr.")
+        raise SettingsValidationError("Video default min_target_xpsnr must be less than or equal to target_xpsnr.")
     target_size_mb = _float_field("target_size_mb", minimum=1, maximum=100_000)
     max_height = _int_field("max_height", minimum=0, maximum=4320)
 
@@ -1217,9 +1221,9 @@ def normalize_host_source_root_overrides(
         try:
             raw_value = json.loads(text)
         except json.JSONDecodeError as exc:
-            raise ValueError(f"Library path overrides must be valid JSON for {host_label}.") from exc
+            raise SettingsValidationError(f"Library path overrides must be valid JSON for {host_label}.") from exc
     if not isinstance(raw_value, dict):
-        raise ValueError(f"Library path overrides must be a JSON object for {host_label}.")
+        raise SettingsValidationError(f"Library path overrides must be a JSON object for {host_label}.")
 
     normalized: dict[str, str] = {}
     for key, path in raw_value.items():
@@ -1227,7 +1231,7 @@ def normalize_host_source_root_overrides(
         if not key_text:
             continue
         if key_text not in known_library_keys:
-            raise ValueError(f"Unknown library override '{key_text}' for {host_label}.")
+            raise SettingsValidationError(f"Unknown library override '{key_text}' for {host_label}.")
         path_text = str(path or "").strip()
         if not path_text:
             continue

--- a/mediaforce/web/settings_runtime.py
+++ b/mediaforce/web/settings_runtime.py
@@ -4,9 +4,12 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
-from mediaforce.core.config import MediaforceConfig
+from mediaforce.core.config import FOLDER_POLICY_OVERRIDES_KEY, MediaforceConfig
 from mediaforce.encoding.encode_queue import DEFAULT_SCHEDULER_POLICY
 from mediaforce.hosts.config import normalize_host_capabilities
+from mediaforce.library.library_settings import DEFAULT_LIBRARY_PROFILES, LIBRARY_PROFILE_OPTIONS, \
+    LIBRARY_TYPE_OPTIONS, default_library_policy, library_production_supported, library_type_label, \
+    normalize_library_availability, normalize_library_definition, normalize_library_policy, normalize_library_type
 from mediaforce.remote import DEFAULT_HOST_CAPABILITIES, DEFAULT_HOST_MEDIA_ACCESS, normalize_host_media_access
 from mediaforce.core.type_defs import JSONValue
 from mediaforce.tuning.size_goals import megabytes_to_bytes
@@ -64,46 +67,154 @@ HOST_CAPABILITY_OPTIONS = (
 )
 
 
-def settings_library_rows(source_root_map: dict[str, Path], *, min_rows: int = 3) -> list[dict[str, str]]:
+class SettingsValidationError(ValueError):
+    pass
+
+
+def settings_library_rows(source_root_map: dict[str, Path], *, min_rows: int = 3) -> list[dict[str, Any]]:
     rows = [
         {
             "key": key,
+            "label": key.replace("_", " ").replace("-", " ").title(),
             "path": str(path),
             "color": DEFAULT_LIBRARY_COLOR_PALETTE[index % len(DEFAULT_LIBRARY_COLOR_PALETTE)],
+            "library_type": normalize_library_type(None, key=key),
         }
         for index, (key, path) in enumerate(source_root_map.items())
     ]
     return index_settings_library_rows(rows, min_rows=min_rows)
 
 
-def settings_library_rows_for_config(config: MediaforceConfig, *, min_rows: int = 3) -> list[dict[str, str]]:
-    media = config.raw.get("media")
-    source_roots = media.get("source_roots") if isinstance(media, dict) else None
+def settings_library_rows_for_config(config: MediaforceConfig, *, min_rows: int = 3) -> list[dict[str, Any]]:
     library_colors = library_color_map_for_config(config)
-    rows: list[dict[str, str]] = []
-    if isinstance(source_roots, dict):
-        for key, value in source_roots.items():
-            key_text = str(key).strip()
-            path_text = stringify_pathlike(value)
-            if not key_text and not path_text:
-                continue
-            rows.append({"key": key_text, "path": path_text, "color": library_colors.get(key_text, "")})
+    plex = config.metadata.get("plex")
+    plex_roots = plex.get("library_roots") if isinstance(plex, dict) else None
+    plex_root_map = plex_roots if isinstance(plex_roots, dict) else {}
+    rows: list[dict[str, Any]] = []
+    for definition in config.library_definitions:
+        key = str(definition["key"])
+        rows.append(
+            {
+                "key": key,
+                "label": str(definition["label"]),
+                "path": str(definition.get("path") or ""),
+                "color": str(definition.get("color") or library_colors.get(key, "")),
+                "library_type": str(definition["type"]),
+                "availability": str(definition["availability"]),
+                "default_profile": str(definition["default_profile"]),
+                "plex_path": str(definition.get("plex_path") or plex_root_map.get(key) or ""),
+                "policy": dict(definition["policy"]),
+            }
+        )
     return index_settings_library_rows(rows, min_rows=min_rows)
 
 
-def index_settings_library_rows(rows: list[dict[str, str]], *, min_rows: int = 1) -> list[dict[str, str]]:
-    indexed = [
-        {
-            "index": str(index),
-            "key": row.get("key", ""),
-            "path": row.get("path", ""),
-            "color": row.get("color", ""),
-        }
-        for index, row in enumerate(rows)
-    ]
+def index_settings_library_rows(rows: list[dict[str, Any]], *, min_rows: int = 1) -> list[dict[str, Any]]:
+    indexed: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        key = str(row.get("key") or "").strip()
+        library_type = normalize_library_type(row.get("library_type") or row.get("type"), key=key)
+        definition = normalize_library_definition(
+            {
+                "label": row.get("label"),
+                "type": library_type,
+                "availability": row.get("availability"),
+                "default_profile": row.get("default_profile"),
+                "policy": row.get("policy"),
+            },
+            key=key,
+        )
+        indexed.append(
+            {
+                "index": str(index),
+                "key": key,
+                "label": definition["label"],
+                "path": str(row.get("path") or ""),
+                "color": str(row.get("color") or ""),
+                "library_type": library_type,
+                "availability": definition["availability"],
+                "default_profile": definition["default_profile"],
+                "plex_path": str(row.get("plex_path") or ""),
+                "policy": definition["policy"],
+                "readiness": library_readiness(
+                    key=key,
+                    label=str(definition["label"]),
+                    path=str(row.get("path") or ""),
+                    library_type=library_type,
+                    availability=str(definition["availability"]),
+                    policy=dict(definition["policy"]),
+                ),
+                "type_change_confirmation": "",
+            }
+        )
     while len(indexed) < min_rows:
-        indexed.append({"index": str(len(indexed)), "key": "", "path": "", "color": "#0f766e"})
+        indexed.append(empty_settings_library_row(len(indexed)))
     return indexed
+
+
+def empty_settings_library_row(index: int) -> dict[str, Any]:
+    library_type = "other"
+    return {
+        "index": str(index),
+        "key": "",
+        "label": "",
+        "path": "",
+        "color": "#0f766e",
+        "library_type": library_type,
+        "availability": "browse_only",
+        "default_profile": DEFAULT_LIBRARY_PROFILES[library_type],
+        "plex_path": "",
+        "policy": default_library_policy(library_type),
+        "readiness": {"state": "incomplete", "label": "Incomplete", "detail": "Add a label and local path."},
+        "type_change_confirmation": "",
+    }
+
+
+def library_readiness(
+        *,
+        key: str,
+        label: str,
+        path: str,
+        library_type: str,
+        availability: str,
+        policy: dict[str, Any],
+) -> dict[str, str]:
+    if not key or not label.strip() or not path.strip():
+        return {"state": "incomplete", "label": "Incomplete", "detail": "Add a label, root ID, and local path."}
+    if availability == "disabled":
+        return {"state": "disabled", "label": "Disabled", "detail": "Mediaforce will not scan or process this library."}
+    if library_type == "spatial":
+        missing = []
+        if not str(policy.get("playback_target") or "").strip():
+            missing.append("playback target")
+        if str(policy.get("stereo_layout") or "unknown") == "unknown":
+            missing.append("stereo layout")
+        if str(policy.get("projection") or "unknown") == "unknown":
+            missing.append("projection")
+        if missing:
+            return {
+                "state": "incomplete",
+                "label": "Incomplete",
+                "detail": f"Add {', '.join(missing)} before playback qualification.",
+            }
+        return {
+            "state": "blocked",
+            "label": "Safety blocked",
+            "detail": "Browse-only until 3D / VR playback qualification is implemented.",
+        }
+    if availability == "browse_only":
+        return {
+            "state": "browse_only",
+            "label": "Browse only",
+            "detail": "Mediaforce scans and shows this library but never processes it.",
+        }
+    if not library_production_supported(library_type):
+        return {
+            "state": "blocked",
+            "label": "Workflow blocked",
+            "detail": f"{library_type_label(library_type)} production is not available yet.",
+        }
+    return {"state": "ready", "label": "Ready", "detail": "Scanning and production processing are enabled."}
 
 
 def settings_remote_rows(remote_hosts: list[dict[str, Any]], *, min_rows: int = 3) -> list[dict[str, Any]]:
@@ -503,6 +614,70 @@ def normalize_encode_queue_scheduler(raw: dict[str, Any] | None) -> dict[str, An
     return normalized
 
 
+def normalize_submitted_library_policy(library_type: str, value: Any) -> dict[str, Any]:
+    policy = normalize_library_policy(normalize_library_type(library_type), value)
+    if library_type == "tv":
+        lifecycle_mode = str(policy.get("series_lifecycle_mode") or "auto").strip().lower()
+        if lifecycle_mode not in {"auto", "on", "off"}:
+            raise SettingsValidationError("TV current-season protection must be Automatic, Always, or Off.")
+        return {
+            "series_lifecycle_mode": lifecycle_mode,
+            "current_season_inactive_days": _library_policy_integer(
+                policy.get("current_season_inactive_days"), label="Current-season inactivity", minimum=1, maximum=3650
+            ),
+            "season_acquisition_hold_days": _library_policy_integer(
+                policy.get("season_acquisition_hold_days"), label="New-season hold", minimum=0, maximum=365
+            ),
+            "series_metadata_stale_days": _library_policy_integer(
+                policy.get("series_metadata_stale_days"), label="Series metadata freshness", minimum=1, maximum=365
+            ),
+        }
+    if library_type == "movie":
+        grouping = str(policy.get("grouping") or "title")
+        editions = str(policy.get("editions") or "separate")
+        extras = str(policy.get("extras") or "exclude")
+        ranking = str(policy.get("ranking") or "oldest_added_first")
+        if grouping != "title" or editions != "separate" or extras not in {"exclude", "include"}:
+            raise SettingsValidationError("Choose supported movie grouping, edition, and extras policies.")
+        if ranking not in {"oldest_added_first", "largest_first"}:
+            raise SettingsValidationError("Choose a supported movie ranking policy.")
+        return {"grouping": grouping, "editions": editions, "extras": extras, "ranking": ranking}
+    if library_type == "spatial":
+        stereo_layout = str(policy.get("stereo_layout") or "unknown")
+        projection = str(policy.get("projection") or "unknown")
+        geometry_policy = str(policy.get("geometry_policy") or "preserve")
+        container_profile = str(policy.get("container_profile") or "unqualified")
+        if stereo_layout not in {"unknown", "side_by_side", "top_bottom", "frame_sequential"}:
+            raise SettingsValidationError("Choose a supported 3D stereo layout.")
+        if projection not in {"unknown", "flat", "equirectangular_180", "equirectangular_360"}:
+            raise SettingsValidationError("Choose a supported 3D / VR projection.")
+        if geometry_policy != "preserve" or container_profile != "unqualified":
+            raise SettingsValidationError(
+                "3D / VR geometry and container handling must remain source-preserving and unqualified."
+            )
+        return {
+            "playback_target": str(policy.get("playback_target") or "").strip(),
+            "stereo_layout": stereo_layout,
+            "projection": projection,
+            "geometry_policy": geometry_policy,
+            "container_profile": container_profile,
+        }
+    grouping = str(policy.get("grouping") or "folder")
+    if grouping not in {"folder", "file"}:
+        raise SettingsValidationError("Other libraries must group work by folder or file.")
+    return {"grouping": grouping}
+
+
+def _library_policy_integer(value: Any, *, label: str, minimum: int, maximum: int) -> int:
+    try:
+        normalized = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise SettingsValidationError(f"{label} must be a whole number.") from exc
+    if normalized < minimum or normalized > maximum:
+        raise SettingsValidationError(f"{label} must be between {minimum} and {maximum} days.")
+    return normalized
+
+
 def build_runtime_settings_payload(
         *,
         libraries: list[dict[str, Any]],
@@ -512,6 +687,9 @@ def build_runtime_settings_payload(
         encode_queue_scheduler: dict[str, Any],
         schedule_profiles: list[dict[str, Any]],
         metadata: dict[str, Any] | None = None,
+        existing_library_types: dict[str, str] | None = None,
+        existing_libraries: dict[str, dict[str, Any]] | None = None,
+        existing_library_paths: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     def _text(value: JSONValue, default: str = "") -> str:
         if value is None:
@@ -520,20 +698,95 @@ def build_runtime_settings_payload(
 
     source_roots: dict[str, str] = {}
     library_colors: dict[str, str] = {}
+    library_definitions: list[dict[str, Any]] = []
+    plex_library_roots: dict[str, str] = {}
+    seen_paths: set[str] = set()
+    seen_plex_paths: set[str] = set()
+    current_types = existing_library_types or {}
+    current_libraries = existing_libraries or {}
+    current_paths = existing_library_paths or {}
+    _reject_submitted_secrets(metadata)
+    staging_root = Path(transcode_root).expanduser()
+    if not staging_root.is_absolute():
+        raise SettingsValidationError("The working folder must be an absolute path.")
     for row in libraries:
         key_text = _text(row.get("key", ""))
+        label_text = _text(row.get("label", ""))
         path_text = _text(row.get("path", ""))
-        if not key_text and not path_text:
+        if not key_text and not label_text and not path_text:
             continue
         normalized_key = normalize_library_key(key_text)
         if not normalized_key or not path_text:
-            raise ValueError("Each library row needs both a library name and a mounted path.")
+            raise SettingsValidationError("Each library needs a root ID and local path.")
+        if normalized_key != key_text or not re.fullmatch(r"[a-z0-9][a-z0-9_-]{0,63}", key_text):
+            raise SettingsValidationError("Library root IDs use lowercase letters, numbers, underscores, and hyphens.")
+        if not label_text:
+            label_text = normalized_key.replace("_", " ").replace("-", " ").title()
+        if len(label_text) > 80:
+            raise SettingsValidationError("Library labels must be 80 characters or fewer.")
         if normalized_key in source_roots:
-            raise ValueError(f"Duplicate library name: {normalized_key}")
-        source_roots[normalized_key] = str(Path(path_text).expanduser())
+            raise SettingsValidationError(f"Duplicate library root ID: {normalized_key}")
+        path = Path(path_text).expanduser()
+        if not path.is_absolute() and current_paths.get(normalized_key) != path_text:
+            raise SettingsValidationError("Library local paths must be absolute.")
+        normalized_path = str(path)
+        if normalized_path in seen_paths:
+            raise SettingsValidationError("Each library needs a distinct local path.")
+        if any(_paths_overlap(path, Path(existing)) for existing in seen_paths):
+            raise SettingsValidationError("Library local paths cannot contain one another.")
+        if _paths_overlap(path, staging_root):
+            raise SettingsValidationError("Library paths cannot contain the working folder or be inside it.")
+        explicit_type = _text(row.get("library_type", ""))
+        if explicit_type and explicit_type not in {option["key"] for option in LIBRARY_TYPE_OPTIONS}:
+            raise SettingsValidationError("Choose a supported library type.")
+        library_type = normalize_library_type(explicit_type or None, key=normalized_key)
+        availability_text = _text(row.get("availability", ""))
+        if availability_text and availability_text not in {"production", "browse_only", "disabled"}:
+            raise SettingsValidationError("Choose Production, Browse only, or Disabled for each library.")
+        availability = normalize_library_availability(availability_text or None, library_type=library_type)
+        previous_type = current_types.get(normalized_key)
+        expected_confirmation = f"{normalized_key}:{previous_type}->{library_type}" if previous_type else ""
+        if previous_type and previous_type != library_type and row.get("type_change_confirmation") != expected_confirmation:
+            raise SettingsValidationError("Confirm the library type compatibility preview before saving.")
+        if previous_type and previous_type != library_type:
+            availability = "browse_only"
+        if availability == "production" and not library_production_supported(library_type):
+            raise SettingsValidationError(
+                f"{library_type_label(library_type)} production is not available yet; use Browse only."
+            )
+        profile = _text(row.get("default_profile", DEFAULT_LIBRARY_PROFILES[library_type]))
+        valid_profiles = {option["key"] for option in LIBRARY_PROFILE_OPTIONS[library_type]}
+        if profile not in valid_profiles:
+            raise SettingsValidationError(f"Choose a valid default profile for {library_type_label(library_type)}.")
+        policy = normalize_submitted_library_policy(library_type, row.get("policy"))
+        source_roots[normalized_key] = normalized_path
+        seen_paths.add(normalized_path)
         color_text = normalize_library_color(row.get("color"))
         if color_text is not None:
             library_colors[normalized_key] = color_text
+        plex_path = _text(row.get("plex_path", ""))
+        if plex_path:
+            normalized_plex_path = Path(plex_path).expanduser()
+            if not normalized_plex_path.is_absolute():
+                raise SettingsValidationError("Custom Plex paths must be absolute.")
+            if str(normalized_plex_path) in seen_plex_paths:
+                raise SettingsValidationError("Each custom Plex path must be unique.")
+            plex_library_roots[normalized_key] = str(normalized_plex_path)
+            seen_plex_paths.add(str(normalized_plex_path))
+        library_definitions.append(
+            {
+                **current_libraries.get(normalized_key, {}),
+                "key": normalized_key,
+                "label": label_text,
+                "path": normalized_path,
+                "color": color_text or "",
+                "plex_path": plex_library_roots.get(normalized_key, ""),
+                "type": library_type,
+                "availability": availability,
+                "default_profile": profile,
+                "policy": policy,
+            }
+        )
     if not source_roots:
         raise ValueError("Add at least one library before saving settings.")
     library_colors = library_color_map_from_source_roots(source_roots, library_colors)
@@ -672,12 +925,16 @@ def build_runtime_settings_payload(
         raise ValueError("Unknown schedule profile for host assignment: " + ", ".join(invalid_host_profiles))
 
     normalized_video_defaults = normalize_video_defaults(video_defaults)
-    normalized_metadata = normalize_metadata_settings(metadata, known_library_keys=known_library_keys)
-    staging_root = Path(transcode_root).expanduser()
+    metadata_payload = dict(metadata) if isinstance(metadata, dict) else {}
+    plex_payload = dict(metadata_payload.get("plex")) if isinstance(metadata_payload.get("plex"), dict) else {}
+    plex_payload["library_roots"] = plex_library_roots
+    metadata_payload["plex"] = plex_payload
+    normalized_metadata = normalize_metadata_settings(metadata_payload, known_library_keys=known_library_keys)
     return {
         "media": {
             "source_roots": source_roots,
             "library_colors": library_colors,
+            "libraries": library_definitions,
             "staging_root": str(staging_root),
             "archive_root": str(staging_root / "_replaced"),
         },
@@ -689,6 +946,25 @@ def build_runtime_settings_payload(
         },
         "metadata": normalized_metadata,
     }
+
+
+def _paths_overlap(left: Path, right: Path) -> bool:
+    return left == right or left in right.parents or right in left.parents
+
+
+def _reject_submitted_secrets(value: Any, *, path: tuple[str, ...] = ()) -> None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_text = str(key).strip().lower()
+            next_path = (*path, key_text)
+            secret_key = key_text in {"token", "password", "secret", "api_key", "apikey"}
+            if secret_key and nested is not None and nested != "" and nested is not False:
+                raise SettingsValidationError("Credential values are not accepted in Settings.")
+            _reject_submitted_secrets(nested, path=next_path)
+        return
+    if isinstance(value, list):
+        for nested in value:
+            _reject_submitted_secrets(nested, path=path)
 
 
 def normalize_metadata_settings(
@@ -831,6 +1107,53 @@ def merge_runtime_settings_payload(existing: dict[str, Any], updates: dict[str, 
             merged[key] = nested
             continue
         merged[key] = value
+    return merged
+
+
+def runtime_library_signature(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    media = payload.get("media")
+    if not isinstance(media, dict):
+        return []
+    libraries = media.get("libraries")
+    if not isinstance(libraries, list):
+        return []
+    signature: list[dict[str, Any]] = []
+    for item in libraries:
+        if not isinstance(item, dict):
+            continue
+        key = str(item.get("key") or "").strip()
+        if not key:
+            continue
+        definition = normalize_library_definition(item, key=key)
+        signature.append(
+            {
+                "key": key,
+                "type": definition["type"],
+                "scannable": definition["availability"] != "disabled",
+            }
+        )
+    return sorted(signature, key=lambda item: str(item["key"]))
+
+
+def bind_runtime_library_overrides(payload: dict[str, Any], previous_types: dict[str, str]) -> dict[str, Any]:
+    if not previous_types:
+        return payload
+    overrides = payload.get(FOLDER_POLICY_OVERRIDES_KEY)
+    if not isinstance(overrides, list):
+        return payload
+    merged = dict(payload)
+    rebound: list[Any] = []
+    for override in overrides:
+        if not isinstance(override, dict):
+            rebound.append(override)
+            continue
+        root = str(override.get("path_prefix") or "").strip("/").split("/", 1)[0]
+        previous_type = previous_types.get(root)
+        if previous_type and not str(override.get("library_type") or "").strip():
+            rebound.append({**override, "library_type": previous_type})
+            continue
+        rebound.append(override)
+    merged[FOLDER_POLICY_OVERRIDES_KEY] = rebound
     return merged
 
 

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -17,6 +17,7 @@ from mediaforce.core.db_tables import (
     encode_queue_state,
     item_events,
     library_items,
+    scan_runs,
     series_metadata,
     staged_artifacts,
 )
@@ -27,6 +28,7 @@ from mediaforce.web.runtime.folder_tuning_advice import (
     calibration_draft_hash,
     calibration_policy_hash,
 )
+from mediaforce.web.runtime.catalog_signature import save_catalog_signature
 
 FIXTURE_SCAN_ID = "web-smoke-fixtures"
 LEGACY_FIXTURE_SCAN_IDS = ("fixture-scan",)
@@ -676,6 +678,11 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 calibration_jobs.c.job_id.like("web-smoke-%")
             )
         )
+        connection.execute(
+            scan_runs.delete().where(
+                scan_runs.c.scan_id.in_((FIXTURE_SCAN_ID, *LEGACY_FIXTURE_SCAN_IDS))
+            )
+        )
         fixture_ids = [
             int(row["id"])
             for row in connection.execute(
@@ -711,6 +718,7 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
         )
 
         if profile == "empty":
+            save_catalog_signature(config)
             return {
                 "profile": profile,
                 "folderRoutes": [],
@@ -983,6 +991,25 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
             inserted_ids.append(int(result.inserted_primary_key[0]))
         for row, item_id in zip(rows, inserted_ids, strict=True):
             row["id"] = item_id
+        scan_timestamp = _now()
+        connection.execute(
+            scan_runs.insert().values(
+                scan_id=FIXTURE_SCAN_ID,
+                started_at=scan_timestamp,
+                completed_at=scan_timestamp,
+                owner_pid=None,
+                last_progress_at=scan_timestamp,
+                roots_json=json.dumps(
+                    {key: str(path) for key, path in config.scan_source_root_map.items()},
+                    sort_keys=True,
+                ),
+                scope="full",
+                prefixes_json=None,
+                file_count=len(rows),
+                reprobed_count=len(rows),
+                unchanged_count=0,
+            )
+        )
         rows_by_prefix = {str(row["parent_dir"]): row for row in rows}
         ids_by_rel_path = {
             str(row["rel_path"]): item_id
@@ -1266,6 +1293,7 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
         )
 
     _write_review_states(config, rows_by_prefix)
+    save_catalog_signature(config)
 
     return {
         "profile": profile,

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -2223,7 +2223,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 "ranking": "oldest_added_first",
             },
         }
-        with self.assertRaisesRegex(ValueError, "compatibility preview"):
+        with self.assertRaises(settings_runtime.SettingsValidationError) as raised:
             web_app._build_runtime_settings_payload(
                 libraries=[row],
                 remote_hosts=[],
@@ -2232,6 +2232,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 schedule_profiles=[],
                 existing_library_types={"tv": "tv"},
             )
+        self.assertIn("compatibility preview", raised.exception.public_message)
 
         payload = web_app._build_runtime_settings_payload(
             libraries=[
@@ -2251,7 +2252,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(payload["media"]["libraries"][0]["availability"], "browse_only")
 
     def test_runtime_settings_payload_rejects_non_tv_production(self) -> None:
-        with self.assertRaisesRegex(ValueError, "production is not available"):
+        with self.assertRaises(settings_runtime.SettingsValidationError) as raised:
             web_app._build_runtime_settings_payload(
                 libraries=[
                     {
@@ -2268,6 +2269,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 encode_queue_scheduler={"mode": "anytime", "start_hour": 22, "end_hour": 8, "timezone": "local"},
                 schedule_profiles=[],
             )
+        self.assertIn("production is not available", raised.exception.public_message)
 
     def test_typed_library_maps_scan_browse_only_but_only_produce_ready_roots(self) -> None:
         self.config.raw["media"]["source_roots"] = {
@@ -2385,7 +2387,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertNotEqual(self.config.resolve_policy("tv/Example/Season 01")["video"].get("crf"), 22)
 
     def test_runtime_settings_payload_rejects_submitted_secret_values(self) -> None:
-        with self.assertRaisesRegex(ValueError, "Credential values are not accepted"):
+        with self.assertRaises(settings_runtime.SettingsValidationError) as raised:
             web_app._build_runtime_settings_payload(
                 libraries=[{"key": "tv", "path": str(self.root / "source" / "tv")}],
                 remote_hosts=[],
@@ -2394,6 +2396,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 schedule_profiles=[],
                 metadata={"plex": {"token": "must-not-persist"}},
             )
+        self.assertEqual(raised.exception.public_message, "Credential values are not accepted in Settings.")
+        self.assertEqual(str(raised.exception), "Settings validation failed.")
 
     def test_runtime_settings_payload_defaults_host_schedule_to_always(self) -> None:
         payload = web_app._build_runtime_settings_payload(
@@ -2587,7 +2591,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(payload["remote_hosts"][0]["staging_root"], str(self.root / "remote-staging"))
 
     def test_runtime_settings_payload_rejects_unknown_library_override(self) -> None:
-        with self.assertRaisesRegex(ValueError, "Unknown library override"):
+        with self.assertRaises(settings_runtime.SettingsValidationError) as raised:
             web_app._build_runtime_settings_payload(
                 libraries=[{"key": "tv", "path": str(self.root / "source" / "tv")}],
                 remote_hosts=[
@@ -2604,9 +2608,10 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 encode_queue_scheduler={"mode": "anytime", "start_hour": 22, "end_hour": 8, "timezone": "local"},
                 schedule_profiles=[],
             )
+        self.assertIn("Unknown library override", raised.exception.public_message)
 
     def test_runtime_settings_payload_rejects_unknown_host_schedule_profile(self) -> None:
-        with self.assertRaisesRegex(ValueError, "Unknown schedule profile"):
+        with self.assertRaises(settings_runtime.SettingsValidationError) as raised:
             web_app._build_runtime_settings_payload(
                 libraries=[{"key": "tv", "path": str(self.root / "source" / "tv")}],
                 remote_hosts=[
@@ -2623,9 +2628,10 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 encode_queue_scheduler={"mode": "anytime", "start_hour": 22, "end_hour": 8, "timezone": "local"},
                 schedule_profiles=[],
             )
+        self.assertIn("Unknown schedule profile", raised.exception.public_message)
 
     def test_runtime_settings_payload_rejects_reserved_schedule_profile_key(self) -> None:
-        with self.assertRaisesRegex(ValueError, "reserved"):
+        with self.assertRaises(settings_runtime.SettingsValidationError) as raised:
             web_app._build_runtime_settings_payload(
                 libraries=[{"key": "tv", "path": str(self.root / "source" / "tv")}],
                 remote_hosts=[],
@@ -2640,6 +2646,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                     }
                 ],
             )
+        self.assertIn("reserved", raised.exception.public_message)
 
     def test_runtime_settings_payload_preserves_allowed_libraries_for_host(self) -> None:
         payload = web_app._build_runtime_settings_payload(
@@ -2823,7 +2830,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(payload["encode_queue"]["schedule_profiles"][0]["all_day_days_of_week"], ["sun"])
 
     def test_build_runtime_settings_payload_rejects_schedule_profile_without_days(self) -> None:
-        with self.assertRaisesRegex(ValueError, "Select at least one day"):
+        with self.assertRaises(settings_runtime.SettingsValidationError) as raised:
             settings_runtime.build_runtime_settings_payload(
                 libraries=[{"key": "movies", "path": str(self.root / "source" / "movies"), "color": "#123456"}],
                 remote_hosts=[],
@@ -2840,6 +2847,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                     }
                 ],
             )
+        self.assertIn("Select at least one day", raised.exception.public_message)
 
     def test_host_runtime_rows_mark_never_schedule_as_disabled(self) -> None:
         self.config.raw["remote_hosts"] = [

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -23,7 +23,7 @@ from sqlalchemy import select
 from sqlalchemy import update
 
 from mediaforce import execution, quality, remote, review, state_cleanup
-from mediaforce.core import binaries
+from mediaforce.core import binaries, config as config_runtime
 from mediaforce.core.config import ConfigPaths, MediaforceConfig
 from mediaforce.core.db import DBClient, open_db
 from mediaforce.core.db_tables import calibration_jobs
@@ -2177,6 +2177,224 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(payload["encode_queue"]["schedule_profiles"][0]["key"], "late_night")
         self.assertEqual(payload["encode_queue"]["schedule_profiles"][0]["timezone"], "host_local")
 
+    def test_runtime_settings_payload_persists_canonical_typed_library_rows(self) -> None:
+        payload = web_app._build_runtime_settings_payload(
+            libraries=[
+                {
+                    "key": "movies",
+                    "label": "Movies",
+                    "path": str(self.root / "source" / "movies"),
+                    "color": "#4e6fa6",
+                    "library_type": "movie",
+                    "availability": "browse_only",
+                    "default_profile": "movie_balanced",
+                    "plex_path": "/mnt/media/movies",
+                    "policy": {
+                        "grouping": "title",
+                        "editions": "separate",
+                        "extras": "exclude",
+                        "ranking": "oldest_added_first",
+                    },
+                }
+            ],
+            remote_hosts=[],
+            transcode_root=str(self.root / "staging"),
+            encode_queue_scheduler={"mode": "anytime", "start_hour": 22, "end_hour": 8, "timezone": "local"},
+            schedule_profiles=[],
+        )
+
+        self.assertEqual(payload["media"]["source_roots"], {"movies": str(self.root / "source" / "movies")})
+        self.assertEqual(payload["media"]["libraries"][0]["type"], "movie")
+        self.assertEqual(payload["media"]["libraries"][0]["path"], str(self.root / "source" / "movies"))
+        self.assertEqual(payload["metadata"]["plex"]["library_roots"], {"movies": "/mnt/media/movies"})
+
+    def test_runtime_settings_payload_requires_root_bound_type_change_confirmation(self) -> None:
+        row = {
+            "key": "tv",
+            "label": "TV Shows",
+            "path": str(self.root / "source" / "tv"),
+            "library_type": "movie",
+            "availability": "browse_only",
+            "default_profile": "movie_balanced",
+            "policy": {
+                "grouping": "title",
+                "editions": "separate",
+                "extras": "exclude",
+                "ranking": "oldest_added_first",
+            },
+        }
+        with self.assertRaisesRegex(ValueError, "compatibility preview"):
+            web_app._build_runtime_settings_payload(
+                libraries=[row],
+                remote_hosts=[],
+                transcode_root=str(self.root / "staging"),
+                encode_queue_scheduler={"mode": "anytime", "start_hour": 22, "end_hour": 8, "timezone": "local"},
+                schedule_profiles=[],
+                existing_library_types={"tv": "tv"},
+            )
+
+        payload = web_app._build_runtime_settings_payload(
+            libraries=[
+                {
+                    **row,
+                    "availability": "production",
+                    "type_change_confirmation": "tv:tv->movie",
+                }
+            ],
+            remote_hosts=[],
+            transcode_root=str(self.root / "staging"),
+            encode_queue_scheduler={"mode": "anytime", "start_hour": 22, "end_hour": 8, "timezone": "local"},
+            schedule_profiles=[],
+            existing_library_types={"tv": "tv"},
+        )
+        self.assertEqual(payload["media"]["libraries"][0]["type"], "movie")
+        self.assertEqual(payload["media"]["libraries"][0]["availability"], "browse_only")
+
+    def test_runtime_settings_payload_rejects_non_tv_production(self) -> None:
+        with self.assertRaisesRegex(ValueError, "production is not available"):
+            web_app._build_runtime_settings_payload(
+                libraries=[
+                    {
+                        "key": "movies",
+                        "label": "Movies",
+                        "path": str(self.root / "source" / "movies"),
+                        "library_type": "movie",
+                        "availability": "production",
+                        "default_profile": "movie_balanced",
+                    }
+                ],
+                remote_hosts=[],
+                transcode_root=str(self.root / "staging"),
+                encode_queue_scheduler={"mode": "anytime", "start_hour": 22, "end_hour": 8, "timezone": "local"},
+                schedule_profiles=[],
+            )
+
+    def test_typed_library_maps_scan_browse_only_but_only_produce_ready_roots(self) -> None:
+        self.config.raw["media"]["source_roots"] = {
+            "tv": str(self.root / "source" / "tv"),
+            "movies": str(self.root / "source" / "movies"),
+            "other": str(self.root / "source" / "other"),
+        }
+        self.config.raw["media"]["libraries"] = [
+            {
+                "key": "movies",
+                "path": str(self.root / "source" / "movies"),
+                "type": "movie",
+                "availability": "browse_only",
+            },
+            {
+                "key": "tv",
+                "path": str(self.root / "source" / "tv"),
+                "type": "tv",
+                "availability": "production",
+            },
+            {
+                "key": "other",
+                "path": str(self.root / "source" / "other"),
+                "type": "other",
+                "availability": "disabled",
+            },
+        ]
+
+        self.assertEqual(list(self.config.configured_source_root_map), ["movies", "tv", "other"])
+        self.assertEqual(list(self.config.scan_source_root_map), ["movies", "tv"])
+        self.assertEqual(list(self.config.source_root_map), ["tv"])
+
+    def test_canonical_library_rows_do_not_require_legacy_source_roots(self) -> None:
+        self.config.raw["media"] = {
+            "libraries": [
+                {
+                    "key": "shows",
+                    "label": "Shows",
+                    "path": str(self.root / "source" / "shows"),
+                    "type": "tv",
+                    "availability": "production",
+                }
+            ]
+        }
+
+        self.assertEqual(list(self.config.configured_source_root_map), ["shows"])
+        self.assertEqual(list(self.config.source_root_map), ["shows"])
+
+    def test_canonical_config_cannot_enable_unsupported_library_production(self) -> None:
+        self.config.raw["media"]["libraries"] = [
+            {
+                "key": "movies",
+                "path": str(self.root / "source" / "movies"),
+                "type": "movie",
+                "availability": "production",
+            }
+        ]
+
+        self.assertEqual(list(self.config.scan_source_root_map), ["movies"])
+        self.assertEqual(self.config.source_root_map, {})
+
+    def test_library_scan_signature_ignores_operator_order(self) -> None:
+        first = {
+            "media": {
+                "libraries": [
+                    {"key": "movies", "type": "movie", "availability": "browse_only"},
+                    {"key": "tv", "type": "tv", "availability": "production"},
+                ]
+            }
+        }
+        second = {
+            "media": {
+                "libraries": [
+                    {"key": "tv", "type": "tv", "availability": "production"},
+                    {"key": "movies", "type": "movie", "availability": "browse_only"},
+                ]
+            }
+        }
+
+        self.assertEqual(
+            settings_runtime.runtime_library_signature(first),
+            settings_runtime.runtime_library_signature(second),
+        )
+
+    def test_type_change_preserves_but_disables_incompatible_runtime_overrides(self) -> None:
+        payload = {
+            "folder_policy_overrides": [
+                {"path_prefix": "tv/Example/Season 01", "video": {"crf": 22}},
+                {"path_prefix": "movies/Example", "video": {"crf": 24}},
+            ]
+        }
+
+        rebound = settings_runtime.bind_runtime_library_overrides(payload, {"tv": "tv"})
+
+        self.assertEqual(rebound["folder_policy_overrides"][0]["library_type"], "tv")
+        self.assertNotIn("library_type", rebound["folder_policy_overrides"][1])
+
+        self.config.raw["media"]["libraries"] = [
+            {
+                "key": "tv",
+                "path": str(self.root / "source" / "tv"),
+                "type": "movie",
+                "availability": "browse_only",
+            }
+        ]
+        normalized_overrides = config_runtime._normalize_folder_policy_overrides(
+            rebound["folder_policy_overrides"]
+        )
+        self.config.raw["overrides"] = normalized_overrides
+        self.assertEqual(normalized_overrides[0]["library_type"], "tv")
+        self.config.raw.setdefault("video", {})
+        self.config.raw.setdefault("audio", {})
+        self.config.raw.setdefault("subtitle", {})
+        self.config.raw.setdefault("planning", {})
+        self.assertNotEqual(self.config.resolve_policy("tv/Example/Season 01")["video"].get("crf"), 22)
+
+    def test_runtime_settings_payload_rejects_submitted_secret_values(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Credential values are not accepted"):
+            web_app._build_runtime_settings_payload(
+                libraries=[{"key": "tv", "path": str(self.root / "source" / "tv")}],
+                remote_hosts=[],
+                transcode_root=str(self.root / "staging"),
+                encode_queue_scheduler={"mode": "anytime", "start_hour": 22, "end_hour": 8, "timezone": "local"},
+                schedule_profiles=[],
+                metadata={"plex": {"token": "must-not-persist"}},
+            )
+
     def test_runtime_settings_payload_defaults_host_schedule_to_always(self) -> None:
         payload = web_app._build_runtime_settings_payload(
             libraries=[{"key": "tv", "path": str(self.root / "source" / "tv")}],
@@ -3203,6 +3421,39 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
             self.assertTrue(web_app._scan_is_stale(connection, self.config, prefix=None))
 
+    def test_full_scan_becomes_stale_when_library_type_changes(self) -> None:
+        source_path = self._create_source_file("typed-scan-episode.mkv")
+        self.config.raw["media"]["libraries"] = [
+            {
+                "key": "tv",
+                "path": str(self.root / "source" / "tv"),
+                "type": "tv",
+                "availability": "production",
+            }
+        ]
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_library_item(connection, source_path)
+            now = web_app._now_iso()
+            self._insert_scan_run(
+                connection,
+                scan_id="scan-typed",
+                started_at=now,
+                completed_at=now,
+                roots_json=json.dumps({"tv": str(self.root / "source" / "tv")}),
+                scope="full",
+                prefixes_json=None,
+                file_count=1,
+                reprobed_count=0,
+                unchanged_count=0,
+            )
+            web_app._save_catalog_signature(self.config)
+            self.assertFalse(web_app._scan_is_stale(connection, self.config, prefix=None))
+
+            self.config.raw["media"]["libraries"][0]["type"] = "movie"
+            self.config.raw["media"]["libraries"][0]["availability"] = "browse_only"
+
+            self.assertTrue(web_app._scan_is_stale(connection, self.config, prefix=None))
+
     def test_full_scan_becomes_stale_after_fifteen_minutes(self) -> None:
         source_path = self._create_source_file("episode-b.mkv")
 
@@ -3281,6 +3532,19 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             assert refreshed_job is not None
             self.assertEqual(refreshed_job["status"], "queued")
             self.assertNotEqual(refreshed_job["job_id"], "scan-stale-job")
+
+    def test_forced_scan_schedules_even_when_catalog_is_fresh(self) -> None:
+        fake_thread = Mock()
+        with open_db(self.config.paths.db_path) as connection, patch(
+            "mediaforce.web.runtime.job_runtime.scan_is_stale",
+            return_value=False,
+        ), patch.object(web_app.threading, "Thread", return_value=fake_thread):
+            job = web_app._maybe_schedule_scan(connection, self.config, prefix=None, force=True)
+
+        self.assertIsNotNone(job)
+        assert job is not None
+        self.assertEqual(job["status"], "queued")
+        fake_thread.start.assert_called_once()
 
     def test_scheduler_uses_host_local_time_for_windows(self) -> None:
         policy = web_app._normalize_encode_queue_scheduler(
@@ -12575,6 +12839,46 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             assert job is not None
             self.assertEqual(job["job_id"], "job-queued-runtime")
             self.assertEqual(job["host"]["key"], "local")
+
+    def test_load_next_runnable_encode_job_holds_browse_only_library_work(self) -> None:
+        source_path = self._create_source_file("episode-browse-only.mkv")
+        staging_path = self._staging_path("episode-browse-only.mkv")
+        self.config.raw["media"]["libraries"] = [
+            {
+                "key": "tv",
+                "path": str(self.root / "source" / "tv"),
+                "type": "tv",
+                "availability": "browse_only",
+            }
+        ]
+
+        with open_db(self.config.paths.db_path) as connection:
+            item_id = self._insert_library_item(connection, source_path)
+            self._write_manifest(
+                "manifest-browse-only.json",
+                [{"library_item_id": item_id, "staging_path": str(staging_path)}],
+            )
+            self._save_job(
+                connection,
+                job_id="job-browse-only",
+                manifest_name="manifest-browse-only.json",
+                host={},
+                status="queued",
+                attempt_count=0,
+            )
+            connection.commit()
+            deps = Mock()
+            deps.now_iso.return_value = web_app._now_iso()
+
+            with patch("mediaforce.web.runtime.encode_runtime.select_encode_host") as select_host:
+                job = encode_runtime.load_next_runnable_encode_job(connection, self.config, deps)
+
+            self.assertIsNone(job)
+            select_host.assert_not_called()
+            blocked = load_encode_job(connection, "job-browse-only")
+            self.assertIsNotNone(blocked)
+            assert blocked is not None
+            self.assertEqual(blocked["waiting_reason"], "Library is Browse only or Disabled in Settings.")
 
     def test_process_encode_queue_once_dispatches_multiple_jobs(self) -> None:
         manifest_path = self._write_manifest(

--- a/tests/test_web_route_security.py
+++ b/tests/test_web_route_security.py
@@ -12,6 +12,7 @@ from starlette.routing import Route
 from mediaforce.web.routes.completed import COMPLETED_CLEANUP_ERROR_MESSAGE, register_completed_routes
 from mediaforce.web.routes.folders import register_folder_routes
 from mediaforce.web.routes.settings import SETTINGS_SAVE_ERROR_MESSAGE, register_settings_routes
+from mediaforce.web.settings_runtime import SettingsValidationError
 
 
 def _json_request(payload: dict[str, Any]) -> Request:
@@ -124,6 +125,29 @@ class WebRouteSecurityTests(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(json.loads(response.body), {"ok": False, "message": SETTINGS_SAVE_ERROR_MESSAGE})
         self.assertNotIn("/Volumes/media/private", response.body.decode())
+
+    def test_settings_save_returns_explicit_operator_validation_detail(self) -> None:
+        app = FastAPI()
+
+        def save_settings_action(**_kwargs: Any) -> dict[str, Any]:
+            raise SettingsValidationError("Library local paths must be absolute.")
+
+        register_settings_routes(
+            app,
+            settings_payload=lambda _include_archive_cleanup: {},
+            save_settings_action=save_settings_action,
+            library_type_preview_action=lambda _key, _library_type: {},
+            archive_cleanup_payload=lambda _transcode_root: {},
+            clear_archive_cleanup_action=lambda _transcode_root: {},
+        )
+
+        response = asyncio.run(_route_endpoint(app, "/api/settings", "POST")(_json_request({})))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            json.loads(response.body),
+            {"ok": False, "message": "Library local paths must be absolute."},
+        )
 
     def test_completed_cleanup_hides_internal_validation_detail(self) -> None:
         app = FastAPI()

--- a/tests/test_web_route_security.py
+++ b/tests/test_web_route_security.py
@@ -114,6 +114,7 @@ class WebRouteSecurityTests(unittest.TestCase):
             app,
             settings_payload=lambda _include_archive_cleanup: {},
             save_settings_action=save_settings_action,
+            library_type_preview_action=lambda _key, _library_type: {},
             archive_cleanup_payload=lambda _transcode_root: {},
             clear_archive_cleanup_action=lambda _transcode_root: {},
         )


### PR DESCRIPTION
## Summary
- add a canonical ordered typed-library settings contract with compatibility projections for existing configuration
- expose type-specific TV, Movies, 3D/VR, and Other controls in the Settings workstation
- enforce browse-only/disabled safety across scanning, candidate selection, queue dispatch, and type changes
- preserve environment-only credential handling and document the new architecture

## Safety
- only TV libraries can currently enter production processing
- Movies, 3D/VR, and Other remain browse-only until their production workflows are implemented
- queued work is held or requeued when a library leaves production availability
- library type changes require an explicit compatibility preview and return the root to browse-only

## Validation
- `bash scripts/pre-commit-check.sh`
- 865 backend tests
- 191 frontend unit tests
- Svelte typecheck, Prettier/ESLint, frontend build, CLI smoke
- desktop and narrow Playwright route smoke
- manual desktop/narrow Settings review, including light/dark and confirmation flows
- PyCharm changed-files inspection: 0 findings
- independent safety review: approved

Closes #190