### PR TITLE
Restore first-class Movies library workflow

### DIFF
--- a/docs/architecture/typed-library-settings.md
+++ b/docs/architecture/typed-library-settings.md
@@ -38,9 +38,10 @@ first typed save.
 - `disabled`: neither scan nor process; a full scan marks former catalog rows
   missing
 
-TV is the only production-enabled type in this phase. Movies remains Browse
-only until the Movies workflow is complete. Other remains Browse only until its
-bounded generic workflow is complete. Spatial media remains safety-blocked
+TV and Movies are production-enabled types. Movies keeps extras and uncertain
+nested files out of title-wide production by default while exact-file actions
+remain deliberate. Other remains Browse only until its bounded generic workflow
+is complete. Spatial media remains safety-blocked
 until the 3D/VR qualification plan proves geometry, stream, metadata, audio,
 and target-device playback invariants.
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -13,6 +13,8 @@ briefs as evidence only.
 - `docs/design/basic-user-vocabulary.md`: user-facing term and workflow-state
   reference. Use the vocabulary as product language, not as proof that old route
   layouts are valid.
+- `docs/design/movies-workflow.md`: active Movies Library and movie-specific
+  Folder Studio contract.
 - `docs/style/workstation-ui.md`: operator-workstation doctrine.
 - `docs/style/frontend.md`: Svelte/frontend implementation and validation
   expectations.

--- a/docs/design/movies-workflow.md
+++ b/docs/design/movies-workflow.md
@@ -1,0 +1,45 @@
+# Movies Workflow Design Brief
+
+The Movies workflow extends Mediaforce's existing manifest-driven pipeline with
+movie-title projections and movie-specific operator language. It does not add a
+second encode path.
+
+## Operator model
+
+- Library remains one workstation surface with TV and Movies as explicit views.
+- A root-level movie file is one exact-file title.
+- A conventional movie directory is one title containing one or more feature or
+  edition files plus separately visible extras.
+- Editions remain distinct rows and distinct exact-file actions.
+- Extras stay visible but are excluded from title-wide production unless the
+  configured movie policy includes them or the operator opens the exact extra.
+- Unknown nested files remain visible and blocked from title-wide production
+  until the operator deliberately opens the exact file.
+
+## Layout
+
+- Movies uses a dense title list with a persistent inspector, not a poster wall.
+- The list exposes state, title, file membership, size, reclaim estimate, age
+  provenance, and the next action.
+- The inspector exposes every feature, edition, extra, and uncertain member as
+  a reachable row.
+- Narrow layouts stack the inspector below the selected title without horizontal
+  page overflow.
+
+## Folder Studio
+
+- Movie scopes reuse the existing folder APIs, calibration, manifests, queue,
+  validation, promotion, and recovery machinery.
+- The route selects movie or TV presentation from `media_scope.domain`.
+- Movie copy uses title, feature, edition, extra, and file. It never uses show,
+  season, episode, or lifecycle language.
+- Movie membership is visible before sample or queue actions.
+
+## Safety
+
+- Typed movie roots may enter Production only after this workflow is available.
+- Broad title scopes exclude extras and uncertain nested files by default.
+- Exact-file scopes remain the deliberate escape hatch for an extra or unusual
+  file.
+- Promotion remains per source file, so adjacent editions, extras, subtitles,
+  and sidecars are never removed as collateral work.

--- a/docs/development/browser-qa-matrix.md
+++ b/docs/development/browser-qa-matrix.md
@@ -36,6 +36,15 @@ The managed smoke seeds a compact but non-empty workflow dataset:
 - Queue density: two pending `tv/Example Show/Season 1` items and one lower
   priority movie folder. The representative episode is 88 minutes so the goal
   screen resolves the 300 MB / 45 minute default to approximately 587 MB.
+- Movies Library: `/movies` includes a root-level exact file, a conventional
+  title directory with two independently reachable editions, an excluded
+  featurette, an uncertain nested file, active processing, completed titles,
+  and a preflight promotion conflict.
+- Movie Studio: `/folders/movies/Loose%20Feature.mkv`,
+  `/folders/movies/Editions%20Showcase`,
+  `/folders/movies/Waiting%20Encode`, and
+  `/folders/movies/Promotion%20Conflict` cover exact-file, editions/extras,
+  active-job, and collision-blocked states on desktop and narrow viewports.
 - Folder Studio: `/folders/tv/Example%20Show/Season%201`, including enough item
   metadata to render policy comparison, sample facts, queue state, and side
   context.

--- a/frontend/src/lib/api/placeholders.ts
+++ b/frontend/src/lib/api/placeholders.ts
@@ -6,6 +6,7 @@ import type {
 	FolderStatusPayload,
 	HostsPayload,
 	MediaScopePayload,
+	MovieLibraryPayload,
 	QueueLane
 } from './types';
 
@@ -48,6 +49,14 @@ export const initialFoldersPayload: DashboardFoldersPayload = {
 };
 
 export const initialHosts: HostsPayload = { compact: true, hosts: [] };
+
+export const initialMovieLibrary: MovieLibraryPayload = {
+	schema_version: 1,
+	libraries: [],
+	titles: [],
+	catalog_empty: false,
+	details_loading: true
+};
 
 function loadingMediaScope(prefix: string): MediaScopePayload {
 	return {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -134,6 +134,103 @@ export interface FolderCard {
 	details_loading: boolean;
 }
 
+export type MovieMemberRole = 'feature' | 'extra' | 'uncertain';
+export type MovieScopeMode = 'single_file' | 'title_folder';
+export type MovieSavingsConfidence = 'pending' | 'measured' | 'estimated' | 'unavailable';
+
+export interface MovieAgeEvidence {
+	timestamp: string | null;
+	source: 'plex' | 'mediaforce_discovered' | 'filesystem_mtime' | 'unknown';
+}
+
+export interface MovieWorkflowItemState {
+	item_id: number;
+	rel_path: string;
+	status: string;
+	state: string;
+	lane: WorkflowLane;
+	has_staged_output: boolean;
+	blocker?: string | null;
+}
+
+export interface MoviePromotionConflict {
+	kind: 'duplicate_destination' | 'destination_exists';
+	destination_path: string;
+	member_prefixes: string[];
+	detail: string;
+}
+
+export interface MovieMember {
+	item_id: number;
+	prefix: string;
+	rel_path: string;
+	root: string;
+	title_prefix: string;
+	title: string;
+	scope_mode: MovieScopeMode;
+	role: MovieMemberRole;
+	label: string;
+	edition_label?: string | null;
+	extra_category?: string | null;
+	status: string;
+	size_bytes: number;
+	duration_seconds?: number | null;
+	video_codec?: string | null;
+	included_by_default: boolean;
+	selection_blocker?: string | null;
+	exact_action_available: boolean;
+	age?: MovieAgeEvidence | null;
+	workflow_state?: MovieWorkflowItemState | null;
+	promotion_conflicts: MoviePromotionConflict[];
+	details_loading: boolean;
+}
+
+export interface MovieLibraryRoot {
+	key: string;
+	label: string;
+	availability: 'production' | 'browse_only';
+	default_profile: string;
+	policy: Record<string, unknown>;
+}
+
+export interface MovieTitle {
+	prefix: string;
+	root: string;
+	library_label: string;
+	availability: 'production' | 'browse_only';
+	policy: Record<string, unknown>;
+	title: string;
+	scope_mode: MovieScopeMode;
+	item_count: number;
+	feature_count: number;
+	edition_count: number;
+	extra_count: number;
+	uncertain_count: number;
+	included_item_count: number;
+	total_size_bytes: number;
+	included_size_bytes: number;
+	projected_reclaim_bytes?: number | null;
+	known_saved_bytes?: number | null;
+	estimated_savings_bytes?: number | null;
+	savings_confidence: MovieSavingsConfidence;
+	age?: MovieAgeEvidence | null;
+	workflow_state?: FolderWorkflowState | null;
+	review_badge?: { label?: string | null; tone?: string | null; detail?: string | null } | null;
+	promotion_conflicts: MoviePromotionConflict[];
+	members: MovieMember[];
+	details_loading: boolean;
+	active_member_prefix?: string;
+	active_member?: MovieMember;
+}
+
+export interface MovieLibraryPayload {
+	schema_version: number;
+	libraries: MovieLibraryRoot[];
+	titles: MovieTitle[];
+	catalog_empty: boolean;
+	details_loading: boolean;
+}
+
 export interface QueueLane {
 	running: Array<Record<string, unknown>>;
 	queued: Array<Record<string, unknown>>;
@@ -870,6 +967,7 @@ export interface FolderPayload {
 	encode_candidate_count?: number;
 	workflow_state?: FolderWorkflowState | null;
 	lifecycle?: LifecycleState | null;
+	movie_context?: MovieTitle | null;
 }
 
 export interface FolderBenchPreviewResponse {

--- a/frontend/src/lib/components/season/SeasonLibrary.svelte
+++ b/frontend/src/lib/components/season/SeasonLibrary.svelte
@@ -24,6 +24,7 @@
 		sortShowCards,
 		type LibrarySort
 	} from '$lib/season/library';
+	import LibraryModeNav from '$lib/components/workstation/LibraryModeNav.svelte';
 
 	let {
 		dashboard,
@@ -215,6 +216,7 @@
 </svelte:head>
 
 <main class="season-library">
+	<LibraryModeNav active="tv" />
 	<header class="page-heading">
 		<div>
 			<h1>Your library</h1>

--- a/frontend/src/lib/components/shell/AppShell.svelte
+++ b/frontend/src/lib/components/shell/AppShell.svelte
@@ -16,7 +16,13 @@
 	function isActive(href: string): boolean {
 		const pathname = page.url.pathname;
 		if (href === '/')
-			return pathname === '/' || pathname === '/folders' || pathname.startsWith('/folders/');
+			return (
+				pathname === '/' ||
+				pathname === '/movies' ||
+				pathname.startsWith('/movies/') ||
+				pathname === '/folders' ||
+				pathname.startsWith('/folders/')
+			);
 		return pathname === href || pathname.startsWith(`${href}/`);
 	}
 </script>

--- a/frontend/src/lib/components/workstation/LibraryModeNav.svelte
+++ b/frontend/src/lib/components/workstation/LibraryModeNav.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	let { active }: { active: 'tv' | 'movie' } = $props();
+</script>
+
+<nav class="library-mode-nav" aria-label="Library type">
+	<a
+		href={resolve('/')}
+		class:active={active === 'tv'}
+		aria-current={active === 'tv' ? 'page' : undefined}>TV</a
+	>
+	<a
+		href={resolve('/movies')}
+		class:active={active === 'movie'}
+		aria-current={active === 'movie' ? 'page' : undefined}>Movies</a
+	>
+</nav>
+
+<style>
+	.library-mode-nav {
+		align-items: center;
+		border-bottom: 1px solid var(--mf-line);
+		display: flex;
+		gap: 22px;
+		margin-bottom: 24px;
+	}
+
+	a {
+		border-bottom: 2px solid transparent;
+		color: var(--mf-fg-secondary);
+		font-size: 13px;
+		font-weight: 700;
+		letter-spacing: 0.02em;
+		padding: 12px 1px 10px;
+		text-decoration: none;
+	}
+
+	a:hover {
+		color: var(--mf-fg-primary);
+	}
+
+	a.active {
+		border-bottom-color: var(--mf-active-fg);
+		color: var(--mf-active-fg);
+	}
+</style>

--- a/frontend/src/lib/components/workstation/MovieLibraryPage.svelte
+++ b/frontend/src/lib/components/workstation/MovieLibraryPage.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	import { fetchJson } from '$lib/api/client';
+	import { initialMovieLibrary } from '$lib/api/placeholders';
+	import type { MovieLibraryPayload } from '$lib/api/types';
+	import { mergeMovieLibraryPayloads } from '$lib/movies/library';
+	import MovieLibraryView from './MovieLibraryView.svelte';
+
+	let structure = $state<MovieLibraryPayload>(initialMovieLibrary);
+	let details = $state<MovieLibraryPayload>(initialMovieLibrary);
+	let payload = $state<MovieLibraryPayload>(initialMovieLibrary);
+	let structurePending = $state(true);
+	let detailsPending = $state(true);
+	let loadError = $state('');
+	let detailsError = $state('');
+	let disposed = false;
+
+	onMount(() => {
+		disposed = false;
+		let refreshTimer: number | undefined;
+		void hydrateStructure().finally(() => {
+			if (disposed) return;
+			void hydrateDetails();
+			refreshTimer = window.setInterval(() => void hydrateDetails(true), 7000);
+		});
+
+		return () => {
+			disposed = true;
+			if (refreshTimer) window.clearInterval(refreshTimer);
+		};
+	});
+
+	async function hydrateStructure() {
+		try {
+			const response = await fetchJson<MovieLibraryPayload>('/api/dashboard/library/movies');
+			if (disposed) return;
+			structure = response;
+			loadError = '';
+			syncPayload();
+		} catch (error) {
+			if (disposed) return;
+			loadError = error instanceof Error ? error.message : 'The movie title index could not open.';
+		} finally {
+			if (!disposed) structurePending = false;
+		}
+	}
+
+	async function hydrateDetails(background = false) {
+		if (!background) detailsPending = true;
+		try {
+			const response = await fetchJson<MovieLibraryPayload>(
+				'/api/dashboard/library/movies/details'
+			);
+			if (disposed) return;
+			details = response;
+			detailsError = '';
+			syncPayload();
+		} catch (error) {
+			if (disposed) return;
+			detailsError =
+				error instanceof Error ? error.message : 'Movie workflow details could not load.';
+		} finally {
+			if (!disposed) detailsPending = false;
+		}
+	}
+
+	function syncPayload() {
+		payload = mergeMovieLibraryPayloads(structure, details);
+	}
+</script>
+
+<MovieLibraryView {payload} {structurePending} {detailsPending} {loadError} {detailsError} />

--- a/frontend/src/lib/components/workstation/MovieLibraryView.svelte
+++ b/frontend/src/lib/components/workstation/MovieLibraryView.svelte
@@ -1,0 +1,1038 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	import type { MovieLibraryPayload, MovieMember, MovieTitle } from '$lib/api/types';
+	import { folderRoutePath } from '$lib/folder-display';
+	import LibraryModeNav from './LibraryModeNav.svelte';
+
+	let {
+		payload,
+		structurePending = false,
+		detailsPending = false,
+		loadError = '',
+		detailsError = ''
+	}: {
+		payload: MovieLibraryPayload;
+		structurePending?: boolean;
+		detailsPending?: boolean;
+		loadError?: string;
+		detailsError?: string;
+	} = $props();
+
+	let query = $state('');
+	let rootFilter = $state('all');
+	let stateFilter = $state<'all' | 'attention' | 'ready' | 'processing' | 'explicit'>('all');
+	let sortMode = $state<'priority' | 'name' | 'size' | 'savings' | 'oldest'>('priority');
+	let selectedPrefix = $state('');
+
+	const titles = $derived.by(() => {
+		const normalizedQuery = query.trim().toLocaleLowerCase();
+		const filtered = payload.titles.filter((title) => {
+			if (rootFilter !== 'all' && title.root !== rootFilter) return false;
+			if (normalizedQuery) {
+				const haystack = [
+					title.title,
+					title.prefix,
+					...title.members.map((member) => `${member.label} ${member.edition_label ?? ''}`)
+				]
+					.join(' ')
+					.toLocaleLowerCase();
+				if (!haystack.includes(normalizedQuery)) return false;
+			}
+			return stateFilter === 'all' || titleStateGroup(title) === stateFilter;
+		});
+		return [...filtered].sort((left, right) => compareTitles(left, right, sortMode));
+	});
+
+	const selectedTitle = $derived(
+		titles.find((title) => title.prefix === selectedPrefix) ?? titles[0] ?? null
+	);
+	const totalSize = $derived(
+		payload.titles.reduce((total, title) => total + title.total_size_bytes, 0)
+	);
+	const totalReclaim = $derived(
+		payload.titles.reduce((total, title) => total + (title.projected_reclaim_bytes ?? 0), 0)
+	);
+	const actionableCount = $derived(
+		payload.titles.filter((title) =>
+			['encode', 'validate', 'promote', 'processing', 'attention'].includes(
+				title.workflow_state?.primary_lane ?? ''
+			)
+		).length
+	);
+	const conflictCount = $derived(
+		payload.titles.reduce((total, title) => total + title.promotion_conflicts.length, 0)
+	);
+
+	$effect(() => {
+		if (selectedTitle && selectedPrefix !== selectedTitle.prefix)
+			selectedPrefix = selectedTitle.prefix;
+	});
+
+	function compareTitles(left: MovieTitle, right: MovieTitle, mode: typeof sortMode): number {
+		if (mode === 'name') return left.title.localeCompare(right.title);
+		if (mode === 'size') return right.total_size_bytes - left.total_size_bytes;
+		if (mode === 'savings')
+			return (right.projected_reclaim_bytes ?? -1) - (left.projected_reclaim_bytes ?? -1);
+		if (mode === 'oldest')
+			return ageValue(left) - ageValue(right) || left.title.localeCompare(right.title);
+		return titlePriority(left) - titlePriority(right) || left.title.localeCompare(right.title);
+	}
+
+	function titlePriority(title: MovieTitle): number {
+		if (title.promotion_conflicts.length) return 0;
+		return {
+			attention: 1,
+			processing: 2,
+			validate: 3,
+			promote: 4,
+			encode: 5,
+			mixed: 6,
+			none: 7,
+			complete: 8,
+			blocked: 9
+		}[title.workflow_state?.primary_lane ?? 'none'];
+	}
+
+	function titleStateGroup(title: MovieTitle): typeof stateFilter {
+		if (title.promotion_conflicts.length || title.workflow_state?.primary_lane === 'attention') {
+			return 'attention';
+		}
+		if (title.workflow_state?.primary_lane === 'processing') return 'processing';
+		if (title.workflow_state?.state === 'explicit_selection_required') return 'explicit';
+		if (
+			['encode', 'validate', 'promote', 'mixed'].includes(title.workflow_state?.primary_lane ?? '')
+		) {
+			return 'ready';
+		}
+		return 'all';
+	}
+
+	function ageValue(title: MovieTitle): number {
+		const timestamp = title.age?.timestamp;
+		return timestamp ? Date.parse(timestamp) || Number.MAX_SAFE_INTEGER : Number.MAX_SAFE_INTEGER;
+	}
+
+	function formatBytes(value: number | null | undefined): string {
+		if (value == null) return 'Pending';
+		if (value < 1024) return `${value} B`;
+		const units = ['KB', 'MB', 'GB', 'TB'];
+		let size = value;
+		let unit = -1;
+		while (size >= 1024 && unit < units.length - 1) {
+			size /= 1024;
+			unit += 1;
+		}
+		return `${size >= 10 ? size.toFixed(0) : size.toFixed(1)} ${units[unit]}`;
+	}
+
+	function formatAge(title: MovieTitle): string {
+		if (title.details_loading) return 'Age pending';
+		if (!title.age?.timestamp) return 'Age unavailable';
+		const date = new Intl.DateTimeFormat(undefined, {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric'
+		}).format(new Date(title.age.timestamp));
+		return `${date} · ${ageSourceLabel(title.age.source)}`;
+	}
+
+	function ageSourceLabel(source: string): string {
+		if (source === 'plex') return 'Plex added';
+		if (source === 'mediaforce_discovered') return 'first scan';
+		if (source === 'filesystem_mtime') return 'file modified';
+		return 'unknown source';
+	}
+
+	function memberLabel(member: MovieMember): string {
+		if (member.edition_label) return member.edition_label;
+		if (member.role === 'feature') return 'Main feature';
+		if (member.role === 'extra') return member.extra_category ?? 'Extra';
+		return 'Uncertain membership';
+	}
+
+	function workflowTone(title: MovieTitle): string {
+		if (title.promotion_conflicts.length) return 'attention';
+		return title.workflow_state?.tone ?? 'idle';
+	}
+
+	function policyValue(title: MovieTitle, key: string, fallback: string): string {
+		const value = title.policy[key];
+		return typeof value === 'string' && value ? value : fallback;
+	}
+
+	function moveTitleSelection(event: KeyboardEvent, currentIndex: number) {
+		let nextIndex: number;
+		if (event.key === 'ArrowDown') nextIndex = Math.min(currentIndex + 1, titles.length - 1);
+		else if (event.key === 'ArrowUp') nextIndex = Math.max(currentIndex - 1, 0);
+		else if (event.key === 'Home') nextIndex = 0;
+		else if (event.key === 'End') nextIndex = titles.length - 1;
+		else return;
+		event.preventDefault();
+		const nextTitle = titles[nextIndex];
+		if (!nextTitle) return;
+		selectedPrefix = nextTitle.prefix;
+		requestAnimationFrame(() => {
+			document
+				.querySelector<HTMLElement>(`[data-movie-title-row="${CSS.escape(nextTitle.prefix)}"]`)
+				?.focus();
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>Your movie library · Mediaforce</title>
+	<meta
+		name="description"
+		content="Inspect movie titles, editions, extras, workflow state, and safe promotion readiness."
+	/>
+</svelte:head>
+
+<main class="movie-library">
+	<LibraryModeNav active="movie" />
+
+	<header class="page-heading">
+		<div class="page-heading__copy">
+			<span class="eyebrow">Movie workstation</span>
+			<h1>Movies</h1>
+			<p>
+				Process one title, edition, or deliberate extra without pulling unrelated files into the
+				run.
+			</p>
+		</div>
+		<div class="library-totals" aria-label="Movie library totals">
+			<div><strong>{payload.titles.length}</strong><span>titles</span></div>
+			<div><strong>{formatBytes(totalSize)}</strong><span>stored</span></div>
+			<div>
+				<strong>{detailsPending ? '…' : formatBytes(totalReclaim)}</strong><span
+					>projected reclaim</span
+				>
+			</div>
+			<div><strong>{actionableCount}</strong><span>active or ready</span></div>
+		</div>
+	</header>
+
+	{#if loadError}
+		<div class="notice notice--danger" role="alert">
+			<strong>The movie library could not open.</strong>
+			<span>{loadError}</span>
+		</div>
+	{/if}
+	{#if detailsError && payload.titles.length}
+		<div class="notice" role="status">
+			<strong>Titles are available.</strong>
+			<span>{detailsError} Workflow and savings details may be stale.</span>
+		</div>
+	{/if}
+	{#if conflictCount}
+		<div class="notice notice--danger" role="alert">
+			<strong
+				>{conflictCount} promotion {conflictCount === 1 ? 'conflict' : 'conflicts'} need review.</strong
+			>
+			<span>No conflicting destination is replaced automatically.</span>
+		</div>
+	{/if}
+
+	<section class="workbench" aria-busy={structurePending}>
+		<header class="workbench__toolbar">
+			<div class="search-field">
+				<label for="movie-search">Find title or edition</label>
+				<input
+					id="movie-search"
+					bind:value={query}
+					type="search"
+					placeholder="Search movie files"
+				/>
+			</div>
+			{#if payload.libraries.length > 1}
+				<label>
+					<span>Library</span>
+					<select bind:value={rootFilter}>
+						<option value="all">All movie libraries</option>
+						{#each payload.libraries as library (library.key)}
+							<option value={library.key}>{library.label}</option>
+						{/each}
+					</select>
+				</label>
+			{/if}
+			<label>
+				<span>State</span>
+				<select bind:value={stateFilter}>
+					<option value="all">All states</option>
+					<option value="attention">Needs attention</option>
+					<option value="processing">Processing</option>
+					<option value="ready">Ready work</option>
+					<option value="explicit">Explicit selection</option>
+				</select>
+			</label>
+			<label>
+				<span>Sort</span>
+				<select bind:value={sortMode}>
+					<option value="priority">Operational priority</option>
+					<option value="name">Title A–Z</option>
+					<option value="size">Largest stored</option>
+					<option value="savings">Most reclaim</option>
+					<option value="oldest">Oldest added</option>
+				</select>
+			</label>
+		</header>
+
+		{#if structurePending && !payload.titles.length}
+			<div class="empty-state" role="status">
+				<span class="loading-mark" aria-hidden="true"></span>
+				<strong>Reading movie titles</strong>
+				<p>Files appear first; workflow details follow.</p>
+			</div>
+		{:else if !payload.titles.length && !loadError}
+			<div class="empty-state">
+				<strong>No movie titles are indexed yet.</strong>
+				<p>
+					Add or scan a typed Movies root in Settings. Root-level files and title folders both
+					appear here.
+				</p>
+				<a class="primary-link" href={resolve('/settings')}>Open Settings</a>
+			</div>
+		{:else if !titles.length}
+			<div class="empty-state">
+				<strong>No titles match these filters.</strong>
+				<p>Clear the search or widen the workflow state filter.</p>
+			</div>
+		{:else}
+			<div class="workbench__body">
+				<div class="title-index" aria-label="Movie titles">
+					<div class="title-index__header" aria-hidden="true">
+						<span>Title</span><span>Files</span><span>Stored</span><span>Workflow</span>
+					</div>
+					{#each titles as title, index (title.prefix)}
+						<button
+							type="button"
+							class="title-row"
+							class:selected={selectedTitle?.prefix === title.prefix}
+							data-movie-title-row={title.prefix}
+							tabindex={selectedTitle?.prefix === title.prefix ? 0 : -1}
+							onclick={() => (selectedPrefix = title.prefix)}
+							onkeydown={(event) => moveTitleSelection(event, index)}
+							aria-pressed={selectedTitle?.prefix === title.prefix}
+						>
+							<span class="title-row__identity">
+								<strong>{title.title}</strong>
+								<small
+									>{title.scope_mode === 'single_file'
+										? 'Exact movie file'
+										: title.library_label}</small
+								>
+							</span>
+							<span class="title-row__count">
+								<strong>{title.item_count}</strong>
+								<small>
+									{title.feature_count}
+									{title.feature_count === 1 ? 'feature' : 'features'}
+									{#if title.extra_count}
+										· {title.extra_count} extras{/if}
+								</small>
+							</span>
+							<span class="title-row__size">
+								<strong>{formatBytes(title.total_size_bytes)}</strong>
+								<small>
+									{title.details_loading
+										? 'Reclaim pending'
+										: `${formatBytes(title.projected_reclaim_bytes)} reclaim · ${title.savings_confidence}`}
+								</small>
+							</span>
+							<span class="state-badge" data-tone={workflowTone(title)}>
+								{title.promotion_conflicts.length
+									? 'Promotion conflict'
+									: (title.workflow_state?.label ?? (title.details_loading ? 'Loading' : 'Ready'))}
+							</span>
+						</button>
+					{/each}
+				</div>
+
+				{#if selectedTitle}
+					<aside class="title-inspector" aria-label={`${selectedTitle.title} details`}>
+						<header class="inspector-heading">
+							<div>
+								<span class="eyebrow">{selectedTitle.library_label}</span>
+								<h2>{selectedTitle.title}</h2>
+								<p>{selectedTitle.prefix}</p>
+							</div>
+							<span class="state-badge" data-tone={workflowTone(selectedTitle)}>
+								{selectedTitle.workflow_state?.label ?? 'Loading'}
+							</span>
+						</header>
+
+						<div class="inspector-facts">
+							<div>
+								<span>Scope</span><strong
+									>{selectedTitle.scope_mode === 'single_file'
+										? 'Exact file'
+										: 'Movie title'}</strong
+								>
+							</div>
+							<div>
+								<span>Stored</span><strong>{formatBytes(selectedTitle.total_size_bytes)}</strong>
+							</div>
+							<div>
+								<span>Projected reclaim</span><strong
+									>{formatBytes(selectedTitle.projected_reclaim_bytes)}</strong
+								>
+							</div>
+							<div><span>Ranking age</span><strong>{formatAge(selectedTitle)}</strong></div>
+						</div>
+
+						{#if selectedTitle.availability === 'browse_only'}
+							<div class="inline-alert">
+								<strong>Browse only</strong>
+								<span
+									>Files remain visible, but processing actions are disabled for this library.</span
+								>
+							</div>
+						{/if}
+						{#if selectedTitle.promotion_conflicts.length}
+							<div class="inline-alert inline-alert--danger">
+								<strong>Promotion blocked</strong>
+								{#each selectedTitle.promotion_conflicts as conflict (`${conflict.kind}:${conflict.destination_path}`)}
+									<span>{conflict.detail} <code>{conflict.destination_path}</code></span>
+								{/each}
+							</div>
+						{/if}
+
+						<div class="policy-strip" aria-label="Movie library policy">
+							<span>Titles grouped</span>
+							<span>Editions {policyValue(selectedTitle, 'editions', 'separate')}</span>
+							<span>Extras {policyValue(selectedTitle, 'extras', 'exclude')}</span>
+						</div>
+
+						<section class="member-list" aria-labelledby="movie-files-heading">
+							<div class="section-heading">
+								<div>
+									<h3 id="movie-files-heading">Files and editions</h3>
+									<p>
+										Every indexed file stays reachable. Only identified features join title-wide
+										work by default.
+									</p>
+								</div>
+								<span>{selectedTitle.members.length}</span>
+							</div>
+							{#each selectedTitle.members as member (member.item_id)}
+								<div class="member-row" data-role={member.role}>
+									<div class="member-row__copy">
+										<div class="member-row__heading">
+											<strong>{memberLabel(member)}</strong>
+											<span>{member.status.replaceAll('_', ' ')}</span>
+										</div>
+										<p>{member.label}</p>
+										<small>
+											{formatBytes(member.size_bytes)}
+											{#if member.video_codec}
+												· {member.video_codec.toUpperCase()}{/if}
+											{#if member.included_by_default}
+												· Included in title work{:else}
+												· Exact selection only{/if}
+										</small>
+										{#if member.selection_blocker && !member.included_by_default}
+											<span class="member-row__reason">{member.selection_blocker}</span>
+										{/if}
+									</div>
+									<a class="member-link" href={resolve(folderRoutePath(member.prefix))}
+										>Open exact file</a
+									>
+								</div>
+							{/each}
+						</section>
+
+						<footer class="inspector-actions">
+							<a class="primary-link" href={resolve(folderRoutePath(selectedTitle.prefix))}>
+								Open {selectedTitle.scope_mode === 'single_file' ? 'file' : 'title'} Studio
+							</a>
+							<span>{selectedTitle.workflow_state?.detail ?? 'Workflow details are loading.'}</span>
+						</footer>
+					</aside>
+				{/if}
+			</div>
+		{/if}
+	</section>
+</main>
+
+<style>
+	.movie-library {
+		margin: 0 auto;
+		max-width: 1400px;
+		padding: 30px 28px 54px;
+	}
+
+	.page-heading {
+		align-items: end;
+		display: flex;
+		gap: 28px;
+		justify-content: space-between;
+		margin-bottom: 22px;
+	}
+
+	.page-heading__copy {
+		max-width: 660px;
+	}
+
+	.eyebrow {
+		color: var(--mf-fg-muted);
+		font-size: 11px;
+		font-weight: 800;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+	}
+
+	h1,
+	h2,
+	h3,
+	p {
+		margin: 0;
+	}
+
+	h1 {
+		font-size: clamp(30px, 4vw, 44px);
+		letter-spacing: -0.04em;
+		margin-top: 4px;
+	}
+
+	.page-heading p,
+	.inspector-heading p,
+	.section-heading p,
+	.inspector-actions span {
+		color: var(--mf-fg-secondary);
+		font-size: 13px;
+		line-height: 1.55;
+	}
+
+	.library-totals {
+		background: var(--mf-bg-panel);
+		border: 1px solid var(--mf-line);
+		display: grid;
+		grid-template-columns: repeat(4, minmax(90px, 1fr));
+		min-width: min(100%, 460px);
+	}
+
+	.library-totals div {
+		border-left: 1px solid var(--mf-line);
+		padding: 14px 16px;
+	}
+
+	.library-totals div:first-child {
+		border-left: 0;
+	}
+
+	.library-totals strong,
+	.library-totals span {
+		display: block;
+	}
+
+	.library-totals strong {
+		font-size: 17px;
+	}
+
+	.library-totals span {
+		color: var(--mf-fg-muted);
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		margin-top: 3px;
+		text-transform: uppercase;
+	}
+
+	.notice,
+	.inline-alert {
+		background: var(--mf-bg-panel);
+		border: 1px solid var(--mf-line-strong);
+		display: grid;
+		gap: 4px;
+		margin-bottom: 14px;
+		padding: 12px 14px;
+	}
+
+	.notice span,
+	.inline-alert span {
+		color: var(--mf-fg-secondary);
+		font-size: 12px;
+	}
+
+	.notice--danger,
+	.inline-alert--danger {
+		border-left: 4px solid var(--mf-fail-fg);
+	}
+
+	.inline-alert {
+		margin: 0;
+	}
+
+	.inline-alert code {
+		font-size: 11px;
+		word-break: break-all;
+	}
+
+	.workbench {
+		background: var(--mf-bg-panel);
+		border: 1px solid var(--mf-line);
+		box-shadow: var(--mf-shadow-popover);
+	}
+
+	.workbench__toolbar {
+		align-items: end;
+		border-bottom: 1px solid var(--mf-line);
+		display: grid;
+		gap: 12px;
+		grid-template-columns: minmax(240px, 1fr) repeat(3, minmax(130px, auto));
+		padding: 14px;
+	}
+
+	.workbench__toolbar label,
+	.search-field {
+		display: grid;
+		gap: 5px;
+	}
+
+	.workbench__toolbar label > span,
+	.search-field label {
+		color: var(--mf-fg-muted);
+		font-size: 10px;
+		font-weight: 800;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	input,
+	select {
+		background: var(--mf-bg-input);
+		border: 1px solid var(--mf-line-strong);
+		border-radius: 4px;
+		color: var(--mf-fg-primary);
+		font: inherit;
+		font-size: 13px;
+		min-height: 38px;
+		padding: 0 10px;
+	}
+
+	.workbench__body {
+		display: grid;
+		grid-template-columns: minmax(520px, 1.12fr) minmax(390px, 0.88fr);
+		min-height: 570px;
+	}
+
+	.title-index {
+		border-right: 1px solid var(--mf-line);
+		min-width: 0;
+	}
+
+	.title-index__header,
+	.title-row {
+		display: grid;
+		grid-template-columns: minmax(210px, 1.5fr) minmax(105px, 0.65fr) minmax(120px, 0.7fr) minmax(
+				130px,
+				0.8fr
+			);
+	}
+
+	.title-index__header {
+		background: var(--mf-bg-strip);
+		border-bottom: 1px solid var(--mf-line);
+		color: var(--mf-fg-muted);
+		font-size: 10px;
+		font-weight: 800;
+		letter-spacing: 0.08em;
+		padding: 9px 14px;
+		text-transform: uppercase;
+	}
+
+	.title-row {
+		align-items: center;
+		background: transparent;
+		border: 0;
+		border-bottom: 1px solid var(--mf-line);
+		color: inherit;
+		cursor: pointer;
+		font: inherit;
+		gap: 12px;
+		padding: 13px 14px;
+		text-align: left;
+		width: 100%;
+	}
+
+	.title-row:hover,
+	.title-row.selected {
+		background: var(--mf-active-bg);
+	}
+
+	.title-row.selected {
+		box-shadow: inset 3px 0 0 var(--mf-active-fg);
+	}
+
+	.title-row__identity,
+	.title-row__count,
+	.title-row__size {
+		min-width: 0;
+	}
+
+	.title-row strong,
+	.title-row small {
+		display: block;
+	}
+
+	.title-row__identity strong {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.title-row small {
+		color: var(--mf-fg-muted);
+		font-size: 11px;
+		line-height: 1.4;
+		margin-top: 3px;
+	}
+
+	.state-badge {
+		border: 1px solid var(--mf-line-strong);
+		color: var(--mf-fg-secondary);
+		display: inline-flex;
+		font-size: 10px;
+		font-weight: 800;
+		justify-self: start;
+		letter-spacing: 0.04em;
+		line-height: 1.3;
+		padding: 5px 7px;
+		text-transform: uppercase;
+	}
+
+	.state-badge[data-tone='active'] {
+		border-color: var(--mf-active-fg);
+		color: var(--mf-active-fg);
+	}
+
+	.state-badge[data-tone='attention'] {
+		border-color: var(--mf-fail-fg);
+		color: var(--mf-fail-fg);
+	}
+
+	.state-badge[data-tone='ready'] {
+		border-color: var(--mf-wait-fg);
+		color: var(--mf-wait-fg);
+	}
+
+	.state-badge[data-tone='success'] {
+		border-color: var(--mf-ready-fg);
+		color: var(--mf-ready-fg);
+	}
+
+	.title-inspector {
+		display: grid;
+		gap: 16px;
+		min-width: 0;
+		padding: 20px;
+	}
+
+	.inspector-heading,
+	.section-heading,
+	.inspector-actions {
+		align-items: start;
+		display: flex;
+		gap: 16px;
+		justify-content: space-between;
+	}
+
+	.inspector-heading h2 {
+		font-size: 24px;
+		letter-spacing: -0.025em;
+		margin: 4px 0;
+	}
+
+	.inspector-heading p {
+		font-family: var(--mf-font-mono);
+		font-size: 11px;
+		word-break: break-all;
+	}
+
+	.inspector-facts {
+		border: 1px solid var(--mf-line);
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.inspector-facts div {
+		border-bottom: 1px solid var(--mf-line);
+		border-right: 1px solid var(--mf-line);
+		padding: 10px 12px;
+	}
+
+	.inspector-facts div:nth-child(2n) {
+		border-right: 0;
+	}
+
+	.inspector-facts div:nth-last-child(-n + 2) {
+		border-bottom: 0;
+	}
+
+	.inspector-facts span,
+	.inspector-facts strong {
+		display: block;
+	}
+
+	.inspector-facts span {
+		color: var(--mf-fg-muted);
+		font-size: 10px;
+		font-weight: 800;
+		letter-spacing: 0.07em;
+		text-transform: uppercase;
+	}
+
+	.inspector-facts strong {
+		font-size: 12px;
+		margin-top: 4px;
+	}
+
+	.policy-strip {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 7px;
+	}
+
+	.policy-strip span {
+		background: var(--mf-bg-strip);
+		border: 1px solid var(--mf-line);
+		color: var(--mf-fg-secondary);
+		font-size: 10px;
+		font-weight: 700;
+		padding: 5px 7px;
+		text-transform: capitalize;
+	}
+
+	.member-list {
+		display: grid;
+		gap: 8px;
+	}
+
+	.section-heading {
+		border-bottom: 1px solid var(--mf-line);
+		padding-bottom: 9px;
+	}
+
+	.section-heading h3 {
+		font-size: 15px;
+	}
+
+	.section-heading > span {
+		color: var(--mf-fg-muted);
+		font-size: 12px;
+		font-weight: 800;
+	}
+
+	.member-row {
+		align-items: center;
+		border: 1px solid var(--mf-line);
+		display: flex;
+		gap: 12px;
+		justify-content: space-between;
+		padding: 10px 11px;
+	}
+
+	.member-row[data-role='extra'],
+	.member-row[data-role='uncertain'] {
+		border-left: 3px solid var(--mf-line-strong);
+	}
+
+	.member-row__copy {
+		min-width: 0;
+	}
+
+	.member-row__heading {
+		align-items: baseline;
+		display: flex;
+		gap: 8px;
+	}
+
+	.member-row__heading span,
+	.member-row small,
+	.member-row__reason {
+		color: var(--mf-fg-muted);
+		font-size: 10px;
+	}
+
+	.member-row__heading span {
+		text-transform: capitalize;
+	}
+
+	.member-row p {
+		font-family: var(--mf-font-mono);
+		font-size: 11px;
+		margin: 3px 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.member-row__reason {
+		display: block;
+		line-height: 1.4;
+		margin-top: 5px;
+	}
+
+	.member-link,
+	.primary-link {
+		background: var(--mf-active-fg);
+		border: 1px solid var(--mf-active-fg);
+		border-radius: 4px;
+		color: var(--mf-fg-on-accent);
+		font-size: 11px;
+		font-weight: 800;
+		padding: 8px 10px;
+		text-decoration: none;
+		white-space: nowrap;
+	}
+
+	.member-link {
+		background: transparent;
+		color: var(--mf-active-fg);
+	}
+
+	.inspector-actions {
+		align-items: center;
+		border-top: 1px solid var(--mf-line);
+		padding-top: 14px;
+	}
+
+	.inspector-actions span {
+		max-width: 56%;
+		text-align: right;
+	}
+
+	.empty-state {
+		align-items: center;
+		display: grid;
+		gap: 7px;
+		justify-items: center;
+		min-height: 420px;
+		padding: 44px;
+		text-align: center;
+	}
+
+	.empty-state p {
+		color: var(--mf-fg-secondary);
+		font-size: 13px;
+		max-width: 520px;
+	}
+
+	.loading-mark {
+		animation: pulse 900ms ease-in-out infinite;
+		background: var(--mf-active-fg);
+		height: 8px;
+		width: 8px;
+	}
+
+	@keyframes pulse {
+		50% {
+			opacity: 0.25;
+		}
+	}
+
+	@media (max-width: 900px) {
+		.page-heading {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.library-totals {
+			min-width: 0;
+		}
+
+		.workbench__body {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		.title-index {
+			border-bottom: 1px solid var(--mf-line);
+			border-right: 0;
+		}
+	}
+
+	@media (max-width: 760px) {
+		.movie-library {
+			padding: 20px 12px 42px;
+		}
+
+		.library-totals {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		.library-totals div:nth-child(3) {
+			border-left: 0;
+			border-top: 1px solid var(--mf-line);
+		}
+
+		.library-totals div:nth-child(4) {
+			border-top: 1px solid var(--mf-line);
+		}
+
+		.workbench__toolbar {
+			grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+		}
+
+		.search-field {
+			grid-column: 1 / -1;
+		}
+
+		.title-index__header {
+			display: none;
+		}
+
+		.title-row {
+			grid-template-columns: minmax(0, 1fr) auto;
+		}
+
+		.title-row__count,
+		.title-row__size {
+			display: none;
+		}
+
+		.title-inspector {
+			padding: 16px;
+		}
+
+		.inspector-heading,
+		.inspector-actions,
+		.member-row {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.inspector-actions span {
+			max-width: none;
+			text-align: left;
+		}
+
+		.member-link,
+		.primary-link {
+			text-align: center;
+		}
+	}
+
+	@media (max-width: 460px) {
+		.workbench__toolbar,
+		.inspector-facts {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		.inspector-facts div,
+		.inspector-facts div:nth-child(2n),
+		.inspector-facts div:nth-last-child(-n + 2) {
+			border-bottom: 1px solid var(--mf-line);
+			border-right: 0;
+		}
+
+		.inspector-facts div:last-child {
+			border-bottom: 0;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.loading-mark {
+			animation: none;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/workstation/MovieStudioView.svelte
+++ b/frontend/src/lib/components/workstation/MovieStudioView.svelte
@@ -1,0 +1,962 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	import { apiDownloadHref, postJson } from '$lib/api/client';
+	import type {
+		FolderBenchConfirmResponse,
+		FolderBenchPreviewResponse,
+		FolderPayload,
+		FolderStatusPayload,
+		HostsPayload,
+		MovieMember
+	} from '$lib/api/types';
+	import { folderRoutePath, folderRoutePrefix } from '$lib/folder-display';
+	import StateBadge from './StateBadge.svelte';
+	import WorkstationPanel from './WorkstationPanel.svelte';
+
+	let {
+		folder,
+		status,
+		hosts,
+		folderPending = false,
+		onMutate = async () => {},
+		loadError = null
+	}: {
+		folder: FolderPayload;
+		status: FolderStatusPayload;
+		hosts: HostsPayload;
+		folderPending?: boolean;
+		onMutate?: () => Promise<void>;
+		loadError?: string | null;
+	} = $props();
+
+	let note = $state('');
+	let selectedHostKey = $state('');
+	let pendingAction = $state('');
+	let actionMessage = $state('');
+	let actionError = $state('');
+
+	const context = $derived(folder.movie_context ?? null);
+	const title = $derived(
+		context?.title ?? folder.media_scope.title ?? folder.prefix.split('/').at(-1) ?? 'Movie'
+	);
+	const activeMember = $derived(
+		context?.active_member ??
+			context?.members.find((member) => member.prefix === folder.prefix) ??
+			(context?.scope_mode === 'single_file' ? context.members[0] : undefined)
+	);
+	const workflow = $derived(
+		status.workflow_state ?? folder.workflow_state ?? context?.workflow_state ?? null
+	);
+	const calibration = $derived(asRecord(folder.calibration));
+	const pendingProposal = $derived(asRecord(folder.pending_proposal));
+	const reviewGate = $derived(asRecord(folder.review_gate));
+	const calibrationJob = $derived(asRecord(folder.calibration_job));
+	const encodeJob = $derived(folder.encode_job ?? null);
+	const sampleItem = $derived(asRecord(folder.sample_item));
+	const hostOptions = $derived(
+		(folder.sample_host_options ?? [])
+			.map((host) => asRecord(host))
+			.filter((host) => asText(host.key) && host.available !== false)
+	);
+	const activeHostCount = $derived(hosts.hosts.filter((host) => host.available).length);
+	const isBrowseOnly = $derived(context?.availability === 'browse_only');
+	const isBusy = $derived(Boolean(pendingAction));
+	const conflicts = $derived(context?.promotion_conflicts ?? []);
+	const reviewReady = $derived(
+		Boolean(
+			calibration.review_media_ready ||
+			calibration.browser_review_ready ||
+			calibration.compare_clips
+		)
+	);
+	const reviewPackHref = $derived(
+		apiDownloadHref(`/api/folders/${folderRoutePrefix(folder.prefix)}/review-compare/download`)
+	);
+	const exactScope = $derived(folder.media_scope.match === 'exact_item');
+	const scopeNoun = $derived(exactScope ? 'movie file' : 'movie title');
+
+	$effect(() => {
+		const folderHostKey = String(folder.sample_host_key ?? '').trim();
+		if (!selectedHostKey || !hostOptions.some((host) => asText(host.key) === selectedHostKey)) {
+			selectedHostKey = folderHostKey || asText(hostOptions[0]?.key);
+		}
+	});
+
+	async function prepareSample() {
+		if (isBrowseOnly || isBusy) return;
+		await runAction('prepare-sample', async () => {
+			const response = await postJson<FolderBenchPreviewResponse>(
+				`/api/folders/${folderRoutePrefix(folder.prefix)}/ai-tune/preview`,
+				{
+					note:
+						note.trim() ||
+						'Prepare a representative movie sample using the current size and quality policy.',
+					host_key: selectedHostKey
+				}
+			);
+			note = '';
+			return response.message || 'Sample plan ready. Review it before starting work.';
+		});
+	}
+
+	async function startSample() {
+		if (isBrowseOnly || isBusy) return;
+		await runAction('start-sample', async () => {
+			const response = await postJson<FolderBenchConfirmResponse>(
+				`/api/folders/${folderRoutePrefix(folder.prefix)}/ai-tune/confirm`,
+				{ proposal_id: asText(pendingProposal.proposal_id) }
+			);
+			return response.message || 'Sample run queued.';
+		});
+	}
+
+	async function retrySample() {
+		if (isBrowseOnly || isBusy) return;
+		await runAction('retry-sample', async () => {
+			const response = await postJson<FolderBenchConfirmResponse>(
+				`/api/folders/${folderRoutePrefix(folder.prefix)}/ai-tune/confirm`,
+				{ proposal_id: '' }
+			);
+			return response.message || 'Sample retry queued.';
+		});
+	}
+
+	async function approveAndQueue() {
+		if (isBrowseOnly || isBusy) return;
+		await runAction('approve-queue', async () => {
+			const response = await postJson<{ ok: boolean; message?: string }>(
+				`/api/folders/${folderRoutePrefix(folder.prefix)}/save-profile`,
+				{
+					confirm_high_impact: true,
+					confirm_size_tradeoff: true,
+					reviewed_draft_hash: asText(calibration.draft_hash)
+				}
+			);
+			return response.message || `Approved the sample and queued this ${scopeNoun}.`;
+		});
+	}
+
+	async function queueApproved() {
+		if (isBrowseOnly || isBusy) return;
+		await runAction('queue-title', async () => {
+			const response = await postJson<{ ok: boolean; message?: string }>(
+				`/api/folders/${folderRoutePrefix(folder.prefix)}/queue-encode`,
+				{ notes: '', bypass_schedule: false }
+			);
+			return response.message || `Queued this ${scopeNoun}.`;
+		});
+	}
+
+	async function validateOutputs() {
+		await folderAction('validate-outputs', 'Validated the ready movie output.');
+	}
+
+	async function promoteOutputs() {
+		if (conflicts.length) return;
+		await folderAction('promote-outputs', 'Promoted the validated movie output.');
+	}
+
+	async function retryEncode() {
+		if (isBrowseOnly || isBusy) return;
+		await runAction('retry-encode', async () => {
+			const response = await postJson<{ ok: boolean; message?: string }>(
+				'/api/encode-queue/retry-prefix',
+				{ prefix: folder.prefix }
+			);
+			return response.message || `Queued a retry for this ${scopeNoun}.`;
+		});
+	}
+
+	async function stopSample() {
+		if (isBusy) return;
+		await runAction('stop-sample', async () => {
+			const response = await postJson<{ ok?: boolean; message?: string }>(
+				'/api/calibration-queue/stop',
+				{}
+			);
+			return response.message || 'Stopped queued and running sample work.';
+		});
+	}
+
+	async function folderAction(endpoint: 'validate-outputs' | 'promote-outputs', fallback: string) {
+		if (isBrowseOnly || isBusy) return;
+		await runAction(endpoint, async () => {
+			const response = await postJson<{
+				ok: boolean;
+				message?: string;
+				conflicts?: Array<Record<string, unknown>>;
+			}>(`/api/folders/${folderRoutePrefix(folder.prefix)}/${endpoint}`, {});
+			if (!response.ok) throw new Error(response.message || 'The movie action could not run.');
+			return response.message || fallback;
+		});
+	}
+
+	async function runAction(action: string, operation: () => Promise<string>) {
+		pendingAction = action;
+		actionMessage = '';
+		actionError = '';
+		try {
+			actionMessage = await operation();
+			await onMutate();
+		} catch (error) {
+			actionError = error instanceof Error ? error.message : 'The movie action could not run.';
+		} finally {
+			pendingAction = '';
+		}
+	}
+
+	function primaryAction():
+		| 'prepare'
+		| 'start'
+		| 'monitor-sample'
+		| 'queue'
+		| 'validate'
+		| 'promote'
+		| 'retry'
+		| 'monitor'
+		| 'none' {
+		if (isBrowseOnly) return 'none';
+		const calibrationStatus = asText(calibrationJob.status);
+		if (['queued', 'running'].includes(calibrationStatus)) return 'monitor-sample';
+		const encodeStatus = String(encodeJob?.status ?? '');
+		if (['queued', 'running', 'retry_backoff'].includes(encodeStatus)) return 'monitor';
+		if (['failed', 'stopped', 'needs_attention'].includes(encodeStatus)) return 'retry';
+		if (workflow?.next_action.kind === 'validate_outputs') return 'validate';
+		if (workflow?.next_action.kind === 'promote_outputs') return 'promote';
+		if (Object.keys(pendingProposal).length) return 'start';
+		if (reviewGate.status === 'accepted') return 'queue';
+		if (reviewReady) return 'queue';
+		return 'prepare';
+	}
+
+	function badgeTone(): 'active' | 'ready' | 'wait' | 'fail' | 'idle' {
+		if (conflicts.length || workflow?.tone === 'attention') return 'fail';
+		if (workflow?.tone === 'active') return 'active';
+		if (workflow?.tone === 'ready' || workflow?.tone === 'success') return 'ready';
+		if (workflow?.state === 'explicit_selection_required') return 'wait';
+		return 'idle';
+	}
+
+	function formatBytes(value: unknown): string {
+		let size = Number(value ?? 0);
+		if (!Number.isFinite(size) || size <= 0) return 'Unknown';
+		const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+		let unit = 0;
+		while (size >= 1024 && unit < units.length - 1) {
+			size /= 1024;
+			unit += 1;
+		}
+		return `${size >= 10 ? size.toFixed(0) : size.toFixed(1)} ${units[unit]}`;
+	}
+
+	function memberRole(member: MovieMember): string {
+		if (member.edition_label) return member.edition_label;
+		if (member.role === 'feature') return 'Main feature';
+		if (member.role === 'extra') return member.extra_category ?? 'Extra';
+		return 'Uncertain file';
+	}
+
+	function asRecord(value: unknown): Record<string, unknown> {
+		return value && typeof value === 'object' && !Array.isArray(value)
+			? (value as Record<string, unknown>)
+			: {};
+	}
+
+	function asText(value: unknown): string {
+		return typeof value === 'string' ? value.trim() : '';
+	}
+
+	function downloadReviewPack() {
+		window.location.assign(reviewPackHref);
+	}
+</script>
+
+<svelte:head>
+	<title>{title} · Movie Studio · Mediaforce</title>
+</svelte:head>
+
+<main class="movie-studio" data-folder-ready-marker={title}>
+	<nav class="breadcrumb" aria-label="Breadcrumb">
+		<a href={resolve('/movies')}>Movies</a><span aria-hidden="true">/</span><span>{title}</span>
+	</nav>
+
+	<header class="studio-heading">
+		<div>
+			<span class="eyebrow">Movie Studio · {exactScope ? 'Exact file' : 'Title scope'}</span>
+			<h1>{title}</h1>
+			<p>{folder.prefix}</p>
+		</div>
+		<StateBadge
+			tone={badgeTone()}
+			label={conflicts.length ? 'Promotion conflict' : (workflow?.label ?? 'Loading')}
+		/>
+	</header>
+
+	{#if loadError}
+		<div class="notice notice--danger" role="alert">
+			<strong>Studio could not open.</strong><span>{loadError}</span>
+		</div>
+	{/if}
+	{#if actionError}
+		<div class="notice notice--danger" role="alert">
+			<strong>Action stopped.</strong><span>{actionError}</span>
+		</div>
+	{/if}
+	{#if actionMessage}
+		<div class="notice" role="status">
+			<strong>Movie state updated.</strong><span>{actionMessage}</span>
+		</div>
+	{/if}
+	{#if isBrowseOnly}
+		<div class="notice" role="status">
+			<strong>Browse-only movie library</strong>
+			<span
+				>Files and evidence remain visible. Production actions stay disabled until this root is set
+				to Production in Settings.</span
+			>
+		</div>
+	{/if}
+	{#if conflicts.length}
+		<div class="notice notice--danger" role="alert">
+			<strong>Promotion is blocked before any file is replaced.</strong>
+			{#each conflicts as conflict (`${conflict.kind}:${conflict.destination_path}`)}
+				<span>{conflict.detail} <code>{conflict.destination_path}</code></span>
+			{/each}
+		</div>
+	{/if}
+
+	<section class="status-strip" aria-label="Movie workflow status">
+		<div><span>Scope</span><strong>{exactScope ? 'Exact movie file' : 'Movie title'}</strong></div>
+		<div><span>Workflow</span><strong>{workflow?.label ?? 'Loading'}</strong></div>
+		<div>
+			<span>Sample</span><strong
+				>{asText(calibrationJob.status) || (reviewReady ? 'Review ready' : 'Not prepared')}</strong
+			>
+		</div>
+		<div>
+			<span>Processing</span><strong
+				>{String(encodeJob?.status ?? 'Idle').replaceAll('_', ' ')}</strong
+			>
+		</div>
+		<div><span>Hosts online</span><strong>{activeHostCount}</strong></div>
+	</section>
+
+	<div class="studio-grid">
+		<div class="studio-grid__main">
+			<WorkstationPanel eyebrow="Decision" title="Next movie action" meta={scopeNoun}>
+				<div class="decision-panel">
+					<div class="decision-copy">
+						<strong>{workflow?.detail ?? 'Reading workflow state and sample evidence.'}</strong>
+						<p>
+							{exactScope
+								? 'This action applies only to the selected file.'
+								: 'Title-wide work includes identified feature files. Extras and uncertain files remain exact-selection only.'}
+						</p>
+					</div>
+					<div class="decision-actions">
+						{#if primaryAction() === 'prepare'}
+							<button
+								class="primary"
+								disabled={folderPending || isBusy || !selectedHostKey}
+								onclick={prepareSample}
+							>
+								{pendingAction === 'prepare-sample' ? 'Preparing…' : 'Prepare review sample'}
+							</button>
+						{:else if primaryAction() === 'start'}
+							<button class="primary" disabled={isBusy} onclick={startSample}>
+								{pendingAction === 'start-sample' ? 'Starting…' : 'Start planned sample'}
+							</button>
+						{:else if primaryAction() === 'monitor-sample'}
+							<a class="primary" href={resolve('/ops')}>Monitor sample</a>
+							<button class="secondary" disabled={isBusy} onclick={stopSample}
+								>Stop sample work</button
+							>
+						{:else if primaryAction() === 'queue'}
+							{#if reviewGate.status === 'accepted'}
+								<button class="primary" disabled={isBusy} onclick={queueApproved}
+									>Queue movie work</button
+								>
+							{:else}
+								<button class="primary" disabled={isBusy} onclick={approveAndQueue}
+									>Approve sample and queue</button
+								>
+							{/if}
+						{:else if primaryAction() === 'validate'}
+							<button class="primary" disabled={isBusy} onclick={validateOutputs}
+								>Validate outputs</button
+							>
+						{:else if primaryAction() === 'promote'}
+							<button
+								class="primary"
+								disabled={isBusy || conflicts.length > 0}
+								onclick={promoteOutputs}>Promote safely</button
+							>
+						{:else if primaryAction() === 'retry'}
+							<button class="primary" disabled={isBusy} onclick={retryEncode}
+								>Resume unfinished work</button
+							>
+						{:else if primaryAction() === 'monitor'}
+							<a class="primary" href={resolve('/ops')}>Monitor processing</a>
+						{:else}
+							<a class="primary" href={resolve('/settings')}>Open library settings</a>
+						{/if}
+					</div>
+				</div>
+			</WorkstationPanel>
+
+			<WorkstationPanel
+				eyebrow="Sample bench"
+				title="Prepare and review"
+				meta={reviewReady ? 'Evidence ready' : 'No approved sample'}
+			>
+				<div class="sample-bench">
+					{#if Object.keys(pendingProposal).length}
+						<div class="sample-plan">
+							<strong>Sample plan is ready</strong>
+							<p>Nothing starts until you confirm this plan.</p>
+							<button class="secondary" disabled={isBusy || isBrowseOnly} onclick={startSample}
+								>Start sample</button
+							>
+						</div>
+					{/if}
+					<div class="sample-facts">
+						<div>
+							<span>Representative file</span><strong
+								>{asText(sampleItem.rel_path) || activeMember?.label || 'Pending'}</strong
+							>
+						</div>
+						<div>
+							<span>Source size</span><strong
+								>{formatBytes(sampleItem.source_size_bytes ?? activeMember?.size_bytes)}</strong
+							>
+						</div>
+						<div>
+							<span>Video</span><strong
+								>{asText(sampleItem.video_codec).toUpperCase() ||
+									activeMember?.video_codec?.toUpperCase() ||
+									'Unknown'}</strong
+							>
+						</div>
+						<div>
+							<span>Review gate</span><strong
+								>{asText(reviewGate.status).replaceAll('_', ' ') || 'Not reviewed'}</strong
+							>
+						</div>
+					</div>
+
+					<label class="request-field">
+						<span>Operator request</span>
+						<textarea
+							bind:value={note}
+							rows="4"
+							placeholder="Example: preserve grain and make the feature about 35% smaller."
+						></textarea>
+					</label>
+					<div class="bench-controls">
+						<label>
+							<span>Sample host</span>
+							<select bind:value={selectedHostKey} disabled={!hostOptions.length}>
+								{#if !hostOptions.length}<option value="">No sample host available</option>{/if}
+								{#each hostOptions as host (asText(host.key))}
+									<option value={asText(host.key)}>{asText(host.label) || asText(host.key)}</option>
+								{/each}
+							</select>
+						</label>
+						<button
+							class="secondary"
+							disabled={isBusy || isBrowseOnly || !selectedHostKey}
+							onclick={prepareSample}>Prepare new sample</button
+						>
+						{#if status.retryable_sample_job}
+							<button class="secondary" disabled={isBusy || isBrowseOnly} onclick={retrySample}
+								>Retry failed sample</button
+							>
+						{/if}
+						{#if reviewReady}
+							<button class="secondary" type="button" onclick={downloadReviewPack}
+								>Download review pack</button
+							>
+						{/if}
+					</div>
+				</div>
+			</WorkstationPanel>
+		</div>
+
+		<aside class="studio-grid__rail">
+			<WorkstationPanel
+				eyebrow="Title scope"
+				title="Files and editions"
+				meta={`${context?.members.length ?? 0} indexed`}
+			>
+				<div class="member-list">
+					{#each context?.members ?? [] as member (member.item_id)}
+						<div
+							class="member-row"
+							class:active={member.prefix === folder.prefix}
+							data-role={member.role}
+						>
+							<div>
+								<strong>{memberRole(member)}</strong>
+								<span>{member.label}</span>
+								<small>
+									{formatBytes(member.size_bytes)} · {member.status.replaceAll('_', ' ')}
+									{member.included_by_default ? ' · title work' : ' · exact only'}
+								</small>
+							</div>
+							<a href={resolve(folderRoutePath(member.prefix))}>Open</a>
+						</div>
+					{/each}
+					{#if !context?.members.length}
+						<div class="panel-empty">Movie membership is still loading.</div>
+					{/if}
+				</div>
+			</WorkstationPanel>
+
+			<WorkstationPanel
+				eyebrow="Safety"
+				title="Selection contract"
+				meta={exactScope ? 'Exact match' : 'Feature default'}
+			>
+				<div class="safety-list">
+					<div>
+						<strong>Features</strong><span>Included in title-wide sample and encode work.</span>
+					</div>
+					<div>
+						<strong>Editions</strong><span
+							>Remain separate files with independent destinations.</span
+						>
+					</div>
+					<div>
+						<strong>Extras</strong><span
+							>Visible here; open an exact file to process one deliberately.</span
+						>
+					</div>
+					<div>
+						<strong>Promotion</strong><span
+							>Destination collisions block the entire action before replacement.</span
+						>
+					</div>
+				</div>
+			</WorkstationPanel>
+		</aside>
+	</div>
+</main>
+
+<style>
+	.movie-studio {
+		margin: 0 auto;
+		max-width: 1360px;
+		padding: 24px 28px 56px;
+	}
+
+	.breadcrumb {
+		align-items: center;
+		color: var(--mf-fg-tertiary);
+		display: flex;
+		font-size: var(--mf-text-xs);
+		gap: var(--mf-space-3);
+		margin-bottom: var(--mf-space-6);
+	}
+
+	.breadcrumb a {
+		color: var(--mf-active-fg);
+		font-weight: var(--mf-weight-semibold);
+		text-decoration: none;
+	}
+
+	.studio-heading {
+		align-items: start;
+		display: flex;
+		gap: var(--mf-space-7);
+		justify-content: space-between;
+		margin-bottom: var(--mf-space-7);
+	}
+
+	.eyebrow {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-bold);
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+	}
+
+	h1,
+	p {
+		margin: 0;
+	}
+
+	h1 {
+		font-size: clamp(28px, 4vw, 40px);
+		letter-spacing: -0.035em;
+		margin: 4px 0;
+	}
+
+	.studio-heading p {
+		color: var(--mf-fg-tertiary);
+		font-family: var(--mf-font-mono);
+		font-size: var(--mf-text-2xs);
+		word-break: break-all;
+	}
+
+	.notice {
+		background: var(--mf-bg-panel);
+		border: var(--mf-border);
+		border-left: 4px solid var(--mf-active-line);
+		display: grid;
+		gap: 3px;
+		margin-bottom: var(--mf-space-5);
+		padding: 11px 13px;
+	}
+
+	.notice--danger {
+		border-left-color: var(--mf-fail-fg);
+	}
+
+	.notice span {
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-xs);
+	}
+
+	.notice code {
+		font-size: 11px;
+		word-break: break-all;
+	}
+
+	.status-strip {
+		background: var(--mf-bg-strip);
+		border: var(--mf-border);
+		display: grid;
+		grid-template-columns: repeat(5, minmax(0, 1fr));
+		margin-bottom: var(--mf-space-6);
+	}
+
+	.status-strip div {
+		border-left: var(--mf-border-muted);
+		padding: 10px 12px;
+	}
+
+	.status-strip div:first-child {
+		border-left: 0;
+	}
+
+	.status-strip span,
+	.status-strip strong {
+		display: block;
+	}
+
+	.status-strip span {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-bold);
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+	}
+
+	.status-strip strong {
+		font-size: var(--mf-text-sm);
+		margin-top: 3px;
+		text-transform: capitalize;
+	}
+
+	.studio-grid {
+		display: grid;
+		gap: var(--mf-space-6);
+		grid-template-columns: minmax(0, 1fr) minmax(320px, 0.38fr);
+	}
+
+	.studio-grid__main,
+	.studio-grid__rail {
+		display: grid;
+		gap: var(--mf-space-6);
+		min-width: 0;
+	}
+
+	.studio-grid__rail {
+		align-content: start;
+	}
+
+	.decision-panel {
+		align-items: center;
+		display: flex;
+		gap: var(--mf-space-7);
+		justify-content: space-between;
+		padding: var(--mf-space-7);
+	}
+
+	.decision-copy {
+		max-width: 680px;
+	}
+
+	.decision-copy strong {
+		font-size: var(--mf-text-xl);
+		line-height: var(--mf-leading-snug);
+	}
+
+	.decision-copy p,
+	.sample-plan p {
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-sm);
+		line-height: var(--mf-leading-normal);
+		margin-top: var(--mf-space-4);
+	}
+
+	.decision-actions,
+	.bench-controls {
+		align-items: center;
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--mf-space-4);
+	}
+
+	.primary,
+	.secondary {
+		align-items: center;
+		border: 1px solid var(--mf-active-fg);
+		border-radius: var(--mf-radius-1);
+		cursor: pointer;
+		display: inline-flex;
+		font: inherit;
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-bold);
+		justify-content: center;
+		min-height: 36px;
+		padding: 0 13px;
+		text-decoration: none;
+	}
+
+	.primary {
+		background: var(--mf-active-solid);
+		color: var(--mf-fg-on-accent);
+	}
+
+	.secondary {
+		background: var(--mf-bg-panel);
+		color: var(--mf-active-fg);
+	}
+
+	button:disabled {
+		cursor: not-allowed;
+		opacity: 0.48;
+	}
+
+	.sample-bench {
+		display: grid;
+		gap: var(--mf-space-6);
+		padding: var(--mf-space-7);
+	}
+
+	.sample-plan {
+		background: var(--mf-active-bg);
+		border: 1px solid var(--mf-active-line);
+		display: grid;
+		gap: var(--mf-space-4);
+		padding: var(--mf-space-6);
+	}
+
+	.sample-plan .secondary {
+		justify-self: start;
+	}
+
+	.sample-facts {
+		border: var(--mf-border-muted);
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.sample-facts div {
+		border-bottom: var(--mf-border-muted);
+		border-right: var(--mf-border-muted);
+		padding: 10px 12px;
+	}
+
+	.sample-facts div:nth-child(2n) {
+		border-right: 0;
+	}
+
+	.sample-facts div:nth-last-child(-n + 2) {
+		border-bottom: 0;
+	}
+
+	.sample-facts span,
+	.sample-facts strong {
+		display: block;
+	}
+
+	.sample-facts span,
+	.request-field > span,
+	.bench-controls label > span {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-bold);
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+	}
+
+	.sample-facts strong {
+		font-size: var(--mf-text-xs);
+		margin-top: 3px;
+		word-break: break-word;
+	}
+
+	.request-field,
+	.bench-controls label {
+		display: grid;
+		gap: var(--mf-space-3);
+	}
+
+	.request-field textarea,
+	.bench-controls select {
+		background: var(--mf-bg-input);
+		border: 1px solid var(--mf-line-strong);
+		border-radius: var(--mf-radius-1);
+		color: var(--mf-fg-primary);
+		font: inherit;
+		font-size: var(--mf-text-sm);
+		padding: 9px 10px;
+	}
+
+	.request-field textarea {
+		resize: vertical;
+	}
+
+	.member-list,
+	.safety-list {
+		display: grid;
+	}
+
+	.member-row,
+	.safety-list div {
+		border-bottom: var(--mf-border-muted);
+		padding: 11px 13px;
+	}
+
+	.member-row:last-child,
+	.safety-list div:last-child {
+		border-bottom: 0;
+	}
+
+	.member-row {
+		align-items: center;
+		display: flex;
+		gap: var(--mf-space-4);
+		justify-content: space-between;
+	}
+
+	.member-row.active {
+		background: var(--mf-active-bg);
+		box-shadow: inset 3px 0 0 var(--mf-active-fg);
+	}
+
+	.member-row[data-role='extra'],
+	.member-row[data-role='uncertain'] {
+		background: var(--mf-bg-panel-2);
+	}
+
+	.member-row strong,
+	.member-row span,
+	.member-row small,
+	.safety-list strong,
+	.safety-list span {
+		display: block;
+	}
+
+	.member-row span {
+		font-family: var(--mf-font-mono);
+		font-size: 10px;
+		margin-top: 2px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.member-row small,
+	.safety-list span {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		line-height: var(--mf-leading-normal);
+		margin-top: 3px;
+	}
+
+	.member-row a {
+		color: var(--mf-active-fg);
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-bold);
+		text-decoration: none;
+	}
+
+	.safety-list strong {
+		font-size: var(--mf-text-xs);
+	}
+
+	.panel-empty {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-xs);
+		padding: var(--mf-space-6);
+	}
+
+	@media (max-width: 980px) {
+		.status-strip {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		.status-strip div:nth-child(odd) {
+			border-left: 0;
+		}
+
+		.status-strip div {
+			border-bottom: var(--mf-border-muted);
+		}
+
+		.status-strip div:last-child {
+			grid-column: 1 / -1;
+		}
+
+		.studio-grid {
+			grid-template-columns: minmax(0, 1fr);
+		}
+	}
+
+	@media (max-width: 680px) {
+		.movie-studio {
+			padding: 18px 12px 44px;
+		}
+
+		.studio-heading,
+		.decision-panel {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.status-strip,
+		.sample-facts {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		.status-strip div,
+		.status-strip div:nth-child(odd),
+		.sample-facts div,
+		.sample-facts div:nth-child(2n),
+		.sample-facts div:nth-last-child(-n + 2) {
+			border-bottom: var(--mf-border-muted);
+			border-left: 0;
+			border-right: 0;
+		}
+
+		.status-strip div:last-child,
+		.sample-facts div:last-child {
+			border-bottom: 0;
+			grid-column: auto;
+		}
+
+		.primary,
+		.secondary {
+			width: 100%;
+		}
+
+		.bench-controls {
+			align-items: stretch;
+			display: grid;
+		}
+	}
+</style>

--- a/frontend/src/lib/movies/library.test.ts
+++ b/frontend/src/lib/movies/library.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MovieLibraryPayload, MovieTitle } from '$lib/api/types';
+import { mergeMovieLibraryPayloads } from './library';
+
+const title: MovieTitle = {
+	prefix: 'films/Example',
+	root: 'films',
+	library_label: 'Movies',
+	availability: 'production',
+	policy: {},
+	title: 'Example',
+	scope_mode: 'title_folder',
+	item_count: 1,
+	feature_count: 1,
+	edition_count: 1,
+	extra_count: 0,
+	uncertain_count: 0,
+	included_item_count: 1,
+	total_size_bytes: 10,
+	included_size_bytes: 10,
+	savings_confidence: 'pending',
+	promotion_conflicts: [],
+	members: [
+		{
+			item_id: 1,
+			prefix: 'films/Example/Example.mkv',
+			rel_path: 'films/Example/Example.mkv',
+			root: 'films',
+			title_prefix: 'films/Example',
+			title: 'Example',
+			scope_mode: 'title_folder',
+			role: 'feature',
+			label: 'Example',
+			status: 'discovered',
+			size_bytes: 10,
+			included_by_default: true,
+			exact_action_available: true,
+			promotion_conflicts: [],
+			details_loading: true
+		}
+	],
+	details_loading: true
+};
+
+function payload(currentTitle: MovieTitle): MovieLibraryPayload {
+	return {
+		schema_version: 1,
+		libraries: [],
+		titles: [currentTitle],
+		catalog_empty: false,
+		details_loading: currentTitle.details_loading
+	};
+}
+
+describe('mergeMovieLibraryPayloads', () => {
+	it('preserves structure order while hydrating title and member details', () => {
+		const merged = mergeMovieLibraryPayloads(
+			payload(title),
+			payload({
+				...title,
+				projected_reclaim_bytes: 4,
+				savings_confidence: 'estimated',
+				details_loading: false,
+				members: [
+					{
+						...title.members[0],
+						details_loading: false,
+						age: { source: 'plex', timestamp: '2020-01-01T00:00:00+00:00' }
+					}
+				]
+			})
+		);
+
+		expect(merged.titles[0]?.projected_reclaim_bytes).toBe(4);
+		expect(merged.titles[0]?.members[0]?.age?.source).toBe('plex');
+	});
+});

--- a/frontend/src/lib/movies/library.ts
+++ b/frontend/src/lib/movies/library.ts
@@ -1,0 +1,39 @@
+import type { MovieLibraryPayload, MovieMember, MovieTitle } from '$lib/api/types';
+
+export function mergeMovieLibraryPayloads(
+	structure: MovieLibraryPayload,
+	details: MovieLibraryPayload
+): MovieLibraryPayload {
+	const detailsByPrefix = new Map(details.titles.map((title) => [title.prefix, title]));
+	const structurePrefixes = new Set(structure.titles.map((title) => title.prefix));
+	const titles = structure.titles.map((title) =>
+		mergeMovieTitle(title, detailsByPrefix.get(title.prefix))
+	);
+	for (const title of details.titles) {
+		if (!structurePrefixes.has(title.prefix)) titles.push(title);
+	}
+	return {
+		schema_version: Math.max(structure.schema_version, details.schema_version),
+		libraries: details.libraries.length ? details.libraries : structure.libraries,
+		titles,
+		catalog_empty: structure.catalog_empty && details.catalog_empty,
+		details_loading: details.details_loading
+	};
+}
+
+function mergeMovieTitle(structure: MovieTitle, details?: MovieTitle): MovieTitle {
+	if (!details) return structure;
+	const detailsByPrefix = new Map(details.members.map((member) => [member.prefix, member]));
+	const structurePrefixes = new Set(structure.members.map((member) => member.prefix));
+	const members = structure.members.map((member) =>
+		mergeMovieMember(member, detailsByPrefix.get(member.prefix))
+	);
+	for (const member of details.members) {
+		if (!structurePrefixes.has(member.prefix)) members.push(member);
+	}
+	return { ...structure, ...details, members };
+}
+
+function mergeMovieMember(structure: MovieMember, details?: MovieMember): MovieMember {
+	return details ? { ...structure, ...details } : structure;
+}

--- a/frontend/src/lib/settings/editor.ts
+++ b/frontend/src/lib/settings/editor.ts
@@ -345,7 +345,7 @@ export function libraryReadiness(
 			detail: 'Mediaforce scans and shows this library but never processes it.'
 		};
 	}
-	if (library.library_type !== 'tv') {
+	if (!['tv', 'movie'].includes(library.library_type)) {
 		return {
 			state: 'blocked',
 			label: 'Workflow blocked',

--- a/frontend/src/routes/folders/[...prefix]/+page.svelte
+++ b/frontend/src/routes/folders/[...prefix]/+page.svelte
@@ -4,16 +4,19 @@
 		initialDashboard,
 		initialFolderPayload,
 		initialFoldersPayload,
-		initialFolderStatusPayload
+		initialFolderStatusPayload,
+		initialHosts
 	} from '$lib/api/placeholders';
 	import type {
 		DashboardFoldersPayload,
 		DashboardSummaryPayload,
 		FolderPayload,
-		FolderStatusPayload
+		FolderStatusPayload,
+		HostsPayload
 	} from '$lib/api/types';
 	import SeasonExperience from '$lib/components/season/SeasonExperience.svelte';
 	import SeasonLibrary from '$lib/components/season/SeasonLibrary.svelte';
+	import MovieStudioView from '$lib/components/workstation/MovieStudioView.svelte';
 
 	let { data }: { data: { mode: 'directory' | 'studio'; prefix: string } } = $props();
 	const mode = $derived(data.mode);
@@ -23,6 +26,7 @@
 	let foldersPayload = $state<DashboardFoldersPayload>(initialFoldersPayload);
 	let folder = $state<FolderPayload>(initialFolderPayload(''));
 	let status = $state<FolderStatusPayload>(initialFolderStatusPayload(''));
+	let hosts = $state<HostsPayload>(initialHosts);
 	let foldersPending = $state(false);
 	let folderPending = $state(false);
 	let loadError = $state<string | null>(null);
@@ -57,21 +61,24 @@
 	}
 
 	async function hydrateStudio(currentPrefix: string) {
+		if (currentPrefix !== prefix) return;
 		const generation = ++hydrationGeneration;
 		folderPending = true;
 		loadError = null;
 		const encodedPrefix = encodePrefix(currentPrefix);
 		try {
-			const [folderPayload, statusPayload] = await Promise.all([
+			const [folderPayload, statusPayload, hostsPayload] = await Promise.all([
 				fetchJson<FolderPayload>(`/api/folders/${encodedPrefix}`),
-				fetchJson<FolderStatusPayload>(`/api/folders/${encodedPrefix}/status`)
+				fetchJson<FolderStatusPayload>(`/api/folders/${encodedPrefix}/status`),
+				fetchJson<HostsPayload>('/api/hosts?compact=1').catch(() => initialHosts)
 			]);
-			if (generation !== hydrationGeneration) return;
+			if (generation !== hydrationGeneration || currentPrefix !== prefix) return;
 			folder = folderPayload;
 			status = statusPayload;
+			hosts = hostsPayload;
 		} catch (error) {
 			if (generation === hydrationGeneration) {
-				loadError = error instanceof Error ? error.message : 'Unable to open this season.';
+				loadError = error instanceof Error ? error.message : 'Unable to open this media scope.';
 			}
 		} finally {
 			if (generation === hydrationGeneration) folderPending = false;
@@ -90,6 +97,7 @@
 		if (currentMode === 'studio') {
 			folder = initialFolderPayload(currentPrefix);
 			status = initialFolderStatusPayload(currentPrefix);
+			hosts = initialHosts;
 			void hydrateStudio(currentPrefix);
 			const refreshTimer = window.setInterval(() => {
 				if (!folderPending) void hydrateStudio(currentPrefix);
@@ -113,19 +121,73 @@
 <svelte:head>
 	<title
 		>{mode === 'studio'
-			? `${prefix.split('/').at(-1)} · Mediaforce`
+			? `${prefix.split('/').at(-1)} · ${folder.media_scope.domain === 'movie' ? 'Movie Studio' : 'Mediaforce'}`
 			: 'Make a TV season smaller · Mediaforce'}</title
 	>
 </svelte:head>
 
 {#if mode === 'studio'}
-	<SeasonExperience
-		{folder}
-		{status}
-		{folderPending}
-		loadError={loadError ?? undefined}
-		onMutate={refreshStudio}
-	/>
+	{#if folderPending && folder.pending}
+		<div class="studio-loading" role="status">
+			<span aria-hidden="true"></span>
+			<strong>Opening Studio</strong>
+			<p>Reading scope, membership, workflow, and worker readiness.</p>
+		</div>
+	{:else if folder.media_scope.domain === 'movie'}
+		<MovieStudioView
+			{folder}
+			{status}
+			{hosts}
+			{folderPending}
+			loadError={loadError ?? undefined}
+			onMutate={refreshStudio}
+		/>
+	{:else}
+		<SeasonExperience
+			{folder}
+			{status}
+			{folderPending}
+			loadError={loadError ?? undefined}
+			onMutate={refreshStudio}
+		/>
+	{/if}
 {:else}
 	<SeasonLibrary {dashboard} {foldersPayload} {foldersPending} loadError={loadError ?? undefined} />
 {/if}
+
+<style>
+	.studio-loading {
+		align-items: center;
+		display: grid;
+		gap: 8px;
+		justify-items: center;
+		min-height: calc(100vh - 120px);
+		padding: 36px;
+		text-align: center;
+	}
+
+	.studio-loading span {
+		animation: studio-pulse 900ms ease-in-out infinite;
+		background: var(--mf-active-fg);
+		height: 9px;
+		width: 9px;
+	}
+
+	.studio-loading p {
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-sm);
+		margin: 0;
+	}
+
+	@keyframes studio-pulse {
+		50% {
+			opacity: 0.25;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.studio-loading span {
+			animation: none;
+		}
+	}
+</style>

--- a/frontend/src/routes/movies/+page.svelte
+++ b/frontend/src/routes/movies/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import MovieLibraryPage from '$lib/components/workstation/MovieLibraryPage.svelte';
+</script>
+
+<MovieLibraryPage />

--- a/mediaforce/core/config.py
+++ b/mediaforce/core/config.py
@@ -84,6 +84,13 @@ class MediaforceConfig:
         return library_definition_map(self.media)
 
     @property
+    def library_type_map(self) -> dict[str, str]:
+        return {
+            key: str(definition.get("type") or "other")
+            for key, definition in self.library_definition_map.items()
+        }
+
+    @property
     def scan_source_root_map(self) -> dict[str, Path]:
         configured = self.configured_source_root_map
         if not isinstance(self.media.get("libraries"), list):

--- a/mediaforce/core/utils.py
+++ b/mediaforce/core/utils.py
@@ -1,9 +1,14 @@
 import hashlib
 import os
+import unicodedata
 from datetime import UTC, datetime
 from pathlib import Path
 
 CONTENT_VERSION_SAMPLE_BYTES = 64 * 1024
+
+
+def filesystem_collision_key(path: Path) -> str:
+    return unicodedata.normalize("NFC", os.path.normpath(str(path))).casefold()
 
 
 def timestamp() -> str:

--- a/mediaforce/encoding/staging.py
+++ b/mediaforce/encoding/staging.py
@@ -20,6 +20,7 @@ from mediaforce.core.type_defs import int_value
 from mediaforce.core.type_defs import object_dict
 from mediaforce.core.type_defs import object_list
 from mediaforce.core.utils import content_version_fingerprint
+from mediaforce.library.media_scopes import logical_library_rel_path
 
 TRANSIENT_FILE_BUSY_ERRNOS = {errno.EBUSY}
 TRANSIENT_FILE_BUSY_RETRY_ATTEMPTS = 8
@@ -450,8 +451,13 @@ def promote_one_item(
     promoted_fingerprint = file_fingerprint(destination_path, promoted_stat, promoted_probe.duration_seconds)
     promoted_content_fingerprint = content_version_fingerprint(destination_path, promoted_stat)
     now = timestamp()
-    rel_path = str(destination_path.relative_to(config.source_root_map[item["media_root"]].parent))
-    parent_dir = str(destination_path.parent.relative_to(config.source_root_map[item["media_root"]].parent))
+    logical_path = logical_library_rel_path(
+        str(item["media_root"]),
+        config.source_root_map[str(item["media_root"])],
+        destination_path,
+    )
+    rel_path = logical_path.as_posix()
+    parent_dir = logical_path.parent.as_posix()
 
     connection.execute(
         update(library_items)

--- a/mediaforce/library/candidate_selection.py
+++ b/mediaforce/library/candidate_selection.py
@@ -1,5 +1,6 @@
 import re
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -11,8 +12,9 @@ from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items, plex_item_metadata, series_metadata, staged_artifacts
 from mediaforce.core.type_defs import object_dict
-from mediaforce.library.media_scopes import is_tv_season_prefix, normalize_scope_prefix, path_matches_scope, \
-    resolve_media_scopes
+from mediaforce.library.library_settings import normalize_library_policy, normalize_library_type
+from mediaforce.library.media_scopes import normalize_scope_prefix, path_matches_scope, resolve_media_scopes
+from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
 from mediaforce.library.workflow_state import ENCODE_CANDIDATE_STATUSES, derive_item_workflow_state
 
 LifecycleMode = Literal["auto", "on", "off"]
@@ -74,6 +76,11 @@ class CandidateDecision:
     season_activity_at: datetime | None
     hold_reasons: tuple[HoldReason, ...]
     manual_override: bool
+    media_role: str | None
+    production_included: bool
+    production_blocker: str | None
+    ranking_mode: str
+    media_domain: str
 
     @property
     def item_id(self) -> int:
@@ -81,7 +88,11 @@ class CandidateDecision:
 
     @property
     def eligible(self) -> bool:
-        return self.workflow_lane == "encode" and (not self.hold_reasons or self.override_applied)
+        return (
+            self.workflow_lane == "encode"
+            and self.production_included
+            and (not self.hold_reasons or self.override_applied)
+        )
 
     @property
     def override_applied(self) -> bool:
@@ -107,6 +118,11 @@ class CandidateDecision:
             "hold_reasons": [reason.to_payload() for reason in self.hold_reasons],
             "manual_override": self.manual_override,
             "override_applied": self.override_applied,
+            "media_role": self.media_role,
+            "production_included": self.production_included,
+            "production_blocker": self.production_blocker,
+            "ranking_mode": self.ranking_mode,
+            "media_domain": self.media_domain,
             "media_age": self.age.to_payload(),
             "season_rank_age": self.season_rank_age.to_payload(),
             "season_activity_at": (
@@ -138,7 +154,7 @@ def project_candidates(
     numbered_by_series: dict[str, set[int]] = {}
     for row in rows:
         item_id = int(row["item_id"])
-        season = season_identity(row)
+        season = season_identity(row, library_types=config.library_type_map)
         season_by_item[item_id] = season
         if season is None:
             continue
@@ -154,13 +170,19 @@ def project_candidates(
         season_prefix: _newest_age_evidence(_media_age(row) for row in grouped_rows)
         for season_prefix, grouped_rows in season_rows.items()
     }
-    resolved_scopes = resolve_media_scopes(connection, prefixes or [])
+    resolved_scopes = resolve_media_scopes(
+        connection,
+        prefixes or [],
+        library_types=config.library_type_map,
+    )
     normalized_override = normalize_scope_prefix(manual_override_prefix or "")
     decisions: list[CandidateDecision] = []
     production_roots = set(config.source_root_map)
+    scan_roots = set(config.scan_source_root_map)
 
     for row in rows:
-        if str(row["media_root"] or "") not in production_roots:
+        media_root = str(row["media_root"] or "")
+        if media_root not in scan_roots:
             continue
         if statuses is not None and str(row["status"] or "") not in statuses:
             continue
@@ -169,6 +191,34 @@ def project_candidates(
             continue
         workflow_lane = derive_item_workflow_state(row).lane
         season = season_by_item[int(row["item_id"])]
+        library = config.library_definition_map.get(media_root, {})
+        library_type = normalize_library_type(library.get("type"), key=media_root)
+        library_policy = normalize_library_policy(library_type, library.get("policy"))
+        membership = (
+            classify_movie_path(rel_path, root=media_root)
+            if library_type == "movie"
+            else None
+        )
+        explicit_exact = any(
+            scope.match == "exact_item" and scope.prefix == rel_path
+            for scope in resolved_scopes
+        )
+        member_included, member_blocker = (
+            movie_item_included(membership, library_policy, explicit_exact=explicit_exact)
+            if membership is not None
+            else (True, None)
+        )
+        production_enabled = media_root in production_roots
+        production_included = production_enabled and member_included
+        production_blocker = member_blocker
+        if not production_enabled:
+            label = str(library.get("label") or media_root or "This library")
+            production_blocker = f"{label} is browse only; set its availability to Production before processing."
+        ranking_mode = (
+            str(library_policy.get("ranking") or "oldest_added_first")
+            if library_type == "movie"
+            else "oldest_added_first"
+        )
         policy = _resolved_policy(config, season.series_prefix if season is not None else rel_path)
         lifecycle_keys = (
             "series_lifecycle_mode",
@@ -176,14 +226,14 @@ def project_candidates(
             "current_season_inactive_days",
             "series_metadata_stale_days",
         )
-        policy_enabled = all(
-            isinstance(config.raw.get(section), dict)
-            for section in ("video", "audio", "subtitle", "planning")
-        ) or any(
-            key in policy
-            for key in lifecycle_keys
+        policy_enabled = season is not None and (
+            all(
+                isinstance(config.raw.get(section), dict)
+                for section in ("video", "audio", "subtitle", "planning")
+            )
+            or any(key in policy for key in lifecycle_keys)
         )
-        mode = _lifecycle_mode(policy.get("series_lifecycle_mode"))
+        mode = _lifecycle_mode(policy.get("series_lifecycle_mode")) if season is not None else "off"
         acquisition_days = _duration_days(policy.get("season_acquisition_hold_days"), 30)
         inactive_days = _duration_days(policy.get("current_season_inactive_days"), 365)
         stale_days = _positive_int(policy.get("series_metadata_stale_days"), 7)
@@ -236,6 +286,11 @@ def project_candidates(
                 season_activity_at=activity_at,
                 hold_reasons=hold_reasons,
                 manual_override=manual_override,
+                media_role=membership.role if membership is not None else None,
+                production_included=production_included,
+                production_blocker=production_blocker,
+                ranking_mode=ranking_mode,
+                media_domain=library_type,
             )
         )
     return decisions
@@ -262,11 +317,11 @@ def encode_candidate_decisions(
 def workflow_eligibility(decisions: list[CandidateDecision]) -> dict[int, tuple[bool, str | None]]:
     return {
         decision.item_id: (
-            decision.eligible,
-            decision.hold_reasons[0].detail if decision.hold_reasons else None,
+            decision.eligible if decision.workflow_lane == "encode" else decision.production_included,
+            decision.production_blocker
+            or (decision.hold_reasons[0].detail if decision.hold_reasons else None),
         )
         for decision in decisions
-        if decision.workflow_lane == "encode"
     }
 
 
@@ -338,17 +393,31 @@ def scope_lifecycle_payload_from_decisions(
         "ranking_added_at": rank_age.isoformat(timespec="seconds") if rank_age is not None else None,
         "can_override_holds": bool(
             held
-            and _is_season_prefix(normalized_prefix)
+            and any(
+                decision.season is not None and decision.season.season_prefix == normalized_prefix
+                for decision in decisions
+            )
             and all(all(reason.code in OVERRIDEABLE_HOLD_CODES for reason in decision.hold_reasons) for decision in held)
         ),
         "seasons": seasons,
     }
 
 
-def season_identity(row: dict[str, Any]) -> SeasonIdentity | None:
+def season_identity(
+        row: dict[str, Any],
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> SeasonIdentity | None:
     rel_path = str(row.get("rel_path") or "")
     parts = Path(rel_path).parts
-    if len(parts) < 3 or parts[0].lower() != "tv":
+    if len(parts) < 3:
+        return None
+    root = parts[0]
+    if library_types is None:
+        is_tv = root.lower() == "tv"
+    else:
+        is_tv = normalize_library_type(library_types.get(root), key=root) == "tv"
+    if not is_tv:
         return None
     label = parts[2]
     match = SEASON_PATTERN.fullmatch(label)
@@ -375,6 +444,15 @@ def season_identity(row: dict[str, Any]) -> SeasonIdentity | None:
 
 def candidate_rank_key(decision: CandidateDecision, *, recommendation_score: float, size_bytes: int) -> tuple[Any, ...]:
     timestamp = decision.season_rank_age.timestamp
+    if decision.ranking_mode == "largest_first":
+        return (
+            -size_bytes,
+            timestamp is None,
+            timestamp or datetime.max.replace(tzinfo=UTC),
+            -recommendation_score,
+            str(decision.row["rel_path"]),
+            decision.item_id,
+        )
     return (
         timestamp is None,
         timestamp or datetime.max.replace(tzinfo=UTC),
@@ -585,10 +663,6 @@ def _lifecycle_mode(value: object) -> LifecycleMode:
     if normalized in {"auto", "on", "off"}:
         return normalized  # type: ignore[return-value]
     return "auto"
-
-
-def _is_season_prefix(prefix: str) -> bool:
-    return is_tv_season_prefix(prefix)
 
 
 def _latest_timestamp(values: Any) -> datetime | None:

--- a/mediaforce/library/folder_profiles.py
+++ b/mediaforce/library/folder_profiles.py
@@ -8,12 +8,13 @@ from sqlalchemy import select
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items
-from mediaforce.core.type_defs import mapping_dict
+from mediaforce.core.type_defs import mapping_dict, object_dict
 from mediaforce.library.media_scopes import resolve_media_scope, scope_rel_path_filter
+from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
 
 
 def inspect_prefix(connection: DBClient, config: MediaforceConfig, prefix: str) -> dict[str, Any]:
-    scope = resolve_media_scope(connection, prefix)
+    scope = resolve_media_scope(connection, prefix, library_types=config.library_type_map)
     rows = [
         mapping_dict(row)
         for row in connection.execute(
@@ -22,6 +23,21 @@ def inspect_prefix(connection: DBClient, config: MediaforceConfig, prefix: str) 
             .order_by(library_items.c.rel_path)
         ).mappings().fetchall()
     ]
+    if scope.domain == "movie":
+        library = config.library_definition_map.get(scope.root, {})
+        policy = object_dict(library.get("policy"))
+        rows = [
+            row
+            for row in rows
+            if (
+                membership := classify_movie_path(str(row["rel_path"]), root=scope.root)
+            ) is not None
+            and movie_item_included(
+                membership,
+                policy,
+                explicit_exact=scope.match == "exact_item",
+            )[0]
+        ]
     if not rows:
         return {"prefix": prefix, "item_count": 0, "rows": []}
 
@@ -38,7 +54,7 @@ def inspect_prefix(connection: DBClient, config: MediaforceConfig, prefix: str) 
         for audio in json.loads(row["audio_summary_json"]):
             audio_codecs[f"{audio.get('codec_name')}:{audio.get('channels')}"] += 1
         rel_parts = Path(str(row["rel_path"])).parts
-        if len(rel_parts) >= 3:
+        if scope.domain == "tv" and len(rel_parts) >= 3:
             seasons[rel_parts[2]] += 1
 
     policy = config.resolve_policy(prefix)

--- a/mediaforce/library/library_settings.py
+++ b/mediaforce/library/library_settings.py
@@ -168,4 +168,4 @@ def library_type_label(library_type: str) -> str:
 
 
 def library_production_supported(library_type: str) -> bool:
-    return library_type == "tv"
+    return library_type in {"tv", "movie"}

--- a/mediaforce/library/media_scopes.py
+++ b/mediaforce/library/media_scopes.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from pathlib import PurePosixPath
-from typing import Any, Literal
+from pathlib import Path, PurePosixPath
+from typing import Any, Literal, Mapping
 
 from sqlalchemy import and_, exists, literal, or_, select, true, union_all
 
@@ -19,6 +19,11 @@ ScopeKind = Literal[
 ]
 ScopeMatch = Literal["exact_item", "descendants"]
 ScopeGroup = tuple[str, str, str, str]
+
+
+def logical_library_rel_path(root: str, root_path: Path, item_path: Path) -> PurePosixPath:
+    relative_path = item_path.relative_to(root_path)
+    return PurePosixPath(root, *relative_path.parts)
 
 
 class MediaScopeConflict(ValueError):
@@ -69,33 +74,51 @@ def normalize_scope_prefix(prefix: str) -> str:
     return str(prefix or "").strip().strip("/")
 
 
-def media_group_scope_for_rel_path(rel_path: str) -> MediaScope | None:
+def media_group_scope_for_rel_path(
+        rel_path: str,
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> MediaScope | None:
     normalized = normalize_scope_prefix(rel_path)
     parts = PurePosixPath(normalized).parts
     if len(parts) < 2:
         return None
-    if parts[0].lower() == "tv" and len(parts) >= 4:
-        return media_scope_from_prefix("/".join(parts[:3]), match="descendants")
-    if parts[0].lower() == "tv" and len(parts) == 3:
-        return media_scope_from_prefix(normalized, match="exact_item")
+    domain = _scope_domain(parts[0], library_types)
+    if domain == "tv" and len(parts) >= 4:
+        return media_scope_from_prefix("/".join(parts[:3]), match="descendants", library_types=library_types)
+    if domain == "tv" and len(parts) == 3:
+        return media_scope_from_prefix(normalized, match="exact_item", library_types=library_types)
     if len(parts) == 2:
-        return media_scope_from_prefix(normalized, match="exact_item")
-    return media_scope_from_prefix("/".join(parts[:2]), match="descendants")
+        return media_scope_from_prefix(normalized, match="exact_item", library_types=library_types)
+    return media_scope_from_prefix("/".join(parts[:2]), match="descendants", library_types=library_types)
 
 
-def tv_series_scope_for_rel_path(rel_path: str) -> MediaScope | None:
+def tv_series_scope_for_rel_path(
+        rel_path: str,
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> MediaScope | None:
     normalized = normalize_scope_prefix(rel_path)
     parts = PurePosixPath(normalized).parts
-    if len(parts) < 3 or parts[0].lower() != "tv":
+    if len(parts) < 3 or _scope_domain(parts[0], library_types) != "tv":
         return None
-    return media_scope_from_prefix("/".join(parts[:2]), match="descendants")
+    return media_scope_from_prefix(
+        "/".join(parts[:2]),
+        match="descendants",
+        library_types=library_types,
+    )
 
 
-def media_scope_from_prefix(prefix: str, *, match: ScopeMatch) -> MediaScope:
+def media_scope_from_prefix(
+        prefix: str,
+        *,
+        match: ScopeMatch,
+        library_types: Mapping[str, str] | None = None,
+) -> MediaScope:
     normalized = normalize_scope_prefix(prefix)
     parts = PurePosixPath(normalized).parts
     root = parts[0] if parts else ""
-    domain = _scope_domain(root)
+    domain = _scope_domain(root, library_types)
     root_title = _root_title(root)
     title = root_title if root else "Library"
     subtitle = "Library"
@@ -157,11 +180,21 @@ def media_scope_from_prefix(prefix: str, *, match: ScopeMatch) -> MediaScope:
     )
 
 
-def resolve_media_scope(connection: DBClient, prefix: str) -> MediaScope:
-    return resolve_media_scopes(connection, [prefix])[0]
+def resolve_media_scope(
+        connection: DBClient,
+        prefix: str,
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> MediaScope:
+    return resolve_media_scopes(connection, [prefix], library_types=library_types)[0]
 
 
-def resolve_media_scopes(connection: DBClient, prefixes: list[str]) -> list[MediaScope]:
+def resolve_media_scopes(
+        connection: DBClient,
+        prefixes: list[str],
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> list[MediaScope]:
     normalized_prefixes = [normalize_scope_prefix(prefix) for prefix in prefixes]
     if not normalized_prefixes:
         return []
@@ -210,6 +243,7 @@ def resolve_media_scopes(connection: DBClient, prefixes: list[str]) -> list[Medi
         scopes_by_prefix[prefix] = media_scope_from_prefix(
             prefix,
             match="exact_item" if exact_match else "descendants",
+            library_types=library_types,
         )
     return [scopes_by_prefix[prefix] for prefix in normalized_prefixes]
 
@@ -293,19 +327,23 @@ def scopes_overlap(left: MediaScope | str, right: MediaScope | str) -> bool:
     )
 
 
-def is_tv_season_prefix(prefix: str) -> bool:
+def is_tv_season_prefix(prefix: str, *, library_types: Mapping[str, str] | None = None) -> bool:
     parts = PurePosixPath(normalize_scope_prefix(prefix)).parts
-    return len(parts) == 3 and parts[0].lower() == "tv"
+    return len(parts) == 3 and _scope_domain(parts[0], library_types) == "tv"
 
 
-def is_tv_series_prefix(prefix: str) -> bool:
+def is_tv_series_prefix(prefix: str, *, library_types: Mapping[str, str] | None = None) -> bool:
     parts = PurePosixPath(normalize_scope_prefix(prefix)).parts
-    return len(parts) == 2 and parts[0].lower() == "tv"
+    return len(parts) == 2 and _scope_domain(parts[0], library_types) == "tv"
 
 
-def series_context_for_prefix(prefix: str) -> dict[str, str] | None:
+def series_context_for_prefix(
+        prefix: str,
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> dict[str, str] | None:
     normalized = normalize_scope_prefix(prefix)
-    if not is_tv_season_prefix(normalized):
+    if not is_tv_season_prefix(normalized, library_types=library_types):
         return None
     parts = PurePosixPath(normalized).parts
     return {"prefix": "/".join(parts[:2]), "title": parts[1]}
@@ -317,7 +355,12 @@ def _legacy_scope(scope: MediaScope | str) -> MediaScope:
     return media_scope_from_prefix(scope, match="descendants")
 
 
-def _scope_domain(root: str) -> ScopeDomain:
+def _scope_domain(root: str, library_types: Mapping[str, str] | None = None) -> ScopeDomain:
+    configured = str((library_types or {}).get(root) or "").strip().lower()
+    if configured == "tv":
+        return "tv"
+    if configured == "movie":
+        return "movie"
     normalized = root.lower()
     if normalized == "tv":
         return "tv"

--- a/mediaforce/library/metadata_sync.py
+++ b/mediaforce/library/metadata_sync.py
@@ -1,6 +1,7 @@
 import json
 import os
 import uuid
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
 from itertools import chain
@@ -188,7 +189,7 @@ def _sync_plex(
     observed_at_text = observed_at.isoformat(timespec="seconds")
     series_claims: dict[str, set[str]] = {}
     for row, item in claims.values():
-        series_prefix = _series_prefix(str(row["rel_path"] or ""))
+        series_prefix = _series_prefix(str(row["rel_path"] or ""), library_types=config.library_type_map)
         if series_prefix and item.show_rating_key:
             series_claims.setdefault(series_prefix, set()).add(item.show_rating_key)
     referenced_show_keys = {rating_key for rating_keys in series_claims.values() for rating_key in rating_keys}
@@ -236,7 +237,12 @@ def _sync_plex(
     conflicted_series_prefixes = {
         prefix
         for item_id in conflicted_item_ids
-        for prefix in [_series_prefix(str(rows_by_id[item_id]["rel_path"] or ""))]
+        for prefix in [
+            _series_prefix(
+                str(rows_by_id[item_id]["rel_path"] or ""),
+                library_types=config.library_type_map,
+            )
+        ]
         if prefix is not None
     }
     for series_prefix, rating_keys in series_claims.items():
@@ -288,7 +294,7 @@ def _sync_plex(
     local_series_prefixes = {
         prefix
         for row in rows
-        for prefix in [_series_prefix(str(row["rel_path"] or ""))]
+        for prefix in [_series_prefix(str(row["rel_path"] or ""), library_types=config.library_type_map)]
         if prefix is not None
     }
     stale_series_prefixes = local_series_prefixes - refreshed_series - conflicted_series_prefixes
@@ -424,9 +430,15 @@ def _provider_error_message(provider: str, error: ProviderHttpError) -> str:
     return f"{provider} metadata refresh failed; cached metadata was preserved."
 
 
-def _series_prefix(rel_path: str) -> str | None:
+def _series_prefix(
+        rel_path: str,
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> str | None:
     parts = Path(rel_path).parts
-    if len(parts) < 3 or parts[0].lower() != "tv":
+    root = parts[0] if parts else ""
+    configured_type = str((library_types or {}).get(root) or "").strip().lower()
+    if len(parts) < 3 or (configured_type or root.lower()) != "tv":
         return None
     return "/".join(parts[:2])
 

--- a/mediaforce/library/movie_library.py
+++ b/mediaforce/library/movie_library.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import or_, outerjoin, select
+
+from mediaforce.core.config import MediaforceConfig
+from mediaforce.core.db import DBClient
+from mediaforce.core.db_tables import library_items, plex_item_metadata, staged_artifacts
+from mediaforce.core.type_defs import mapping_dict, object_dict
+from mediaforce.core.utils import filesystem_collision_key
+from mediaforce.library.candidate_selection import encode_candidate_decisions, workflow_eligibility
+from mediaforce.library.media_scopes import resolve_media_scope, resolve_media_scopes, scope_rel_path_filter
+from mediaforce.library.movie_workflow import MovieMembership, classify_movie_path, movie_item_included
+from mediaforce.library.workflow_state import build_folder_workflow_states, derive_item_workflow_state
+
+MovieMetrics = Mapping[str, Mapping[str, Any]]
+
+
+def load_movie_library_payload(
+        connection: DBClient,
+        config: MediaforceConfig,
+        *,
+        include_details: bool,
+        metrics_by_prefix: MovieMetrics | None = None,
+        prefixes: list[str] | None = None,
+) -> dict[str, Any]:
+    libraries = _movie_libraries(config)
+    library_by_root = {str(library["key"]): library for library in libraries}
+    if not library_by_root:
+        return {
+            "schema_version": 1,
+            "libraries": [],
+            "titles": [],
+            "catalog_empty": True,
+            "details_loading": not include_details,
+        }
+
+    query = (
+        select(
+            library_items,
+            library_items.c.id.label("item_id"),
+            plex_item_metadata.c.plex_added_at,
+            staged_artifacts.c.library_item_id.label("staged_library_item_id"),
+            staged_artifacts.c.staging_path,
+            staged_artifacts.c.staging_size_bytes,
+            staged_artifacts.c.bytes_saved,
+            staged_artifacts.c.validated_at,
+            staged_artifacts.c.promoted_at,
+        )
+        .select_from(
+            outerjoin(
+                outerjoin(
+                    library_items,
+                    plex_item_metadata,
+                    plex_item_metadata.c.library_item_id == library_items.c.id,
+                ),
+                staged_artifacts,
+                staged_artifacts.c.library_item_id == library_items.c.id,
+            )
+        )
+        .where(library_items.c.media_root.in_(tuple(library_by_root)))
+        .where(library_items.c.status != "missing")
+    )
+    if prefixes:
+        scopes = resolve_media_scopes(
+            connection,
+            prefixes,
+            library_types=config.library_type_map,
+        )
+        query = query.where(or_(*(scope_rel_path_filter(library_items.c.rel_path, scope) for scope in scopes)))
+    rows = connection.execute(query.order_by(library_items.c.rel_path.asc())).mappings().fetchall()
+
+    grouped_rows: dict[str, list[tuple[dict[str, Any], MovieMembership]]] = defaultdict(list)
+    for db_row in rows:
+        row = mapping_dict(db_row)
+        membership = classify_movie_path(str(row["rel_path"]), root=str(row["media_root"]))
+        if membership is not None:
+            grouped_rows[membership.title_prefix].append((row, membership))
+
+    decisions = encode_candidate_decisions(connection, config, prefixes=prefixes or []) if include_details else []
+    decisions_by_item = {decision.item_id: decision for decision in decisions}
+    eligibility = workflow_eligibility(decisions)
+    for grouped in grouped_rows.values():
+        for row, membership in grouped:
+            item_id = int(row["item_id"])
+            library = library_by_root[membership.root]
+            included, blocker = _production_inclusion(library, membership)
+            eligibility.setdefault(item_id, (included, blocker))
+
+    workflows = (
+        build_folder_workflow_states(
+            connection,
+            list(grouped_rows),
+            candidate_eligibility=eligibility,
+            library_types=config.library_type_map,
+        )
+        if include_details and grouped_rows
+        else {}
+    )
+    metrics = metrics_by_prefix or {}
+    titles = [
+        _title_payload(
+            prefix,
+            grouped,
+            library_by_root=library_by_root,
+            decisions_by_item=decisions_by_item,
+            eligibility=eligibility,
+            workflow=workflows.get(prefix),
+            metrics=object_dict(metrics.get(prefix)),
+            config=config,
+            include_details=include_details,
+        )
+        for prefix, grouped in grouped_rows.items()
+    ]
+    titles.sort(key=_title_sort_key)
+    return {
+        "schema_version": 1,
+        "libraries": libraries,
+        "titles": titles,
+        "catalog_empty": not titles,
+        "details_loading": not include_details,
+    }
+
+
+def load_movie_scope_payload(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+) -> dict[str, Any] | None:
+    normalized = str(prefix or "").strip().strip("/")
+    scope = resolve_media_scope(
+        connection,
+        normalized,
+        library_types=config.library_type_map,
+    )
+    if scope.domain != "movie":
+        return None
+    parts = Path(normalized).parts
+    title_prefix = normalized if scope.match == "exact_item" and len(parts) == 2 else "/".join(parts[:2])
+    payload = load_movie_library_payload(
+        connection,
+        config,
+        include_details=True,
+        prefixes=[title_prefix],
+    )
+    for title in payload["titles"]:
+        if str(title.get("prefix") or "") == normalized:
+            return title
+        for member in title.get("members", []):
+            if str(member.get("prefix") or "") == normalized:
+                return {
+                    **title,
+                    "active_member_prefix": normalized,
+                    "active_member": member,
+                }
+    return None
+
+
+def movie_promotion_conflicts(
+        config: MediaforceConfig,
+        rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    candidates = [row for row in rows if row.get("staging_path") and row.get("promoted_at") is None]
+    destinations: dict[str, tuple[Path, list[dict[str, Any]]]] = {}
+    for row in candidates:
+        source_path = Path(str(row["source_path"]))
+        destination = source_path.with_suffix(f".{config.output_container.lstrip('.')}")
+        destination_key = filesystem_collision_key(destination)
+        if destination_key not in destinations:
+            destinations[destination_key] = (destination, [])
+        destinations[destination_key][1].append(row)
+
+    conflicts: list[dict[str, Any]] = []
+    for destination, destination_rows in destinations.values():
+        if len(destination_rows) > 1:
+            conflicts.append({
+                "kind": "duplicate_destination",
+                "destination_path": str(destination),
+                "member_prefixes": [str(row["rel_path"]) for row in destination_rows],
+                "detail": "Multiple movie files would promote to the same destination path.",
+            })
+        for row in destination_rows:
+            source_path = Path(str(row["source_path"]))
+            if destination != source_path and destination.exists():
+                conflicts.append({
+                    "kind": "destination_exists",
+                    "destination_path": str(destination),
+                    "member_prefixes": [str(row["rel_path"])],
+                    "detail": "The promotion destination already exists in the movie library.",
+                })
+    return conflicts
+
+
+def _movie_libraries(config: MediaforceConfig) -> list[dict[str, Any]]:
+    production_roots = set(config.source_root_map)
+    libraries: list[dict[str, Any]] = []
+    for definition in config.library_definitions:
+        if str(definition.get("type") or "") != "movie":
+            continue
+        root = str(definition["key"])
+        configured_availability = str(definition.get("availability") or "browse_only")
+        availability = "production" if root in production_roots else configured_availability
+        if availability == "disabled":
+            continue
+        libraries.append({
+            "key": root,
+            "label": str(definition.get("label") or root),
+            "availability": availability,
+            "default_profile": str(definition.get("default_profile") or "movie_balanced"),
+            "policy": object_dict(definition.get("policy")),
+        })
+    return libraries
+
+
+def _title_payload(
+        prefix: str,
+        grouped: list[tuple[dict[str, Any], MovieMembership]],
+        *,
+        library_by_root: dict[str, dict[str, Any]],
+        decisions_by_item: dict[int, Any],
+        eligibility: dict[int, tuple[bool, str | None]],
+        workflow: Any,
+        metrics: dict[str, Any],
+        config: MediaforceConfig,
+        include_details: bool,
+) -> dict[str, Any]:
+    first_membership = grouped[0][1]
+    library = library_by_root[first_membership.root]
+    conflicts = movie_promotion_conflicts(config, [row for row, _ in grouped]) if include_details else []
+    workflow_items = {
+        item.item_id: item.to_payload()
+        for item in (workflow.items if workflow is not None else ())
+    }
+    members = [
+        _member_payload(
+            row,
+            membership,
+            library=library,
+            decision=decisions_by_item.get(int(row["item_id"])),
+            eligibility=eligibility[int(row["item_id"])],
+            workflow_item=workflow_items.get(int(row["item_id"])),
+            conflicts=conflicts,
+            include_details=include_details,
+        )
+        for row, membership in grouped
+    ]
+    role_counts = Counter(str(member["role"]) for member in members)
+    included_members = [member for member in members if member["included_by_default"]]
+    feature_members = [member for member in members if member["role"] == "feature"]
+    ages = [
+        age
+        for member in included_members
+        if isinstance((age := member.get("age")), Mapping) and age.get("timestamp")
+    ]
+    title_age = min(ages, key=lambda age: str(age["timestamp"])) if ages else None
+    projected_reclaim = int(metrics.get("projected_reclaim_bytes") or 0)
+    known_saved = int(metrics.get("known_saved_bytes") or 0)
+    estimated_savings = int(metrics.get("estimated_savings_bytes") or 0)
+    workflow_payload = workflow.to_payload() if workflow is not None else None
+    workflow_payload = adapt_movie_workflow_payload(workflow_payload, library=library, members=members)
+    return {
+        "prefix": prefix,
+        "root": first_membership.root,
+        "library_label": library["label"],
+        "availability": library["availability"],
+        "policy": library["policy"],
+        "title": first_membership.title,
+        "scope_mode": first_membership.scope_mode,
+        "item_count": len(members),
+        "feature_count": role_counts["feature"],
+        "edition_count": len(feature_members),
+        "extra_count": role_counts["extra"],
+        "uncertain_count": role_counts["uncertain"],
+        "included_item_count": len(included_members),
+        "total_size_bytes": sum(int(member["size_bytes"]) for member in members),
+        "included_size_bytes": sum(int(member["size_bytes"]) for member in included_members),
+        "projected_reclaim_bytes": projected_reclaim if include_details else None,
+        "known_saved_bytes": known_saved if include_details else None,
+        "estimated_savings_bytes": estimated_savings if include_details else None,
+        "savings_confidence": (
+            "measured" if known_saved > 0 and estimated_savings == 0
+            else "estimated" if projected_reclaim > 0
+            else "unavailable"
+        ) if include_details else "pending",
+        "age": title_age if include_details else None,
+        "workflow_state": workflow_payload if include_details else None,
+        "review_badge": {
+            "label": metrics.get("review_badge_label"),
+            "tone": metrics.get("review_badge_tone"),
+            "detail": metrics.get("review_badge_detail"),
+        } if include_details else None,
+        "promotion_conflicts": conflicts if include_details else [],
+        "members": members,
+        "details_loading": not include_details,
+    }
+
+
+def _member_payload(
+        row: dict[str, Any],
+        membership: MovieMembership,
+        *,
+        library: dict[str, Any],
+        decision: Any,
+        eligibility: tuple[bool, str | None],
+        workflow_item: dict[str, Any] | None,
+        conflicts: list[dict[str, Any]],
+        include_details: bool,
+) -> dict[str, Any]:
+    included, blocker = _production_inclusion(library, membership)
+    age = decision.age.to_payload() if decision is not None else _row_age(row)
+    member_conflicts = [
+        conflict
+        for conflict in conflicts
+        if membership.rel_path in conflict["member_prefixes"]
+    ]
+    if include_details and workflow_item is None:
+        workflow_item = derive_item_workflow_state(
+            row,
+            encode_eligible=eligibility[0],
+            policy_blocker=eligibility[1],
+        ).to_payload()
+    return {
+        **membership.to_payload(),
+        "item_id": int(row["item_id"]),
+        "status": str(row.get("status") or "unknown"),
+        "size_bytes": max(0, int(row.get("size_bytes") or 0)),
+        "duration_seconds": row.get("duration_seconds"),
+        "video_codec": row.get("video_codec"),
+        "included_by_default": included,
+        "selection_blocker": blocker,
+        "exact_action_available": library["availability"] == "production",
+        "age": age if include_details else None,
+        "workflow_state": workflow_item if include_details else None,
+        "promotion_conflicts": member_conflicts if include_details else [],
+        "details_loading": not include_details,
+    }
+
+
+def _production_inclusion(
+        library: Mapping[str, Any],
+        membership: MovieMembership,
+) -> tuple[bool, str | None]:
+    if str(library.get("availability") or "") != "production":
+        return False, "This movie library is browse only. Change its availability to Production before processing."
+    return movie_item_included(membership, object_dict(library.get("policy")), explicit_exact=False)
+
+
+def adapt_movie_workflow_payload(
+        payload: dict[str, Any] | None,
+        *,
+        library: Mapping[str, Any],
+        members: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    if payload is None:
+        return None
+    if str(library.get("availability") or "") != "production":
+        return {
+            **payload,
+            "state": "browse_only",
+            "primary_lane": "none",
+            "label": "Browse only",
+            "tone": "idle",
+            "detail": "This movie library is visible but production actions are disabled.",
+            "next_action": {
+                "kind": "none",
+                "label": "Browse title",
+                "enabled": False,
+                "target_prefix": payload["prefix"],
+            },
+        }
+    if payload.get("state") == "held":
+        explicit_count = sum(member["role"] in {"extra", "uncertain"} for member in members)
+        return {
+            **payload,
+            "state": "explicit_selection_required",
+            "label": "Explicit selection required",
+            "detail": f"{explicit_count} movie file(s) require an exact-file action.",
+            "next_action": {
+                "kind": "review_scope",
+                "label": "Review title files",
+                "enabled": True,
+                "target_prefix": payload["prefix"],
+            },
+        }
+    return payload
+
+
+def _row_age(row: Mapping[str, Any]) -> dict[str, Any]:
+    plex_added_at = _parse_timestamp(row.get("plex_added_at"))
+    if plex_added_at is not None:
+        return {"timestamp": plex_added_at.isoformat(timespec="seconds"), "source": "plex"}
+    discovered_at = _parse_timestamp(row.get("discovered_at"))
+    if discovered_at is not None:
+        return {"timestamp": discovered_at.isoformat(timespec="seconds"), "source": "mediaforce_discovered"}
+    mtime_ns = int(row.get("mtime_ns") or 0)
+    if mtime_ns > 0:
+        timestamp = datetime.fromtimestamp(mtime_ns / 1_000_000_000, tz=UTC)
+        return {"timestamp": timestamp.isoformat(timespec="seconds"), "source": "filesystem_mtime"}
+    return {"timestamp": None, "source": "unknown"}
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _title_sort_key(title: Mapping[str, Any]) -> tuple[Any, ...]:
+    workflow = object_dict(title.get("workflow_state"))
+    lane_order = {
+        "attention": 0,
+        "processing": 1,
+        "validate": 2,
+        "promote": 3,
+        "encode": 4,
+        "none": 5,
+        "complete": 6,
+    }
+    return (
+        lane_order.get(str(workflow.get("primary_lane") or "none"), 5),
+        str(title.get("title") or "").casefold(),
+        str(title.get("prefix") or ""),
+    )

--- a/mediaforce/library/movie_workflow.py
+++ b/mediaforce/library/movie_workflow.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+import re
+from typing import Any, Literal, Mapping
+
+MovieRole = Literal["feature", "extra", "uncertain"]
+MovieScopeMode = Literal["single_file", "title_folder"]
+
+_EXTRA_DIRECTORIES = {
+    "behindthescenes": "Behind the scenes",
+    "bonus": "Bonus",
+    "bonusfeatures": "Bonus features",
+    "deletedscenes": "Deleted scenes",
+    "extras": "Extras",
+    "featurettes": "Featurettes",
+    "interviews": "Interviews",
+    "samples": "Samples",
+    "shorts": "Shorts",
+    "trailers": "Trailers",
+}
+_EXTRA_NAME_PATTERNS = (
+    (re.compile(r"(?:^|[-_.\s])behind[-_.\s]*the[-_.\s]*scenes?$", re.IGNORECASE), "Behind the scenes"),
+    (re.compile(r"(?:^|[-_.\s])bonus(?:[-_.\s]*features?)?$", re.IGNORECASE), "Bonus features"),
+    (re.compile(r"(?:^|[-_.\s])deleted[-_.\s]*scenes?$", re.IGNORECASE), "Deleted scenes"),
+    (re.compile(r"(?:^|[-_.\s])featurettes?$", re.IGNORECASE), "Featurettes"),
+    (re.compile(r"(?:^|[-_.\s])interviews?$", re.IGNORECASE), "Interviews"),
+    (re.compile(r"(?:^|[-_.\s])samples?$", re.IGNORECASE), "Samples"),
+    (re.compile(r"(?:^|[-_.\s])shorts?$", re.IGNORECASE), "Shorts"),
+    (re.compile(r"(?:^|[-_.\s])trailers?$", re.IGNORECASE), "Trailers"),
+)
+_EDITION_PATTERNS = (
+    (re.compile(r"\bdirector'?s\s+cut\b", re.IGNORECASE), "Director's Cut"),
+    (re.compile(r"\btheatrical(?:\s+cut)?\b", re.IGNORECASE), "Theatrical Cut"),
+    (re.compile(r"\bextended(?:\s+cut|\s+edition)?\b", re.IGNORECASE), "Extended Edition"),
+    (re.compile(r"\bfinal\s+cut\b", re.IGNORECASE), "Final Cut"),
+    (re.compile(r"\bunrated\b", re.IGNORECASE), "Unrated Edition"),
+    (re.compile(r"\bspecial\s+edition\b", re.IGNORECASE), "Special Edition"),
+    (re.compile(r"\bremaster(?:ed)?\b", re.IGNORECASE), "Remastered"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MovieMembership:
+    rel_path: str
+    root: str
+    title_prefix: str
+    title: str
+    scope_mode: MovieScopeMode
+    role: MovieRole
+    label: str
+    edition_label: str | None = None
+    extra_category: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "rel_path": self.rel_path,
+            "prefix": self.rel_path,
+            "root": self.root,
+            "title_prefix": self.title_prefix,
+            "title": self.title,
+            "scope_mode": self.scope_mode,
+            "role": self.role,
+            "label": self.label,
+            "edition_label": self.edition_label,
+            "extra_category": self.extra_category,
+        }
+
+
+def classify_movie_path(rel_path: str, *, root: str) -> MovieMembership | None:
+    normalized = str(rel_path or "").strip().strip("/")
+    parts = PurePosixPath(normalized).parts
+    if len(parts) < 2 or parts[0] != root:
+        return None
+    file_name = parts[-1]
+    file_label = PurePosixPath(file_name).stem or file_name
+    if len(parts) == 2:
+        return MovieMembership(
+            rel_path=normalized,
+            root=root,
+            title_prefix=normalized,
+            title=file_label,
+            scope_mode="single_file",
+            role="feature",
+            label=file_label,
+            edition_label=infer_edition_label(file_label),
+        )
+
+    title = parts[1]
+    title_prefix = "/".join(parts[:2])
+    relative_parts = parts[2:]
+    for directory in relative_parts[:-1]:
+        category = _EXTRA_DIRECTORIES.get(_normalized_token(directory))
+        if category:
+            return MovieMembership(
+                rel_path=normalized,
+                root=root,
+                title_prefix=title_prefix,
+                title=title,
+                scope_mode="title_folder",
+                role="extra",
+                label=file_label,
+                extra_category=category,
+            )
+    extra_category = infer_extra_category(file_label)
+    if extra_category is not None:
+        return MovieMembership(
+            rel_path=normalized,
+            root=root,
+            title_prefix=title_prefix,
+            title=title,
+            scope_mode="title_folder",
+            role="extra",
+            label=file_label,
+            extra_category=extra_category,
+        )
+    if len(relative_parts) == 1:
+        return MovieMembership(
+            rel_path=normalized,
+            root=root,
+            title_prefix=title_prefix,
+            title=title,
+            scope_mode="title_folder",
+            role="feature",
+            label=file_label,
+            edition_label=infer_edition_label(file_label),
+        )
+    return MovieMembership(
+        rel_path=normalized,
+        root=root,
+        title_prefix=title_prefix,
+        title=title,
+        scope_mode="title_folder",
+        role="uncertain",
+        label=file_label,
+    )
+
+
+def movie_item_included(
+        membership: MovieMembership,
+        policy: Mapping[str, Any],
+        *,
+        explicit_exact: bool,
+) -> tuple[bool, str | None]:
+    if explicit_exact or membership.role == "feature":
+        return True, None
+    if membership.role == "extra" and str(policy.get("extras") or "exclude") == "include":
+        return True, None
+    if membership.role == "extra":
+        return False, "Extras are excluded from title-wide processing by this movie library policy."
+    return False, "This nested movie file needs an explicit exact-file action before processing."
+
+
+def infer_edition_label(value: str) -> str | None:
+    tagged = re.search(r"\{edition[-_: ]+([^}]+)\}", value, re.IGNORECASE)
+    if tagged is not None:
+        label = tagged.group(1).strip(" -_:")
+        if label:
+            return label
+    for pattern, label in _EDITION_PATTERNS:
+        if pattern.search(value):
+            return label
+    return None
+
+
+def infer_extra_category(value: str) -> str | None:
+    for pattern, category in _EXTRA_NAME_PATTERNS:
+        if pattern.search(value):
+            return category
+    return None
+
+
+def _normalized_token(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())

--- a/mediaforce/library/representatives.py
+++ b/mediaforce/library/representatives.py
@@ -15,6 +15,7 @@ from mediaforce.core.db_tables import library_items
 from mediaforce.core.evidence import build_evidence_envelope, stable_policy_hash, stable_source_id
 from mediaforce.core.type_defs import mapping_dict, object_dict, object_list
 from mediaforce.library.media_scopes import resolve_media_scope, scope_rel_path_filter
+from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
 from mediaforce.library.planner import build_manifest_item
 
 REPRESENTATIVE_SELECTION_TOOL = "mediaforce.representative_selection"
@@ -121,7 +122,7 @@ def load_representative_selection(
         config: MediaforceConfig,
         prefix: str,
 ) -> RepresentativeSelection | None:
-    scope = resolve_media_scope(connection, prefix)
+    scope = resolve_media_scope(connection, prefix, library_types=config.library_type_map)
     rows = connection.execute(
         select(library_items)
         .where(scope_rel_path_filter(library_items.c.rel_path, scope))
@@ -129,6 +130,21 @@ def load_representative_selection(
     ).mappings().fetchall()
     if not rows:
         return None
+
+    library = config.library_definition_map.get(scope.root, {})
+    if str(library.get("type") or "") == "movie":
+        policy = library.get("policy") if isinstance(library.get("policy"), dict) else {}
+        explicit_exact = scope.match == "exact_item"
+        rows = [
+            row
+            for row in rows
+            if (
+                membership := classify_movie_path(str(row["rel_path"]), root=scope.root)
+            ) is not None
+            and movie_item_included(membership, policy, explicit_exact=explicit_exact)[0]
+        ]
+        if not rows:
+            return None
 
     preferred_rows = [row for row in rows if str(row.get("status") or "") in _PREFERRED_SAMPLE_STATUSES]
     candidate_rows = preferred_rows or list(rows)

--- a/mediaforce/library/run_manifests.py
+++ b/mediaforce/library/run_manifests.py
@@ -118,7 +118,7 @@ def select_candidates(
         .where(library_items.c.status.in_(statuses))
     )
     if prefixes:
-        scopes = resolve_media_scopes(connection, prefixes)
+        scopes = resolve_media_scopes(connection, prefixes, library_types=config.library_type_map)
         query = query.where(or_(*(scope_rel_path_filter(library_items.c.rel_path, scope) for scope in scopes)))
     query = query.order_by(library_items.c.priority_score.desc(), library_items.c.size_bytes.desc())
     if limit is not None:
@@ -243,7 +243,7 @@ def create_folder_manifest(
 ) -> tuple[dict[str, Any], Path]:
     if scan_first:
         scan_library(connection, config, prefixes=[prefix])
-    scope = resolve_media_scope(connection, prefix)
+    scope = resolve_media_scope(connection, prefix, library_types=config.library_type_map)
     rows = select_encode_candidates(
         connection,
         config,

--- a/mediaforce/library/scanner.py
+++ b/mediaforce/library/scanner.py
@@ -29,7 +29,7 @@ from mediaforce.encoding.fingerprint import (
     MEDIA_FINGERPRINT_TOOL_VERSION,
     unavailable_media_fingerprint_summary,
 )
-from mediaforce.library.media_scopes import path_matches_scope
+from mediaforce.library.media_scopes import logical_library_rel_path, path_matches_scope
 from mediaforce.library.planner import recommend_item
 from mediaforce.library.probe import probe_media
 from mediaforce.core.type_defs import int_value, object_list
@@ -75,9 +75,12 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
     pending_writes = 0
 
     for root_name, root_path in scan_source_roots.items():
-        for file_path in _iter_media_files(root_path, prefixes=normalized_prefixes or None, limit=limit,
+        for file_path in _iter_media_files(root_name, root_path, prefixes=normalized_prefixes or None, limit=limit,
                                            seen=stats.total_seen):
             source_path = str(file_path)
+            logical_path = logical_library_rel_path(root_name, root_path, file_path)
+            rel_path = logical_path.as_posix()
+            parent_dir = logical_path.parent.as_posix()
             seen_paths.add(source_path)
             stats.total_seen += 1
 
@@ -109,6 +112,9 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
                         last_scan_id=scan_id,
                         last_seen_at=started_at,
                         updated_at=started_at,
+                        rel_path=rel_path,
+                        media_root=root_name,
+                        parent_dir=parent_dir,
                         content_version_changed_at=case(
                             (library_items.c.status == "missing", started_at),
                             else_=library_items.c.content_version_changed_at,
@@ -129,8 +135,6 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
                 probe = _failed_probe_summary(exc)
             fingerprint = file_fingerprint(file_path=file_path, stat_result=stat_result,
                                            duration_seconds=probe.duration_seconds)
-            rel_path = str(file_path.relative_to(root_path.parent))
-            parent_dir = str(file_path.parent.relative_to(root_path.parent))
             recommendation = recommend_item(
                 {
                     "rel_path": rel_path,
@@ -375,7 +379,11 @@ def _failed_probe_summary(error: Exception) -> ProbeSummary:
 
 
 def _iter_media_files(
-        root_path: Path, prefixes: list[str] | None, limit: int | None, seen: int
+        root_name: str,
+        root_path: Path,
+        prefixes: list[str] | None,
+        limit: int | None,
+        seen: int,
 ) -> Iterator[Path]:
     matched = 0
     for dirpath, _, filenames in os.walk(root_path):
@@ -383,7 +391,7 @@ def _iter_media_files(
             file_path = Path(dirpath, name)
             if file_path.suffix.lower() not in VIDEO_EXTENSIONS:
                 continue
-            rel_path = str(file_path.relative_to(root_path.parent))
+            rel_path = logical_library_rel_path(root_name, root_path, file_path).as_posix()
             if prefixes and not any(path_matches_scope(rel_path, prefix) for prefix in prefixes):
                 continue
             yield file_path

--- a/mediaforce/library/workflow_state.py
+++ b/mediaforce/library/workflow_state.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, Mapping
 
 from sqlalchemy import or_, select
 
@@ -127,8 +127,9 @@ def build_folder_workflow_state(
         prefix: str,
         *,
         candidate_eligibility: dict[int, tuple[bool, str | None]] | None = None,
+        library_types: Mapping[str, str] | None = None,
 ) -> FolderWorkflowState:
-    scope = resolve_media_scope(connection, prefix)
+    scope = resolve_media_scope(connection, prefix, library_types=library_types)
     item_states = tuple(
         derive_item_workflow_state(
             row,
@@ -146,11 +147,12 @@ def build_folder_workflow_states(
         prefixes: list[str],
         *,
         candidate_eligibility: dict[int, tuple[bool, str | None]] | None = None,
+        library_types: Mapping[str, str] | None = None,
 ) -> dict[str, FolderWorkflowState]:
     normalized_prefixes = list(dict.fromkeys(normalize_prefix(prefix) for prefix in prefixes))
     if not normalized_prefixes:
         return {}
-    scopes = resolve_media_scopes(connection, normalized_prefixes)
+    scopes = resolve_media_scopes(connection, normalized_prefixes, library_types=library_types)
     rows = _load_item_rows_for_scopes(connection, scopes)
     job_states = _load_encode_job_states(connection, scopes)
     result: dict[str, FolderWorkflowState] = {}
@@ -198,6 +200,10 @@ def derive_item_workflow_state(
     elif status == "encoding":
         state = "encoding"
         lane = "processing"
+    elif not encode_eligible:
+        state = "held"
+        lane = "none"
+        blocker = policy_blocker or "This item is excluded from the current production scope."
     elif has_staged_output and status == "encoded":
         state = "ready_to_validate"
         lane = "validate"
@@ -209,13 +215,8 @@ def derive_item_workflow_state(
         lane = "blocked"
         blocker = "Encoded item is missing its staged output."
     elif status in ENCODE_CANDIDATE_STATUSES:
-        if encode_eligible:
-            state = "encode_candidate"
-            lane = "encode"
-        else:
-            state = "held"
-            lane = "none"
-            blocker = policy_blocker or "Library lifecycle policy is holding this item."
+        state = "encode_candidate"
+        lane = "encode"
     else:
         state = "idle"
         lane = "none"

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -7,7 +7,7 @@ import re
 import shutil
 import subprocess
 import threading
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import asdict, dataclass
@@ -60,14 +60,16 @@ from mediaforce.execution import (
     validate_manifest_items,
 )
 from mediaforce.library.folder_profiles import inspect_prefix
-from mediaforce.library.media_scopes import is_tv_series_prefix, media_group_scope_for_rel_path, resolve_media_scope, \
-    resolve_media_scopes, scope_rel_path_filter, series_context_for_prefix, tv_series_scope_for_rel_path
+from mediaforce.library.media_scopes import media_group_scope_for_rel_path, resolve_media_scope, resolve_media_scopes, \
+    scope_rel_path_filter, series_context_for_prefix, tv_series_scope_for_rel_path
+from mediaforce.library.movie_library import load_movie_library_payload, load_movie_scope_payload
+from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
 from mediaforce.library.planner import build_manifest_item
 from mediaforce.library.representatives import RepresentativeSelection, load_representative_selection, \
     public_representative_item
 from mediaforce.library.run_manifests import select_encode_candidates
-from mediaforce.library.candidate_selection import encode_candidate_decisions, scope_lifecycle_payload_from_decisions, \
-    workflow_eligibility
+from mediaforce.library.candidate_selection import encode_candidate_decisions, project_candidates, \
+    scope_lifecycle_payload_from_decisions, workflow_eligibility
 from mediaforce.hosts.types import HostSetupResult
 from mediaforce.hosts.config import configured_remote_host_execution_mode
 from mediaforce.core.process_control import ManagedProcessController
@@ -128,7 +130,7 @@ from mediaforce.web.runtime import FolderCard, cached_folder_cards, dashboard_fo
     validate_folder_outputs_action, \
     build_multimodal_review_pack, build_tuning_runtime_toolbelt, load_latest_failed_sample_job_state, \
     load_latest_failed_target_size_job_state, load_retryable_sample_job_state
-from mediaforce.web.runtime.folder_actions import ActionPayload, FolderItem
+from mediaforce.web.runtime.folder_actions import ActionPayload, FolderItem, production_action_blocker
 from mediaforce.web.runtime.folder_cards import list_folder_cards
 from mediaforce.library.workflow_state import build_folder_workflow_state
 from mediaforce.web.runtime.calibration_runtime import CalibrationRunDeps, \
@@ -529,6 +531,32 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             include_series_folders=False,
         )
 
+    def _dashboard_movie_library_payload() -> dict[str, Any]:
+        with open_db(config.paths.db_path) as connection:
+            return load_movie_library_payload(
+                connection,
+                config,
+                include_details=False,
+            )
+
+    def _dashboard_movie_library_details_payload() -> dict[str, Any]:
+        with open_db(config.paths.db_path) as connection:
+            cards = _folder_cards_for_group(
+                config,
+                connection,
+                folder_group=lambda rel_path: _movie_folder_group(
+                    rel_path,
+                    library_types=config.library_type_map,
+                ),
+                minimum_recommended_savings_bytes=None,
+            )
+            return load_movie_library_payload(
+                connection,
+                config,
+                include_details=True,
+                metrics_by_prefix={card.prefix: asdict(card) for card in cards},
+            )
+
     def _dashboard_api_payload(preview_limit: int | None = None) -> dict[str, Any]:
         metric_support = _metric_support()
         return {
@@ -694,6 +722,8 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         dashboard_folders_payload=_dashboard_folders_payload,
         dashboard_library_payload=_dashboard_library_payload,
         dashboard_library_details_payload=_dashboard_library_details_payload,
+        dashboard_movie_library_payload=_dashboard_movie_library_payload,
+        dashboard_movie_library_details_payload=_dashboard_movie_library_details_payload,
     )
     register_settings_routes(
         app,
@@ -726,7 +756,16 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     def _folder_content_payload(normalized_prefix: str) -> tuple[dict[str, Any], int]:
         latest_failed_sample_job_payload: dict[str, Any] | None = None
         with open_db(config.paths.db_path) as connection:
-            media_scope = resolve_media_scope(connection, normalized_prefix)
+            media_scope = resolve_media_scope(
+                connection,
+                normalized_prefix,
+                library_types=config.library_type_map,
+            )
+            movie_context = (
+                load_movie_scope_payload(connection, config, normalized_prefix)
+                if media_scope.domain == "movie"
+                else None
+            )
             calibration_job = _load_job_state(connection, config, normalized_prefix)
             if calibration_job and calibration_job.get("status") in {"queued", "running"}:
                 existing_scan_job = _load_scan_job_state(config, normalized_prefix)
@@ -741,6 +780,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             base_context: dict[str, Any] = {
                 "prefix": normalized_prefix,
                 "media_scope": media_scope.to_payload(),
+                "movie_context": movie_context,
                 "calibration_job": calibration_job,
                 "folder_scan_job": folder_scan_job,
                 "metric_support": metric_support,
@@ -766,9 +806,10 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             pending_proposal = _pending_proposal_public_view(pending_proposal_raw)
             calibration = _load_calibration_state(config, normalized_prefix)
             recent_sessions = _recent_tuning_sessions(connection, normalized_prefix)
-            approved_season_shortcut = sibling_approved_season_memory(
-                connection,
-                prefix=normalized_prefix,
+            approved_season_shortcut = (
+                sibling_approved_season_memory(connection, prefix=normalized_prefix)
+                if media_scope.domain == "tv"
+                else None
             )
             review_gate = _review_gate(calibration)
             hot_spots = _preview_hotspots(sample_item, calibration)
@@ -785,19 +826,28 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             scheduler_policy = object_dict(encode_queue_state.get("scheduler"))
             encode_job = _decorate_encode_job_for_scheduler(config, encode_job)
             encode_queue_summary = _encode_queue_summary_copy(encode_queue, encode_queue_state, encode_job)
-            lifecycle_decisions = encode_candidate_decisions(
-                connection,
-                config,
-                prefixes=[normalized_prefix],
+            lifecycle_decisions = (
+                project_candidates(connection, config, prefixes=[normalized_prefix])
+                if media_scope.domain == "movie"
+                else encode_candidate_decisions(connection, config, prefixes=[normalized_prefix])
             )
-            lifecycle = scope_lifecycle_payload_from_decisions(normalized_prefix, lifecycle_decisions)
-            encode_candidate_count = int(lifecycle.get("eligible_candidate_count") or 0)
+            lifecycle = (
+                scope_lifecycle_payload_from_decisions(normalized_prefix, lifecycle_decisions)
+                if media_scope.domain == "tv"
+                else None
+            )
+            encode_candidate_count = sum(decision.eligible for decision in lifecycle_decisions)
             workflow_state = build_folder_workflow_state(
                 connection,
                 normalized_prefix,
                 candidate_eligibility=workflow_eligibility(lifecycle_decisions),
+                library_types=config.library_type_map,
             ).to_payload()
-            series_context = _folder_series_context(normalized_prefix)
+            series_context = (
+                _folder_series_context(normalized_prefix, library_types=config.library_type_map)
+                if media_scope.domain == "tv"
+                else None
+            )
             latest_failed_sample_job_payload = object_dict(
                 _load_latest_failed_sample_job_state(connection, config, normalized_prefix)
             ) or None
@@ -924,7 +974,10 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             return completed_page_payload(
                 config,
                 connection,
-                folder_group=_folder_group,
+                folder_group=lambda rel_path: _folder_group(
+                    rel_path,
+                    library_types=config.library_type_map,
+                ),
             )
 
     def _clear_completed_backups_action(prefixes: list[str] | None) -> dict[str, Any]:
@@ -935,13 +988,19 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         with open_db(config.paths.db_path) as connection:
             folders = list_completed_folders(
                 connection,
-                folder_group=_folder_group,
+                folder_group=lambda rel_path: _folder_group(
+                    rel_path,
+                    library_types=config.library_type_map,
+                ),
                 archive_root=archive_root,
             )
         valid_prefixes = {folder.prefix for folder in folders}
         result = clear_completed_backups_action(
             config,
-            folder_group=_folder_group,
+            folder_group=lambda rel_path: _folder_group(
+                rel_path,
+                library_types=config.library_type_map,
+            ),
             prefixes=prefixes,
             valid_prefixes=valid_prefixes,
         )
@@ -956,13 +1015,19 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         with open_db(config.paths.db_path) as connection:
             folders = list_completed_folders(
                 connection,
-                folder_group=_folder_group,
+                folder_group=lambda rel_path: _folder_group(
+                    rel_path,
+                    library_types=config.library_type_map,
+                ),
                 archive_root=archive_root,
             )
             valid_prefixes = {folder.prefix for folder in folders}
             result = confirm_originals_removed_action(
                 connection,
-                folder_group=_folder_group,
+                folder_group=lambda rel_path: _folder_group(
+                    rel_path,
+                    library_types=config.library_type_map,
+                ),
                 archive_root=archive_root,
                 prefixes=prefixes,
                 valid_prefixes=valid_prefixes,
@@ -1059,6 +1124,9 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             host_key: str,
             operator_intent: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        blocker = production_action_blocker(config, normalized_prefix)
+        if blocker is not None:
+            return blocker
         return folder_ai_tune_preview_action(
             config,
             _folder_ai_tune_deps(),
@@ -1074,6 +1142,9 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             host_key: str,
             operator_intent: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
+        blocker = production_action_blocker(config, normalized_prefix)
+        if blocker is not None:
+            return blocker
         return folder_ai_tune_action(
             config,
             _folder_ai_tune_deps(),
@@ -1084,6 +1155,9 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         )
 
     def _folder_ai_tune_confirm_action(normalized_prefix: str, proposal_id: str) -> dict[str, Any]:
+        blocker = production_action_blocker(config, normalized_prefix)
+        if blocker is not None:
+            return blocker
         return folder_ai_tune_confirm_action(
             config,
             _folder_ai_tune_deps(),
@@ -1121,6 +1195,9 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         )
 
     def _approve_measured_encode_recovery_action(normalized_prefix: str) -> ActionPayload:
+        blocker = production_action_blocker(config, normalized_prefix)
+        if blocker is not None:
+            return blocker
         return approve_measured_encode_recovery_action(
             config,
             normalized_prefix,
@@ -1238,7 +1315,13 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     def _save_series_lifecycle_action(normalized_prefix: str, mode: str) -> dict[str, Any]:
         nonlocal config
         normalized_mode = mode.strip().lower()
-        if not is_tv_series_prefix(normalized_prefix):
+        with open_db(config.paths.db_path) as connection:
+            media_scope = resolve_media_scope(
+                connection,
+                normalized_prefix,
+                library_types=config.library_type_map,
+            )
+        if media_scope.domain != "tv" or media_scope.kind != "tv_series":
             raise HTTPException(status_code=400, detail="Lifecycle mode can only be set for one TV series.")
         if normalized_mode not in {"auto", "on", "off"}:
             raise HTTPException(status_code=400, detail="Lifecycle mode must be auto, on, or off.")
@@ -1837,7 +1920,7 @@ def _list_library_structure_cards(config: MediaforceConfig, connection: DBClient
     cards = list_library_structure_cards(
         connection,
         config=config,
-        folder_group=_folder_group,
+        folder_group=lambda rel_path: _folder_group(rel_path, library_types=config.library_type_map),
         review_badge_for_prefix=lambda prefix: _folder_review_badge(
             config,
             prefix,
@@ -1845,16 +1928,19 @@ def _list_library_structure_cards(config: MediaforceConfig, connection: DBClient
             calibration_job_badges=calibration_job_badges,
         ),
     )
-    return _attach_media_scopes(connection, cards)
+    return _attach_media_scopes(connection, config, cards)
 
 
 def _list_library_detail_cards(config: MediaforceConfig, connection: DBClient) -> list[FolderCard]:
     return _folder_cards_for_group(
         config,
         connection,
-        folder_group=_tv_season_folder_group,
+        folder_group=lambda rel_path: _tv_season_folder_group(
+            rel_path,
+            library_types=config.library_type_map,
+        ),
         minimum_recommended_savings_bytes=None,
-        rel_path_root="tv/",
+        media_roots={root for root, library_type in config.library_type_map.items() if library_type == "tv"},
     )
 
 
@@ -1879,21 +1965,24 @@ def _list_folder_cards(config: MediaforceConfig, connection: DBClient) -> list[F
         config,
         connection,
         minimum_recommended_savings_bytes=MIN_RECOMMENDED_SAVINGS_BYTES,
-        folder_group=_folder_group,
+        folder_group=lambda rel_path: _folder_group(rel_path, library_types=config.library_type_map),
         age_days=_age_days,
         estimate_savings_bytes=_estimate_savings_bytes,
         review_badge_for_prefix=review_badge_for_prefix,
     )
-    return _attach_media_scopes(connection, cards)
+    return _attach_media_scopes(connection, config, cards)
 
 
 def _list_series_folder_cards(config: MediaforceConfig, connection: DBClient) -> list[FolderCard]:
     return _folder_cards_for_group(
         config,
         connection,
-        folder_group=_tv_series_folder_group,
+        folder_group=lambda rel_path: _tv_series_folder_group(
+            rel_path,
+            library_types=config.library_type_map,
+        ),
         aggregate_badges=True,
-        rel_path_root="tv/",
+        media_roots={root for root, library_type in config.library_type_map.items() if library_type == "tv"},
     )
 
 
@@ -1905,6 +1994,7 @@ def _folder_cards_for_group(
         aggregate_badges: bool = False,
         minimum_recommended_savings_bytes: int | None = MIN_RECOMMENDED_SAVINGS_BYTES,
         rel_path_root: str | None = None,
+        media_roots: set[str] | None = None,
 ) -> list[FolderCard]:
     needs_attention_badges: dict[str, dict[str, str | None]] | None = None
     calibration_job_badges: dict[str, dict[str, str | None]] | None = None
@@ -1939,8 +2029,9 @@ def _folder_cards_for_group(
         estimate_savings_bytes=_estimate_savings_bytes,
         review_badge_for_prefix=review_badge_for_prefix,
         rel_path_root=rel_path_root,
+        media_roots=media_roots,
     )
-    return _attach_media_scopes(connection, cards)
+    return _attach_media_scopes(connection, config, cards)
 
 
 def _preview_folder_cards(config: MediaforceConfig, connection: DBClient) -> list[FolderCard]:
@@ -1950,7 +2041,7 @@ def _preview_folder_cards(config: MediaforceConfig, connection: DBClient) -> lis
         connection,
         config=config,
         minimum_recommended_savings_bytes=MIN_RECOMMENDED_SAVINGS_BYTES,
-        folder_group=_folder_group,
+        folder_group=lambda rel_path: _folder_group(rel_path, library_types=config.library_type_map),
         estimate_savings_bytes=_estimate_savings_bytes,
         review_badge_for_prefix=lambda prefix: _folder_review_badge(
             config,
@@ -1959,11 +2050,19 @@ def _preview_folder_cards(config: MediaforceConfig, connection: DBClient) -> lis
             calibration_job_badges=calibration_job_badges,
         ),
     )
-    return _attach_media_scopes(connection, cards)
+    return _attach_media_scopes(connection, config, cards)
 
 
-def _attach_media_scopes(connection: DBClient, cards: list[FolderCard]) -> list[FolderCard]:
-    scopes = resolve_media_scopes(connection, [card.prefix for card in cards])
+def _attach_media_scopes(
+        connection: DBClient,
+        config: MediaforceConfig,
+        cards: list[FolderCard],
+) -> list[FolderCard]:
+    scopes = resolve_media_scopes(
+        connection,
+        [card.prefix for card in cards],
+        library_types=config.library_type_map,
+    )
     for card, scope in zip(cards, scopes, strict=True):
         card.media_scope = scope.to_payload()
     return cards
@@ -2325,7 +2424,11 @@ def _load_folder_staged_items(
     normalized_prefix = normalized_prefix.strip().strip("/")
     if not normalized_prefix or not statuses:
         return []
-    scope = resolve_media_scope(connection, normalized_prefix)
+    scope = resolve_media_scope(
+        connection,
+        normalized_prefix,
+        library_types=config.library_type_map,
+    )
     rows = connection.execute(
         select(library_items)
         .join(staged_artifacts, staged_artifacts.c.library_item_id == library_items.c.id)
@@ -2337,6 +2440,16 @@ def _load_folder_staged_items(
     ).mappings().fetchall()
     items: list[FolderItem] = []
     for row in rows:
+        if scope.domain == "movie":
+            membership = classify_movie_path(str(row["rel_path"]), root=scope.root)
+            library = config.library_definition_map.get(scope.root, {})
+            policy = object_dict(library.get("policy"))
+            if membership is None or not movie_item_included(
+                    membership,
+                    policy,
+                    explicit_exact=scope.match == "exact_item",
+            )[0]:
+                continue
         item = build_manifest_item(mapping_dict(row), config)
         item["staging_host_label"] = str(row.get("encode_host_label") or "").strip() or None
         item["staging_host_key"] = str(row.get("encode_host_key") or "").strip() or None
@@ -2928,25 +3041,52 @@ def _preview_hotspots(sample_item: dict[str, Any], calibration: dict[str, Any] |
     return [round(usable * ratio, 3) for ratio in (0.2, 0.5, 0.8)]
 
 
-def _folder_group(rel_path: str) -> tuple[str, str, str, str] | None:
-    scope = media_group_scope_for_rel_path(rel_path)
+def _folder_group(
+        rel_path: str,
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> tuple[str, str, str, str] | None:
+    scope = media_group_scope_for_rel_path(rel_path, library_types=library_types)
     return scope.group_tuple() if scope is not None else None
 
 
-def _tv_series_folder_group(rel_path: str) -> tuple[str, str, str, str] | None:
-    scope = tv_series_scope_for_rel_path(rel_path)
+def _movie_folder_group(
+        rel_path: str,
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> tuple[str, str, str, str] | None:
+    scope = media_group_scope_for_rel_path(rel_path, library_types=library_types)
+    if scope is None or scope.domain != "movie":
+        return None
+    return scope.group_tuple()
+
+
+def _tv_series_folder_group(
+        rel_path: str,
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> tuple[str, str, str, str] | None:
+    scope = tv_series_scope_for_rel_path(rel_path, library_types=library_types)
     return scope.group_tuple() if scope is not None else None
 
 
-def _tv_season_folder_group(rel_path: str) -> tuple[str, str, str, str] | None:
-    scope = media_group_scope_for_rel_path(rel_path)
+def _tv_season_folder_group(
+        rel_path: str,
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> tuple[str, str, str, str] | None:
+    scope = media_group_scope_for_rel_path(rel_path, library_types=library_types)
     if scope is None or scope.kind != "tv_season":
         return None
     return scope.group_tuple()
 
 
-def _folder_series_context(prefix: str) -> dict[str, str] | None:
-    return series_context_for_prefix(prefix)
+def _folder_series_context(
+        prefix: str,
+        *,
+        library_types: Mapping[str, str] | None = None,
+) -> dict[str, str] | None:
+    return series_context_for_prefix(prefix, library_types=library_types)
 
 
 def _folder_encode_candidate_count(connection: DBClient, config: MediaforceConfig, prefix: str) -> int:

--- a/mediaforce/web/routes/dashboard.py
+++ b/mediaforce/web/routes/dashboard.py
@@ -14,6 +14,8 @@ def register_dashboard_routes(
         dashboard_folders_payload: Callable[[bool], dict[str, Any]],
         dashboard_library_payload: Callable[[], dict[str, Any]],
         dashboard_library_details_payload: Callable[[], dict[str, Any]],
+        dashboard_movie_library_payload: Callable[[], dict[str, Any]],
+        dashboard_movie_library_details_payload: Callable[[], dict[str, Any]],
 ) -> None:
     @app.get("/api/dashboard")
     def api_dashboard(preview_limit: PreviewLimit = None) -> JSONResponse:
@@ -30,3 +32,11 @@ def register_dashboard_routes(
     @app.get("/api/dashboard/library/details")
     def api_dashboard_library_details() -> JSONResponse:
         return JSONResponse(dashboard_library_details_payload())
+
+    @app.get("/api/dashboard/library/movies")
+    def api_dashboard_movie_library() -> JSONResponse:
+        return JSONResponse(dashboard_movie_library_payload())
+
+    @app.get("/api/dashboard/library/movies/details")
+    def api_dashboard_movie_library_details() -> JSONResponse:
+        return JSONResponse(dashboard_movie_library_details_payload())

--- a/mediaforce/web/routes/folders.py
+++ b/mediaforce/web/routes/folders.py
@@ -124,11 +124,10 @@ def register_folder_routes(
             body = await request.json()
         except Exception:
             body = {}
-        return JSONResponse(
-            save_profile_action(
-                prefix.strip("/"),
-                bool(body.get("confirm_high_impact", False)),
-                bool(body.get("confirm_size_tradeoff", False)),
-                str(body.get("reviewed_draft_hash", "")),
-            )
+        result = save_profile_action(
+            prefix.strip("/"),
+            bool(body.get("confirm_high_impact", False)),
+            bool(body.get("confirm_size_tradeoff", False)),
+            str(body.get("reviewed_draft_hash", "")),
         )
+        return JSONResponse(result, status_code=200 if result.get("ok") else 409)

--- a/mediaforce/web/runtime/dashboard_payloads.py
+++ b/mediaforce/web/runtime/dashboard_payloads.py
@@ -9,8 +9,9 @@ from mediaforce.core.db import open_db
 from mediaforce.core.db_tables import library_items
 from mediaforce.encoding.encode_queue import summarize_encode_queue
 from mediaforce.library.media_scopes import resolve_media_scope
+from mediaforce.library.movie_library import adapt_movie_workflow_payload, load_movie_scope_payload
 from mediaforce.library.workflow_state import build_folder_workflow_state
-from mediaforce.library.candidate_selection import encode_candidate_decisions, workflow_eligibility
+from mediaforce.library.candidate_selection import encode_candidate_decisions, project_candidates, workflow_eligibility
 
 
 def dashboard_summary_payload(
@@ -105,21 +106,37 @@ def folder_status_payload(
         load_active_encode_job_for_prefix: Any,
 ) -> dict[str, Any]:
     with open_db(config.paths.db_path) as connection:
-        media_scope = resolve_media_scope(connection, normalized_prefix)
+        media_scope = resolve_media_scope(
+            connection,
+            normalized_prefix,
+            library_types=config.library_type_map,
+        )
         calibration_job = load_job_state(connection, config, normalized_prefix)
         retryable_sample_job = load_retryable_sample_job_state(connection, config, normalized_prefix)
         active_encode_job = load_active_encode_job_for_prefix(connection, normalized_prefix)
         folder_scan_job = load_scan_job_state(config, normalized_prefix)
-        lifecycle_decisions = encode_candidate_decisions(
-            connection,
-            config,
-            prefixes=[normalized_prefix],
+        lifecycle_decisions = (
+            project_candidates(connection, config, prefixes=[normalized_prefix])
+            if media_scope.domain == "movie"
+            else encode_candidate_decisions(connection, config, prefixes=[normalized_prefix])
         )
         workflow_state = build_folder_workflow_state(
             connection,
             normalized_prefix,
             candidate_eligibility=workflow_eligibility(lifecycle_decisions),
+            library_types=config.library_type_map,
         ).to_payload()
+        if media_scope.domain == "movie":
+            movie_context = load_movie_scope_payload(connection, config, normalized_prefix)
+            if movie_context is not None:
+                library = {
+                    "availability": movie_context.get("availability"),
+                }
+                workflow_state = adapt_movie_workflow_payload(
+                    workflow_state,
+                    library=library,
+                    members=list(movie_context.get("members") or []),
+                ) or workflow_state
     polling_active = bool(
         (calibration_job and calibration_job.get("status") in {"queued", "running"})
         or (active_encode_job and active_encode_job.get("status") in {"queued", "retry_backoff", "running"})

--- a/mediaforce/web/runtime/folder_actions.py
+++ b/mediaforce/web/runtime/folder_actions.py
@@ -14,11 +14,13 @@ from mediaforce.core.config import MediaforceConfig, load_config
 from mediaforce.core.db import DBClient, open_db
 from mediaforce.core.db_tables import encode_jobs, library_items, staged_artifacts
 from mediaforce.core.type_defs import float_value, object_dict, object_list
+from mediaforce.core.utils import filesystem_collision_key
 from mediaforce.encoding.encode_queue import ACTIVE_ENCODE_JOB_STATUSES, list_child_encode_jobs, \
     load_latest_terminal_encode_job_for_prefix
 from mediaforce.encoding.staging import safe_unlink
 from mediaforce.library.media_scopes import MediaScope, path_matches_scope, resolve_media_scope, \
     scope_descendant_filter, scope_rel_path_filter
+from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
 from mediaforce.library.workflow_state import build_folder_workflow_state
 from mediaforce.library.run_manifests import create_folder_manifest
 from mediaforce.library.candidate_selection import encode_candidate_decisions, scope_lifecycle_payload_from_decisions, \
@@ -159,6 +161,39 @@ def _no_active_encode_job(_connection: DBClient, _normalized_prefix: str) -> Job
     return None
 
 
+def production_action_blocker(
+        config: MediaforceConfig,
+        normalized_prefix: str,
+) -> ActionPayload | None:
+    root = str(normalized_prefix or "").strip().strip("/").split("/", 1)[0]
+    if not root:
+        if not isinstance(config.media.get("libraries"), list):
+            return None
+        return {
+            "ok": False,
+            "code": "library_not_configured",
+            "message": "Choose one configured library scope before running media actions.",
+        }
+    if root and root in config.source_root_map:
+        return None
+    library = config.library_definition_map.get(root)
+    if library is None:
+        return {
+            "ok": False,
+            "code": "library_not_configured",
+            "message": "This scope is not part of a configured library root. Scan the library before running media actions.",
+        }
+    label = str(library.get("label") or root or "This library")
+    availability = str(library.get("availability") or "browse_only").replace("_", " ")
+    return {
+        "ok": False,
+        "code": "library_not_production",
+        "message": (
+            f"{label} is {availability}. Set its availability to Production before running media actions."
+        ),
+    }
+
+
 def queue_folder_encode_action(
         config: MediaforceConfig,
         normalized_prefix: str,
@@ -178,8 +213,15 @@ def queue_folder_encode_action(
         load_advice_state: LoadAdviceStateFn | None = None,
         load_latest_failed_target_size_job_state: LoadJobStateFn | None = None,
 ) -> ActionPayload:
+    production_blocker = production_action_blocker(config, normalized_prefix)
+    if production_blocker is not None:
+        return production_blocker
     with open_db(config.paths.db_path) as connection:
-        scope = resolve_media_scope(connection, normalized_prefix)
+        scope = resolve_media_scope(
+            connection,
+            normalized_prefix,
+            library_types=config.library_type_map,
+        )
         if override_policy_holds and scope.kind != "tv_season":
             raise HTTPException(status_code=400, detail="Lifecycle holds can only be overridden for one season at a time.")
         existing_job = load_job_state(connection, config, normalized_prefix)
@@ -247,21 +289,29 @@ def queue_folder_encode_action(
                         "target before queueing production."
                     ),
                 )
-        upsert_override(saved_profile_path, normalized_prefix, calibration_policy)
         active_encode_job = load_active_encode_job_for_prefix_fn(connection, normalized_prefix)
         if active_encode_job is not None:
-            recovered = _recover_active_folder_encode_job(
-                connection,
-                active_encode_job,
-                notes=notes,
-                now_iso=now_iso,
-                prepare_terminal_encode_job_for_requeue_fn=prepare_terminal_encode_job_for_requeue_fn,
-                save_encode_job=save_encode_job,
-            )
-            if recovered is not None:
-                return recovered
+            active_prefix = str(active_encode_job.get("prefix") or normalized_prefix).strip().strip("/")
+            if active_prefix == normalized_prefix:
+                requeue_blocker = _movie_requeue_policy_blocker(
+                    connection,
+                    config,
+                    scope,
+                    active_encode_job,
+                )
+                if requeue_blocker is not None:
+                    raise HTTPException(status_code=409, detail=requeue_blocker)
+                recovered = _recover_active_folder_encode_job(
+                    connection,
+                    active_encode_job,
+                    notes=notes,
+                    now_iso=now_iso,
+                    prepare_terminal_encode_job_for_requeue_fn=prepare_terminal_encode_job_for_requeue_fn,
+                    save_encode_job=save_encode_job,
+                )
+                if recovered is not None:
+                    return recovered
             active_status = str(active_encode_job.get("status") or "queued").replace("_", " ")
-            active_prefix = str(active_encode_job.get("prefix") or normalized_prefix)
             return {
                 "ok": False,
                 "message": f"A folder encode is already {active_status} for {active_prefix}.",
@@ -272,8 +322,42 @@ def queue_folder_encode_action(
             "failed",
             "stopped",
         }:
+            requeue_blocker = _movie_requeue_policy_blocker(
+                connection,
+                config,
+                scope,
+                latest_encode_job,
+            )
+            if requeue_blocker is not None:
+                raise HTTPException(status_code=409, detail=requeue_blocker)
             prepare_terminal_encode_job_for_requeue_fn(connection, latest_encode_job)
             _reset_stale_prefix_encoding_items_for_requeue(connection, config, normalized_prefix, now_iso=now_iso)
+        preflight_decisions = encode_candidate_decisions(
+            connection,
+            config,
+            prefixes=[normalized_prefix],
+        )
+        if scope.domain == "movie" and not any(decision.eligible for decision in preflight_decisions):
+            movie_blockers = list(dict.fromkeys(
+                decision.production_blocker
+                for decision in preflight_decisions
+                if decision.production_blocker
+            ))
+            if movie_blockers:
+                raise HTTPException(status_code=409, detail=movie_blockers[0])
+            workflow_state = build_folder_workflow_state(
+                connection,
+                normalized_prefix,
+                candidate_eligibility=workflow_eligibility(preflight_decisions),
+                library_types=config.library_type_map,
+            ).to_payload()
+            next_action = object_dict(workflow_state.get("next_action"))
+            action_label = str(next_action.get("label") or "No action")
+            raise HTTPException(
+                status_code=400,
+                detail=f"No encode candidates were found for this movie scope. Next action: {action_label}.",
+            )
+        upsert_override(saved_profile_path, normalized_prefix, calibration_policy)
         refreshed_config = load_config(config.paths.config_path)
         manifest_kwargs: dict[str, Any] = {"prefix": normalized_prefix}
         if override_policy_holds:
@@ -285,19 +369,29 @@ def queue_folder_encode_action(
                 refreshed_config,
                 prefixes=[normalized_prefix],
             )
-            lifecycle = scope_lifecycle_payload_from_decisions(normalized_prefix, lifecycle_decisions)
-            if int(lifecycle.get("held_candidate_count") or 0) > 0:
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        f"{lifecycle['held_candidate_count']} encode candidate(s) are protected by the library "
-                        "lifecycle policy. Open one season to review or override its hold."
-                    ),
-                )
+            if scope.domain == "movie":
+                movie_blockers = list(dict.fromkeys(
+                    decision.production_blocker
+                    for decision in lifecycle_decisions
+                    if decision.production_blocker
+                ))
+                if movie_blockers:
+                    raise HTTPException(status_code=409, detail=movie_blockers[0])
+            else:
+                lifecycle = scope_lifecycle_payload_from_decisions(normalized_prefix, lifecycle_decisions)
+                if int(lifecycle.get("held_candidate_count") or 0) > 0:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"{lifecycle['held_candidate_count']} encode candidate(s) are protected by the "
+                            "library lifecycle policy. Open one season to review or override its hold."
+                        ),
+                    )
             workflow_state = build_folder_workflow_state(
                 connection,
                 normalized_prefix,
                 candidate_eligibility=workflow_eligibility(lifecycle_decisions),
+                library_types=refreshed_config.library_type_map,
             ).to_payload()
             next_action = object_dict(workflow_state.get("next_action"))
             action_label = str(next_action.get("label") or "No action")
@@ -513,6 +607,9 @@ def validate_folder_outputs_action(
         load_folder_staged_items_fn: LoadFolderStagedItemsFn,
         validate_manifest_items_fn: ValidateManifestItemsFn,
 ) -> ActionPayload:
+    production_blocker = production_action_blocker(config, normalized_prefix)
+    if production_blocker is not None:
+        return production_blocker
     if load_active_encode_job_for_prefix_fn is None:
         load_active_encode_job_for_prefix_fn = _no_active_encode_job
     with open_db(config.paths.db_path) as connection:
@@ -572,6 +669,9 @@ def promote_folder_outputs_action(
         load_folder_staged_items_fn: LoadFolderStagedItemsFn,
         promote_manifest_items_fn: PromoteManifestItemsFn,
 ) -> ActionPayload:
+    production_blocker = production_action_blocker(config, normalized_prefix)
+    if production_blocker is not None:
+        return production_blocker
     if load_active_encode_job_for_prefix_fn is None:
         load_active_encode_job_for_prefix_fn = _no_active_encode_job
     with open_db(config.paths.db_path) as connection:
@@ -597,6 +697,9 @@ def promote_folder_outputs_action(
         )
         if inaccessible_response is not None:
             return inaccessible_response
+        promotion_conflict = _promotion_conflict_response(config, items)
+        if promotion_conflict is not None:
+            return promotion_conflict
         manifest: ManifestPayload = {"items": items}
         promoted_paths = promote_manifest_items_fn(connection, config, manifest, list(range(len(items))), force=False)
     promoted_count = len(promoted_paths)
@@ -605,6 +708,55 @@ def promote_folder_outputs_action(
         "ok": True,
         "message": f"Promoted {promoted_count} validated {file_label} into the library.",
         "promoted_count": promoted_count,
+    }
+
+
+def _promotion_conflict_response(
+        config: MediaforceConfig,
+        items: list[FolderItem],
+) -> ActionPayload | None:
+    destinations: dict[str, tuple[Path, list[str]]] = {}
+    destination_sources: list[tuple[str, Path, Path, str]] = []
+    for item in items:
+        source_value = str(item.get("source_path") or "").strip()
+        if not source_value:
+            continue
+        source_path = Path(source_value)
+        destination_path = source_path.with_suffix(f".{config.output_container.lstrip('.')}")
+        rel_path = str(item.get("rel_path") or source_path)
+        destination_key = filesystem_collision_key(destination_path)
+        if destination_key not in destinations:
+            destinations[destination_key] = (destination_path, [])
+        destinations[destination_key][1].append(rel_path)
+        destination_sources.append((destination_key, destination_path, source_path, rel_path))
+
+    conflicts: list[ActionPayload] = []
+    for destination_key, (destination_path, rel_paths) in destinations.items():
+        if len(rel_paths) > 1:
+            conflicts.append({
+                "kind": "duplicate_destination",
+                "destination_path": str(destination_path),
+                "rel_paths": rel_paths,
+            })
+        for item_key, item_destination, source_path, rel_path in destination_sources:
+            if item_key != destination_key:
+                continue
+            if item_destination != source_path and item_destination.exists():
+                conflicts.append({
+                    "kind": "destination_exists",
+                    "destination_path": str(item_destination),
+                    "rel_paths": [rel_path],
+                })
+    if not conflicts:
+        return None
+    return {
+        "ok": False,
+        "message": (
+            f"Promotion is blocked by {len(conflicts)} destination conflict"
+            f"{'s' if len(conflicts) != 1 else ''}. Review the affected files before replacing anything."
+        ),
+        "promoted_count": 0,
+        "conflicts": conflicts,
     }
 
 
@@ -734,6 +886,58 @@ def _folder_recoverable_children(connection: DBClient, parent_job_id: str) -> li
     ]
 
 
+def _movie_requeue_policy_blocker(
+        connection: DBClient,
+        config: MediaforceConfig,
+        scope: MediaScope,
+        job: JobPayload,
+) -> str | None:
+    if scope.domain != "movie":
+        return None
+    manifest_path = Path(str(job.get("manifest_path") or "").strip())
+    if not str(manifest_path):
+        return None
+    try:
+        manifest = object_dict(json.loads(manifest_path.read_text()))
+    except (OSError, json.JSONDecodeError):
+        return None
+    items = [object_dict(item) for item in object_list(manifest.get("items"))]
+    selected_indexes = [index for index in object_list(job.get("manifest_indexes")) if isinstance(index, int)]
+    if str(job.get("job_kind") or "") == "folder":
+        child_indexes = [
+            index
+            for child in list_child_encode_jobs(connection, str(job.get("job_id") or ""))
+            if str(child.get("status") or "") != "completed"
+            for index in object_list(child.get("manifest_indexes"))
+            if isinstance(index, int)
+        ]
+        if child_indexes:
+            selected_indexes = child_indexes
+    if not selected_indexes:
+        selected_indexes = list(range(len(items)))
+
+    library = config.library_definition_map.get(scope.root, {})
+    policy = object_dict(library.get("policy"))
+    for index in sorted(set(selected_indexes)):
+        if index < 0 or index >= len(items):
+            continue
+        rel_path = str(items[index].get("rel_path") or "").strip()
+        membership = classify_movie_path(rel_path, root=scope.root)
+        if membership is None:
+            continue
+        included, blocker = movie_item_included(
+            membership,
+            policy,
+            explicit_exact=scope.match == "exact_item",
+        )
+        if not included:
+            return (
+                f"The saved retry includes {rel_path}, which is outside the current movie title policy. "
+                f"{blocker or 'Open that exact movie file to retry it deliberately.'}"
+            )
+    return None
+
+
 def _validate_delivery_blocked_by_active_encode(active_encode_job: JobPayload | None) -> ActionPayload | None:
     if not active_encode_job:
         return None
@@ -756,7 +960,11 @@ def _reset_stale_prefix_encoding_items_for_requeue(
     normalized_prefix = str(prefix).strip().strip("/")
     if not normalized_prefix:
         return
-    scope = resolve_media_scope(connection, normalized_prefix)
+    scope = resolve_media_scope(
+        connection,
+        normalized_prefix,
+        library_types=config.library_type_map,
+    )
     protected_prefixes = _active_descendant_encode_prefixes(connection, scope)
     rows = connection.execute(
         select(library_items.c.id, library_items.c.rel_path)
@@ -770,6 +978,15 @@ def _reset_stale_prefix_encoding_items_for_requeue(
         rel_path = str(row["rel_path"] or "").strip()
         if _rel_path_is_within_any_prefix(rel_path, protected_prefixes):
             continue
+        if scope.domain == "movie":
+            membership = classify_movie_path(rel_path, root=scope.root)
+            library = config.library_definition_map.get(scope.root, {})
+            if membership is None or not movie_item_included(
+                    membership,
+                    object_dict(library.get("policy")),
+                    explicit_exact=scope.match == "exact_item",
+            )[0]:
+                continue
         if rel_path:
             output_suffix = str(object_dict(config.media).get("output_container") or "").strip()
             if output_suffix:
@@ -833,6 +1050,9 @@ def save_profile_action(
         confirm_size_tradeoff: bool = False,
         reviewed_draft_hash: str = "",
 ) -> ActionPayload:
+    production_blocker = production_action_blocker(config, normalized_prefix)
+    if production_blocker is not None:
+        return production_blocker
     calibration = load_calibration_state(config, normalized_prefix)
     if not calibration:
         raise HTTPException(status_code=400, detail="No draft calibration found for this folder")

--- a/mediaforce/web/runtime/folder_cards.py
+++ b/mediaforce/web/runtime/folder_cards.py
@@ -11,7 +11,7 @@ from sqlalchemy import select
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items, staged_artifacts
-from mediaforce.library.candidate_selection import CandidateDecision, encode_candidate_decisions, \
+from mediaforce.library.candidate_selection import CandidateDecision, project_candidates, \
     scope_lifecycle_payload_from_decisions, workflow_eligibility
 from mediaforce.library.workflow_state import build_folder_workflow_states
 from mediaforce.library.workflow_state import ENCODE_CANDIDATE_STATUSES
@@ -161,7 +161,7 @@ def preview_folder_cards(
         estimate_savings_bytes: Callable[..., int],
         review_badge_for_prefix: Callable[[str], FolderBadge],
 ) -> list[FolderCard]:
-    decisions = encode_candidate_decisions(connection, config, prefixes=[]) if config is not None else []
+    decisions = project_candidates(connection, config, prefixes=[]) if config is not None else []
     decisions_by_item = {decision.item_id: decision for decision in decisions}
     folder_history, codec_history = _load_savings_history(connection, folder_group=folder_group)
     rows = connection.execute(
@@ -215,11 +215,16 @@ def preview_folder_cards(
         card.total_size_bytes += size_bytes
         status = str(row["status"] or "unknown")
         decision = decisions_by_item.get(int(row["item_id"]))
+        production_included = decision is None or decision.production_included
         codec = str(row["video_codec"] or "unknown")
-        known_saved_bytes = _pending_folder_item_savings_bytes(status=status, bytes_saved=row["bytes_saved"])
+        known_saved_bytes = (
+            _pending_folder_item_savings_bytes(status=status, bytes_saved=row["bytes_saved"])
+            if production_included
+            else None
+        )
         if known_saved_bytes is not None:
             card.known_saved_bytes += known_saved_bytes
-        if status != "promoted":
+        if status != "promoted" and production_included:
             card.pending_count += 1
             if known_saved_bytes is None and _eligible_for_estimate(status, decision):
                 card.estimated_savings_bytes += _estimated_pending_savings_bytes(
@@ -240,7 +245,7 @@ def preview_folder_cards(
         if card.pending_count > 0 and card.projected_reclaim_bytes >= minimum_recommended_savings_bytes
     ]
     _apply_lifecycle(cards, decisions)
-    _apply_folder_workflow_states(connection, cards, decisions)
+    _apply_folder_workflow_states(connection, cards, decisions, config=config)
     _apply_folder_review_badges(cards, review_badge_for_prefix)
     return sorted(
         cards,
@@ -259,16 +264,19 @@ def list_library_structure_cards(
         folder_group: Callable[[str], FolderGroup | None],
         review_badge_for_prefix: Callable[[str], FolderBadge],
 ) -> list[FolderCard]:
-    rows = connection.execute(
-        select(
-            library_items.c.rel_path,
-            library_items.c.size_bytes,
-            library_items.c.status,
-        )
-        .where(library_items.c.status != "missing")
-        .where(library_items.c.rel_path.startswith("tv/", autoescape=True))
-        .order_by(library_items.c.rel_path)
-    ).mappings().fetchall()
+    query = select(
+        library_items.c.rel_path,
+        library_items.c.size_bytes,
+        library_items.c.status,
+    ).where(library_items.c.status != "missing")
+    if config is None:
+        query = query.where(library_items.c.rel_path.startswith("tv/", autoescape=True))
+    else:
+        tv_roots = [root for root, library_type in config.library_type_map.items() if library_type == "tv"]
+        if not tv_roots:
+            return []
+        query = query.where(library_items.c.media_root.in_(tv_roots))
+    rows = connection.execute(query.order_by(library_items.c.rel_path)).mappings().fetchall()
     grouped: dict[str, FolderCard] = {}
     for row in rows:
         group = folder_group(str(row["rel_path"]))
@@ -322,8 +330,9 @@ def list_folder_cards(
         estimate_savings_bytes: Callable[..., int],
         review_badge_for_prefix: Callable[[str], FolderBadge],
         rel_path_root: str | None = None,
+        media_roots: set[str] | None = None,
 ) -> list[FolderCard]:
-    decisions = encode_candidate_decisions(connection, config, prefixes=[]) if config is not None else []
+    decisions = project_candidates(connection, config, prefixes=[]) if config is not None else []
     decisions_by_item = {decision.item_id: decision for decision in decisions}
     folder_history, codec_history = _load_savings_history(connection, folder_group=folder_group)
     query = (
@@ -348,6 +357,10 @@ def list_folder_cards(
     )
     if rel_path_root:
         query = query.where(library_items.c.rel_path.startswith(rel_path_root, autoescape=True))
+    if media_roots is not None:
+        if not media_roots:
+            return []
+        query = query.where(library_items.c.media_root.in_(tuple(media_roots)))
     rows = connection.execute(query.order_by(library_items.c.rel_path)).mappings().fetchall()
     grouped: dict[str, FolderCard] = {}
     for row in rows:
@@ -387,10 +400,15 @@ def list_folder_cards(
         card.average_age_days += path_age_days
         status = str(row["status"] or "unknown")
         codec = str(row["video_codec"] or "unknown")
-        known_saved_bytes = _pending_folder_item_savings_bytes(status=status, bytes_saved=row["bytes_saved"])
+        production_included = decision is None or decision.production_included
+        known_saved_bytes = (
+            _pending_folder_item_savings_bytes(status=status, bytes_saved=row["bytes_saved"])
+            if production_included
+            else None
+        )
         if known_saved_bytes is not None:
             card.known_saved_bytes += known_saved_bytes
-        if status != "promoted":
+        if status != "promoted" and production_included:
             card.pending_count += 1
             if known_saved_bytes is not None:
                 card.sort_score += known_saved_bytes / (1024 ** 3)
@@ -421,7 +439,7 @@ def list_folder_cards(
         )
     ]
     _apply_lifecycle(cards, decisions)
-    _apply_folder_workflow_states(connection, cards, decisions)
+    _apply_folder_workflow_states(connection, cards, decisions, config=config)
     _apply_folder_review_badges(cards, review_badge_for_prefix)
     return sorted(
         cards,
@@ -475,6 +493,8 @@ def _apply_folder_workflow_states(
         connection: DBClient,
         cards: list[FolderCard],
         decisions: list[CandidateDecision] | None = None,
+        *,
+        config: MediaforceConfig | None = None,
 ) -> None:
     if not cards:
         return
@@ -482,6 +502,7 @@ def _apply_folder_workflow_states(
         connection,
         [card.prefix for card in cards],
         candidate_eligibility=workflow_eligibility(decisions or []),
+        library_types=config.library_type_map if config is not None else None,
     )
     for card in cards:
         workflow = workflow_by_prefix.get(card.prefix)

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -50,6 +50,9 @@ VALIDATION_PREFIX = "tv/Validation Ready/Season 1"
 PROMOTION_PREFIX = "tv/Promotion Ready/Season 1"
 FINISHED_PREFIX = "tv/Finished Show/Season 1"
 ENCODE_WAITING_PREFIX = "movies/Waiting Encode"
+MOVIE_LOOSE_PREFIX = "movies/Loose Feature.mkv"
+MOVIE_EDITIONS_PREFIX = "movies/Editions Showcase"
+MOVIE_CONFLICT_PREFIX = "movies/Promotion Conflict"
 CURRENT_PREVIOUS_PREFIX = "tv/Current Season/Season 1"
 CURRENT_SEASON_PREFIX = "tv/Current Season/Season 2"
 CURRENT_SERIES_PREFIX = "tv/Current Season"
@@ -74,6 +77,9 @@ FIXTURE_PREFIXES = (
     PROMOTION_PREFIX,
     FINISHED_PREFIX,
     ENCODE_WAITING_PREFIX,
+    MOVIE_LOOSE_PREFIX,
+    MOVIE_EDITIONS_PREFIX,
+    MOVIE_CONFLICT_PREFIX,
     CURRENT_PREVIOUS_PREFIX,
     CURRENT_SEASON_PREFIX,
     PROTECTED_READY_PREFIX,
@@ -984,6 +990,78 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 recommendation_reason="Fixture approved current season requires an explicit lifecycle override.",
                 age_days=5,
             ),
+            _library_item(
+                project_root=project_root,
+                media_root="movies",
+                rel_path="movies/Loose Feature.mkv",
+                size_bytes=11 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=72,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture root-level exact movie file for browser QA.",
+                age_days=1_200,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="movies",
+                rel_path="movies/Editions Showcase/Editions Showcase - Theatrical.mkv",
+                size_bytes=12 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=74,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture theatrical movie edition for browser QA.",
+                age_days=980,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="movies",
+                rel_path="movies/Editions Showcase/Editions Showcase - Director's Cut.mkv",
+                size_bytes=14 * 1024**3,
+                status="planned",
+                video_codec="h264",
+                priority_score=73,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture independently reachable movie edition for browser QA.",
+                age_days=960,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="movies",
+                rel_path="movies/Editions Showcase/Featurettes/Making Of.mkv",
+                size_bytes=650 * 1024**2,
+                status="discovered",
+                video_codec="h264",
+                priority_score=20,
+                recommendation="review_encode",
+                recommendation_reason="Fixture excluded movie extra for browser QA.",
+                age_days=950,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="movies",
+                rel_path="movies/Editions Showcase/Disc 2/Alternate.mkv",
+                size_bytes=4 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=18,
+                recommendation="review_encode",
+                recommendation_reason="Fixture uncertain nested movie file for browser QA.",
+                age_days=940,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="movies",
+                rel_path="movies/Promotion Conflict/Feature.mp4",
+                size_bytes=9 * 1024**3,
+                status="validated",
+                video_codec="h264",
+                priority_score=70,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture movie promotion collision for browser QA.",
+                age_days=900,
+            ),
         ]
         inserted_ids: list[int] = []
         for row in rows:
@@ -1155,6 +1233,29 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 )
             )
 
+        movie_conflict_row = rows_by_prefix[MOVIE_CONFLICT_PREFIX]
+        movie_conflict_id = ids_by_rel_path[str(movie_conflict_row["rel_path"])]
+        movie_conflict_destination = Path(str(movie_conflict_row["source_path"])).with_suffix(".mkv")
+        movie_conflict_destination.parent.mkdir(parents=True, exist_ok=True)
+        movie_conflict_destination.write_bytes(b"mediaforce smoke conflicting movie destination\n")
+        movie_conflict_staging = staging_root / Path(str(movie_conflict_row["rel_path"])).with_suffix(".mkv")
+        movie_conflict_staging.parent.mkdir(parents=True, exist_ok=True)
+        movie_conflict_staging.write_bytes(b"mediaforce smoke staged movie output\n")
+        connection.execute(
+            staged_artifacts.insert().values(
+                library_item_id=movie_conflict_id,
+                source_rel_path=movie_conflict_row["rel_path"],
+                source_size_bytes=movie_conflict_row["size_bytes"],
+                staging_path=str(movie_conflict_staging),
+                staging_size_bytes=max(1, int(movie_conflict_row["size_bytes"]) // 2),
+                bytes_saved=max(1, int(movie_conflict_row["size_bytes"]) // 2),
+                size_ratio=0.5,
+                staged_at=timestamp,
+                validated_at=timestamp,
+                updated_at=timestamp,
+            )
+        )
+
         policy = config.resolve_policy(rows[0]["rel_path"])
         for item_id, row, job in (
             (
@@ -1305,6 +1406,30 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 "route": "/folders/tv/Example%20Show/Season%201",
                 "marker": "Example Show",
                 "stageMarker": "Choose a size for Season 1",
+            },
+            {
+                "label": "Movie Studio editions fixture",
+                "route": "/folders/movies/Editions%20Showcase",
+                "marker": "Editions Showcase",
+                "stageMarker": "Files and editions",
+            },
+            {
+                "label": "Movie Studio exact-file fixture",
+                "route": "/folders/movies/Loose%20Feature.mkv",
+                "marker": "Loose Feature",
+                "stageMarker": "Exact Movie File",
+            },
+            {
+                "label": "Movie Studio promotion-conflict fixture",
+                "route": "/folders/movies/Promotion%20Conflict",
+                "marker": "Promotion Conflict",
+                "stageMarker": "Promotion is blocked",
+            },
+            {
+                "label": "Movie Studio active-processing fixture",
+                "route": "/folders/movies/Waiting%20Encode",
+                "marker": "Waiting Encode",
+                "stageMarker": "Monitor processing",
             },
             {
                 "label": "Folder Studio sampling fixture",

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -42,6 +42,8 @@ const endpointChecks = [
   ["Dashboard folders", "/api/dashboard/folders"],
   ["Library structure", "/api/dashboard/library"],
   ["Library details", "/api/dashboard/library/details"],
+  ["Movie library structure", "/api/dashboard/library/movies"],
+  ["Movie library details", "/api/dashboard/library/movies/details"],
   ["Host status", "/api/hosts?compact=1"],
   ["Settings initial payload", "/api/settings?include_archive_cleanup=0"],
   ["Completed payload", "/api/completed"],
@@ -49,6 +51,7 @@ const endpointChecks = [
 
 const routeChecks = [
   ["Library", "/", "Your library"],
+  ["Movies Library", "/movies", "MOVIE WORKSTATION"],
   ["Folders compatibility", "/folders", "Your library"],
   ["Activity", "/ops", "What’s happening"],
   ["Settings", "/settings", "Library and working space"],

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -2251,25 +2251,24 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(payload["media"]["libraries"][0]["type"], "movie")
         self.assertEqual(payload["media"]["libraries"][0]["availability"], "browse_only")
 
-    def test_runtime_settings_payload_rejects_non_tv_production(self) -> None:
-        with self.assertRaises(settings_runtime.SettingsValidationError) as raised:
-            web_app._build_runtime_settings_payload(
-                libraries=[
-                    {
-                        "key": "movies",
-                        "label": "Movies",
-                        "path": str(self.root / "source" / "movies"),
-                        "library_type": "movie",
-                        "availability": "production",
-                        "default_profile": "movie_balanced",
-                    }
-                ],
-                remote_hosts=[],
-                transcode_root=str(self.root / "staging"),
-                encode_queue_scheduler={"mode": "anytime", "start_hour": 22, "end_hour": 8, "timezone": "local"},
-                schedule_profiles=[],
-            )
-        self.assertIn("production is not available", raised.exception.public_message)
+    def test_runtime_settings_payload_accepts_movie_production(self) -> None:
+        payload = web_app._build_runtime_settings_payload(
+            libraries=[
+                {
+                    "key": "movies",
+                    "label": "Movies",
+                    "path": str(self.root / "source" / "movies"),
+                    "library_type": "movie",
+                    "availability": "production",
+                    "default_profile": "movie_balanced",
+                }
+            ],
+            remote_hosts=[],
+            transcode_root=str(self.root / "staging"),
+            encode_queue_scheduler={"mode": "anytime", "start_hour": 22, "end_hour": 8, "timezone": "local"},
+            schedule_profiles=[],
+        )
+        self.assertEqual(payload["media"]["libraries"][0]["availability"], "production")
 
     def test_typed_library_maps_scan_browse_only_but_only_produce_ready_roots(self) -> None:
         self.config.raw["media"]["source_roots"] = {
@@ -2318,7 +2317,38 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(list(self.config.configured_source_root_map), ["shows"])
         self.assertEqual(list(self.config.source_root_map), ["shows"])
 
-    def test_canonical_config_cannot_enable_unsupported_library_production(self) -> None:
+    def test_custom_typed_tv_root_appears_in_library_structure(self) -> None:
+        self.config.raw["media"]["libraries"] = [
+            {
+                "key": "shows",
+                "label": "Shows",
+                "path": str(self.root / "source" / "Shows on Disk"),
+                "type": "tv",
+                "availability": "production",
+            }
+        ]
+        source = self._create_source_file("custom-tv-root.mkv")
+        with open_db(self.config.paths.db_path) as connection:
+            item_id = self._insert_library_item(connection, source)
+            connection.execute(
+                update(library_items)
+                .where(library_items.c.id == item_id)
+                .values(
+                    media_root="shows",
+                    rel_path="shows/Example/Season 1/Episode.mkv",
+                    parent_dir="shows/Example/Season 1",
+                )
+            )
+            with patch.object(
+                    web_app,
+                    "_folder_review_badge",
+                    return_value={"label": None, "tone": None, "detail": None},
+            ):
+                cards = web_app._list_library_structure_cards(self.config, connection)
+
+        self.assertEqual([card.prefix for card in cards], ["shows/Example/Season 1"])
+
+    def test_canonical_config_enables_movie_production(self) -> None:
         self.config.raw["media"]["libraries"] = [
             {
                 "key": "movies",
@@ -2329,7 +2359,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         ]
 
         self.assertEqual(list(self.config.scan_source_root_map), ["movies"])
-        self.assertEqual(self.config.source_root_map, {})
+        self.assertEqual(list(self.config.source_root_map), ["movies"])
 
     def test_library_scan_signature_ignores_operator_order(self) -> None:
         first = {
@@ -7542,8 +7572,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual([status.key for status in statuses], ["first-host", "second-host"])
 
     def test_remote_host_status_targets_current_machine_without_ssh_probe(self) -> None:
-        source_root = Path(next(iter(self.config.source_root_map.values())))
-        source_root.mkdir(parents=True, exist_ok=True)
+        for source_root in self.config.source_root_map.values():
+            Path(source_root).mkdir(parents=True, exist_ok=True)
         self.config.staging_root.mkdir(parents=True, exist_ok=True)
         host: dict[str, object] = {
             "host": "cbusillo@localhost",
@@ -9292,6 +9322,79 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             self.assertEqual(library_row["fingerprint"], "promoted-fingerprint")
             self.assertEqual(staged_row["promoted_path"], str(destination_path))
             self.assertEqual(staged_row["archived_source_path"], str(archived_source))
+
+    def test_promote_one_item_preserves_custom_library_root_identity(self) -> None:
+        physical_root = self.root / "source" / "Movies on Disk"
+        source_path = physical_root / "Example" / "Feature.mkv"
+        source_path.parent.mkdir(parents=True)
+        source_path.write_text("source")
+        staging_path = self.root / "staging" / "films" / "Example" / "Feature.mp4"
+        staging_path.parent.mkdir(parents=True)
+        staging_path.write_text("encoded")
+        media = dict(self.config.raw["media"])
+        media.update({
+            "source_roots": {"films": str(physical_root)},
+            "output_container": "mp4",
+        })
+        custom_config = MediaforceConfig(
+            raw={**self.config.raw, "media": media},
+            paths=self.config.paths,
+        )
+        promoted_probe = ProbeSummary(
+            duration_seconds=60.0,
+            video_codec="av1",
+            video_bitrate=900000,
+            width=1920,
+            height=1080,
+            pix_fmt="yuv420p10le",
+            audio_track_count=1,
+            subtitle_track_count=0,
+            english_audio_count=1,
+            english_subtitle_count=0,
+            default_audio_language="eng",
+            default_subtitle_language=None,
+            audio_summary_json="[]",
+            subtitle_summary_json="[]",
+        )
+
+        with open_db(custom_config.paths.db_path) as connection:
+            item_id = self._insert_library_item(
+                connection,
+                source_path,
+                status="validated",
+                rel_path="films/Example/Feature.mkv",
+            )
+            connection.execute(
+                staged_artifacts.insert().values(
+                    library_item_id=item_id,
+                    staging_path=str(staging_path),
+                    validation_json=json.dumps({"passed": True}),
+                    updated_at=web_app._now_iso(),
+                )
+            )
+            item = {
+                "library_item_id": item_id,
+                "source_path": str(source_path),
+                "rel_path": "films/Example/Feature.mkv",
+                "media_root": "films",
+            }
+
+            with patch("mediaforce.execution.probe_media", return_value=promoted_probe), patch(
+                    "mediaforce.execution.file_fingerprint", return_value="promoted-fingerprint"
+            ):
+                execution.promote_one_item(connection, custom_config, item, force=False)
+
+            library_row = self._library_item_value(
+                connection,
+                item_id,
+                library_items.c.media_root,
+                library_items.c.rel_path,
+                library_items.c.parent_dir,
+            )
+
+        self.assertEqual(library_row["media_root"], "films")
+        self.assertEqual(library_row["rel_path"], "films/Example/Feature.mp4")
+        self.assertEqual(library_row["parent_dir"], "films/Example")
 
     def test_run_tracked_process_reports_progress_snapshots(self) -> None:
         class FakeTextProcess:
@@ -17139,7 +17242,10 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         raw = {
             "state": {"cleanup": {"transient_artifact_retention_days": 14}},
             "media": {
-                "source_roots": {"tv": str(self.root / "source" / "tv")},
+                "source_roots": {
+                    "tv": str(self.root / "source" / "tv"),
+                    "other": str(self.root / "source" / "other"),
+                },
                 "staging_root": str(self.root / "staging"),
                 "archive_root": str(self.root / "archive"),
             },

--- a/tests/test_library_lifecycle.py
+++ b/tests/test_library_lifecycle.py
@@ -45,6 +45,19 @@ class LibraryLifecycleTests(unittest.TestCase):
         self.assertIsNone(plex_special.season_number)
         self.assertTrue(plex_special.is_special)
 
+    def test_season_identity_uses_typed_root_authority(self) -> None:
+        custom_tv = season_identity(
+            {"rel_path": "shows/Example/Season 1/Episode.mkv"},
+            library_types={"shows": "tv"},
+        )
+        movie_named_tv = season_identity(
+            {"rel_path": "tv/Example/Season 1.mkv"},
+            library_types={"tv": "movie"},
+        )
+
+        self.assertEqual(custom_tv.season_prefix, "shows/Example/Season 1")
+        self.assertIsNone(movie_named_tv)
+
     def test_auto_protects_only_highest_numbered_active_season(self) -> None:
         config = self._config()
         with open_db(config.paths.db_path) as connection:

--- a/tests/test_media_scopes.py
+++ b/tests/test_media_scopes.py
@@ -29,6 +29,10 @@ class MediaScopeTests(unittest.TestCase):
         other_folder = media_group_scope_for_rel_path("other/Concert/Night 1.mkv")
         tv_season = media_group_scope_for_rel_path("tv/Show/Season 2/Episode 1.mkv")
         tv_series = tv_series_scope_for_rel_path("tv/Show/Season 2/Episode 1.mkv")
+        custom_tv_series = tv_series_scope_for_rel_path(
+            "shows/Show/Season 2/Episode 1.mkv",
+            library_types={"shows": "tv"},
+        )
 
         self.assertIsNotNone(movie_file)
         self.assertEqual((movie_file.kind, movie_file.match, movie_file.prefix), ("movie_file", "exact_item", "movies/Foo.mkv"))
@@ -43,6 +47,8 @@ class MediaScopeTests(unittest.TestCase):
         self.assertEqual((tv_season.kind, tv_season.prefix), ("tv_season", "tv/Show/Season 2"))
         self.assertIsNotNone(tv_series)
         self.assertEqual((tv_series.kind, tv_series.prefix), ("tv_series", "tv/Show"))
+        self.assertIsNotNone(custom_tv_series)
+        self.assertEqual((custom_tv_series.kind, custom_tv_series.prefix), ("tv_series", "shows/Show"))
 
     def test_web_grouping_preserves_tv_and_exposes_exact_root_files(self) -> None:
         self.assertEqual(

--- a/tests/test_movie_workflow.py
+++ b/tests/test_movie_workflow.py
@@ -1,0 +1,566 @@
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from mediaforce.core.config import ConfigPaths, MediaforceConfig
+from mediaforce.core.db import DBClient, open_db, reset_engine_cache
+from mediaforce.core.db_tables import library_items, plex_item_metadata, staged_artifacts
+from mediaforce.library.candidate_selection import candidate_rank_key, project_candidates, workflow_eligibility
+from mediaforce.library.media_scopes import media_group_scope_for_rel_path, resolve_media_scope
+from mediaforce.library.movie_library import load_movie_library_payload
+from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
+from mediaforce.library.representatives import load_representative_selection
+from mediaforce.library.workflow_state import build_folder_workflow_state
+from mediaforce.web.runtime.folder_actions import _promotion_conflict_response
+from mediaforce.web.runtime.folder_actions import _reset_stale_prefix_encoding_items_for_requeue
+from mediaforce.web.runtime.folder_actions import promote_folder_outputs_action, queue_folder_encode_action, \
+    validate_folder_outputs_action
+
+
+class MovieWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        self.config = self._config(extras="exclude")
+
+    def tearDown(self) -> None:
+        reset_engine_cache()
+        self.temp_dir.cleanup()
+
+    def test_classifies_features_editions_extras_and_uncertain_members(self) -> None:
+        feature = classify_movie_path(
+            "films/Example/Example - Director's Cut.mkv",
+            root="films",
+        )
+        extra = classify_movie_path("films/Example/Featurettes/Making Of.mkv", root="films")
+        direct_trailer = classify_movie_path("films/Example/Example-trailer.mkv", root="films")
+        uncertain = classify_movie_path("films/Example/Disc 2/Alternate.mkv", root="films")
+        single_file = classify_movie_path("films/Loose Feature.mkv", root="films")
+
+        self.assertEqual((feature.role, feature.edition_label), ("feature", "Director's Cut"))
+        self.assertEqual((extra.role, extra.extra_category), ("extra", "Featurettes"))
+        self.assertEqual((direct_trailer.role, direct_trailer.extra_category), ("extra", "Trailers"))
+        self.assertEqual(uncertain.role, "uncertain")
+        self.assertEqual((single_file.role, single_file.scope_mode), ("feature", "single_file"))
+        self.assertFalse(movie_item_included(extra, {"extras": "exclude"}, explicit_exact=False)[0])
+        self.assertTrue(movie_item_included(extra, {"extras": "exclude"}, explicit_exact=True)[0])
+
+    def test_custom_typed_root_resolves_movie_scopes(self) -> None:
+        scope = media_group_scope_for_rel_path(
+            "films/Example/Example.mkv",
+            library_types={"films": "movie"},
+        )
+        self.assertEqual((scope.domain, scope.kind, scope.scope_label), ("movie", "movie_title", "Title"))
+
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_item(connection, "films/Loose Feature.mkv")
+            exact = resolve_media_scope(
+                connection,
+                "films/Loose Feature.mkv",
+                library_types=self.config.library_type_map,
+            )
+        self.assertEqual((exact.domain, exact.kind, exact.match), ("movie", "movie_file", "exact_item"))
+
+    def test_title_scope_excludes_extras_and_uncertain_members_but_exact_scope_allows_them(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            feature_id = self._insert_item(connection, "films/Example/Example.mkv")
+            edition_id = self._insert_item(connection, "films/Example/Example - Director's Cut.mkv")
+            extra_id = self._insert_item(connection, "films/Example/Extras/Trailer.mkv")
+            uncertain_id = self._insert_item(connection, "films/Example/Disc 2/Alternate.mkv")
+
+            title_decisions = project_candidates(connection, self.config, prefixes=["films/Example"])
+            exact_extra = project_candidates(
+                connection,
+                self.config,
+                prefixes=["films/Example/Extras/Trailer.mkv"],
+            )
+
+        decisions = {decision.item_id: decision for decision in title_decisions}
+        self.assertTrue(decisions[feature_id].eligible)
+        self.assertTrue(decisions[edition_id].eligible)
+        self.assertFalse(decisions[extra_id].eligible)
+        self.assertIn("Extras are excluded", decisions[extra_id].production_blocker)
+        self.assertFalse(decisions[uncertain_id].eligible)
+        self.assertIn("explicit exact-file", decisions[uncertain_id].production_blocker)
+        self.assertEqual([decision.item_id for decision in exact_extra if decision.eligible], [extra_id])
+
+    def test_representative_selection_ignores_extras_for_title_scope(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            feature_id = self._insert_item(
+                connection,
+                "films/Example/Example.mkv",
+                size_bytes=8 * 1024**3,
+            )
+            self._insert_item(
+                connection,
+                "films/Example/Extras/Trailer.mkv",
+                size_bytes=200 * 1024**2,
+            )
+            selection = load_representative_selection(connection, self.config, "films/Example")
+
+        self.assertIsNotNone(selection)
+        self.assertEqual(selection.primary_item()["library_item_id"], feature_id)
+        self.assertEqual(selection.public_payload()["coverage"]["candidate_item_count"], 1)
+
+    def test_movie_ranking_can_prefer_largest_or_oldest_plex_item(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            older_id = self._insert_item(connection, "films/Older.mkv", size_bytes=2_000)
+            larger_id = self._insert_item(connection, "films/Larger.mkv", size_bytes=9_000)
+            self._insert_plex_age(connection, older_id, "2010-01-01T00:00:00+00:00")
+            self._insert_plex_age(connection, larger_id, "2020-01-01T00:00:00+00:00")
+
+            oldest = project_candidates(connection, self.config, prefixes=[])
+            largest_config = self._config(extras="exclude", ranking="largest_first")
+            largest = project_candidates(connection, largest_config, prefixes=[])
+
+        oldest_sorted = sorted(
+            oldest,
+            key=lambda decision: candidate_rank_key(
+                decision,
+                recommendation_score=0,
+                size_bytes=int(decision.row["size_bytes"]),
+            ),
+        )
+        largest_sorted = sorted(
+            largest,
+            key=lambda decision: candidate_rank_key(
+                decision,
+                recommendation_score=0,
+                size_bytes=int(decision.row["size_bytes"]),
+            ),
+        )
+        self.assertEqual(oldest_sorted[0].item_id, older_id)
+        self.assertEqual(oldest_sorted[0].age.source, "plex")
+        self.assertEqual(largest_sorted[0].item_id, larger_id)
+
+    def test_typed_movie_root_can_enter_production_while_other_and_spatial_remain_blocked(self) -> None:
+        config = self._config(
+            extras="exclude",
+            additional_libraries=[
+                {
+                    "key": "other",
+                    "path": str(self.root / "other"),
+                    "type": "other",
+                    "availability": "production",
+                },
+                {
+                    "key": "vr",
+                    "path": str(self.root / "vr"),
+                    "type": "spatial",
+                    "availability": "production",
+                },
+            ],
+        )
+        self.assertEqual(set(config.source_root_map), {"films"})
+
+    def test_movie_library_payload_keeps_editions_extras_age_and_conflicts_visible(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            first_id = self._insert_item(connection, "films/Example/Example.mp4")
+            second_id = self._insert_item(connection, "films/Example/Example.mkv")
+            trailer_id = self._insert_item(connection, "films/Example/Example-trailer.mkv")
+            self._insert_plex_age(connection, first_id, "2020-01-01T00:00:00+00:00")
+            self._insert_stage(connection, first_id, "films/Example/Example.mp4")
+            self._insert_stage(connection, second_id, "films/Example/Example.mkv")
+            payload = load_movie_library_payload(
+                connection,
+                self.config,
+                include_details=True,
+                metrics_by_prefix={
+                    "films/Example": {
+                        "projected_reclaim_bytes": 512,
+                        "estimated_savings_bytes": 512,
+                    }
+                },
+            )
+
+        title = payload["titles"][0]
+        members = {member["item_id"]: member for member in title["members"]}
+        self.assertEqual(title["edition_count"], 2)
+        self.assertEqual(title["extra_count"], 1)
+        self.assertEqual(title["savings_confidence"], "estimated")
+        self.assertEqual(title["age"]["source"], "plex")
+        self.assertFalse(members[trailer_id]["included_by_default"])
+        self.assertEqual(title["promotion_conflicts"][0]["kind"], "duplicate_destination")
+
+    def test_movie_library_payload_uses_mediaforce_discovery_age_fallback(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_item(connection, "films/Example/Example.mkv")
+            payload = load_movie_library_payload(
+                connection,
+                self.config,
+                include_details=True,
+            )
+
+        self.assertEqual(payload["titles"][0]["age"]["source"], "mediaforce_discovered")
+
+    def test_promotion_preflight_blocks_duplicate_output_destinations(self) -> None:
+        conflict = _promotion_conflict_response(
+            self.config,
+            [
+                {"source_path": str(self.root / "Cut.mp4"), "rel_path": "films/Cut.mp4"},
+                {"source_path": str(self.root / "Cut.avi"), "rel_path": "films/Cut.avi"},
+            ],
+        )
+
+        self.assertIsNotNone(conflict)
+        self.assertFalse(conflict["ok"])
+        self.assertEqual(conflict["conflicts"][0]["kind"], "duplicate_destination")
+
+    def test_promotion_preflight_blocks_case_equivalent_destinations(self) -> None:
+        conflict = _promotion_conflict_response(
+            self.config,
+            [
+                {"source_path": str(self.root / "Cut.mp4"), "rel_path": "films/Cut.mp4"},
+                {"source_path": str(self.root / "cut.avi"), "rel_path": "films/cut.avi"},
+            ],
+        )
+
+        self.assertIsNotNone(conflict)
+        self.assertEqual(conflict["conflicts"][0]["kind"], "duplicate_destination")
+
+    def test_browse_only_movie_library_blocks_validation_and_promotion_actions(self) -> None:
+        browse_config = self._config(extras="exclude", availability="browse_only")
+
+        validate_result = validate_folder_outputs_action(
+            browse_config,
+            "films/Example",
+            load_folder_staged_items_fn=lambda *_args, **_kwargs: self.fail("staged items should not load"),
+            validate_manifest_items_fn=lambda *_args, **_kwargs: self.fail("validation should not run"),
+        )
+        promote_result = promote_folder_outputs_action(
+            browse_config,
+            "films/Example",
+            load_folder_staged_items_fn=lambda *_args, **_kwargs: self.fail("staged items should not load"),
+            promote_manifest_items_fn=lambda *_args, **_kwargs: self.fail("promotion should not run"),
+        )
+
+        self.assertEqual(validate_result["code"], "library_not_production")
+        self.assertEqual(promote_result["code"], "library_not_production")
+
+    def test_typed_libraries_block_stale_physical_root_prefixes(self) -> None:
+        result = validate_folder_outputs_action(
+            self.config,
+            "Movies on Disk/Example",
+            load_folder_staged_items_fn=lambda *_args, **_kwargs: self.fail("staged items should not load"),
+            validate_manifest_items_fn=lambda *_args, **_kwargs: self.fail("validation should not run"),
+        )
+
+        self.assertEqual(result["code"], "library_not_configured")
+
+    def test_title_retry_reset_leaves_extras_and_uncertain_members_untouched(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            feature_id = self._insert_item(
+                connection,
+                "films/Example/Example.mkv",
+                status="encoding",
+            )
+            extra_id = self._insert_item(
+                connection,
+                "films/Example/Extras/Trailer.mkv",
+                status="encoding",
+            )
+            uncertain_id = self._insert_item(
+                connection,
+                "films/Example/Disc 2/Alternate.mkv",
+                status="encoding",
+            )
+            for item_id, rel_path in (
+                (feature_id, "films/Example/Example.mkv"),
+                (extra_id, "films/Example/Extras/Trailer.mkv"),
+                (uncertain_id, "films/Example/Disc 2/Alternate.mkv"),
+            ):
+                self._insert_stage(connection, item_id, rel_path)
+
+            _reset_stale_prefix_encoding_items_for_requeue(
+                connection,
+                self.config,
+                "films/Example",
+                now_iso=lambda: "2026-07-13T00:00:00+00:00",
+            )
+            statuses = dict(connection.execute(
+                select(library_items.c.id, library_items.c.status)
+                .where(library_items.c.id.in_((feature_id, extra_id, uncertain_id)))
+            ).fetchall())
+            staged_ids = set(connection.execute(select(staged_artifacts.c.library_item_id)).scalars().all())
+
+        self.assertEqual(statuses[feature_id], "planned")
+        self.assertEqual(statuses[extra_id], "encoding")
+        self.assertEqual(statuses[uncertain_id], "encoding")
+        self.assertNotIn(feature_id, staged_ids)
+        self.assertIn(extra_id, staged_ids)
+        self.assertIn(uncertain_id, staged_ids)
+
+    def test_title_workflow_hides_exact_extra_delivery_until_the_exact_scope_is_opened(self) -> None:
+        extra_prefix = "films/Example/Extras/Trailer.mkv"
+        with open_db(self.config.paths.db_path) as connection:
+            extra_id = self._insert_item(connection, extra_prefix, status="encoded")
+            self._insert_stage(connection, extra_id, extra_prefix)
+            title_decisions = project_candidates(connection, self.config, prefixes=["films/Example"])
+            exact_decisions = project_candidates(connection, self.config, prefixes=[extra_prefix])
+            title_workflow = build_folder_workflow_state(
+                connection,
+                "films/Example",
+                candidate_eligibility=workflow_eligibility(title_decisions),
+                library_types=self.config.library_type_map,
+            )
+            exact_workflow = build_folder_workflow_state(
+                connection,
+                extra_prefix,
+                candidate_eligibility=workflow_eligibility(exact_decisions),
+                library_types=self.config.library_type_map,
+            )
+
+        self.assertEqual(title_workflow.items[0].lane, "none")
+        self.assertIn("Extras are excluded", title_workflow.items[0].blocker)
+        self.assertEqual(exact_workflow.items[0].lane, "validate")
+
+    def test_exact_extra_retry_resets_only_that_explicit_file(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            extra_id = self._insert_item(
+                connection,
+                "films/Example/Extras/Trailer.mkv",
+                status="encoding",
+            )
+            self._insert_stage(connection, extra_id, "films/Example/Extras/Trailer.mkv")
+
+            _reset_stale_prefix_encoding_items_for_requeue(
+                connection,
+                self.config,
+                "films/Example/Extras/Trailer.mkv",
+                now_iso=lambda: "2026-07-13T00:00:00+00:00",
+            )
+            status = connection.execute(
+                select(library_items.c.status).where(library_items.c.id == extra_id)
+            ).scalar_one()
+            staged = connection.execute(
+                select(staged_artifacts.c.library_item_id)
+                .where(staged_artifacts.c.library_item_id == extra_id)
+            ).scalar_one_or_none()
+
+        self.assertEqual(status, "planned")
+        self.assertIsNone(staged)
+
+    def test_extras_only_queue_failure_does_not_persist_a_profile_override(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_item(connection, "films/Extras Only/Featurettes/Making Of.mkv")
+        persisted: list[str] = []
+
+        with self.assertRaises(HTTPException) as raised:
+            queue_folder_encode_action(
+                self.config,
+                "films/Extras Only",
+                "",
+                False,
+                now_iso=lambda: "2026-07-13T00:00:00+00:00",
+                load_job_state=lambda *_args: None,
+                load_calibration_state=lambda *_args: {"policy": {}},
+                review_gate=lambda _calibration: {"can_confirm_full": True, "message": "Ready"},
+                upsert_override=lambda *_args: persisted.append("persisted"),
+                load_active_encode_job_for_prefix_fn=lambda *_args: None,
+                clear_terminal_encode_jobs_for_prefix_fn=lambda *_args: None,
+                prepare_terminal_encode_job_for_requeue_fn=lambda *_args: None,
+                save_encode_job=lambda *_args: None,
+            )
+
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertIn("Extras are excluded", str(raised.exception.detail))
+        self.assertEqual(persisted, [])
+
+    def test_title_queue_does_not_recover_an_active_exact_extra_job(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_item(connection, "films/Example/Extras/Trailer.mkv", status="encoding")
+
+        active_job = {
+            "job_id": "exact-extra",
+            "prefix": "films/Example/Extras/Trailer.mkv",
+            "job_kind": "folder",
+            "status": "running",
+        }
+        with patch("mediaforce.web.runtime.folder_actions._recover_active_folder_encode_job") as recover:
+            result = queue_folder_encode_action(
+                self.config,
+                "films/Example",
+                "",
+                False,
+                now_iso=lambda: "2026-07-13T00:00:00+00:00",
+                load_job_state=lambda *_args: None,
+                load_calibration_state=lambda *_args: {"policy": {}},
+                review_gate=lambda _calibration: {"can_confirm_full": True, "message": "Ready"},
+                upsert_override=lambda *_args: None,
+                load_active_encode_job_for_prefix_fn=lambda *_args: active_job,
+                clear_terminal_encode_jobs_for_prefix_fn=lambda *_args: None,
+                prepare_terminal_encode_job_for_requeue_fn=lambda *_args: None,
+                save_encode_job=lambda *_args: None,
+            )
+
+        self.assertFalse(result["ok"])
+        self.assertIn("Extras/Trailer.mkv", result["message"])
+        recover.assert_not_called()
+
+    def test_title_retry_preserves_artifacts_from_an_old_manifest_with_extras(self) -> None:
+        feature_prefix = "films/Example/Feature.mkv"
+        extra_prefix = "films/Example/Extras/Trailer.mkv"
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_item(connection, feature_prefix)
+        manifest_path = self.root / "old-movie-manifest.json"
+        manifest_path.write_text(
+            '{"items":[{"library_item_id":99,"rel_path":"films/Example/Extras/Trailer.mkv"}]}'
+        )
+        terminal_job = {
+            "job_id": "old-title-job",
+            "prefix": "films/Example",
+            "job_kind": "single",
+            "status": "failed",
+            "manifest_path": str(manifest_path),
+            "manifest_indexes": [0],
+        }
+        prepared: list[str] = []
+
+        with patch(
+            "mediaforce.web.runtime.folder_actions.load_latest_terminal_encode_job_for_prefix",
+            return_value=terminal_job,
+        ), self.assertRaises(HTTPException) as raised:
+            queue_folder_encode_action(
+                self.config,
+                "films/Example",
+                "",
+                False,
+                now_iso=lambda: "2026-07-13T00:00:00+00:00",
+                load_job_state=lambda *_args: None,
+                load_calibration_state=lambda *_args: {"policy": {}},
+                review_gate=lambda _calibration: {"can_confirm_full": True, "message": "Ready"},
+                upsert_override=lambda *_args: None,
+                load_active_encode_job_for_prefix_fn=lambda *_args: None,
+                clear_terminal_encode_jobs_for_prefix_fn=lambda *_args: None,
+                prepare_terminal_encode_job_for_requeue_fn=lambda *_args: prepared.append("prepared"),
+                save_encode_job=lambda *_args: None,
+            )
+
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertIn(extra_prefix, str(raised.exception.detail))
+        self.assertEqual(prepared, [])
+
+    def _config(
+            self,
+            *,
+            extras: str,
+            ranking: str = "oldest_added_first",
+            availability: str = "production",
+            additional_libraries: list[dict[str, object]] | None = None,
+    ) -> MediaforceConfig:
+        libraries: list[dict[str, object]] = [
+            {
+                "key": "films",
+                "label": "Movies",
+                "path": str(self.root / "films"),
+                "type": "movie",
+                "availability": availability,
+                "default_profile": "movie_balanced",
+                "policy": {
+                    "grouping": "title",
+                    "editions": "separate",
+                    "extras": extras,
+                    "ranking": ranking,
+                },
+            },
+            *(additional_libraries or []),
+        ]
+        return MediaforceConfig(
+            raw={
+                "media": {
+                    "libraries": libraries,
+                    "output_container": "mkv",
+                    "staging_root": str(self.root / "staging"),
+                    "archive_root": str(self.root / "archive"),
+                },
+                "video": {},
+                "audio": {},
+                "subtitle": {},
+                "planning": {},
+                "validation": {},
+                "overrides": [],
+                "remote_hosts": [],
+            },
+            paths=ConfigPaths(
+                project_root=self.root,
+                config_path=self.root / "config.toml",
+                db_path=self.root / "library.sqlite3",
+                run_manifest_dir=self.root / "runs",
+                web_state_dir=self.root / "web",
+                review_dir=self.root / "review",
+                runtime_settings_path=self.root / "runtime-settings.json",
+            ),
+        )
+
+    @staticmethod
+    def _insert_item(
+            connection: DBClient,
+            rel_path: str,
+            *,
+            size_bytes: int = 1024,
+            status: str = "discovered",
+    ) -> int:
+        timestamp = datetime.now(tz=UTC).isoformat(timespec="seconds")
+        path = Path(rel_path)
+        result = connection.execute(
+            library_items.insert().values(
+                source_path=f"/media/{rel_path}",
+                rel_path=rel_path,
+                media_root=path.parts[0],
+                parent_dir=str(path.parent),
+                file_name=path.name,
+                container=path.suffix.lstrip(".") or "mkv",
+                size_bytes=size_bytes,
+                mtime_ns=1_700_000_000_000_000_000,
+                fingerprint=f"movie-{rel_path}",
+                duration_seconds=7_200.0,
+                video_codec="h264",
+                audio_summary_json="[]",
+                subtitle_summary_json="[]",
+                status=status,
+                priority_score=50,
+                recommendation="priority_encode",
+                recommendation_reason="Movie workflow fixture.",
+                last_scan_id="movie-scan",
+                discovered_at=timestamp,
+                last_seen_at=timestamp,
+                updated_at=timestamp,
+            )
+        )
+        return int(result.inserted_primary_key[0])
+
+    @staticmethod
+    def _insert_stage(connection: DBClient, item_id: int, rel_path: str) -> None:
+        timestamp = datetime.now(tz=UTC).isoformat(timespec="seconds")
+        connection.execute(
+            staged_artifacts.insert().values(
+                library_item_id=item_id,
+                staging_path=f"/staging/{rel_path}.mkv",
+                staging_size_bytes=512,
+                bytes_saved=512,
+                validated_at=timestamp,
+                updated_at=timestamp,
+            )
+        )
+
+    @staticmethod
+    def _insert_plex_age(connection: DBClient, item_id: int, added_at: str) -> None:
+        connection.execute(
+            plex_item_metadata.insert().values(
+                library_item_id=item_id,
+                plex_server_id="server",
+                plex_item_rating_key=f"movie-{item_id}",
+                plex_part_path=f"/media/{item_id}.mkv",
+                plex_added_at=added_at,
+                observed_at=added_at,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scanner_runtime.py
+++ b/tests/test_scanner_runtime.py
@@ -5,10 +5,16 @@ import unittest
 from pathlib import Path
 from typing import Any, cast
 
+from sqlalchemy import select
+
+from mediaforce.core.config import ConfigPaths, MediaforceConfig
+from mediaforce.core.db import open_db, reset_engine_cache
+from mediaforce.core.db_tables import library_items
 from mediaforce.library.scanner import (
     _cadence_summary_present,
     _content_version_changed,
     _failed_probe_summary,
+    _iter_media_files,
     _media_fingerprint_present,
     scan_library,
 )
@@ -93,6 +99,71 @@ class ScannerRuntimeTests(unittest.TestCase):
         self.assertGreaterEqual(len(connection.statements), 2)
         self.assertTrue(connection.statements[0])
         self.assertTrue(connection.statements[-1])
+
+    def test_media_file_prefixes_use_the_configured_root_key(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            physical_root = Path(temp_dir) / "Movies on Disk"
+            feature = physical_root / "Example" / "Feature.mkv"
+            feature.parent.mkdir(parents=True)
+            feature.write_bytes(b"movie")
+
+            matches = list(
+                _iter_media_files(
+                    "films",
+                    physical_root,
+                    prefixes=["films/Example"],
+                    limit=None,
+                    seen=0,
+                )
+            )
+
+        self.assertEqual(matches, [feature])
+
+    def test_rescan_rewrites_catalog_identity_to_the_configured_root_key(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            physical_root = project_root / "Movies on Disk"
+            feature = physical_root / "Example" / "Feature.mkv"
+            feature.parent.mkdir(parents=True)
+            feature.write_bytes(b"not a real movie")
+            paths = ConfigPaths(
+                project_root=project_root,
+                config_path=project_root / "config.toml",
+                db_path=project_root / "library.sqlite3",
+                run_manifest_dir=project_root / "runs",
+                web_state_dir=project_root / "web",
+                review_dir=project_root / "review",
+                runtime_settings_path=project_root / "runtime-settings.json",
+            )
+
+            def config_for(key: str) -> MediaforceConfig:
+                return MediaforceConfig(
+                    raw={
+                        "media": {"source_roots": {key: str(physical_root)}},
+                        "video": {},
+                        "audio": {},
+                        "subtitle": {},
+                        "planning": {},
+                        "validation": {},
+                        "overrides": [],
+                        "remote_hosts": [],
+                    },
+                    paths=paths,
+                )
+
+            try:
+                with open_db(paths.db_path) as connection:
+                    scan_library(connection, config_for("legacy_movies"))
+                    scan_library(connection, config_for("films"))
+                    row = connection.execute(
+                        select(library_items.c.media_root, library_items.c.rel_path, library_items.c.parent_dir)
+                    ).mappings().one()
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(row["media_root"], "films")
+        self.assertEqual(row["rel_path"], "films/Example/Feature.mkv")
+        self.assertEqual(row["parent_dir"], "films/Example")
 
     def test_failed_probe_becomes_blocked_unknown_evidence(self) -> None:
         summary = _failed_probe_summary(RuntimeError("corrupt media"))

--- a/tests/test_web_route_security.py
+++ b/tests/test_web_route_security.py
@@ -105,6 +105,35 @@ class WebRouteSecurityTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(captured_intents[0]["size_goal"]["mode"], "absolute")
 
+    def test_folder_save_profile_failure_returns_conflict_status(self) -> None:
+        app = FastAPI()
+        register_folder_routes(
+            app,
+            folder_status_payload=lambda _prefix: {},
+            folder_content_payload=lambda _prefix: ({}, 200),
+            download_review_compare_action=lambda _prefix: None,
+            folder_ai_tune_action=lambda *_args: {},
+            folder_ai_tune_preview_action=lambda *_args: {},
+            folder_ai_tune_confirm_action=lambda *_args: {},
+            clear_folder_tuning_action=lambda _prefix: {},
+            save_series_lifecycle_action=lambda _prefix, _mode: {},
+            approve_measured_encode_recovery_action=lambda _prefix: {},
+            queue_folder_encode_action=lambda *_args: {},
+            validate_folder_outputs_action=lambda _prefix: {},
+            promote_folder_outputs_action=lambda _prefix: {},
+            save_profile_action=lambda *_args: {
+                "ok": False,
+                "code": "library_not_production",
+                "message": "Movies is browse only.",
+            },
+        )
+        endpoint = _route_endpoint(app, "/api/folders/{prefix:path}/save-profile", "POST")
+
+        response = asyncio.run(endpoint("films/Example", _json_request({})))
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(json.loads(response.body)["code"], "library_not_production")
+
     def test_settings_save_hides_internal_validation_detail(self) -> None:
         app = FastAPI()
 


### PR DESCRIPTION
## Summary
- add config-aware movie title and exact-file projections with safe extras/uncertain exclusion, edition separation, deterministic age provenance, and manifest recovery boundaries
- add dedicated Movies Library APIs and a movie-specific Folder Studio over the shared production pipeline
- add a dense desktop/narrow workstation UI with keyboard navigation, conflict/browse-only states, and structure-first hydration
- extend backend, frontend, route-smoke, and browser fixtures for single files, conventional folders, editions, extras, active jobs, and promotion conflicts

## Safety
- fail closed for browse-only and unknown roots on write-capable actions
- preserve exact-file boundaries during retry, validation, promotion, and cleanup
- preflight filesystem-equivalent destination collisions before promotion
- keep movie work free of TV lifecycle semantics while preserving custom typed TV roots

## Validation
- `bash scripts/pre-commit-check.sh` (890 backend tests, 192 frontend tests, typecheck, lint, build, desktop/narrow/empty route smoke)
- `uv build`
- headed browser review at desktop and narrow widths, including keyboard navigation and promotion-conflict states
- independent backend/product-risk and UI reviews; findings addressed

Closes #187