### PR TITLE
Block infeasible movie targets before processing

### DIFF
--- a/docs/architecture/stream-budget-ledger.md
+++ b/docs/architecture/stream-budget-ledger.md
@@ -54,6 +54,15 @@ The ledger distinguishes four deterministic states:
 Arithmetic infeasibility is never delegated to an LLM. Quality risk remains a
 separate measured outcome for target-size search and operator review.
 
+`stream_budget_projection_blocker()` exposes the same deterministic arithmetic
+for planning surfaces. Movie candidate projection and CLI/web start actions use
+that result before creating sample jobs, manifests, or encode jobs. Sample
+confirmation checks the proposed policy, while production queueing checks the
+accepted calibration policy through an in-memory override before persisting it.
+A target whose lower sample-band bound is above the configured source-relative
+cap is a hard workflow blocker; `requires_measurement` remains available for
+measured review instead of being treated as impossible.
+
 ## Target-size search
 
 The first representative sample is seeded from the approved whole-episode size

--- a/docs/development/browser-qa-matrix.md
+++ b/docs/development/browser-qa-matrix.md
@@ -46,6 +46,8 @@ The managed smoke seeds a compact but non-empty workflow dataset:
   `/folders/movies/Waiting%20Encode`, and
   `/folders/movies/Promotion%20Conflict` cover exact-file, editions/extras,
   active-job, and collision-blocked states on desktop and narrow viewports.
+  `/folders/movies/Target%20Too%20Large` proves a source-cap-infeasible target
+  shows `Needs attention`, explains the 80% cap, and disables sample/queue work.
 - Folder Studio: `/folders/tv/Example%20Show/Season%201`, including enough item
   metadata to render policy comparison, sample facts, queue state, and side
   context.

--- a/frontend/src/lib/components/workstation/MovieStudioView.svelte
+++ b/frontend/src/lib/components/workstation/MovieStudioView.svelte
@@ -62,6 +62,7 @@
 	);
 	const activeHostCount = $derived(hosts.hosts.filter((host) => host.available).length);
 	const isBrowseOnly = $derived(context?.availability === 'browse_only');
+	const isWorkflowBlocked = $derived(workflow?.primary_lane === 'blocked');
 	const isBusy = $derived(Boolean(pendingAction));
 	const conflicts = $derived(context?.promotion_conflicts ?? []);
 	const reviewReady = $derived(
@@ -96,6 +97,8 @@
 					host_key: selectedHostKey
 				}
 			);
+			if (!response.ok)
+				throw new Error(response.message || 'The movie target is not ready for sampling.');
 			note = '';
 			return response.message || 'Sample plan ready. Review it before starting work.';
 		});
@@ -108,6 +111,7 @@
 				`/api/folders/${folderRoutePrefix(folder.prefix)}/ai-tune/confirm`,
 				{ proposal_id: asText(pendingProposal.proposal_id) }
 			);
+			if (!response.ok) throw new Error(response.message || 'The movie sample could not start.');
 			return response.message || 'Sample run queued.';
 		});
 	}
@@ -119,6 +123,7 @@
 				`/api/folders/${folderRoutePrefix(folder.prefix)}/ai-tune/confirm`,
 				{ proposal_id: '' }
 			);
+			if (!response.ok) throw new Error(response.message || 'The movie sample could not restart.');
 			return response.message || 'Sample retry queued.';
 		});
 	}
@@ -134,6 +139,7 @@
 					reviewed_draft_hash: asText(calibration.draft_hash)
 				}
 			);
+			if (!response.ok) throw new Error(response.message || 'The movie work could not be queued.');
 			return response.message || `Approved the sample and queued this ${scopeNoun}.`;
 		});
 	}
@@ -145,6 +151,7 @@
 				`/api/folders/${folderRoutePrefix(folder.prefix)}/queue-encode`,
 				{ notes: '', bypass_schedule: false }
 			);
+			if (!response.ok) throw new Error(response.message || 'The movie work could not be queued.');
 			return response.message || `Queued this ${scopeNoun}.`;
 		});
 	}
@@ -228,6 +235,7 @@
 		if (Object.keys(pendingProposal).length && pendingProposalCanQueue) return 'start';
 		if (reviewGate.status === 'accepted') return 'queue';
 		if (reviewReady) return 'queue';
+		if (isWorkflowBlocked) return 'none';
 		return 'prepare';
 	}
 
@@ -479,7 +487,8 @@
 						<button
 							class="secondary"
 							disabled={isBusy || isBrowseOnly || !selectedHostKey}
-							onclick={prepareSample}>Prepare new sample</button
+							onclick={prepareSample}
+							>{isWorkflowBlocked ? 'Draft revised sample' : 'Prepare new sample'}</button
 						>
 						{#if status.retryable_sample_job}
 							<button class="secondary" disabled={isBusy || isBrowseOnly} onclick={retrySample}

--- a/mediaforce/cli.py
+++ b/mediaforce/cli.py
@@ -12,6 +12,7 @@ from mediaforce.execution import describe_item_plan, encode_manifest_items, prom
     validate_manifest_items
 from mediaforce.encoding.bakeoff import DEFAULT_BAKEOFF_ENGINES, build_bakeoff_plan, write_bakeoff_plan
 from mediaforce.library.folder_profiles import inspect_prefix
+from mediaforce.library.candidate_selection import scope_target_size_blocker
 from mediaforce.library.planner import recommend_item
 from mediaforce.library.run_manifests import build_run_manifest as build_db_run_manifest, \
     select_candidates as select_run_manifest_candidates, \
@@ -21,6 +22,10 @@ from mediaforce.library.scanner import scan_library
 from mediaforce.library.metadata_sync import sync_external_metadata
 from mediaforce.review import generate_compare_clips
 from mediaforce.state_cleanup import purge_transient_artifacts
+
+
+class TargetSizePreflightBlocked(RuntimeError):
+    pass
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -157,6 +162,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         if args.command == "plan":
+            blocker = _target_size_blocker_for_prefixes(connection, config, args.prefix)
+            if blocker is not None:
+                print(f"Plan blocked: {blocker}")
+                return 2
             rows = _select_encode_candidates(
                 connection,
                 config,
@@ -175,14 +184,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         if args.command == "campaign":
-            manifest, output_path = _create_campaign_manifest(
-                connection,
-                config,
-                prefix=args.prefix,
-                limit=args.limit,
-                buckets=args.bucket or None,
-                output_path=args.output,
-            )
+            try:
+                manifest, output_path = _create_campaign_manifest(
+                    connection,
+                    config,
+                    prefix=args.prefix,
+                    limit=args.limit,
+                    buckets=args.bucket or None,
+                    output_path=args.output,
+                )
+            except TargetSizePreflightBlocked as exc:
+                print(f"Campaign blocked: {exc}")
+                return 2
             print(f"\nCampaign manifest: {output_path}")
             if manifest["items"]:
                 print("\nFirst item plan:")
@@ -206,14 +219,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
         if args.command == "run":
-            manifest, output_path = _create_campaign_manifest(
-                connection,
-                config,
-                prefix=args.prefix,
-                limit=args.limit,
-                buckets=args.bucket or None,
-                output_path=args.output,
-            )
+            try:
+                manifest, output_path = _create_campaign_manifest(
+                    connection,
+                    config,
+                    prefix=args.prefix,
+                    limit=args.limit,
+                    buckets=args.bucket or None,
+                    output_path=args.output,
+                )
+            except TargetSizePreflightBlocked as exc:
+                print(f"Run blocked: {exc}")
+                return 2
             print(f"\nRun manifest: {output_path}")
             if not manifest["items"]:
                 print("No items selected for this run.")
@@ -465,6 +482,9 @@ def _create_campaign_manifest(
     )
     summary = inspect_prefix(connection, config, prefix)
     _print_folder_summary(summary)
+    blocker = scope_target_size_blocker(connection, config, prefix)
+    if blocker is not None:
+        raise TargetSizePreflightBlocked(blocker.message)
     rows = _select_encode_candidates(
         connection,
         config,
@@ -475,6 +495,18 @@ def _create_campaign_manifest(
     manifest = _build_run_manifest(rows, config)
     manifest_path = _write_manifest(connection, config, manifest, output_path)
     return manifest, manifest_path
+
+
+def _target_size_blocker_for_prefixes(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefixes: list[str],
+) -> str | None:
+    for prefix in prefixes:
+        blocker = scope_target_size_blocker(connection, config, prefix)
+        if blocker is not None:
+            return blocker.message
+    return None
 
 
 def _resolve_manifest_path(connection: DBClient, manifest_path: Path | None) -> Path:

--- a/mediaforce/core/config.py
+++ b/mediaforce/core/config.py
@@ -342,6 +342,19 @@ def upsert_runtime_folder_policy_override(path: Path, prefix: str, policy: dict[
     update_runtime_settings(path, _apply)
 
 
+def with_folder_policy_override(
+        config: MediaforceConfig,
+        prefix: str,
+        policy: dict[str, Any],
+) -> MediaforceConfig:
+    raw = copy.deepcopy(config.raw)
+    overrides = raw.get("overrides")
+    normalized_overrides = list(overrides) if isinstance(overrides, list) else []
+    normalized_overrides.append(_build_folder_policy_override(prefix, policy))
+    raw["overrides"] = normalized_overrides
+    return MediaforceConfig(raw=raw, paths=config.paths)
+
+
 def update_runtime_folder_policy_values(
         path: Path,
         prefix: str,

--- a/mediaforce/library/candidate_selection.py
+++ b/mediaforce/library/candidate_selection.py
@@ -15,7 +15,13 @@ from mediaforce.core.type_defs import object_dict
 from mediaforce.library.library_settings import normalize_library_policy, normalize_library_type
 from mediaforce.library.media_scopes import normalize_scope_prefix, path_matches_scope, resolve_media_scopes
 from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
-from mediaforce.library.workflow_state import ENCODE_CANDIDATE_STATUSES, derive_item_workflow_state
+from mediaforce.library.planner import build_manifest_item
+from mediaforce.library.workflow_state import ENCODE_CANDIDATE_STATUSES, EncodeEligibility, derive_item_workflow_state
+from mediaforce.tuning.stream_budget import (
+    StreamBudgetLedger,
+    StreamBudgetProjectionBlocker,
+    stream_budget_projection_blocker,
+)
 
 LifecycleMode = Literal["auto", "on", "off"]
 ProviderState = Literal["active", "ended", "unknown", "stale"]
@@ -79,6 +85,7 @@ class CandidateDecision:
     media_role: str | None
     production_included: bool
     production_blocker: str | None
+    target_size_blocker: StreamBudgetProjectionBlocker | None
     ranking_mode: str
     media_domain: str
 
@@ -91,6 +98,7 @@ class CandidateDecision:
         return (
             self.workflow_lane == "encode"
             and self.production_included
+            and self.target_size_blocker is None
             and (not self.hold_reasons or self.override_applied)
         )
 
@@ -121,6 +129,11 @@ class CandidateDecision:
             "media_role": self.media_role,
             "production_included": self.production_included,
             "production_blocker": self.production_blocker,
+            "target_size_blocker": (
+                self.target_size_blocker.to_payload()
+                if self.target_size_blocker is not None
+                else None
+            ),
             "ranking_mode": self.ranking_mode,
             "media_domain": self.media_domain,
             "media_age": self.age.to_payload(),
@@ -214,6 +227,11 @@ def project_candidates(
         if not production_enabled:
             label = str(library.get("label") or media_root or "This library")
             production_blocker = f"{label} is browse only; set its availability to Production before processing."
+        target_size_blocker = (
+            _target_size_projection_blocker(row, config)
+            if library_type == "movie" and workflow_lane == "encode" and production_included
+            else None
+        )
         ranking_mode = (
             str(library_policy.get("ranking") or "oldest_added_first")
             if library_type == "movie"
@@ -289,6 +307,7 @@ def project_candidates(
                 media_role=membership.role if membership is not None else None,
                 production_included=production_included,
                 production_blocker=production_blocker,
+                target_size_blocker=target_size_blocker,
                 ranking_mode=ranking_mode,
                 media_domain=library_type,
             )
@@ -314,15 +333,44 @@ def encode_candidate_decisions(
     )
 
 
-def workflow_eligibility(decisions: list[CandidateDecision]) -> dict[int, tuple[bool, str | None]]:
+def scope_target_size_blocker(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+) -> StreamBudgetProjectionBlocker | None:
+    blocked = [
+        decision
+        for decision in encode_candidate_decisions(connection, config, prefixes=[prefix])
+        if decision.target_size_blocker is not None
+    ]
+    if not blocked:
+        return None
+    blocked.sort(key=lambda decision: str(decision.row.get("rel_path") or ""))
+    return blocked[0].target_size_blocker
+
+
+def workflow_eligibility(decisions: list[CandidateDecision]) -> dict[int, EncodeEligibility]:
     return {
-        decision.item_id: (
-            decision.eligible if decision.workflow_lane == "encode" else decision.production_included,
-            decision.production_blocker
-            or (decision.hold_reasons[0].detail if decision.hold_reasons else None),
+        decision.item_id: EncodeEligibility(
+            eligible=decision.eligible if decision.workflow_lane == "encode" else decision.production_included,
+            blocker=(
+                decision.production_blocker
+                or (decision.target_size_blocker.message if decision.target_size_blocker is not None else None)
+                or (decision.hold_reasons[0].detail if decision.hold_reasons else None)
+            ),
+            blocked=decision.target_size_blocker is not None,
         )
         for decision in decisions
     }
+
+
+def _target_size_projection_blocker(
+        row: dict[str, Any],
+        config: MediaforceConfig,
+) -> StreamBudgetProjectionBlocker | None:
+    item = build_manifest_item(row, config)
+    ledger = StreamBudgetLedger.from_payload(object_dict(item.get("stream_budget_ledger")))
+    return stream_budget_projection_blocker(ledger)
 
 
 def scope_lifecycle_payload(

--- a/mediaforce/library/movie_library.py
+++ b/mediaforce/library/movie_library.py
@@ -16,7 +16,7 @@ from mediaforce.core.utils import filesystem_collision_key
 from mediaforce.library.candidate_selection import CandidateDecision, project_candidates, workflow_eligibility
 from mediaforce.library.media_scopes import resolve_media_scope, resolve_media_scopes, scope_rel_path_filter
 from mediaforce.library.movie_workflow import MovieMembership, classify_movie_path, movie_item_included
-from mediaforce.library.workflow_state import build_folder_workflow_states, derive_item_workflow_state
+from mediaforce.library.workflow_state import EncodeEligibility, build_folder_workflow_states, derive_item_workflow_state
 
 MovieMetrics = Mapping[str, Mapping[str, Any]]
 
@@ -97,7 +97,7 @@ def load_movie_library_payload(
             item_id = int(row["item_id"])
             library = library_by_root[membership.root]
             included, blocker = _production_inclusion(library, membership)
-            eligibility.setdefault(item_id, (included, blocker))
+            eligibility.setdefault(item_id, EncodeEligibility(eligible=included, blocker=blocker))
 
     workflows = (
         build_folder_workflow_states(
@@ -236,7 +236,7 @@ def _title_payload(
         *,
         library_by_root: dict[str, dict[str, Any]],
         decisions_by_item: dict[int, Any],
-        eligibility: dict[int, tuple[bool, str | None]],
+        eligibility: dict[int, EncodeEligibility],
         workflow: Any,
         metrics: dict[str, Any],
         metrics_available: bool,
@@ -334,7 +334,7 @@ def _member_payload(
         *,
         library: dict[str, Any],
         decision: Any,
-        eligibility: tuple[bool, str | None],
+        eligibility: EncodeEligibility,
         workflow_item: dict[str, Any] | None,
         conflicts: list[dict[str, Any]],
         include_details: bool,
@@ -349,8 +349,9 @@ def _member_payload(
     if include_details and workflow_item is None:
         workflow_item = derive_item_workflow_state(
             row,
-            encode_eligible=eligibility[0],
-            policy_blocker=eligibility[1],
+            encode_eligible=eligibility.eligible,
+            policy_blocker=eligibility.blocker,
+            encode_blocked=eligibility.blocked,
         ).to_payload()
     return {
         **membership.to_payload(),

--- a/mediaforce/library/workflow_state.py
+++ b/mediaforce/library/workflow_state.py
@@ -70,6 +70,13 @@ class WorkflowNextAction:
 
 
 @dataclass(frozen=True, slots=True)
+class EncodeEligibility:
+    eligible: bool
+    blocker: str | None = None
+    blocked: bool = False
+
+
+@dataclass(frozen=True, slots=True)
 class ItemWorkflowState:
     item_id: int
     rel_path: str
@@ -126,16 +133,12 @@ def build_folder_workflow_state(
         connection: DBClient,
         prefix: str,
         *,
-        candidate_eligibility: dict[int, tuple[bool, str | None]] | None = None,
+        candidate_eligibility: Mapping[int, EncodeEligibility] | None = None,
         library_types: Mapping[str, str] | None = None,
 ) -> FolderWorkflowState:
     scope = resolve_media_scope(connection, prefix, library_types=library_types)
     item_states = tuple(
-        derive_item_workflow_state(
-            row,
-            encode_eligible=(candidate_eligibility or {}).get(int(row["item_id"]), (True, None))[0],
-            policy_blocker=(candidate_eligibility or {}).get(int(row["item_id"]), (True, None))[1],
-        )
+        _derive_item_workflow_state(row, candidate_eligibility)
         for row in _load_item_rows(connection, scope)
     )
     job_state = _load_encode_job_state(connection, scope)
@@ -146,7 +149,7 @@ def build_folder_workflow_states(
         connection: DBClient,
         prefixes: list[str],
         *,
-        candidate_eligibility: dict[int, tuple[bool, str | None]] | None = None,
+        candidate_eligibility: Mapping[int, EncodeEligibility] | None = None,
         library_types: Mapping[str, str] | None = None,
 ) -> dict[str, FolderWorkflowState]:
     normalized_prefixes = list(dict.fromkeys(normalize_prefix(prefix) for prefix in prefixes))
@@ -158,11 +161,7 @@ def build_folder_workflow_states(
     result: dict[str, FolderWorkflowState] = {}
     for scope in scopes:
         item_states = tuple(
-            derive_item_workflow_state(
-                row,
-                encode_eligible=(candidate_eligibility or {}).get(int(row["item_id"]), (True, None))[0],
-                policy_blocker=(candidate_eligibility or {}).get(int(row["item_id"]), (True, None))[1],
-            )
+            _derive_item_workflow_state(row, candidate_eligibility)
             for row in rows
             if path_matches_scope(str(row["rel_path"]), scope)
         )
@@ -183,6 +182,7 @@ def derive_item_workflow_state(
         *,
         encode_eligible: bool = True,
         policy_blocker: str | None = None,
+        encode_blocked: bool = False,
 ) -> ItemWorkflowState:
     status = str(row["status"] or "idle")
     has_staged_output = row["staged_library_item_id"] is not None and row["staging_path"] is not None
@@ -201,8 +201,8 @@ def derive_item_workflow_state(
         state = "encoding"
         lane = "processing"
     elif not encode_eligible:
-        state = "held"
-        lane = "none"
+        state = "blocked" if encode_blocked else "held"
+        lane = "blocked" if encode_blocked else "none"
         blocker = policy_blocker or "This item is excluded from the current production scope."
     elif has_staged_output and status == "encoded":
         state = "ready_to_validate"
@@ -229,6 +229,23 @@ def derive_item_workflow_state(
         lane=lane,
         has_staged_output=has_staged_output,
         blocker=blocker,
+    )
+
+
+def _derive_item_workflow_state(
+        row: DBRow,
+        candidate_eligibility: Mapping[int, EncodeEligibility] | None,
+) -> ItemWorkflowState:
+    eligibility = (
+        candidate_eligibility.get(int(row["item_id"]), EncodeEligibility(eligible=True))
+        if candidate_eligibility is not None
+        else EncodeEligibility(eligible=True)
+    )
+    return derive_item_workflow_state(
+        row,
+        encode_eligible=eligibility.eligible,
+        policy_blocker=eligibility.blocker,
+        encode_blocked=eligibility.blocked,
     )
 
 

--- a/mediaforce/tuning/stream_budget.py
+++ b/mediaforce/tuning/stream_budget.py
@@ -72,6 +72,29 @@ class StreamBudgetEntry:
 
 
 @dataclass(frozen=True, slots=True)
+class StreamBudgetProjectionBlocker:
+    code: str
+    message: str
+    target_size_bytes: int | None
+    target_lower_bound_bytes: int | None
+    source_cap_percent: float | None
+    source_cap_total_bytes: int | None
+    non_video_bytes: int | None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "status": "infeasible",
+            "code": self.code,
+            "message": self.message,
+            "target_size_bytes": self.target_size_bytes,
+            "target_lower_bound_bytes": self.target_lower_bound_bytes,
+            "source_cap_percent": self.source_cap_percent,
+            "source_cap_total_bytes": self.source_cap_total_bytes,
+            "non_video_bytes": self.non_video_bytes,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class StreamBudgetLedger:
     ledger_id: str
     source_id: str
@@ -302,6 +325,51 @@ def resolve_stream_budget_ledger(
         item_payload,
         resolved_size_goal=resolved_size_goal,
         stream_plan=stream_plan,
+    )
+
+
+def stream_budget_projection_blocker(
+        ledger: StreamBudgetLedger,
+) -> StreamBudgetProjectionBlocker | None:
+    target_lower_bound = _target_lower_bound_bytes(ledger)
+    if ledger.arithmetic_infeasible:
+        code = ledger.feasibility_reasons[0] if ledger.feasibility_reasons else "arithmetically_infeasible_stream_budget"
+        message = {
+            "target_consumed_by_minimum_non_video_bytes": (
+                "The requested size target leaves no room for video. Increase the target or reduce preserved streams."
+            ),
+            "target_consumed_by_reserved_non_video_bytes": (
+                "The requested size target leaves no room for video. Increase the target or reduce preserved streams."
+            ),
+        }.get(code, "The requested size target is arithmetically infeasible for this file.")
+        return _projection_blocker(
+            ledger,
+            code=code,
+            message=message,
+            target_lower_bound=target_lower_bound,
+        )
+    if ledger.source_cap_status == "arithmetically_infeasible":
+        return _projection_blocker(
+            ledger,
+            code="source_relative_cap_consumed_by_non_video_budget",
+            message=(
+                f"Preserved streams consume the {_source_cap_label(ledger)} source cap. "
+                "Reduce preserved streams or increase the maximum encoded percent."
+            ),
+            target_lower_bound=target_lower_bound,
+        )
+    if target_lower_bound is None or ledger.source_cap_total_bytes is None:
+        return None
+    if ledger.source_cap_total_bytes >= target_lower_bound:
+        return None
+    return _projection_blocker(
+        ledger,
+        code="target_lower_bound_exceeds_source_relative_cap",
+        message=(
+            f"Target size exceeds the {_source_cap_label(ledger)} source cap. "
+            "Lower the target or increase the maximum encoded percent."
+        ),
+        target_lower_bound=target_lower_bound,
     )
 
 
@@ -778,6 +846,41 @@ def _feasibility(
     if aggressive_reasons:
         return "aggressive_but_measurable", tuple(dict.fromkeys(aggressive_reasons))
     return "feasible", ()
+
+
+def _projection_blocker(
+        ledger: StreamBudgetLedger,
+        *,
+        code: str,
+        message: str,
+        target_lower_bound: int | None,
+) -> StreamBudgetProjectionBlocker:
+    return StreamBudgetProjectionBlocker(
+        code=code,
+        message=message,
+        target_size_bytes=ledger.total_target_bytes,
+        target_lower_bound_bytes=target_lower_bound,
+        source_cap_percent=ledger.source_cap_percent,
+        source_cap_total_bytes=ledger.source_cap_total_bytes,
+        non_video_bytes=ledger.non_video_bytes,
+    )
+
+
+def _target_lower_bound_bytes(ledger: StreamBudgetLedger) -> int | None:
+    resolved_lower_bound = _optional_int(ledger.size_goal.get("sample_lower_bound_bytes"))
+    if resolved_lower_bound is not None:
+        return resolved_lower_bound
+    if ledger.total_target_bytes is None:
+        return None
+    tolerance = _optional_float(ledger.size_goal.get("sample_projection_tolerance_percent"))
+    normalized_tolerance = max(tolerance if tolerance is not None else 10.0, 0.0)
+    return int(round(ledger.total_target_bytes * (1.0 - normalized_tolerance / 100.0)))
+
+
+def _source_cap_label(ledger: StreamBudgetLedger) -> str:
+    if ledger.source_cap_percent is None:
+        return "configured"
+    return f"{ledger.source_cap_percent:g}%"
 
 
 def _source_cap_status(

--- a/mediaforce/tuning/target_size_search.py
+++ b/mediaforce/tuning/target_size_search.py
@@ -7,7 +7,11 @@ from typing import Any, Callable, Literal
 from mediaforce.core.evidence import stable_json_hash
 from mediaforce.core.type_defs import float_value, int_value, object_dict
 from mediaforce.encoding.quality import QualitySearchResult, SampleEncodeResult
-from mediaforce.tuning.stream_budget import StreamBudgetLedger
+from mediaforce.tuning.stream_budget import (
+    StreamBudgetLedger,
+    StreamBudgetProjectionBlocker,
+    stream_budget_projection_blocker,
+)
 
 
 TARGET_SIZE_SEARCH_SCHEMA_VERSION = 1
@@ -146,11 +150,11 @@ def search_target_size(
             trace=trace,
         )
     validated_transform_plan = dict(object_dict(transform_plan))
-    source_cap_issue = _source_cap_issue(stream_budget_ledger)
-    if source_cap_issue is not None:
+    source_cap_blocker = _source_cap_blocker(stream_budget_ledger)
+    if source_cap_blocker is not None:
         trace = _trace_payload(
             status="infeasible",
-            reason=source_cap_issue,
+            reason=source_cap_blocker.code,
             ledger=stream_budget_ledger,
             candidates=[],
             selected=None,
@@ -162,7 +166,7 @@ def search_target_size(
             transform_plan=validated_transform_plan,
         )
         raise TargetSizeSearchError(
-            "The approved size target cannot be reached without violating the approved source-relative cap.",
+            source_cap_blocker.message,
             status="infeasible",
             trace=trace,
         )
@@ -698,16 +702,14 @@ def _distance(candidate: dict[str, Any]) -> float:
     return distance if distance > 0 else 10 ** 30
 
 
-def _source_cap_issue(ledger: StreamBudgetLedger) -> str | None:
-    if ledger.source_cap_status == "arithmetically_infeasible":
-        return "source_relative_cap_consumed_by_non_video_budget"
-    if ledger.source_cap_video_bytes is None or ledger.non_video_bytes is None or ledger.total_target_bytes is None:
+def _source_cap_blocker(ledger: StreamBudgetLedger) -> StreamBudgetProjectionBlocker | None:
+    blocker = stream_budget_projection_blocker(ledger)
+    if blocker is None or blocker.code not in {
+        "source_relative_cap_consumed_by_non_video_budget",
+        "target_lower_bound_exceeds_source_relative_cap",
+    }:
         return None
-    lower, _ = _sample_bounds(ledger)
-    cap_total = ledger.source_cap_video_bytes + ledger.non_video_bytes
-    if cap_total < lower:
-        return "target_lower_bound_exceeds_source_relative_cap"
-    return None
+    return blocker
 
 
 def _sample_bounds(ledger: StreamBudgetLedger) -> tuple[int, int]:

--- a/mediaforce/web/runtime/folder_actions.py
+++ b/mediaforce/web/runtime/folder_actions.py
@@ -10,7 +10,7 @@ from typing import Any, Protocol, TypeAlias
 from fastapi import HTTPException
 from sqlalchemy import delete, or_, select, update
 
-from mediaforce.core.config import MediaforceConfig, load_config
+from mediaforce.core.config import MediaforceConfig, load_config, with_folder_policy_override
 from mediaforce.core.db import DBClient, open_db
 from mediaforce.core.db_tables import encode_jobs, library_items, staged_artifacts
 from mediaforce.core.type_defs import float_value, object_dict, object_list
@@ -24,7 +24,7 @@ from mediaforce.library.movie_workflow import classify_movie_path, movie_item_in
 from mediaforce.library.workflow_state import build_folder_workflow_state
 from mediaforce.library.run_manifests import create_folder_manifest
 from mediaforce.library.candidate_selection import encode_candidate_decisions, scope_lifecycle_payload_from_decisions, \
-    workflow_eligibility
+    scope_target_size_blocker, workflow_eligibility
 from mediaforce.tuning.quality_risk import build_quality_risk_contract
 from mediaforce.tuning.quality_risk import append_quality_risk_record
 from mediaforce.tuning.size_goals import operator_intent_from_policy
@@ -234,6 +234,32 @@ def queue_folder_encode_action(
         if calibration is None:
             raise HTTPException(status_code=400, detail="Run a sampled calibration first.")
         calibration_payload = object_dict(calibration)
+        calibration_policy = object_dict(calibration_payload.get("policy"))
+        calibration_video = object_dict(calibration_policy.get("video"))
+        if {"target_size_mb", "target_size_bytes", "size_goal_mode"} & calibration_video.keys():
+            calibration_intent = operator_intent_from_policy(
+                calibration_video,
+                default_video_policy=object_dict(config.raw.get("video")),
+                audio_policy=object_dict(calibration_policy.get("audio")),
+                subtitle_policy=object_dict(calibration_policy.get("subtitle")),
+            )
+            if calibration_intent.size_goal.requires_confirmation:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Confirm whether the saved legacy size is runtime-normalized or an absolute per-episode "
+                        "target before queueing production."
+                    ),
+                )
+        preflight_config = with_folder_policy_override(config, normalized_prefix, calibration_policy)
+        target_size_blocker = scope_target_size_blocker(connection, preflight_config, normalized_prefix)
+        if target_size_blocker is not None:
+            return {
+                "ok": False,
+                "code": target_size_blocker.code,
+                "message": target_size_blocker.message,
+                "target_size_blocker": target_size_blocker.to_payload(),
+            }
         latest_failed_sample_job = (
             load_latest_failed_target_size_job_state(connection, config, normalized_prefix)
             if load_latest_failed_target_size_job_state is not None
@@ -269,24 +295,6 @@ def queue_folder_encode_action(
                     detail=(
                         "The current review evidence was rejected after approval. "
                         "Make and approve a revised test before starting the season."
-                    ),
-                )
-        saved_profile_path = config.paths.runtime_settings_path
-        calibration_policy = object_dict(calibration_payload.get("policy"))
-        calibration_video = object_dict(calibration_policy.get("video"))
-        if {"target_size_mb", "target_size_bytes", "size_goal_mode"} & calibration_video.keys():
-            calibration_intent = operator_intent_from_policy(
-                calibration_video,
-                default_video_policy=object_dict(config.raw.get("video")),
-                audio_policy=object_dict(calibration_policy.get("audio")),
-                subtitle_policy=object_dict(calibration_policy.get("subtitle")),
-            )
-            if calibration_intent.size_goal.requires_confirmation:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        "Confirm whether the saved legacy size is runtime-normalized or an absolute per-episode "
-                        "target before queueing production."
                     ),
                 )
         active_encode_job = load_active_encode_job_for_prefix_fn(connection, normalized_prefix)
@@ -334,7 +342,7 @@ def queue_folder_encode_action(
             _reset_stale_prefix_encoding_items_for_requeue(connection, config, normalized_prefix, now_iso=now_iso)
         preflight_decisions = encode_candidate_decisions(
             connection,
-            config,
+            preflight_config,
             prefixes=[normalized_prefix],
         )
         if scope.domain == "movie" and not any(decision.eligible for decision in preflight_decisions):
@@ -349,7 +357,7 @@ def queue_folder_encode_action(
                 connection,
                 normalized_prefix,
                 candidate_eligibility=workflow_eligibility(preflight_decisions),
-                library_types=config.library_type_map,
+                library_types=preflight_config.library_type_map,
             ).to_payload()
             next_action = object_dict(workflow_state.get("next_action"))
             action_label = str(next_action.get("label") or "No action")
@@ -357,6 +365,7 @@ def queue_folder_encode_action(
                 status_code=400,
                 detail=f"No encode candidates were found for this movie scope. Next action: {action_label}.",
             )
+        saved_profile_path = config.paths.runtime_settings_path
         upsert_override(saved_profile_path, normalized_prefix, calibration_policy)
         refreshed_config = load_config(config.paths.config_path)
         manifest_kwargs: dict[str, Any] = {"prefix": normalized_prefix}
@@ -489,6 +498,20 @@ def approve_measured_encode_recovery_action(
             status_code=400,
             detail="This failure does not have enough measured quality data for one-click recovery.",
         )
+    preflight_config = with_folder_policy_override(
+        config,
+        normalized_prefix,
+        object_dict(recovery.get("policy")),
+    )
+    with open_db(config.paths.db_path) as connection:
+        target_size_blocker = scope_target_size_blocker(connection, preflight_config, normalized_prefix)
+    if target_size_blocker is not None:
+        return {
+            "ok": False,
+            "code": target_size_blocker.code,
+            "message": target_size_blocker.message,
+            "target_size_blocker": target_size_blocker.to_payload(),
+        }
 
     calibration_payload["policy"] = recovery["policy"]
     calibration_payload["accepted_at"] = now_iso()

--- a/mediaforce/web/runtime/folder_ai_tuning.py
+++ b/mediaforce/web/runtime/folder_ai_tuning.py
@@ -20,6 +20,7 @@ from mediaforce.tuning.quality_risk import (
     with_quality_risk_intent,
 )
 from mediaforce.tuning.size_goals import operator_intent_from_policy
+from mediaforce.tuning.stream_budget import StreamBudgetProjectionBlocker, stream_budget_projection_blocker
 from mediaforce.web.runtime.folder_tuning_advice import operator_preserves_source_resolution, operator_request_from_intent
 from mediaforce.web.runtime.folder_tuning_helpers import (
     allows_measured_size_quality_tradeoff,
@@ -109,6 +110,34 @@ def _output_container(config: MediaforceConfig, sample_item: dict[str, Any]) -> 
         return configured
     item_container = str(sample_item.get("output_container") or sample_item.get("container") or "").strip()
     return item_container.removeprefix(".") or "mkv"
+
+
+def _prepare_sample_item(
+        config: MediaforceConfig,
+        sample_item: dict[str, Any],
+        policy: dict[str, Any],
+) -> tuple[dict[str, Any], StreamBudgetProjectionBlocker | None]:
+    prepared = dict(sample_item)
+    prepared["resolved_policy"] = policy
+    output_container = _output_container(config, prepared)
+    prepared["output_container"] = output_container
+    ledger = resolve_stream_budget_ledger(
+        prepared,
+        default_video_policy=object_dict(config.raw.get("video")),
+        output_container=output_container,
+        prefer_persisted=False,
+    )
+    prepared["stream_budget_ledger"] = ledger.to_payload()
+    return prepared, stream_budget_projection_blocker(ledger)
+
+
+def _target_size_blocker_response(blocker: StreamBudgetProjectionBlocker) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "code": blocker.code,
+        "message": blocker.message,
+        "target_size_blocker": blocker.to_payload(),
+    }
 
 
 def _latest_failed_sample_job_payload(job: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -687,6 +716,9 @@ def folder_ai_tune_confirm_action(
         legacy_size_issue = _unconfirmed_legacy_size_issue(config, final_policy)
         if legacy_size_issue is not None:
             return {"ok": False, "message": legacy_size_issue}
+        queued_sample_item, target_size_blocker = _prepare_sample_item(config, sample_item, final_policy)
+        if target_size_blocker is not None:
+            return _target_size_blocker_response(target_size_blocker)
         current_advice_state = (
             object_dict(deps.load_advice_state(config, normalized_prefix))
             if deps.load_advice_state is not None
@@ -752,16 +784,6 @@ def folder_ai_tune_confirm_action(
                 advice_payload["learning_artifact"] = learning_artifact
             deps.save_advice_state(config, normalized_prefix, advice_payload)
 
-        queued_sample_item = dict(sample_item)
-        queued_sample_item["resolved_policy"] = final_policy
-        output_container = _output_container(config, queued_sample_item)
-        queued_sample_item["output_container"] = output_container
-        queued_sample_item["stream_budget_ledger"] = resolve_stream_budget_ledger(
-            queued_sample_item,
-            default_video_policy=object_dict(config.raw.get("video")),
-            output_container=output_container,
-            prefer_persisted=False,
-        ).to_payload()
         job_payload = {
             "job_id": uuid.uuid4().hex[:12],
             "status": "queued",
@@ -828,17 +850,15 @@ def _retry_latest_sample_job(
             sample_item = deps.sample_item(connection, config, normalized_prefix)
             if sample_item is None:
                 raise HTTPException(status_code=404, detail=f"No sample item found for {normalized_prefix}")
-            refreshed_sample_item = object_dict(sample_item)
-            refreshed_sample_item["resolved_policy"] = object_dict(existing_job.get("policy"))
-            output_container = _output_container(config, refreshed_sample_item)
-            refreshed_sample_item["output_container"] = output_container
-            refreshed_sample_item["stream_budget_ledger"] = resolve_stream_budget_ledger(
-                refreshed_sample_item,
-                default_video_policy=object_dict(config.raw.get("video")),
-                output_container=output_container,
-                prefer_persisted=False,
-            ).to_payload()
-            stored_sample_item = _job_sample_item_payload(refreshed_sample_item)
+            stored_sample_item = object_dict(sample_item)
+        prepared_sample_item, target_size_blocker = _prepare_sample_item(
+            config,
+            stored_sample_item,
+            object_dict(existing_job.get("policy")),
+        )
+        if target_size_blocker is not None:
+            return _target_size_blocker_response(target_size_blocker)
+        stored_sample_item = _job_sample_item_payload(prepared_sample_item)
 
         job_payload = {
             **existing_job,

--- a/mediaforce/web/runtime/folder_cards.py
+++ b/mediaforce/web/runtime/folder_cards.py
@@ -433,6 +433,8 @@ def list_folder_cards(
             card.pending_count += 1
             if known_saved_bytes is not None:
                 card.sort_score += known_saved_bytes / (1024 ** 3)
+            elif decision is not None and decision.target_size_blocker is not None:
+                card.estimate_unavailable_count += 1
             elif _eligible_for_estimate(status, decision):
                 if decision is not None and decision.media_domain == "movie":
                     card.estimate_unavailable_count += 1

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -53,6 +53,7 @@ ENCODE_WAITING_PREFIX = "movies/Waiting Encode"
 MOVIE_LOOSE_PREFIX = "movies/Loose Feature.mkv"
 MOVIE_EDITIONS_PREFIX = "movies/Editions Showcase"
 MOVIE_CONFLICT_PREFIX = "movies/Promotion Conflict"
+MOVIE_TARGET_BLOCKED_PREFIX = "movies/Target Too Large"
 CURRENT_PREVIOUS_PREFIX = "tv/Current Season/Season 1"
 CURRENT_SEASON_PREFIX = "tv/Current Season/Season 2"
 CURRENT_SERIES_PREFIX = "tv/Current Season"
@@ -80,6 +81,7 @@ FIXTURE_PREFIXES = (
     MOVIE_LOOSE_PREFIX,
     MOVIE_EDITIONS_PREFIX,
     MOVIE_CONFLICT_PREFIX,
+    MOVIE_TARGET_BLOCKED_PREFIX,
     CURRENT_PREVIOUS_PREFIX,
     CURRENT_SEASON_PREFIX,
     PROTECTED_READY_PREFIX,
@@ -1005,6 +1007,19 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
             _library_item(
                 project_root=project_root,
                 media_root="movies",
+                rel_path="movies/Target Too Large/Feature.mkv",
+                size_bytes=360_000_000,
+                status="discovered",
+                video_codec="hevc",
+                priority_score=71,
+                recommendation="review_encode",
+                recommendation_reason="Fixture movie target exceeds the source-relative cap.",
+                duration_seconds=5_520.0,
+                age_days=1_100,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="movies",
                 rel_path="movies/Editions Showcase/Editions Showcase - Theatrical.mkv",
                 size_bytes=12 * 1024**3,
                 status="discovered",
@@ -1430,6 +1445,12 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 "route": "/folders/movies/Waiting%20Encode",
                 "marker": "Waiting Encode",
                 "stageMarker": "Monitor processing",
+            },
+            {
+                "label": "Movie Studio infeasible-target fixture",
+                "route": "/folders/movies/Target%20Too%20Large",
+                "marker": "Target Too Large",
+                "stageMarker": "Target size exceeds the 80% source cap.",
             },
             {
                 "label": "Folder Studio sampling fixture",

--- a/tests/test_library_lifecycle.py
+++ b/tests/test_library_lifecycle.py
@@ -10,7 +10,7 @@ from mediaforce.core.db import DBClient, open_db, reset_engine_cache
 from mediaforce.core.db_tables import library_items, plex_item_metadata, series_metadata
 from mediaforce.library.candidate_selection import project_candidates, season_identity
 from mediaforce.library.run_manifests import build_run_manifest, create_folder_manifest, select_encode_candidates
-from mediaforce.library.workflow_state import build_folder_workflow_state, derive_item_workflow_state
+from mediaforce.library.workflow_state import EncodeEligibility, build_folder_workflow_state, derive_item_workflow_state
 from mediaforce.web.routes.folders import _request_flag
 from mediaforce.web.runtime.folder_cards import list_folder_cards
 
@@ -376,8 +376,11 @@ class LibraryLifecycleTests(unittest.TestCase):
                 connection,
                 "tv/Show",
                 candidate_eligibility={
-                    eligible_item_id: (True, None),
-                    held_item_id: (False, "This season is still receiving episodes."),
+                    eligible_item_id: EncodeEligibility(eligible=True),
+                    held_item_id: EncodeEligibility(
+                        eligible=False,
+                        blocker="This season is still receiving episodes.",
+                    ),
                 },
             )
 

--- a/tests/test_movie_workflow.py
+++ b/tests/test_movie_workflow.py
@@ -7,7 +7,8 @@ from unittest.mock import Mock, patch
 from fastapi import HTTPException
 from sqlalchemy import select
 
-from mediaforce.core.config import ConfigPaths, MediaforceConfig
+from mediaforce.cli import main as cli_main
+from mediaforce.core.config import ConfigPaths, MediaforceConfig, with_folder_policy_override
 from mediaforce.core.db import DBClient, open_db, reset_engine_cache
 from mediaforce.core.db_tables import library_items, plex_item_metadata, staged_artifacts
 from mediaforce.library.candidate_selection import candidate_rank_key, project_candidates, workflow_eligibility
@@ -435,6 +436,72 @@ class MovieWorkflowTests(unittest.TestCase):
         projection_mock.assert_not_called()
         self.assertEqual(payload["titles"][0]["workflow_state"]["state"], "encode_candidates")
 
+    def test_movie_library_payload_accepts_partial_candidate_projection(self) -> None:
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_item(connection, "films/Example/Example.mkv")
+            payload = load_movie_library_payload(
+                connection,
+                self.config,
+                include_details=True,
+                candidate_decisions=[],
+            )
+
+        title = payload["titles"][0]
+        self.assertEqual(title["workflow_state"]["state"], "encode_candidates")
+        self.assertEqual(title["members"][0]["workflow_state"]["state"], "encode_candidate")
+
+    def test_target_size_projection_blocks_small_movie_and_keeps_larger_movie_ready(self) -> None:
+        config = self._config(extras="exclude", video=self._target_size_video_policy())
+        blocked_prefix = "films/Small Target"
+        feasible_prefix = "films/Larger Target"
+        with open_db(config.paths.db_path) as connection:
+            blocked_id = self._insert_item(
+                connection,
+                f"{blocked_prefix}/Feature.mkv",
+                size_bytes=360_000_000,
+                duration_seconds=5_520.0,
+            )
+            feasible_id = self._insert_item(
+                connection,
+                f"{feasible_prefix}/Feature.mkv",
+                size_bytes=800_000_000,
+                duration_seconds=5_520.0,
+            )
+            extra_id = self._insert_item(
+                connection,
+                f"{feasible_prefix}/Featurettes/Making Of.mkv",
+                size_bytes=120_000_000,
+                duration_seconds=1_200.0,
+            )
+            decisions = project_candidates(connection, config, prefixes=[])
+            decisions_by_id = {decision.item_id: decision for decision in decisions}
+            blocked_workflow = build_folder_workflow_state(
+                connection,
+                blocked_prefix,
+                candidate_eligibility=workflow_eligibility(decisions),
+                library_types=config.library_type_map,
+            )
+            feasible_workflow = build_folder_workflow_state(
+                connection,
+                feasible_prefix,
+                candidate_eligibility=workflow_eligibility(decisions),
+                library_types=config.library_type_map,
+            )
+
+        blocker = decisions_by_id[blocked_id].target_size_blocker
+        self.assertIsNotNone(blocker)
+        self.assertEqual(blocker.code, "target_lower_bound_exceeds_source_relative_cap")
+        self.assertFalse(decisions_by_id[blocked_id].eligible)
+        self.assertEqual(blocked_workflow.state, "blocked")
+        self.assertEqual(blocked_workflow.primary_lane, "blocked")
+        self.assertEqual(blocked_workflow.label, "Needs attention")
+        self.assertIn("Target size exceeds the 80% source cap", blocked_workflow.detail)
+        self.assertTrue(decisions_by_id[feasible_id].eligible)
+        self.assertIsNone(decisions_by_id[feasible_id].target_size_blocker)
+        self.assertFalse(decisions_by_id[extra_id].production_included)
+        self.assertIsNone(decisions_by_id[extra_id].target_size_blocker)
+        self.assertEqual(feasible_workflow.state, "encode_candidates")
+
     def test_promotion_preflight_blocks_duplicate_output_destinations(self) -> None:
         conflict = _promotion_conflict_response(
             self.config,
@@ -608,6 +675,152 @@ class MovieWorkflowTests(unittest.TestCase):
         self.assertIn("Extras are excluded", str(raised.exception.detail))
         self.assertEqual(persisted, [])
 
+    def test_infeasible_target_queue_stops_before_profile_manifest_or_job_writes(self) -> None:
+        config = self._config(extras="exclude", video=self._target_size_video_policy())
+        prefix = "films/Small Target"
+        with open_db(config.paths.db_path) as connection:
+            self._insert_item(
+                connection,
+                f"{prefix}/Feature.mkv",
+                size_bytes=360_000_000,
+                duration_seconds=5_520.0,
+            )
+        persisted: list[str] = []
+        queued: list[dict[str, object]] = []
+
+        with patch("mediaforce.web.runtime.folder_actions.create_folder_manifest") as create_manifest:
+            result = queue_folder_encode_action(
+                config,
+                prefix,
+                "",
+                False,
+                now_iso=lambda: "2026-07-13T00:00:00+00:00",
+                load_job_state=lambda *_args: None,
+                load_calibration_state=lambda *_args: {"policy": {}},
+                review_gate=lambda _calibration: {"can_confirm_full": True, "message": "Ready"},
+                upsert_override=lambda *_args: persisted.append("persisted"),
+                load_active_encode_job_for_prefix_fn=lambda *_args: None,
+                clear_terminal_encode_jobs_for_prefix_fn=lambda *_args: None,
+                prepare_terminal_encode_job_for_requeue_fn=lambda *_args: None,
+                save_encode_job=lambda *_args: queued.append(_args[-1]),
+            )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["code"], "target_lower_bound_exceeds_source_relative_cap")
+        self.assertIn("Target size exceeds the 80% source cap", result["message"])
+        self.assertEqual(persisted, [])
+        self.assertEqual(queued, [])
+        create_manifest.assert_not_called()
+
+    def test_revised_feasible_target_can_queue_movie_work(self) -> None:
+        config = self._config(extras="exclude", video=self._target_size_video_policy())
+        prefix = "films/Revised Target"
+        rel_path = f"{prefix}/Feature.mkv"
+        with open_db(config.paths.db_path) as connection:
+            self._insert_item(
+                connection,
+                rel_path,
+                size_bytes=360_000_000,
+                duration_seconds=5_520.0,
+            )
+        calibration_policy = config.resolve_policy(rel_path)
+        calibration_policy["video"].update(self._absolute_target_video_policy(200_000_000))
+        approved_config = with_folder_policy_override(config, prefix, calibration_policy)
+        persisted: list[str] = []
+        queued: list[dict[str, object]] = []
+        manifest = {"items": [{"rel_path": rel_path}]}
+        manifest_path = self.root / "runs" / "feasible.json"
+
+        with patch("mediaforce.web.runtime.folder_actions.load_config", return_value=approved_config), patch(
+            "mediaforce.web.runtime.folder_actions.create_folder_manifest",
+            return_value=(manifest, manifest_path),
+        ):
+            result = queue_folder_encode_action(
+                config,
+                prefix,
+                "",
+                False,
+                now_iso=lambda: "2026-07-13T00:00:00+00:00",
+                load_job_state=lambda *_args: None,
+                load_calibration_state=lambda *_args: {"policy": calibration_policy},
+                review_gate=lambda _calibration: {"can_confirm_full": True, "message": "Ready"},
+                upsert_override=lambda *_args: persisted.append("persisted"),
+                load_active_encode_job_for_prefix_fn=lambda *_args: None,
+                clear_terminal_encode_jobs_for_prefix_fn=lambda *_args: None,
+                prepare_terminal_encode_job_for_requeue_fn=lambda *_args: None,
+                save_encode_job=lambda *_args: queued.append(_args[-1]),
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(persisted, ["persisted"])
+        self.assertEqual([job["job_kind"] for job in queued], ["folder", "shard"])
+        self.assertTrue(all(job["manifest_path"] == str(manifest_path) for job in queued))
+
+    def test_approved_infeasible_target_blocks_before_profile_manifest_or_job_writes(self) -> None:
+        config = self._config(extras="exclude", video=self._target_size_video_policy())
+        prefix = "films/Larger Target"
+        rel_path = f"{prefix}/Feature.mkv"
+        with open_db(config.paths.db_path) as connection:
+            self._insert_item(
+                connection,
+                rel_path,
+                size_bytes=800_000_000,
+                duration_seconds=5_520.0,
+            )
+        calibration_policy = config.resolve_policy(rel_path)
+        calibration_policy["video"].update(self._absolute_target_video_policy(800_000_000))
+        persisted: list[str] = []
+        queued: list[dict[str, object]] = []
+
+        with patch("mediaforce.web.runtime.folder_actions.create_folder_manifest") as create_manifest:
+            result = queue_folder_encode_action(
+                config,
+                prefix,
+                "",
+                False,
+                now_iso=lambda: "2026-07-13T00:00:00+00:00",
+                load_job_state=lambda *_args: None,
+                load_calibration_state=lambda *_args: {"policy": calibration_policy},
+                review_gate=lambda _calibration: {"can_confirm_full": True, "message": "Ready"},
+                upsert_override=lambda *_args: persisted.append("persisted"),
+                load_active_encode_job_for_prefix_fn=lambda *_args: None,
+                clear_terminal_encode_jobs_for_prefix_fn=lambda *_args: None,
+                prepare_terminal_encode_job_for_requeue_fn=lambda *_args: None,
+                save_encode_job=lambda *_args: queued.append(_args[-1]),
+            )
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["code"], "target_lower_bound_exceeds_source_relative_cap")
+        self.assertEqual(persisted, [])
+        self.assertEqual(queued, [])
+        create_manifest.assert_not_called()
+
+    def test_cli_plan_reports_target_blocker_without_writing_a_manifest(self) -> None:
+        config = self._config(extras="exclude", video=self._target_size_video_policy())
+        prefix = "films/Small Target"
+        with open_db(config.paths.db_path) as connection:
+            self._insert_item(
+                connection,
+                f"{prefix}/Feature.mkv",
+                size_bytes=360_000_000,
+                duration_seconds=5_520.0,
+            )
+
+        with patch("mediaforce.cli.load_config", return_value=config), patch(
+            "mediaforce.cli.purge_transient_artifacts"
+        ), patch("mediaforce.cli._write_manifest") as write_manifest, patch("builtins.print") as print_line:
+            exit_code = cli_main([
+                "--config",
+                str(config.paths.config_path),
+                "plan",
+                "--prefix",
+                prefix,
+            ])
+
+        self.assertEqual(exit_code, 2)
+        self.assertTrue(any("Target size exceeds the 80% source cap" in str(call) for call in print_line.call_args_list))
+        write_manifest.assert_not_called()
+
     def test_title_queue_does_not_recover_an_active_exact_extra_job(self) -> None:
         with open_db(self.config.paths.db_path) as connection:
             self._insert_item(connection, "films/Example/Extras/Trailer.mkv", status="encoding")
@@ -689,6 +902,7 @@ class MovieWorkflowTests(unittest.TestCase):
             ranking: str = "oldest_added_first",
             availability: str = "production",
             additional_libraries: list[dict[str, object]] | None = None,
+            video: dict[str, object] | None = None,
     ) -> MediaforceConfig:
         libraries: list[dict[str, object]] = [
             {
@@ -715,7 +929,7 @@ class MovieWorkflowTests(unittest.TestCase):
                     "staging_root": str(self.root / "staging"),
                     "archive_root": str(self.root / "archive"),
                 },
-                "video": {},
+                "video": video or {},
                 "audio": {},
                 "subtitle": {},
                 "planning": {},
@@ -756,6 +970,7 @@ class MovieWorkflowTests(unittest.TestCase):
             *,
             size_bytes: int = 1024,
             status: str = "discovered",
+            duration_seconds: float = 7_200.0,
     ) -> int:
         timestamp = datetime.now(tz=UTC).isoformat(timespec="seconds")
         path = Path(rel_path)
@@ -770,7 +985,7 @@ class MovieWorkflowTests(unittest.TestCase):
                 size_bytes=size_bytes,
                 mtime_ns=1_700_000_000_000_000_000,
                 fingerprint=f"movie-{rel_path}",
-                duration_seconds=7_200.0,
+                duration_seconds=duration_seconds,
                 video_codec="h264",
                 audio_summary_json="[]",
                 subtitle_summary_json="[]",
@@ -785,6 +1000,34 @@ class MovieWorkflowTests(unittest.TestCase):
             )
         )
         return int(result.inserted_primary_key[0])
+
+    @staticmethod
+    def _target_size_video_policy() -> dict[str, object]:
+        return {
+            "target_size_mb": 300,
+            "target_size_bytes": 300_000_000,
+            "target_runtime_minutes": 45,
+            "size_goal_schema_version": 1,
+            "size_goal_mode": "normalized",
+            "size_goal_source": "config_default",
+            "sample_projection_tolerance_percent": 10,
+            "final_output_tolerance_percent": 5,
+            "max_encoded_percent": 80,
+        }
+
+    @staticmethod
+    def _absolute_target_video_policy(target_size_bytes: int) -> dict[str, object]:
+        return {
+            "target_size_mb": target_size_bytes / 1_000_000,
+            "target_size_bytes": target_size_bytes,
+            "target_runtime_minutes": 92,
+            "size_goal_schema_version": 1,
+            "size_goal_mode": "absolute",
+            "size_goal_source": "operator_request",
+            "sample_projection_tolerance_percent": 10,
+            "final_output_tolerance_percent": 5,
+            "max_encoded_percent": 80,
+        }
 
     @staticmethod
     def _insert_stage(connection: DBClient, item_id: int, rel_path: str) -> None:

--- a/tests/test_stream_budget.py
+++ b/tests/test_stream_budget.py
@@ -10,6 +10,7 @@ from mediaforce.tuning.stream_budget import (
     StreamBudgetIdentityError,
     StreamBudgetLedger,
     resolve_stream_budget_ledger,
+    stream_budget_projection_blocker,
 )
 
 
@@ -230,6 +231,84 @@ class StreamBudgetTests(unittest.TestCase):
         self.assertEqual(ledger.source_cap_total_bytes, 800_000_000)
         self.assertEqual(ledger.source_cap_video_bytes, 696_000_000)
         self.assertEqual(ledger.source_cap_video_percent, 69.6)
+
+    def test_projection_blocks_target_band_above_source_cap(self) -> None:
+        ledger = self._ledger(
+            target_bytes=600_000_000,
+            source_size_bytes=360_000_000,
+            audio={
+                "index": 1,
+                "codec_name": "aac",
+                "channels": 2,
+                "language": "eng",
+                "default": 1,
+                "size_bytes": 12_000_000,
+            },
+        )
+
+        blocker = stream_budget_projection_blocker(ledger)
+
+        self.assertIsNotNone(blocker)
+        self.assertEqual(blocker.code, "target_lower_bound_exceeds_source_relative_cap")
+        self.assertEqual(blocker.target_lower_bound_bytes, 540_000_000)
+        self.assertEqual(blocker.source_cap_total_bytes, 288_000_000)
+        self.assertIn("80% source cap", blocker.message)
+
+    def test_projection_allows_target_band_below_source_cap(self) -> None:
+        ledger = self._ledger(
+            target_bytes=600_000_000,
+            source_size_bytes=800_000_000,
+            audio={
+                "index": 1,
+                "codec_name": "aac",
+                "channels": 2,
+                "language": "eng",
+                "default": 1,
+                "size_bytes": 12_000_000,
+            },
+        )
+
+        self.assertIsNone(stream_budget_projection_blocker(ledger))
+
+    def test_projection_blocks_target_consumed_by_non_video_budget(self) -> None:
+        ledger = self._ledger(
+            target_bytes=10_000_000,
+            source_size_bytes=1_000_000_000,
+            audio={
+                "index": 1,
+                "codec_name": "aac",
+                "channels": 2,
+                "language": "eng",
+                "default": 1,
+                "size_bytes": 12_000_000,
+            },
+        )
+
+        blocker = stream_budget_projection_blocker(ledger)
+
+        self.assertIsNotNone(blocker)
+        self.assertTrue(blocker.code.startswith("target_consumed_by_"))
+        self.assertIn("leaves no room for video", blocker.message)
+
+    def test_projection_blocks_source_cap_consumed_by_non_video_budget(self) -> None:
+        ledger = self._ledger(
+            target_bytes=600_000_000,
+            source_size_bytes=100_000_000,
+            audio={
+                "index": 1,
+                "codec_name": "aac",
+                "channels": 2,
+                "language": "eng",
+                "default": 1,
+                "size_bytes": 100_000_000,
+            },
+        )
+
+        blocker = stream_budget_projection_blocker(ledger)
+
+        self.assertIsNotNone(blocker)
+        self.assertEqual(blocker.code, "source_relative_cap_consumed_by_non_video_budget")
+        self.assertIn("consume the 80% source cap", blocker.message)
 
     def test_ledger_round_trip_rejects_stale_policy(self) -> None:
         ledger = self._ledger(

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -1669,6 +1669,94 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(captured[0]["allow_measured_size_quality_increase"])
 
+    def test_sample_confirmation_blocks_infeasible_target_before_saving_job(self) -> None:
+        saved_jobs: list[dict[str, Any]] = []
+        host = HostStatus(
+            key="host-1",
+            label="M4 Studio",
+            mode="ssh",
+            priority=10,
+            capabilities=["sample_calibration"],
+            available=True,
+            message="Mounted and ready",
+            missing_paths=[],
+        )
+        pending_proposal = {
+            "proposal_id": "proposal-1",
+            "can_queue": True,
+            "host": {"key": host.key},
+            "operator_note": "",
+            "action": "baseline",
+            "applied_policy": {
+                "video": {
+                    "target_size_mb": 600,
+                    "target_size_bytes": 600_000_000,
+                    "target_runtime_minutes": 92,
+                    "size_goal_schema_version": 1,
+                    "size_goal_mode": "absolute",
+                    "size_goal_source": "operator_request",
+                    "sample_projection_tolerance_percent": 10,
+                    "final_output_tolerance_percent": 5,
+                    "max_encoded_percent": 80,
+                }
+            },
+            "advice_payload": {},
+        }
+        sample_item = {
+            "rel_path": "movies/Small Target/Feature.mkv",
+            "source_path": str(self.root / "source" / "movies" / "Small Target" / "Feature.mkv"),
+            "source_size_bytes": 360_000_000,
+            "video_codec": "hevc",
+            "duration_seconds": 5_520.0,
+            "audio_summary": [],
+            "subtitle_summary": [],
+            "resolved_policy": {"video": {}},
+        }
+        deps = FolderAiTuneDeps(
+            resolve_sample_host=lambda *_args, **_kwargs: host,
+            load_job_state=lambda *_args, **_kwargs: None,
+            load_retryable_sample_job_state=lambda *_args, **_kwargs: None,
+            sample_item=lambda *_args, **_kwargs: dict(sample_item),
+            operator_requested_experiment=lambda *_args, **_kwargs: None,
+            load_calibration_state=lambda *_args, **_kwargs: None,
+            recent_tuning_sessions=lambda *_args, **_kwargs: [],
+            matching_request_history=lambda *_args, **_kwargs: None,
+            metric_support=lambda: {},
+            maybe_seed_baseline_policy=lambda *_args, **_kwargs: None,
+            seed_advice_payload=lambda *_args, **_kwargs: None,
+            proposal_alignment_issue=lambda *_args, **_kwargs: None,
+            now_iso=lambda: "2026-07-13T00:00:00+00:00",
+            proposal_signal_copy=lambda *_args, **_kwargs: "",
+            proposal_context_snapshot=lambda *_args, **_kwargs: {},
+            save_pending_proposal=lambda *_args, **_kwargs: None,
+            pending_proposal_public_view=lambda payload: payload,
+            build_tuning_runtime_toolbelt=lambda *_args, **_kwargs: {},
+            review_pack_dir=lambda *_args, **_kwargs: self.root / "review-pack",
+            remove_path_if_exists=lambda *_args, **_kwargs: None,
+            build_multimodal_review_pack=lambda *_args, **_kwargs: None,
+            multimodal_review_pack_public_view=lambda *_args, **_kwargs: None,
+            tuning_advice_payload=lambda *_args, **_kwargs: {},
+            load_pending_proposal=lambda *_args, **_kwargs: dict(pending_proposal),
+            apply_policy_fragment=lambda current, fragment: {
+                **current,
+                "video": {
+                    **object_dict(current.get("video")),
+                    **object_dict(fragment.get("video")),
+                },
+            },
+            save_advice_state=lambda *_args, **_kwargs: None,
+            save_job_state=lambda _connection, _config, _prefix, payload: saved_jobs.append(dict(payload)),
+            clear_pending_proposal=lambda *_args, **_kwargs: None,
+            record_tuning_session=lambda *_args, **_kwargs: "session-1",
+        )
+
+        result = folder_ai_tune_confirm_action(self.config, deps, "movies/Small Target", "proposal-1")
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["code"], "target_lower_bound_exceeds_source_relative_cap")
+        self.assertIn("Target size exceeds the 80% source cap", result["message"])
+        self.assertEqual(saved_jobs, [])
+
     def test_completed_cleanup_route_passes_selected_prefixes(self) -> None:
         from mediaforce.web import app as web_app
 


### PR DESCRIPTION
## Summary
- promote source-relative target infeasibility into a shared stream-budget preflight contract
- project hard blockers into Movies Library/Studio and stop CLI, sample confirmation, recovery, manifest, profile, and encode-job writes before work begins
- evaluate the exact proposed or accepted calibration policy so operators can lower the target and retry safely
- add deterministic 360 MB blocked / 800 MB feasible coverage plus desktop and narrow browser fixtures

## Validation
- `bash scripts/pre-commit-check.sh` — 908 backend tests, CLI smoke, frontend check/lint/unit/build, desktop+narrow route smoke
- `uv build`
- `uv run mediaforce plan --prefix "movies/Time Runner (1993)"` — concise source-cap block, exit 2, no traceback
- `uv run mediaforce run "movies/Time Runner (1993)"` — scan completes, then source-cap block before manifest/review work
- real browser: Movies shows `Needs attention`; Studio explains the 80% cap, links to Settings, and exposes a revised-draft path without starting sample work
- independent backend, edge-case, and browser reviews completed; final release review reported no blocking findings
- PyCharm changed-files inspection initially passed; the final post-fix rerun was inconclusive because IDE indexing did not settle after one allowed retry

Closes #194
