### PR TITLE
Harden Movies workflow from real-catalog dogfood

### DIFF
--- a/docs/design/movies-workflow.md
+++ b/docs/design/movies-workflow.md
@@ -21,6 +21,9 @@ second encode path.
 - Movies uses a dense title list with a persistent inspector, not a poster wall.
 - The list exposes state, title, file membership, size, reclaim estimate, age
   provenance, and the next action.
+- Reclaim is evidence-backed: an unmeasured movie reports no estimate rather
+  than borrowing TV or generic codec history. Known staged savings remain
+  visible independently.
 - The inspector exposes every feature, edition, extra, and uncertain member as
   a reachable row.
 - Narrow layouts stack the inspector below the selected title without horizontal
@@ -34,6 +37,9 @@ second encode path.
 - Movie copy uses title, feature, edition, extra, and file. It never uses show,
   season, episode, or lifecycle language.
 - Movie membership is visible before sample or queue actions.
+- Structure renders before details; background detail refreshes never overlap.
+- A failed or non-queueable sample proposal stays visible as a blocked plan and
+  never exposes a start action.
 
 ## Safety
 

--- a/docs/development/browser-qa-matrix.md
+++ b/docs/development/browser-qa-matrix.md
@@ -39,7 +39,8 @@ The managed smoke seeds a compact but non-empty workflow dataset:
 - Movies Library: `/movies` includes a root-level exact file, a conventional
   title directory with two independently reachable editions, an excluded
   featurette, an uncertain nested file, active processing, completed titles,
-  and a preflight promotion conflict.
+  and a preflight promotion conflict. Unmeasured titles show `No estimate`
+  rather than inheriting TV codec-history savings.
 - Movie Studio: `/folders/movies/Loose%20Feature.mkv`,
   `/folders/movies/Editions%20Showcase`,
   `/folders/movies/Waiting%20Encode`, and

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -132,6 +132,7 @@ export interface FolderCard {
 	lifecycle?: LifecycleState | null;
 	media_scope?: MediaScopePayload | null;
 	details_loading: boolean;
+	estimate_unavailable_count?: number;
 }
 
 export type MovieMemberRole = 'feature' | 'extra' | 'uncertain';

--- a/frontend/src/lib/components/workstation/MovieLibraryPage.svelte
+++ b/frontend/src/lib/components/workstation/MovieLibraryPage.svelte
@@ -19,15 +19,22 @@
 	onMount(() => {
 		disposed = false;
 		let refreshTimer: number | undefined;
-		void hydrateStructure().finally(() => {
+		void hydrateStructure().finally(async () => {
 			if (disposed) return;
-			void hydrateDetails();
-			refreshTimer = window.setInterval(() => void hydrateDetails(true), 7000);
+			await hydrateDetails();
+			if (!disposed) scheduleRefresh();
 		});
+
+		function scheduleRefresh() {
+			refreshTimer = window.setTimeout(async () => {
+				await hydrateDetails(true);
+				if (!disposed) scheduleRefresh();
+			}, 7000);
+		}
 
 		return () => {
 			disposed = true;
-			if (refreshTimer) window.clearInterval(refreshTimer);
+			if (refreshTimer) window.clearTimeout(refreshTimer);
 		};
 	});
 

--- a/frontend/src/lib/components/workstation/MovieLibraryView.svelte
+++ b/frontend/src/lib/components/workstation/MovieLibraryView.svelte
@@ -3,6 +3,7 @@
 
 	import type { MovieLibraryPayload, MovieMember, MovieTitle } from '$lib/api/types';
 	import { folderRoutePath } from '$lib/folder-display';
+	import { movieReclaimLowerBound, movieReclaimTotalIsLowerBound } from '$lib/movies/library';
 	import LibraryModeNav from './LibraryModeNav.svelte';
 
 	let {
@@ -51,8 +52,12 @@
 		payload.titles.reduce((total, title) => total + title.total_size_bytes, 0)
 	);
 	const totalReclaim = $derived(
-		payload.titles.reduce((total, title) => total + (title.projected_reclaim_bytes ?? 0), 0)
+		payload.titles.reduce((total, title) => total + (movieReclaimLowerBound(title) ?? 0), 0)
 	);
+	const reclaimCoverage = $derived(
+		payload.titles.filter((title) => movieReclaimLowerBound(title) != null).length
+	);
+	const reclaimHasUnknowns = $derived(movieReclaimTotalIsLowerBound(payload.titles));
 	const actionableCount = $derived(
 		payload.titles.filter((title) =>
 			['encode', 'validate', 'promote', 'processing', 'attention'].includes(
@@ -114,7 +119,7 @@
 	}
 
 	function formatBytes(value: number | null | undefined): string {
-		if (value == null) return 'Pending';
+		if (value == null) return 'No estimate';
 		if (value < 1024) return `${value} B`;
 		const units = ['KB', 'MB', 'GB', 'TB'];
 		let size = value;
@@ -124,6 +129,14 @@
 			unit += 1;
 		}
 		return `${size >= 10 ? size.toFixed(0) : size.toFixed(1)} ${units[unit]}`;
+	}
+
+	function formatReclaim(title: MovieTitle): string {
+		const lowerBound = movieReclaimLowerBound(title);
+		if (lowerBound == null) return 'No estimate';
+		return title.projected_reclaim_bytes == null
+			? `At least ${formatBytes(lowerBound)}`
+			: formatBytes(lowerBound);
 	}
 
 	function formatAge(title: MovieTitle): string {
@@ -204,9 +217,15 @@
 			<div><strong>{payload.titles.length}</strong><span>titles</span></div>
 			<div><strong>{formatBytes(totalSize)}</strong><span>stored</span></div>
 			<div>
-				<strong>{detailsPending ? '…' : formatBytes(totalReclaim)}</strong><span
-					>projected reclaim</span
-				>
+				<strong
+					>{detailsPending
+						? '…'
+						: reclaimCoverage === 0
+							? 'No estimate'
+							: reclaimHasUnknowns
+								? `At least ${formatBytes(totalReclaim)}`
+								: formatBytes(totalReclaim)}</strong
+				><span>projected reclaim</span>
 			</div>
 			<div><strong>{actionableCount}</strong><span>active or ready</span></div>
 		</div>
@@ -336,7 +355,9 @@
 								<small>
 									{title.details_loading
 										? 'Reclaim pending'
-										: `${formatBytes(title.projected_reclaim_bytes)} reclaim · ${title.savings_confidence}`}
+										: title.savings_confidence === 'unavailable'
+											? 'No estimate yet'
+											: `${formatReclaim(title)} reclaim · ${title.savings_confidence}`}
 								</small>
 							</span>
 							<span class="state-badge" data-tone={workflowTone(title)}>
@@ -374,7 +395,9 @@
 							</div>
 							<div>
 								<span>Projected reclaim</span><strong
-									>{formatBytes(selectedTitle.projected_reclaim_bytes)}</strong
+									>{selectedTitle.details_loading
+										? 'Pending'
+										: formatReclaim(selectedTitle)}</strong
 								>
 							</div>
 							<div><span>Ranking age</span><strong>{formatAge(selectedTitle)}</strong></div>

--- a/frontend/src/lib/components/workstation/MovieStudioView.svelte
+++ b/frontend/src/lib/components/workstation/MovieStudioView.svelte
@@ -50,6 +50,7 @@
 	);
 	const calibration = $derived(asRecord(folder.calibration));
 	const pendingProposal = $derived(asRecord(folder.pending_proposal));
+	const pendingProposalCanQueue = $derived(pendingProposal.can_queue === true);
 	const reviewGate = $derived(asRecord(folder.review_gate));
 	const calibrationJob = $derived(asRecord(folder.calibration_job));
 	const encodeJob = $derived(folder.encode_job ?? null);
@@ -101,7 +102,7 @@
 	}
 
 	async function startSample() {
-		if (isBrowseOnly || isBusy) return;
+		if (isBrowseOnly || isBusy || !pendingProposalCanQueue) return;
 		await runAction('start-sample', async () => {
 			const response = await postJson<FolderBenchConfirmResponse>(
 				`/api/folders/${folderRoutePrefix(folder.prefix)}/ai-tune/confirm`,
@@ -224,7 +225,7 @@
 		if (['failed', 'stopped', 'needs_attention'].includes(encodeStatus)) return 'retry';
 		if (workflow?.next_action.kind === 'validate_outputs') return 'validate';
 		if (workflow?.next_action.kind === 'promote_outputs') return 'promote';
-		if (Object.keys(pendingProposal).length) return 'start';
+		if (Object.keys(pendingProposal).length && pendingProposalCanQueue) return 'start';
 		if (reviewGate.status === 'accepted') return 'queue';
 		if (reviewReady) return 'queue';
 		return 'prepare';
@@ -412,12 +413,24 @@
 			>
 				<div class="sample-bench">
 					{#if Object.keys(pendingProposal).length}
-						<div class="sample-plan">
-							<strong>Sample plan is ready</strong>
-							<p>Nothing starts until you confirm this plan.</p>
-							<button class="secondary" disabled={isBusy || isBrowseOnly} onclick={startSample}
-								>Start sample</button
+						<div class:sample-plan--blocked={!pendingProposalCanQueue} class="sample-plan">
+							<strong
+								>{pendingProposalCanQueue
+									? 'Sample plan is ready'
+									: 'Sample plan needs another request'}</strong
 							>
+							<p>
+								{pendingProposalCanQueue
+									? 'Nothing starts until you confirm this plan.'
+									: asText(pendingProposal.message) ||
+										asText(pendingProposal.suggested_follow_up) ||
+										'The bench did not produce a queueable sample plan.'}
+							</p>
+							{#if pendingProposalCanQueue}
+								<button class="secondary" disabled={isBusy || isBrowseOnly} onclick={startSample}
+									>Start sample</button
+								>
+							{/if}
 						</div>
 					{/if}
 					<div class="sample-facts">
@@ -752,6 +765,15 @@
 		display: grid;
 		gap: var(--mf-space-4);
 		padding: var(--mf-space-6);
+	}
+
+	.sample-plan--blocked {
+		background: var(--mf-attention-bg);
+		border-color: var(--mf-attention-line);
+	}
+
+	.sample-plan--blocked strong {
+		color: var(--mf-attention-fg);
 	}
 
 	.sample-plan .secondary {

--- a/frontend/src/lib/movies/library.test.ts
+++ b/frontend/src/lib/movies/library.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import type { MovieLibraryPayload, MovieTitle } from '$lib/api/types';
-import { mergeMovieLibraryPayloads } from './library';
+import {
+	mergeMovieLibraryPayloads,
+	movieReclaimLowerBound,
+	movieReclaimTotalIsLowerBound
+} from './library';
 
 const title: MovieTitle = {
 	prefix: 'films/Example',
@@ -74,5 +78,79 @@ describe('mergeMovieLibraryPayloads', () => {
 
 		expect(merged.titles[0]?.projected_reclaim_bytes).toBe(4);
 		expect(merged.titles[0]?.members[0]?.age?.source).toBe('plex');
+	});
+
+	it('preserves an unavailable reclaim estimate instead of coercing it to zero', () => {
+		const merged = mergeMovieLibraryPayloads(
+			payload(title),
+			payload({
+				...title,
+				projected_reclaim_bytes: null,
+				estimated_savings_bytes: null,
+				known_saved_bytes: 0,
+				savings_confidence: 'unavailable',
+				details_loading: false
+			})
+		);
+
+		expect(merged.titles[0]?.projected_reclaim_bytes).toBeNull();
+		expect(merged.titles[0]?.estimated_savings_bytes).toBeNull();
+		expect(merged.titles[0]?.savings_confidence).toBe('unavailable');
+	});
+});
+
+describe('movieReclaimLowerBound', () => {
+	it('uses measured savings when a mixed title has no complete projection', () => {
+		expect(
+			movieReclaimLowerBound({
+				...title,
+				projected_reclaim_bytes: null,
+				known_saved_bytes: 4,
+				savings_confidence: 'unavailable',
+				details_loading: false
+			})
+		).toBe(4);
+	});
+
+	it('keeps fully unmeasured titles unavailable', () => {
+		expect(
+			movieReclaimLowerBound({
+				...title,
+				projected_reclaim_bytes: null,
+				known_saved_bytes: 0,
+				savings_confidence: 'unavailable',
+				details_loading: false
+			})
+		).toBeNull();
+	});
+});
+
+describe('movieReclaimTotalIsLowerBound', () => {
+	it('qualifies the total when a title has only a measured lower bound', () => {
+		expect(
+			movieReclaimTotalIsLowerBound([
+				{
+					...title,
+					projected_reclaim_bytes: null,
+					known_saved_bytes: 4,
+					savings_confidence: 'unavailable',
+					details_loading: false
+				}
+			])
+		).toBe(true);
+	});
+
+	it('treats zero as a complete projection when it is explicitly measured', () => {
+		expect(
+			movieReclaimTotalIsLowerBound([
+				{
+					...title,
+					projected_reclaim_bytes: 0,
+					known_saved_bytes: 0,
+					savings_confidence: 'measured',
+					details_loading: false
+				}
+			])
+		).toBe(false);
 	});
 });

--- a/frontend/src/lib/movies/library.ts
+++ b/frontend/src/lib/movies/library.ts
@@ -21,6 +21,15 @@ export function mergeMovieLibraryPayloads(
 	};
 }
 
+export function movieReclaimLowerBound(title: MovieTitle): number | null {
+	if (title.projected_reclaim_bytes != null) return title.projected_reclaim_bytes;
+	return (title.known_saved_bytes ?? 0) > 0 ? (title.known_saved_bytes ?? null) : null;
+}
+
+export function movieReclaimTotalIsLowerBound(titles: MovieTitle[]): boolean {
+	return titles.some((title) => title.projected_reclaim_bytes == null);
+}
+
 function mergeMovieTitle(structure: MovieTitle, details?: MovieTitle): MovieTitle {
 	if (!details) return structure;
 	const detailsByPrefix = new Map(details.members.map((member) => [member.prefix, member]));

--- a/frontend/src/routes/folders/[...prefix]/+page.svelte
+++ b/frontend/src/routes/folders/[...prefix]/+page.svelte
@@ -29,6 +29,7 @@
 	let hosts = $state<HostsPayload>(initialHosts);
 	let foldersPending = $state(false);
 	let folderPending = $state(false);
+	let folderHydrated = $state(false);
 	let loadError = $state<string | null>(null);
 	let hydrationGeneration = 0;
 
@@ -81,7 +82,10 @@
 				loadError = error instanceof Error ? error.message : 'Unable to open this media scope.';
 			}
 		} finally {
-			if (generation === hydrationGeneration) folderPending = false;
+			if (generation === hydrationGeneration) {
+				folderPending = false;
+				folderHydrated = true;
+			}
 		}
 	}
 
@@ -95,6 +99,7 @@
 		loadError = null;
 
 		if (currentMode === 'studio') {
+			folderHydrated = false;
 			folder = initialFolderPayload(currentPrefix);
 			status = initialFolderStatusPayload(currentPrefix);
 			hosts = initialHosts;
@@ -121,17 +126,22 @@
 <svelte:head>
 	<title
 		>{mode === 'studio'
-			? `${prefix.split('/').at(-1)} · ${folder.media_scope.domain === 'movie' ? 'Movie Studio' : 'Mediaforce'}`
+			? `${prefix.split('/').at(-1)} · ${folder.pending ? 'Studio' : folder.media_scope.domain === 'movie' ? 'Movie Studio' : 'Mediaforce'}`
 			: 'Make a TV season smaller · Mediaforce'}</title
 	>
 </svelte:head>
 
 {#if mode === 'studio'}
-	{#if folderPending && folder.pending}
+	{#if !folderHydrated && (folder.pending || folderPending)}
 		<div class="studio-loading" role="status">
 			<span aria-hidden="true"></span>
 			<strong>Opening Studio</strong>
 			<p>Reading scope, membership, workflow, and worker readiness.</p>
+		</div>
+	{:else if folder.pending}
+		<div class="studio-loading" role="alert">
+			<strong>Studio could not open</strong>
+			<p>{loadError ?? 'The media scope is unavailable.'}</p>
 		</div>
 	{:else if folder.media_scope.domain === 'movie'}
 		<MovieStudioView

--- a/mediaforce/library/movie_library.py
+++ b/mediaforce/library/movie_library.py
@@ -13,7 +13,7 @@ from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items, plex_item_metadata, staged_artifacts
 from mediaforce.core.type_defs import mapping_dict, object_dict
 from mediaforce.core.utils import filesystem_collision_key
-from mediaforce.library.candidate_selection import encode_candidate_decisions, workflow_eligibility
+from mediaforce.library.candidate_selection import CandidateDecision, project_candidates, workflow_eligibility
 from mediaforce.library.media_scopes import resolve_media_scope, resolve_media_scopes, scope_rel_path_filter
 from mediaforce.library.movie_workflow import MovieMembership, classify_movie_path, movie_item_included
 from mediaforce.library.workflow_state import build_folder_workflow_states, derive_item_workflow_state
@@ -28,6 +28,7 @@ def load_movie_library_payload(
         include_details: bool,
         metrics_by_prefix: MovieMetrics | None = None,
         prefixes: list[str] | None = None,
+        candidate_decisions: list[CandidateDecision] | None = None,
 ) -> dict[str, Any]:
     libraries = _movie_libraries(config)
     library_by_root = {str(library["key"]): library for library in libraries}
@@ -82,7 +83,13 @@ def load_movie_library_payload(
         if membership is not None:
             grouped_rows[membership.title_prefix].append((row, membership))
 
-    decisions = encode_candidate_decisions(connection, config, prefixes=prefixes or []) if include_details else []
+    decisions = (
+        candidate_decisions
+        if include_details and candidate_decisions is not None
+        else project_candidates(connection, config, prefixes=prefixes or [])
+        if include_details
+        else []
+    )
     decisions_by_item = {decision.item_id: decision for decision in decisions}
     eligibility = workflow_eligibility(decisions)
     for grouped in grouped_rows.values():
@@ -112,6 +119,7 @@ def load_movie_library_payload(
             eligibility=eligibility,
             workflow=workflows.get(prefix),
             metrics=object_dict(metrics.get(prefix)),
+            metrics_available=prefix in metrics,
             config=config,
             include_details=include_details,
         )
@@ -131,6 +139,9 @@ def load_movie_scope_payload(
         connection: DBClient,
         config: MediaforceConfig,
         prefix: str,
+        *,
+        metrics_by_prefix: MovieMetrics | None = None,
+        candidate_decisions: list[CandidateDecision] | None = None,
 ) -> dict[str, Any] | None:
     normalized = str(prefix or "").strip().strip("/")
     scope = resolve_media_scope(
@@ -146,7 +157,9 @@ def load_movie_scope_payload(
         connection,
         config,
         include_details=True,
+        metrics_by_prefix=metrics_by_prefix,
         prefixes=[title_prefix],
+        candidate_decisions=candidate_decisions,
     )
     for title in payload["titles"]:
         if str(title.get("prefix") or "") == normalized:
@@ -226,6 +239,7 @@ def _title_payload(
         eligibility: dict[int, tuple[bool, str | None]],
         workflow: Any,
         metrics: dict[str, Any],
+        metrics_available: bool,
         config: MediaforceConfig,
         include_details: bool,
 ) -> dict[str, Any]:
@@ -258,9 +272,22 @@ def _title_payload(
         if isinstance((age := member.get("age")), Mapping) and age.get("timestamp")
     ]
     title_age = min(ages, key=lambda age: str(age["timestamp"])) if ages else None
-    projected_reclaim = int(metrics.get("projected_reclaim_bytes") or 0)
+    estimate_unavailable_count = (
+        int(metrics.get("estimate_unavailable_count") or 0)
+        if metrics_available
+        else 1
+    )
+    projected_reclaim = (
+        None
+        if estimate_unavailable_count > 0
+        else int(metrics.get("projected_reclaim_bytes") or 0)
+    )
     known_saved = int(metrics.get("known_saved_bytes") or 0)
-    estimated_savings = int(metrics.get("estimated_savings_bytes") or 0)
+    estimated_savings = (
+        None
+        if estimate_unavailable_count > 0
+        else int(metrics.get("estimated_savings_bytes") or 0)
+    )
     workflow_payload = workflow.to_payload() if workflow is not None else None
     workflow_payload = adapt_movie_workflow_payload(workflow_payload, library=library, members=members)
     return {
@@ -283,8 +310,9 @@ def _title_payload(
         "known_saved_bytes": known_saved if include_details else None,
         "estimated_savings_bytes": estimated_savings if include_details else None,
         "savings_confidence": (
-            "measured" if known_saved > 0 and estimated_savings == 0
-            else "estimated" if projected_reclaim > 0
+            "unavailable" if estimate_unavailable_count > 0
+            else "measured" if known_saved > 0 and estimated_savings == 0
+            else "estimated" if projected_reclaim and projected_reclaim > 0
             else "unavailable"
         ) if include_details else "pending",
         "age": title_age if include_details else None,

--- a/mediaforce/library/movie_workflow.py
+++ b/mediaforce/library/movie_workflow.py
@@ -30,6 +30,24 @@ _EXTRA_NAME_PATTERNS = (
     (re.compile(r"(?:^|[-_.\s])shorts?$", re.IGNORECASE), "Shorts"),
     (re.compile(r"(?:^|[-_.\s])trailers?$", re.IGNORECASE), "Trailers"),
 )
+_EXTRA_TOKEN_SEQUENCES = (
+    (("behind", "the", "scenes"), "Behind the scenes"),
+    (("bonus", "features"), "Bonus features"),
+    (("deleted", "scenes"), "Deleted scenes"),
+    (("bonus",), "Bonus features"),
+    (("extra",), "Extras"),
+    (("extras",), "Extras"),
+    (("featurette",), "Featurettes"),
+    (("featurettes",), "Featurettes"),
+    (("interview",), "Interviews"),
+    (("interviews",), "Interviews"),
+    (("sample",), "Samples"),
+    (("samples",), "Samples"),
+    (("short",), "Shorts"),
+    (("shorts",), "Shorts"),
+    (("trailer",), "Trailers"),
+    (("trailers",), "Trailers"),
+)
 _EDITION_PATTERNS = (
     (re.compile(r"\bdirector'?s\s+cut\b", re.IGNORECASE), "Director's Cut"),
     (re.compile(r"\btheatrical(?:\s+cut)?\b", re.IGNORECASE), "Theatrical Cut"),
@@ -39,6 +57,7 @@ _EDITION_PATTERNS = (
     (re.compile(r"\bspecial\s+edition\b", re.IGNORECASE), "Special Edition"),
     (re.compile(r"\bremaster(?:ed)?\b", re.IGNORECASE), "Remastered"),
 )
+_TITLE_YEAR_SUFFIX = re.compile(r"\s*[([{](?:18|19|20)\d{2}[)\]}]\s*$")
 
 
 @dataclass(frozen=True, slots=True)
@@ -103,7 +122,7 @@ def classify_movie_path(rel_path: str, *, root: str) -> MovieMembership | None:
                 label=file_label,
                 extra_category=category,
             )
-    extra_category = infer_extra_category(file_label)
+    extra_category = infer_extra_category(file_label, title=title)
     if extra_category is not None:
         return MovieMembership(
             rel_path=normalized,
@@ -164,12 +183,26 @@ def infer_edition_label(value: str) -> str | None:
     return None
 
 
-def infer_extra_category(value: str) -> str | None:
+def infer_extra_category(value: str, *, title: str | None = None) -> str | None:
+    tokens = _tokens(value)
+    if title:
+        title_tokens = _tokens(_TITLE_YEAR_SUFFIX.sub("", title))
+        if tokens[:len(title_tokens)] == title_tokens:
+            tokens = tokens[len(title_tokens):]
+    for sequence, category in _EXTRA_TOKEN_SEQUENCES:
+        width = len(sequence)
+        if any(tuple(tokens[index:index + width]) == sequence for index in range(len(tokens) - width + 1)):
+            return category
+    candidate = " ".join(tokens)
     for pattern, category in _EXTRA_NAME_PATTERNS:
-        if pattern.search(value):
+        if pattern.search(candidate):
             return category
     return None
 
 
 def _normalized_token(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def _tokens(value: str) -> list[str]:
+    return re.findall(r"[a-z0-9]+", value.lower())

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -68,7 +68,7 @@ from mediaforce.library.planner import build_manifest_item
 from mediaforce.library.representatives import RepresentativeSelection, load_representative_selection, \
     public_representative_item
 from mediaforce.library.run_manifests import select_encode_candidates
-from mediaforce.library.candidate_selection import encode_candidate_decisions, project_candidates, \
+from mediaforce.library.candidate_selection import CandidateDecision, encode_candidate_decisions, project_candidates, \
     scope_lifecycle_payload_from_decisions, workflow_eligibility
 from mediaforce.hosts.types import HostSetupResult
 from mediaforce.hosts.config import configured_remote_host_execution_mode
@@ -541,6 +541,19 @@ def create_app(config_path: Path | None = None) -> FastAPI:
 
     def _dashboard_movie_library_details_payload() -> dict[str, Any]:
         with open_db(config.paths.db_path) as connection:
+            movie_roots = {
+                root
+                for root, library_type in config.library_type_map.items()
+                if library_type == "movie"
+            }
+            if not movie_roots:
+                return load_movie_library_payload(
+                    connection,
+                    config,
+                    include_details=True,
+                    candidate_decisions=[],
+                )
+            decisions = project_candidates(connection, config, prefixes=sorted(movie_roots))
             cards = _folder_cards_for_group(
                 config,
                 connection,
@@ -549,12 +562,17 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                     library_types=config.library_type_map,
                 ),
                 minimum_recommended_savings_bytes=None,
+                media_roots=movie_roots,
+                candidate_decisions=decisions,
+                include_lifecycle=False,
+                include_workflow_states=False,
             )
             return load_movie_library_payload(
                 connection,
                 config,
                 include_details=True,
                 metrics_by_prefix={card.prefix: asdict(card) for card in cards},
+                candidate_decisions=decisions,
             )
 
     def _dashboard_api_payload(preview_limit: int | None = None) -> dict[str, Any]:
@@ -761,11 +779,32 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 normalized_prefix,
                 library_types=config.library_type_map,
             )
-            movie_context = (
-                load_movie_scope_payload(connection, config, normalized_prefix)
-                if media_scope.domain == "movie"
-                else None
-            )
+            movie_context = None
+            if media_scope.domain == "movie":
+                membership = classify_movie_path(normalized_prefix, root=media_scope.root)
+                movie_title_prefix = membership.title_prefix if membership is not None else normalized_prefix
+                movie_decisions = project_candidates(connection, config, prefixes=[movie_title_prefix])
+                movie_cards = _folder_cards_for_group(
+                    config,
+                    connection,
+                    folder_group=lambda rel_path: _movie_folder_group(
+                        rel_path,
+                        library_types=config.library_type_map,
+                    ),
+                    minimum_recommended_savings_bytes=None,
+                    rel_path_root=movie_title_prefix,
+                    media_roots={media_scope.root},
+                    candidate_decisions=movie_decisions,
+                    include_lifecycle=False,
+                    include_workflow_states=False,
+                )
+                movie_context = load_movie_scope_payload(
+                    connection,
+                    config,
+                    normalized_prefix,
+                    metrics_by_prefix={card.prefix: asdict(card) for card in movie_cards},
+                    candidate_decisions=movie_decisions,
+                )
             calibration_job = _load_job_state(connection, config, normalized_prefix)
             if calibration_job and calibration_job.get("status") in {"queued", "running"}:
                 existing_scan_job = _load_scan_job_state(config, normalized_prefix)
@@ -1995,6 +2034,9 @@ def _folder_cards_for_group(
         minimum_recommended_savings_bytes: int | None = MIN_RECOMMENDED_SAVINGS_BYTES,
         rel_path_root: str | None = None,
         media_roots: set[str] | None = None,
+        candidate_decisions: list[CandidateDecision] | None = None,
+        include_lifecycle: bool = True,
+        include_workflow_states: bool = True,
 ) -> list[FolderCard]:
     needs_attention_badges: dict[str, dict[str, str | None]] | None = None
     calibration_job_badges: dict[str, dict[str, str | None]] | None = None
@@ -2030,6 +2072,9 @@ def _folder_cards_for_group(
         review_badge_for_prefix=review_badge_for_prefix,
         rel_path_root=rel_path_root,
         media_roots=media_roots,
+        candidate_decisions=candidate_decisions,
+        include_lifecycle=include_lifecycle,
+        include_workflow_states=include_workflow_states,
     )
     return _attach_media_scopes(connection, config, cards)
 

--- a/mediaforce/web/runtime/folder_cards.py
+++ b/mediaforce/web/runtime/folder_cards.py
@@ -44,6 +44,7 @@ class FolderCard:
     lifecycle: dict[str, object] | None = None
     media_scope: dict[str, object] | None = None
     details_loading: bool = False
+    estimate_unavailable_count: int = 0
 
 
 @dataclass(slots=True)
@@ -163,7 +164,11 @@ def preview_folder_cards(
 ) -> list[FolderCard]:
     decisions = project_candidates(connection, config, prefixes=[]) if config is not None else []
     decisions_by_item = {decision.item_id: decision for decision in decisions}
-    folder_history, codec_history = _load_savings_history(connection, folder_group=folder_group)
+    folder_history, codec_history = _load_savings_history(
+        connection,
+        folder_group=folder_group,
+        decisions_by_item=decisions_by_item,
+    )
     rows = connection.execute(
         select(
             library_items.c.id.label("item_id"),
@@ -227,14 +232,17 @@ def preview_folder_cards(
         if status != "promoted" and production_included:
             card.pending_count += 1
             if known_saved_bytes is None and _eligible_for_estimate(status, decision):
-                card.estimated_savings_bytes += _estimated_pending_savings_bytes(
-                    size_bytes=size_bytes,
-                    video_codec=codec,
-                    audio_summary_json=str(row["audio_summary_json"] or "[]"),
-                    estimate_savings_bytes=estimate_savings_bytes,
-                    folder_history=folder_history.get(prefix),
-                    codec_history=codec_history.get(_canonical_video_codec(codec)),
-                )
+                if decision is not None and decision.media_domain == "movie":
+                    card.estimate_unavailable_count += 1
+                else:
+                    card.estimated_savings_bytes += _estimated_pending_savings_bytes(
+                        size_bytes=size_bytes,
+                        video_codec=codec,
+                        audio_summary_json=str(row["audio_summary_json"] or "[]"),
+                        estimate_savings_bytes=estimate_savings_bytes,
+                        folder_history=folder_history.get(prefix),
+                        codec_history=_codec_history_for_decision(codec_history, decision, codec),
+                    )
         card.statuses[status] = card.statuses.get(status, 0) + 1
         card.video_codecs[codec] = card.video_codecs.get(codec, 0) + 1
     for card in grouped.values():
@@ -331,10 +339,23 @@ def list_folder_cards(
         review_badge_for_prefix: Callable[[str], FolderBadge],
         rel_path_root: str | None = None,
         media_roots: set[str] | None = None,
+        candidate_decisions: list[CandidateDecision] | None = None,
+        include_lifecycle: bool = True,
+        include_workflow_states: bool = True,
 ) -> list[FolderCard]:
-    decisions = project_candidates(connection, config, prefixes=[]) if config is not None else []
+    decisions = (
+        candidate_decisions
+        if candidate_decisions is not None
+        else project_candidates(connection, config, prefixes=[])
+        if config is not None
+        else []
+    )
     decisions_by_item = {decision.item_id: decision for decision in decisions}
-    folder_history, codec_history = _load_savings_history(connection, folder_group=folder_group)
+    folder_history, codec_history = _load_savings_history(
+        connection,
+        folder_group=folder_group,
+        decisions_by_item=decisions_by_item,
+    )
     query = (
         select(
             library_items.c.id.label("item_id"),
@@ -413,16 +434,19 @@ def list_folder_cards(
             if known_saved_bytes is not None:
                 card.sort_score += known_saved_bytes / (1024 ** 3)
             elif _eligible_for_estimate(status, decision):
-                estimated_savings = _estimated_pending_savings_bytes(
-                    size_bytes=size_bytes,
-                    video_codec=codec,
-                    audio_summary_json=str(row["audio_summary_json"] or "[]"),
-                    estimate_savings_bytes=estimate_savings_bytes,
-                    folder_history=folder_history.get(prefix),
-                    codec_history=codec_history.get(_canonical_video_codec(codec)),
-                )
-                card.estimated_savings_bytes += estimated_savings
-                card.sort_score += estimated_savings / (1024 ** 3)
+                if decision is not None and decision.media_domain == "movie":
+                    card.estimate_unavailable_count += 1
+                else:
+                    estimated_savings = _estimated_pending_savings_bytes(
+                        size_bytes=size_bytes,
+                        video_codec=codec,
+                        audio_summary_json=str(row["audio_summary_json"] or "[]"),
+                        estimate_savings_bytes=estimate_savings_bytes,
+                        folder_history=folder_history.get(prefix),
+                        codec_history=_codec_history_for_decision(codec_history, decision, codec),
+                    )
+                    card.estimated_savings_bytes += estimated_savings
+                    card.sort_score += estimated_savings / (1024 ** 3)
         card.statuses[status] = card.statuses.get(status, 0) + 1
         card.video_codecs[codec] = card.video_codecs.get(codec, 0) + 1
     cards = list(grouped.values())
@@ -438,8 +462,10 @@ def list_folder_cards(
             or card.projected_reclaim_bytes >= minimum_recommended_savings_bytes
         )
     ]
-    _apply_lifecycle(cards, decisions)
-    _apply_folder_workflow_states(connection, cards, decisions, config=config)
+    if include_lifecycle:
+        _apply_lifecycle(cards, decisions)
+    if include_workflow_states:
+        _apply_folder_workflow_states(connection, cards, decisions, config=config)
     _apply_folder_review_badges(cards, review_badge_for_prefix)
     return sorted(
         cards,
@@ -547,6 +573,7 @@ def _copy_folder_card(card: FolderCard, *, include_review_badges: bool = True) -
         workflow_state=deepcopy(card.workflow_state),
         lifecycle=deepcopy(card.lifecycle),
         details_loading=card.details_loading,
+        estimate_unavailable_count=card.estimate_unavailable_count,
     )
 
 
@@ -590,9 +617,11 @@ def _load_savings_history(
         connection: DBClient,
         *,
         folder_group: Callable[[str], FolderGroup | None],
-) -> tuple[dict[str, SavingsHistory], dict[str, SavingsHistory]]:
+        decisions_by_item: dict[int, CandidateDecision],
+) -> tuple[dict[str, SavingsHistory], dict[tuple[str, str], SavingsHistory]]:
     rows = connection.execute(
         select(
+            library_items.c.id.label("item_id"),
             library_items.c.rel_path,
             library_items.c.status,
             staged_artifacts.c.source_rel_path,
@@ -612,7 +641,7 @@ def _load_savings_history(
     ).mappings().fetchall()
 
     folder_history: dict[str, SavingsHistory] = {}
-    codec_history: dict[str, SavingsHistory] = {}
+    codec_history: dict[tuple[str, str], SavingsHistory] = {}
     for row in rows:
         source_size_bytes = int(row["source_size_bytes"] or 0)
         if source_size_bytes <= 0:
@@ -624,10 +653,21 @@ def _load_savings_history(
         if group is not None and codec is not None:
             history = folder_history.setdefault(group[0], SavingsHistory())
             history.record(source_size_bytes=source_size_bytes, bytes_saved=bytes_saved, codec_key=codec)
-        if codec is not None:
-            history = codec_history.setdefault(codec, SavingsHistory())
+        decision = decisions_by_item.get(int(row["item_id"]))
+        if codec is not None and decision is not None:
+            history = codec_history.setdefault((decision.media_domain, codec), SavingsHistory())
             history.record(source_size_bytes=source_size_bytes, bytes_saved=bytes_saved, codec_key=codec)
     return folder_history, codec_history
+
+
+def _codec_history_for_decision(
+        codec_history: dict[tuple[str, str], SavingsHistory],
+        decision: CandidateDecision | None,
+        codec: str,
+) -> SavingsHistory | None:
+    if decision is None:
+        return None
+    return codec_history.get((decision.media_domain, _canonical_video_codec(codec)))
 
 
 def _estimated_pending_savings_bytes(

--- a/tests/test_movie_workflow.py
+++ b/tests/test_movie_workflow.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from fastapi import HTTPException
 from sqlalchemy import select
@@ -11,8 +11,8 @@ from mediaforce.core.config import ConfigPaths, MediaforceConfig
 from mediaforce.core.db import DBClient, open_db, reset_engine_cache
 from mediaforce.core.db_tables import library_items, plex_item_metadata, staged_artifacts
 from mediaforce.library.candidate_selection import candidate_rank_key, project_candidates, workflow_eligibility
-from mediaforce.library.media_scopes import media_group_scope_for_rel_path, resolve_media_scope
-from mediaforce.library.movie_library import load_movie_library_payload
+from mediaforce.library.media_scopes import ScopeDomain, media_group_scope_for_rel_path, resolve_media_scope
+from mediaforce.library.movie_library import load_movie_library_payload, load_movie_scope_payload
 from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
 from mediaforce.library.representatives import load_representative_selection
 from mediaforce.library.workflow_state import build_folder_workflow_state
@@ -20,6 +20,7 @@ from mediaforce.web.runtime.folder_actions import _promotion_conflict_response
 from mediaforce.web.runtime.folder_actions import _reset_stale_prefix_encoding_items_for_requeue
 from mediaforce.web.runtime.folder_actions import promote_folder_outputs_action, queue_folder_encode_action, \
     validate_folder_outputs_action
+from mediaforce.web.runtime.folder_cards import list_folder_cards
 
 
 class MovieWorkflowTests(unittest.TestCase):
@@ -49,6 +50,40 @@ class MovieWorkflowTests(unittest.TestCase):
         self.assertEqual((single_file.role, single_file.scope_mode), ("feature", "single_file"))
         self.assertFalse(movie_item_included(extra, {"extras": "exclude"}, explicit_exact=False)[0])
         self.assertTrue(movie_item_included(extra, {"extras": "exclude"}, explicit_exact=True)[0])
+
+    def test_classifies_release_named_bonus_and_extras_files_without_misreading_the_title(self) -> None:
+        bonus = classify_movie_path(
+            "movies/Bohemian Rhapsody (2018)/"
+            "Bohemian.Rhapsody.2018.BONUS.Complete.Live.Aid.Performance.1080p.mkv",
+            root="movies",
+        )
+        extras = classify_movie_path(
+            "movies/Jurassic World Rebirth (2025)/"
+            "Jurassic World Rebirth 2025 Extras 1080p BluRay Remux.mkv",
+            root="movies",
+        )
+        titled_extra = classify_movie_path(
+            "movies/The Extras (2005)/The Extras 2005 1080p BluRay.mkv",
+            root="movies",
+        )
+
+        self.assertEqual((bonus.role, bonus.extra_category), ("extra", "Bonus features"))
+        self.assertEqual((extras.role, extras.extra_category), ("extra", "Extras"))
+        self.assertEqual(titled_extra.role, "feature")
+
+    def test_title_words_that_match_extra_tokens_remain_features_without_filename_years(self) -> None:
+        feature_paths = (
+            "movies/The Extras (2005)/The Extras.mkv",
+            "movies/Short Term 12 (2013)/Short Term 12.mkv",
+            "movies/Interview with the Vampire (1994)/Interview with the Vampire.mkv",
+            "movies/Bonus (2024)/Bonus.mkv",
+            "movies/Trailer Park Boys The Movie (2006)/Trailer Park Boys The Movie.mkv",
+        )
+
+        memberships = [classify_movie_path(path, root="movies") for path in feature_paths]
+
+        self.assertTrue(all(membership is not None for membership in memberships))
+        self.assertEqual([membership.role for membership in memberships], ["feature"] * len(feature_paths))
 
     def test_custom_typed_root_resolves_movie_scopes(self) -> None:
         scope = media_group_scope_for_rel_path(
@@ -197,6 +232,208 @@ class MovieWorkflowTests(unittest.TestCase):
             )
 
         self.assertEqual(payload["titles"][0]["age"]["source"], "mediaforce_discovered")
+
+    def test_movie_folder_cards_ignore_tv_history_and_report_unavailable_estimate(self) -> None:
+        config = self._config(
+            extras="exclude",
+            additional_libraries=[
+                {
+                    "key": "shows",
+                    "label": "TV",
+                    "path": str(self.root / "shows"),
+                    "type": "tv",
+                    "availability": "production",
+                    "default_profile": "tv_balanced",
+                    "policy": {},
+                },
+            ],
+        )
+        with open_db(config.paths.db_path) as connection:
+            movie_id = self._insert_item(connection, "films/Example/Example.mkv", size_bytes=1_000)
+            tv_id = self._insert_item(
+                connection,
+                "shows/Example/Season 1/Example S01E01.mkv",
+                size_bytes=1_000,
+                status="promoted",
+            )
+            connection.execute(
+                library_items.update()
+                .where(library_items.c.id.in_((movie_id, tv_id)))
+                .values(video_codec="hevc")
+            )
+            self._insert_stage(connection, tv_id, "shows/Example/Season 1/Example S01E01.mkv")
+            connection.execute(
+                staged_artifacts.update()
+                .where(staged_artifacts.c.library_item_id == tv_id)
+                .values(
+                    source_rel_path="shows/Example/Season 1/Example S01E01.mkv",
+                    source_video_codec="hevc",
+                    source_size_bytes=1_000,
+                    bytes_saved=950,
+                    promoted_at="2026-07-13T00:00:00+00:00",
+                )
+            )
+            decisions = project_candidates(connection, config, prefixes=[])
+            estimate_savings = Mock(return_value=160)
+
+            with patch("mediaforce.web.runtime.folder_cards._apply_lifecycle") as lifecycle_mock, patch(
+                    "mediaforce.web.runtime.folder_cards._apply_folder_workflow_states"
+            ) as workflow_mock:
+                cards = list_folder_cards(
+                    connection,
+                    config=config,
+                    minimum_recommended_savings_bytes=None,
+                    folder_group=lambda rel_path: self._movie_group(config, rel_path),
+                    age_days=lambda _path: 0.0,
+                    estimate_savings_bytes=estimate_savings,
+                    review_badge_for_prefix=lambda _prefix: {"label": None, "tone": None, "detail": None},
+                    candidate_decisions=decisions,
+                    include_lifecycle=False,
+                    include_workflow_states=False,
+                )
+
+        self.assertEqual(len(cards), 1)
+        self.assertEqual(cards[0].estimated_savings_bytes, 0)
+        self.assertEqual(cards[0].estimate_unavailable_count, 1)
+        estimate_savings.assert_not_called()
+        lifecycle_mock.assert_not_called()
+        workflow_mock.assert_not_called()
+
+    def test_movie_library_payload_preserves_unavailable_reclaim_as_null(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_item(connection, "films/Example/Example.mkv")
+            payload = load_movie_library_payload(
+                connection,
+                self.config,
+                include_details=True,
+                metrics_by_prefix={
+                    "films/Example": {
+                        "projected_reclaim_bytes": 0,
+                        "estimated_savings_bytes": 0,
+                        "estimate_unavailable_count": 1,
+                    }
+                },
+            )
+
+        title = payload["titles"][0]
+        self.assertIsNone(title["projected_reclaim_bytes"])
+        self.assertIsNone(title["estimated_savings_bytes"])
+        self.assertEqual(title["known_saved_bytes"], 0)
+        self.assertEqual(title["savings_confidence"], "unavailable")
+
+    def test_movie_scope_payload_preserves_unavailable_reclaim_as_null(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_item(connection, "films/Example/Example.mkv")
+            decisions = project_candidates(connection, self.config, prefixes=["films/Example"])
+            payload = load_movie_scope_payload(
+                connection,
+                self.config,
+                "films/Example",
+                metrics_by_prefix={
+                    "films/Example": {
+                        "projected_reclaim_bytes": 0,
+                        "estimated_savings_bytes": 0,
+                        "estimate_unavailable_count": 1,
+                    }
+                },
+                candidate_decisions=decisions,
+            )
+            payload_without_metrics = load_movie_scope_payload(
+                connection,
+                self.config,
+                "films/Example",
+                candidate_decisions=decisions,
+            )
+
+        self.assertIsNotNone(payload)
+        self.assertIsNone(payload["projected_reclaim_bytes"])
+        self.assertIsNone(payload["estimated_savings_bytes"])
+        self.assertEqual(payload["savings_confidence"], "unavailable")
+        self.assertIsNotNone(payload_without_metrics)
+        self.assertIsNone(payload_without_metrics["projected_reclaim_bytes"])
+
+    def test_tv_folder_cards_ignore_movie_codec_history(self) -> None:
+        config = self._config(
+            extras="exclude",
+            additional_libraries=[
+                {
+                    "key": "shows",
+                    "label": "TV",
+                    "path": str(self.root / "shows"),
+                    "type": "tv",
+                    "availability": "production",
+                    "default_profile": "tv_balanced",
+                    "policy": {},
+                },
+            ],
+        )
+        with open_db(config.paths.db_path) as connection:
+            pending_id = self._insert_item(
+                connection,
+                "shows/Example/Season 1/Example S01E01.mkv",
+                size_bytes=1_000,
+            )
+            movie_id = self._insert_item(
+                connection,
+                "films/Example/Example.mkv",
+                size_bytes=1_000,
+                status="promoted",
+            )
+            connection.execute(
+                library_items.update()
+                .where(library_items.c.id.in_((pending_id, movie_id)))
+                .values(video_codec="h264")
+            )
+            self._insert_stage(connection, movie_id, "films/Example/Example.mkv")
+            connection.execute(
+                staged_artifacts.update()
+                .where(staged_artifacts.c.library_item_id == movie_id)
+                .values(
+                    source_rel_path="films/Example/Example.mkv",
+                    source_video_codec="h264",
+                    source_size_bytes=1_000,
+                    bytes_saved=900,
+                    promoted_at="2026-07-13T00:00:00+00:00",
+                )
+            )
+            decisions = project_candidates(
+                connection,
+                config,
+                prefixes=[],
+                manual_override_prefix="shows/Example/Season 1",
+            )
+            estimate_savings = Mock(return_value=420)
+            cards = list_folder_cards(
+                connection,
+                config=config,
+                minimum_recommended_savings_bytes=None,
+                folder_group=lambda rel_path: self._domain_group(config, rel_path, "tv"),
+                age_days=lambda _path: 0.0,
+                estimate_savings_bytes=estimate_savings,
+                review_badge_for_prefix=lambda _prefix: {"label": None, "tone": None, "detail": None},
+                candidate_decisions=decisions,
+                include_lifecycle=False,
+                include_workflow_states=False,
+            )
+
+        self.assertEqual(len(cards), 1)
+        self.assertEqual(cards[0].estimated_savings_bytes, 420)
+        estimate_savings.assert_called_once()
+
+    def test_movie_library_payload_reuses_precomputed_candidate_projection(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_item(connection, "films/Example/Example.mkv")
+            decisions = project_candidates(connection, self.config, prefixes=[])
+            with patch("mediaforce.library.movie_library.project_candidates") as projection_mock:
+                payload = load_movie_library_payload(
+                    connection,
+                    self.config,
+                    include_details=True,
+                    candidate_decisions=decisions,
+                )
+
+        projection_mock.assert_not_called()
+        self.assertEqual(payload["titles"][0]["workflow_state"]["state"], "encode_candidates")
 
     def test_promotion_preflight_blocks_duplicate_output_destinations(self) -> None:
         conflict = _promotion_conflict_response(
@@ -496,6 +733,21 @@ class MovieWorkflowTests(unittest.TestCase):
                 runtime_settings_path=self.root / "runtime-settings.json",
             ),
         )
+
+    @staticmethod
+    def _movie_group(config: MediaforceConfig, rel_path: str) -> tuple[str, str, str, str] | None:
+        return MovieWorkflowTests._domain_group(config, rel_path, "movie")
+
+    @staticmethod
+    def _domain_group(
+            config: MediaforceConfig,
+            rel_path: str,
+            domain: ScopeDomain,
+    ) -> tuple[str, str, str, str] | None:
+        scope = media_group_scope_for_rel_path(rel_path, library_types=config.library_type_map)
+        if scope is None or scope.domain != domain:
+            return None
+        return scope.group_tuple()
 
     @staticmethod
     def _insert_item(


### PR DESCRIPTION
## Summary
- isolate savings history by media domain and report unmeasured movie reclaim as unavailable instead of borrowing TV outcomes
- reuse one movie-only candidate projection and skip irrelevant lifecycle/workflow card work, cutting real catalog details from roughly 53–61 seconds to about 1 second
- keep Movie Library refreshes sequential, preserve Movie Studio during background hydration, and prevent non-queueable advisor proposals from appearing startable
- classify direct BONUS/Extras release files conservatively while protecting legitimate titles such as *The Extras*, *Short Term 12*, and *Interview with the Vampire*
- preserve measured lower bounds with explicit “At least” copy and distinguish pending details from settled unavailable estimates

## Real catalog dogfood
- exercised 498 movie titles totaling about 1.5 TB
- `/api/dashboard/library/movies/details`: about 1.02 seconds after the fix
- `Time Runner (1993)` Studio payload: about 0.78 seconds with `null` reclaim and `unavailable` confidence
- verified direct Bohemian Rhapsody BONUS and Jurassic World Rebirth Extras files are excluded from title-wide work
- a deterministic Time Runner run failed safely before encoding on an infeasible target; an Apollo 18 run reached full encoding, then its incomplete staging output was cleaned without promoting or changing the source

## Validation
- `bash scripts/pre-commit-check.sh` — 897 backend tests plus frontend checks, lint, unit/build, and desktop/narrow route smoke
- `uv build`
- real-browser review at 1024 px and 390 px, including delayed details hydration and no document-width overflow
- multi-agent adversarial review; findings were addressed before the final gates

## Follow-up
- #194 tracks blocking infeasible movie size targets before processing
- #176 retains the advisor timeout evidence from this dogfood pass

Refs #187
Refs #194