### PR TITLE
Calibrate final-size retries from completed output

### DIFF
--- a/docs/architecture/stream-budget-ledger.md
+++ b/docs/architecture/stream-budget-ledger.md
@@ -84,10 +84,16 @@ structured infeasibility, quality-conflict, or needs-review outcomes.
 
 Production encodes verify actual output bytes against the resolved final band
 from the same size goal, currently ±5% by default. A final miss can retry only
-once, and only by reusing a candidate already measured and recorded in the
-search trace. If no bounded measured retry is available, or if the retry budget
-is exhausted, the item enters a needs-review failure state rather than falling
-back to quality-first encoding or silently relaxing the approved constraint.
+once. The completed output calibrates the sample curve's video-byte projection;
+an already measured candidate may be reused when that corrected projection is
+inside the final band. Otherwise Mediaforce may interpolate one integer CRF
+between measured quality-safe candidates and run one targeted sample at that
+CRF. The replacement full encode starts only when the new sample supplies a real
+quality score that meets the configured floor, remains under the
+source-relative cap, and its calibrated total projection is inside the final
+band. If no bounded measured retry is available, or if the retry budget is
+exhausted, the item enters a needs-review failure state rather than falling back
+to quality-first encoding or silently relaxing the approved constraint.
 
 ## Fallbacks and migration
 

--- a/mediaforce/encoding/manifest.py
+++ b/mediaforce/encoding/manifest.py
@@ -211,6 +211,7 @@ def encode_one_item(
         resolve_item_staging_path: Callable[..., Path],
         effective_video_preset: Callable[..., int],
         search_quality: Callable[..., Any],
+        measure_quality_candidate: Callable[..., Any],
         select_streams: Callable[[dict[str, Any]], dict[str, Any]],
         build_ffmpeg_command: Callable[..., list[str]],
         detect_video_crop: Callable[..., str | None] | None,
@@ -426,7 +427,44 @@ def encode_one_item(
             ) or final_trace
             if final_verification.passed:
                 break
-            retry_quality = retry_quality_result_for_final_miss(quality_result, final_verification)
+            safe_unlink(staging_path)
+            quality_result.target_size_trace = final_trace
+
+            def measure_retry_candidate(crf: float) -> Any:
+                if progress_callback is not None:
+                    progress_callback(
+                        {
+                            "progress_state": "quality_search",
+                            "phase_label": "Measuring retry",
+                            "fps": None,
+                            "speed": None,
+                            "eta_seconds": None,
+                            "elapsed_seconds": 0.0,
+                            "out_time_seconds": 0.0,
+                        }
+                    )
+                return measure_quality_candidate(
+                    quality_source_path,
+                    policy["video"],
+                    crf=crf,
+                    source_codec=str(item.get("video_codec") or ""),
+                    width=width,
+                    height=height,
+                    detected_crop=detected_crop,
+                    cadence_decision=cadence_decision,
+                    cadence_evidence=cadence_evidence,
+                    cadence_source_fingerprint=current_source_fingerprint,
+                    process_controller=process_controller,
+                    host=quality_search_host,
+                    quality_temp_dir=_quality_temp_dir_for_encode_host(config, quality_search_host),
+                )
+
+            retry_quality = retry_quality_result_for_final_miss(
+                quality_result,
+                final_verification,
+                measure_candidate=measure_retry_candidate,
+            )
+            final_trace = object_dict(quality_result.target_size_trace) or final_trace
             retry_payload = final_verification.to_payload()
             retry_payload.update(
                 {
@@ -438,13 +476,14 @@ def encode_one_item(
             )
             if retry_quality is None:
                 raise FinalSizeMissError(_final_size_miss_message(final_verification))
+            final_trace = object_dict(retry_quality.target_size_trace) or final_trace
+            retry_payload["target_size_trace"] = final_trace
             retry_count += 1
             retry_payload["retry_count"] = retry_count
             retry_payload["next_crf"] = retry_quality.crf
             record_event(connection, item["library_item_id"], "encoding_target_size_retry", retry_payload)
             connection.commit()
             safe_unlink(temp_output)
-            safe_unlink(staging_path)
             quality_result = retry_quality
             ffmpeg_cmd = build_ffmpeg_command(
                 source_path=source_path,

--- a/mediaforce/encoding/quality_search.py
+++ b/mediaforce/encoding/quality_search.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable
 
@@ -8,6 +9,18 @@ from mediaforce.tuning.target_size_search import build_target_size_transform_pla
 from mediaforce.tuning.stream_budget import StreamBudgetLedger
 
 MAX_CRF_SEARCH_CEILING = 63
+
+
+@dataclass(frozen=True, slots=True)
+class _QualityContext:
+    host: dict[str, Any] | None
+    metric_name: str
+    metric_target: float
+    min_metric_score: float
+    relax_step: float
+    svt_params: list[str]
+    preset: int
+    video_filter: str | None
 
 
 def search_quality(
@@ -32,27 +45,21 @@ def search_quality(
         run_crf_search: Callable[..., QualitySearchResult],
         run_sample_encode: Callable[..., SampleEncodeResult] | None = None,
 ) -> QualitySearchResult:
-    quality_host = host
-    if host_media_access_for_host(host) == "stream":
-        quality_host = {**(host or {}), "mode": "local"}
-    metric_name, default_target = select_quality_metric(str(video_policy.get("quality_metric", "auto")))
-    metric_target = float(video_policy.get(f"target_{metric_name.lower()}", default_target))
-    min_target = float(video_policy.get(f"min_target_{metric_name.lower()}", metric_target))
-    relax_step = float(
-        video_policy.get(f"target_relax_step_{metric_name.lower()}", 1.0 if metric_name == "xpsnr" else 0.5)
-    )
-    svt_params = build_svt_params(video_policy)
-    preset = effective_video_preset(video_policy, width=width, height=height)
-    video_filter = build_video_filter(
+    context = _quality_context(
         video_policy,
+        host=host,
         width=width,
         height=height,
         detected_crop=detected_crop,
         cadence_decision=cadence_decision,
         cadence_evidence=cadence_evidence,
         cadence_source_fingerprint=cadence_source_fingerprint,
+        host_media_access_for_host=host_media_access_for_host,
+        select_quality_metric=select_quality_metric,
+        build_svt_params=build_svt_params,
+        effective_video_preset=effective_video_preset,
     )
-    attempted_target = metric_target
+    attempted_target = context.metric_target
     last_error: Exception | None = None
     configured_max_crf = int(video_policy["max_crf"])
     max_encoded_percent = float(video_policy["max_encoded_percent"])
@@ -63,45 +70,45 @@ def search_quality(
             source_path,
             video_policy,
             source_codec=source_codec,
-            metric_name=metric_name,
-            metric_target=metric_target,
-            min_metric_score=min_target,
-            preset=preset,
+            metric_name=context.metric_name,
+            metric_target=context.metric_target,
+            min_metric_score=context.min_metric_score,
+            preset=context.preset,
             pixel_format=str(video_policy["pixel_format"]),
             sample_every=str(video_policy["sample_every"]),
             sample_duration=str(video_policy["sample_duration"]),
             min_crf=int(video_policy["min_crf"]),
             max_crf=configured_max_crf,
-            svt_params=svt_params,
-            video_filter=video_filter,
+            svt_params=context.svt_params,
+            video_filter=context.video_filter,
             stream_budget_ledger=stream_budget_ledger,
-            transform_plan=_transform_plan_payload(cadence_decision, video_filter),
+            transform_plan=_transform_plan_payload(cadence_decision, context.video_filter),
             process_controller=process_controller,
-            host=quality_host,
+            host=context.host,
             quality_temp_dir=quality_temp_dir,
             run_sample_encode=run_sample_encode,
         )
 
-    while attempted_target >= min_target:
+    while attempted_target >= context.min_metric_score:
         for max_crf in _max_crf_attempts(configured_max_crf):
             try:
                 return run_crf_search(
                     source_path,
                     source_codec=source_codec,
-                    preferred_metric=metric_name,
+                    preferred_metric=context.metric_name,
                     metric_target=attempted_target,
-                    preset=preset,
+                    preset=context.preset,
                     pixel_format=str(video_policy["pixel_format"]),
                     sample_every=str(video_policy["sample_every"]),
                     sample_duration=str(video_policy["sample_duration"]),
                     min_crf=int(video_policy["min_crf"]),
                     max_crf=max_crf,
                     max_encoded_percent=max_encoded_percent,
-                    svt_params=svt_params,
-                    video_filter=video_filter,
+                    svt_params=context.svt_params,
+                    video_filter=context.video_filter,
                     thorough=bool(video_policy.get("thorough", False)),
                     process_controller=process_controller,
-                    host=quality_host,
+                    host=context.host,
                     quality_temp_dir=quality_temp_dir,
                 )
             except QualitySearchError as exc:
@@ -109,11 +116,63 @@ def search_quality(
                 if max_crf < MAX_CRF_SEARCH_CEILING and _failed_to_find_suitable_crf(exc):
                     continue
                 break
-        attempted_target = round(attempted_target - relax_step, 3)
+        attempted_target = round(attempted_target - context.relax_step, 3)
 
     if last_error is not None:
         raise last_error
     raise RuntimeError("Quality search did not run")
+
+
+def measure_quality_candidate(
+        source_path: Path,
+        video_policy: dict[str, Any],
+        *,
+        crf: float,
+        source_codec: str | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        detected_crop: str | None = None,
+        cadence_decision: dict[str, Any] | None = None,
+        cadence_evidence: dict[str, Any] | None = None,
+        cadence_source_fingerprint: str | None = None,
+        process_controller: Any = None,
+        host: dict[str, Any] | None = None,
+        quality_temp_dir: Path | None = None,
+        host_media_access_for_host: Callable[[dict[str, Any] | None], str],
+        select_quality_metric: Callable[[str], tuple[str, float]],
+        build_svt_params: Callable[[dict[str, Any]], list[str]],
+        effective_video_preset: Callable[..., int],
+        run_sample_encode: Callable[..., SampleEncodeResult],
+) -> SampleEncodeResult:
+    context = _quality_context(
+        video_policy,
+        host=host,
+        width=width,
+        height=height,
+        detected_crop=detected_crop,
+        cadence_decision=cadence_decision,
+        cadence_evidence=cadence_evidence,
+        cadence_source_fingerprint=cadence_source_fingerprint,
+        host_media_access_for_host=host_media_access_for_host,
+        select_quality_metric=select_quality_metric,
+        build_svt_params=build_svt_params,
+        effective_video_preset=effective_video_preset,
+    )
+    return run_sample_encode(
+        source_path,
+        source_codec=source_codec,
+        preferred_metric=context.metric_name,
+        crf=crf,
+        preset=context.preset,
+        pixel_format=str(video_policy["pixel_format"]),
+        sample_every=str(video_policy["sample_every"]),
+        sample_duration=str(video_policy["sample_duration"]),
+        svt_params=context.svt_params,
+        video_filter=context.video_filter,
+        process_controller=process_controller,
+        host=context.host,
+        quality_temp_dir=quality_temp_dir,
+    )
 
 
 def _max_crf_attempts(configured_max_crf: int) -> list[int]:
@@ -124,6 +183,53 @@ def _max_crf_attempts(configured_max_crf: int) -> list[int]:
 
 def _failed_to_find_suitable_crf(exc: QualitySearchError) -> bool:
     return "failed to find a suitable crf" in str(exc).lower()
+
+
+def _quality_context(
+        video_policy: dict[str, Any],
+        *,
+        host: dict[str, Any] | None,
+        width: int | None,
+        height: int | None,
+        detected_crop: str | None,
+        cadence_decision: dict[str, Any] | None,
+        cadence_evidence: dict[str, Any] | None,
+        cadence_source_fingerprint: str | None,
+        host_media_access_for_host: Callable[[dict[str, Any] | None], str],
+        select_quality_metric: Callable[[str], tuple[str, float]],
+        build_svt_params: Callable[[dict[str, Any]], list[str]],
+        effective_video_preset: Callable[..., int],
+) -> _QualityContext:
+    quality_host = host
+    if host_media_access_for_host(host) == "stream":
+        quality_host = {**(host or {}), "mode": "local"}
+    metric_name, default_target = select_quality_metric(str(video_policy.get("quality_metric", "auto")))
+    metric_target = float(video_policy.get(f"target_{metric_name.lower()}", default_target))
+    min_metric_score = float(video_policy.get(f"min_target_{metric_name.lower()}", metric_target))
+    relax_step = float(
+        video_policy.get(
+            f"target_relax_step_{metric_name.lower()}",
+            1.0 if metric_name == "xpsnr" else 0.5,
+        )
+    )
+    return _QualityContext(
+        host=quality_host,
+        metric_name=metric_name,
+        metric_target=metric_target,
+        min_metric_score=min_metric_score,
+        relax_step=relax_step,
+        svt_params=build_svt_params(video_policy),
+        preset=effective_video_preset(video_policy, width=width, height=height),
+        video_filter=build_video_filter(
+            video_policy,
+            width=width,
+            height=height,
+            detected_crop=detected_crop,
+            cadence_decision=cadence_decision,
+            cadence_evidence=cadence_evidence,
+            cadence_source_fingerprint=cadence_source_fingerprint,
+        ),
+    )
 
 
 def _transform_plan_payload(cadence_decision: dict[str, Any] | None, video_filter: str | None) -> dict[str, Any]:

--- a/mediaforce/execution.py
+++ b/mediaforce/execution.py
@@ -17,7 +17,8 @@ from mediaforce.encoding.manifest import describe_item_plan as describe_item_pla
 from mediaforce.encoding.progress import _ffmpeg_command_with_progress as _ffmpeg_command_with_progress_impl, \
     _progress_float as _progress_float_impl, _progress_out_time_seconds as _progress_out_time_seconds_impl, \
     _progress_speed as _progress_speed_impl, _update_ffmpeg_progress_state as _update_ffmpeg_progress_state_impl
-from mediaforce.encoding.quality_search import search_quality as _search_quality_impl
+from mediaforce.encoding.quality_search import measure_quality_candidate as _measure_quality_candidate_impl, \
+    search_quality as _search_quality_impl
 from mediaforce.encoding.runner import run_encode_command as _run_encode_command_impl, \
     run_streamed_remote_encode_command as _run_streamed_remote_encode_command_impl, \
     run_tracked_process as _run_tracked_process_impl
@@ -35,7 +36,8 @@ from mediaforce.encoding.ffmpeg import ffmpeg_hwaccel_input_args
 from mediaforce.library.probe import probe_media
 from mediaforce.core.process_control import ManagedProcessController, ProcessCancelledError, run_command
 from mediaforce.core.type_defs import float_value, int_value, object_dict
-from mediaforce.encoding.quality import QualitySearchResult, run_crf_search, run_sample_encode, select_quality_metric
+from mediaforce.encoding.quality import QualitySearchResult, SampleEncodeResult, run_crf_search, run_sample_encode, \
+    select_quality_metric
 from mediaforce.remote import execution_mode_for_host, host_media_access_for_host, remote_shell_path_export_line, \
     run_remote_command, ssh_client_options
 from mediaforce.core.utils import file_fingerprint, timestamp
@@ -215,6 +217,7 @@ def encode_one_item(
         resolve_item_staging_path=resolve_item_staging_path,
         effective_video_preset=effective_video_preset,
         search_quality=_search_quality,
+        measure_quality_candidate=_measure_quality_candidate,
         select_streams=_select_streams,
         build_ffmpeg_command=_build_ffmpeg_command,
         detect_video_crop=_detect_video_crop,
@@ -353,6 +356,44 @@ def _search_quality(
         build_svt_params=build_svt_params,
         effective_video_preset=effective_video_preset,
         run_crf_search=run_crf_search,
+        run_sample_encode=run_sample_encode,
+    )
+
+
+def _measure_quality_candidate(
+        source_path: Path,
+        video_policy: dict[str, Any],
+        *,
+        crf: float,
+        source_codec: str | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        detected_crop: str | None = None,
+        cadence_decision: dict[str, Any] | None = None,
+        cadence_evidence: dict[str, Any] | None = None,
+        cadence_source_fingerprint: str | None = None,
+        process_controller: ManagedProcessController | None = None,
+        host: dict[str, Any] | None = None,
+        quality_temp_dir: Path | None = None,
+) -> SampleEncodeResult:
+    return _measure_quality_candidate_impl(
+        source_path,
+        video_policy,
+        crf=crf,
+        source_codec=source_codec,
+        width=width,
+        height=height,
+        detected_crop=detected_crop,
+        cadence_decision=cadence_decision,
+        cadence_evidence=cadence_evidence,
+        cadence_source_fingerprint=cadence_source_fingerprint,
+        process_controller=process_controller,
+        host=host,
+        quality_temp_dir=quality_temp_dir,
+        host_media_access_for_host=host_media_access_for_host,
+        select_quality_metric=select_quality_metric,
+        build_svt_params=build_svt_params,
+        effective_video_preset=effective_video_preset,
         run_sample_encode=run_sample_encode,
     )
 

--- a/mediaforce/tuning/target_size_search.py
+++ b/mediaforce/tuning/target_size_search.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Literal
@@ -18,6 +19,8 @@ TARGET_SIZE_SEARCH_SCHEMA_VERSION = 1
 TARGET_SIZE_TRANSFORM_PLAN_SCHEMA_VERSION = 1
 MAX_TARGET_SIZE_CANDIDATES = 6
 MAX_FINAL_OUTPUT_RETRIES = 1
+MIN_FINAL_RETRY_CALIBRATION_FACTOR = 0.5
+MAX_FINAL_RETRY_CALIBRATION_FACTOR = 2.0
 
 SearchStatus = Literal["selected", "infeasible", "quality_conflict", "needs_review"]
 CurveShape = Literal["single_point", "monotonic", "non_monotonic"]
@@ -334,13 +337,40 @@ def verify_final_output_size(
 def retry_quality_result_for_final_miss(
         quality: QualitySearchResult,
         verification: FinalSizeVerification,
+        *,
+        measure_candidate: Callable[[float], SampleEncodeResult] | None = None,
 ) -> QualitySearchResult | None:
     trace = object_dict(quality.target_size_trace)
     if not trace or not verification.retry_allowed:
         return None
     selected = object_dict(trace.get("selected_candidate"))
     selected_crf = float_value(selected.get("crf"))
-    if selected_crf <= 0:
+    target = object_dict(trace.get("target"))
+    non_video_bytes = int_value(target.get("non_video_bytes"))
+    selected_predicted_video_bytes = int_value(selected.get("predicted_video_bytes"))
+    actual_output_bytes = int_value(verification.actual_output_bytes)
+    actual_video_bytes = actual_output_bytes - non_video_bytes
+    if (
+            "crf" not in selected
+            or not math.isfinite(selected_crf)
+            or selected_crf < 0
+            or non_video_bytes < 0
+            or selected_predicted_video_bytes <= 0
+            or actual_video_bytes <= 0
+    ):
+        return None
+    calibration_factor = actual_video_bytes / selected_predicted_video_bytes
+    if not MIN_FINAL_RETRY_CALIBRATION_FACTOR <= calibration_factor <= MAX_FINAL_RETRY_CALIBRATION_FACTOR:
+        return None
+    target_size_bytes = int_value(verification.target_size_bytes)
+    lower_bound_bytes = int_value(verification.lower_bound_bytes)
+    upper_bound_bytes = int_value(verification.upper_bound_bytes)
+    if target_size_bytes <= 0 or lower_bound_bytes <= 0 or upper_bound_bytes <= 0:
+        return None
+    source_cap = object_dict(trace.get("source_cap"))
+    source_cap_video_bytes = int_value(source_cap.get("video_cap_bytes")) or None
+    minimum_quality_score = float_value(object_dict(trace.get("quality_floor")).get("minimum"))
+    if minimum_quality_score <= 0:
         return None
     candidates = [object_dict(candidate) for candidate in trace.get("candidates", []) if isinstance(candidate, dict)]
     if verification.status == "over_target":
@@ -348,35 +378,389 @@ def retry_quality_result_for_final_miss(
             candidate for candidate in candidates
             if float_value(candidate.get("crf")) > selected_crf
             and bool(candidate.get("quality_floor_met"))
-            and not bool(candidate.get("violates_source_cap"))
+            and int_value(candidate.get("predicted_video_bytes")) > 0
         ]
-        eligible.sort(key=lambda candidate: (float_value(candidate.get("crf")), _distance(candidate)))
+        eligible.sort(key=lambda candidate: float_value(candidate.get("crf")))
     elif verification.status == "under_target":
         eligible = [
             candidate for candidate in candidates
-            if 0 < float_value(candidate.get("crf")) < selected_crf
+            if candidate.get("crf") is not None
+            and 0 <= float_value(candidate.get("crf")) < selected_crf
             and bool(candidate.get("quality_floor_met"))
-            and not bool(candidate.get("violates_source_cap"))
+            and int_value(candidate.get("predicted_video_bytes")) > 0
         ]
-        eligible.sort(key=lambda candidate: (-float_value(candidate.get("crf")), _distance(candidate)))
+        eligible.sort(key=lambda candidate: -float_value(candidate.get("crf")))
     else:
         return None
     if not eligible:
         return None
-    candidate = eligible[0]
+
+    calibrated = [
+        (
+            candidate,
+            _calibrated_video_bytes(candidate, calibration_factor),
+            _calibrated_total_bytes(candidate, calibration_factor, non_video_bytes),
+        )
+        for candidate in eligible
+    ]
+    calibrated_safe = [
+        entry for entry in calibrated
+        if source_cap_video_bytes is None or entry[1] <= source_cap_video_bytes
+    ]
+    in_band = [
+        entry for entry in calibrated_safe
+        if lower_bound_bytes <= entry[2] <= upper_bound_bytes
+    ]
+    if in_band:
+        candidate, calibrated_video_bytes, calibrated_total_bytes = min(
+            in_band,
+            key=lambda entry: (
+                abs(entry[2] - target_size_bytes),
+                abs(float_value(entry[0].get("crf")) - selected_crf),
+                -float_value(entry[0].get("metric_score")),
+            ),
+        )
+        return _final_retry_quality_result(
+            quality,
+            trace,
+            selected,
+            _candidate_with_calibration(
+                candidate,
+                calibration_factor=calibration_factor,
+                calibrated_video_bytes=calibrated_video_bytes,
+                calibrated_total_bytes=calibrated_total_bytes,
+                source_cap_video_bytes=source_cap_video_bytes,
+                lower_bound_bytes=lower_bound_bytes,
+                upper_bound_bytes=upper_bound_bytes,
+            ),
+            verification,
+            calibration_factor=calibration_factor,
+            non_video_bytes=non_video_bytes,
+            bracket_candidate=candidate,
+        )
+
+    if verification.status == "over_target":
+        bracket = next((entry for entry in calibrated_safe if entry[2] < target_size_bytes), None)
+    else:
+        bracket = next((entry for entry in calibrated_safe if entry[2] > target_size_bytes), None)
+    if bracket is None or measure_candidate is None:
+        return None
+    bracket_candidate, bracket_video_bytes, _bracket_total_bytes = bracket
+    retry_crf = _interpolated_retry_crf(
+        selected_crf=selected_crf,
+        selected_actual_video_bytes=actual_video_bytes,
+        bracket_crf=float_value(bracket_candidate.get("crf")),
+        bracket_calibrated_video_bytes=bracket_video_bytes,
+        non_video_bytes=non_video_bytes,
+        target_size_bytes=target_size_bytes,
+        lower_bound_bytes=lower_bound_bytes,
+        upper_bound_bytes=upper_bound_bytes,
+        source_cap_video_bytes=source_cap_video_bytes,
+        measured_crfs=_measured_integer_crfs(candidates),
+    )
+    if retry_crf is None:
+        return None
+    sample = measure_candidate(retry_crf)
+    measured_candidate = _measured_retry_candidate(
+        sample,
+        trace=trace,
+        crf=retry_crf,
+        non_video_bytes=non_video_bytes,
+        target_size_bytes=target_size_bytes,
+        source_cap_video_bytes=source_cap_video_bytes,
+    )
+    calibrated_video_bytes = round(sample.predicted_encode_size_bytes * calibration_factor)
+    calibrated_total_bytes = calibrated_video_bytes + non_video_bytes
+    candidate = _candidate_with_calibration(
+        measured_candidate,
+        calibration_factor=calibration_factor,
+        calibrated_video_bytes=calibrated_video_bytes,
+        calibrated_total_bytes=calibrated_total_bytes,
+        source_cap_video_bytes=source_cap_video_bytes,
+        lower_bound_bytes=lower_bound_bytes,
+        upper_bound_bytes=upper_bound_bytes,
+    )
+    rejection_reason = None
+    if not math.isfinite(sample.score):
+        rejection_reason = "final_retry_measurement_invalid_quality_score"
+    elif sample.predicted_encode_size_bytes <= 0:
+        rejection_reason = "final_retry_measurement_invalid_projection"
+    elif sample.metric.casefold() != quality.metric.casefold():
+        rejection_reason = "final_retry_measurement_metric_mismatch"
+    elif sample.score < minimum_quality_score:
+        rejection_reason = "final_retry_measurement_below_quality_floor"
+    elif bool(candidate.get("violates_source_cap")):
+        rejection_reason = "final_retry_measurement_exceeds_source_cap"
+    elif not bool(candidate.get("within_calibrated_final_band")):
+        rejection_reason = "final_retry_measurement_outside_final_band"
+    if rejection_reason is not None:
+        quality.target_size_trace = _final_retry_rejection_trace(
+            trace,
+            selected,
+            candidate,
+            verification,
+            calibration_factor=calibration_factor,
+            non_video_bytes=non_video_bytes,
+            bracket_candidate=bracket_candidate,
+            rejection_reason=rejection_reason,
+        )
+        return None
+    retry_trace_candidates = [dict(existing) for existing in candidates]
+    retry_trace_candidates.append(candidate)
+    retry_trace = dict(trace)
+    retry_trace["candidates"] = retry_trace_candidates
+    _refresh_retry_curve(retry_trace)
+    return _final_retry_quality_result(
+        quality,
+        retry_trace,
+        selected,
+        candidate,
+        verification,
+        calibration_factor=calibration_factor,
+        non_video_bytes=non_video_bytes,
+        bracket_candidate=bracket_candidate,
+        stdout=sample.stdout,
+    )
+
+
+def _final_retry_quality_result(
+        quality: QualitySearchResult,
+        trace: dict[str, Any],
+        selected: dict[str, Any],
+        candidate: dict[str, Any],
+        verification: FinalSizeVerification,
+        *,
+        calibration_factor: float,
+        non_video_bytes: int,
+        bracket_candidate: dict[str, Any],
+        stdout: str | None = None,
+) -> QualitySearchResult:
     retry_trace = dict(trace)
     retry_trace["selected_candidate"] = candidate
     retry_trace["status"] = "selected"
-    retry_trace["selection_reason"] = "bounded_final_size_retry_candidate"
+    retry_trace["selection_reason"] = "calibrated_final_size_retry_candidate"
     retry_trace["final_retry_from_candidate"] = selected
+    retry_trace["final_retry_calibration"] = {
+        **_final_retry_calibration_payload(
+            selected,
+            candidate,
+            verification,
+            calibration_factor=calibration_factor,
+            non_video_bytes=non_video_bytes,
+            bracket_candidate=bracket_candidate,
+        ),
+        "status": "selected",
+    }
     return QualitySearchResult(
         crf=float_value(candidate.get("crf")),
         metric=str(candidate.get("metric") or quality.metric),
         target=float_value(candidate.get("metric_target")) or quality.target,
         score=float_value(candidate.get("metric_score")),
-        stdout=quality.stdout,
+        stdout=stdout if stdout is not None else quality.stdout,
         target_size_trace=retry_trace,
     )
+
+
+def _candidate_with_calibration(
+        candidate: dict[str, Any],
+        *,
+        calibration_factor: float,
+        calibrated_video_bytes: int,
+        calibrated_total_bytes: int,
+        source_cap_video_bytes: int | None,
+        lower_bound_bytes: int,
+        upper_bound_bytes: int,
+) -> dict[str, Any]:
+    return {
+        **candidate,
+        "sample_projection_violates_source_cap": bool(candidate.get("violates_source_cap")),
+        "violates_source_cap": (
+            source_cap_video_bytes is not None
+            and calibrated_video_bytes > source_cap_video_bytes
+        ),
+        "projection_calibration_factor": round(calibration_factor, 9),
+        "calibrated_predicted_video_bytes": calibrated_video_bytes,
+        "calibrated_predicted_whole_episode_bytes": calibrated_total_bytes,
+        "within_calibrated_final_band": lower_bound_bytes <= calibrated_total_bytes <= upper_bound_bytes,
+    }
+
+
+def _final_retry_rejection_trace(
+        trace: dict[str, Any],
+        selected: dict[str, Any],
+        candidate: dict[str, Any],
+        verification: FinalSizeVerification,
+        *,
+        calibration_factor: float,
+        non_video_bytes: int,
+        bracket_candidate: dict[str, Any],
+        rejection_reason: str,
+) -> dict[str, Any]:
+    retry_trace = dict(trace)
+    retry_trace["candidates"] = [
+        *[dict(existing) for existing in trace.get("candidates", []) if isinstance(existing, dict)],
+        candidate,
+    ]
+    _refresh_retry_curve(retry_trace)
+    retry_trace["status"] = "needs_review"
+    retry_trace["selection_reason"] = rejection_reason
+    retry_trace["final_retry_from_candidate"] = selected
+    retry_trace["final_retry_calibration"] = {
+        **_final_retry_calibration_payload(
+            selected,
+            candidate,
+            verification,
+            calibration_factor=calibration_factor,
+            non_video_bytes=non_video_bytes,
+            bracket_candidate=bracket_candidate,
+        ),
+        "status": "rejected",
+        "rejection_reason": rejection_reason,
+    }
+    return retry_trace
+
+
+def _refresh_retry_curve(trace: dict[str, Any]) -> None:
+    curve = object_dict(trace.get("curve"))
+    if not curve:
+        return
+    candidates = [candidate for candidate in trace.get("candidates", []) if isinstance(candidate, dict)]
+    retry_measurement_count = sum(candidate.get("role") == "final_retry_measurement" for candidate in candidates)
+    trace["curve"] = {
+        **curve,
+        "search_candidate_count": int_value(curve.get("candidate_count")),
+        "candidate_count": len(candidates),
+        "final_retry_measurement_count": retry_measurement_count,
+    }
+
+
+def _final_retry_calibration_payload(
+        selected: dict[str, Any],
+        candidate: dict[str, Any],
+        verification: FinalSizeVerification,
+        *,
+        calibration_factor: float,
+        non_video_bytes: int,
+        bracket_candidate: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": TARGET_SIZE_SEARCH_SCHEMA_VERSION,
+        "anchor_crf": float_value(selected.get("crf")),
+        "anchor_predicted_video_bytes": int_value(selected.get("predicted_video_bytes")),
+        "anchor_actual_output_bytes": verification.actual_output_bytes,
+        "non_video_bytes": non_video_bytes,
+        "video_projection_factor": round(calibration_factor, 9),
+        "bracket_crf": float_value(bracket_candidate.get("crf")),
+        "selected_retry_crf": float_value(candidate.get("crf")),
+        "calibrated_predicted_video_bytes": int_value(candidate.get("calibrated_predicted_video_bytes")),
+        "calibrated_predicted_whole_episode_bytes": int_value(
+            candidate.get("calibrated_predicted_whole_episode_bytes")
+        ),
+    }
+
+
+def _calibrated_video_bytes(candidate: dict[str, Any], calibration_factor: float) -> int:
+    return round(int_value(candidate.get("predicted_video_bytes")) * calibration_factor)
+
+
+def _calibrated_total_bytes(candidate: dict[str, Any], calibration_factor: float, non_video_bytes: int) -> int:
+    return _calibrated_video_bytes(candidate, calibration_factor) + non_video_bytes
+
+
+def _interpolated_retry_crf(
+        *,
+        selected_crf: float,
+        selected_actual_video_bytes: int,
+        bracket_crf: float,
+        bracket_calibrated_video_bytes: int,
+        non_video_bytes: int,
+        target_size_bytes: int,
+        lower_bound_bytes: int,
+        upper_bound_bytes: int,
+        source_cap_video_bytes: int | None,
+        measured_crfs: set[int],
+) -> float | None:
+    if (
+            selected_actual_video_bytes <= 0
+            or bracket_calibrated_video_bytes <= 0
+            or bracket_crf == selected_crf
+    ):
+        return None
+    start = math.floor(min(selected_crf, bracket_crf)) + 1
+    stop = math.ceil(max(selected_crf, bracket_crf))
+    candidates: list[tuple[float, int]] = []
+    for integer_crf in range(start, stop):
+        if integer_crf in measured_crfs:
+            continue
+        retry_crf = float(integer_crf)
+        fraction = (retry_crf - selected_crf) / (bracket_crf - selected_crf)
+        if not 0 < fraction < 1:
+            continue
+        predicted_video_bytes = round(
+            math.exp(
+                math.log(selected_actual_video_bytes)
+                + (math.log(bracket_calibrated_video_bytes) - math.log(selected_actual_video_bytes)) * fraction
+            )
+        )
+        predicted_total_bytes = predicted_video_bytes + non_video_bytes
+        if (
+                lower_bound_bytes <= predicted_total_bytes <= upper_bound_bytes
+                and (source_cap_video_bytes is None or predicted_video_bytes <= source_cap_video_bytes)
+        ):
+            candidates.append((retry_crf, predicted_total_bytes))
+    if not candidates:
+        return None
+    return min(candidates, key=lambda entry: (abs(entry[1] - target_size_bytes), entry[0]))[0]
+
+
+def _measured_integer_crfs(candidates: list[dict[str, Any]]) -> set[int]:
+    measured: set[int] = set()
+    for candidate in candidates:
+        if candidate.get("crf") is None:
+            continue
+        crf = float_value(candidate.get("crf"))
+        rounded_crf = round(crf) if math.isfinite(crf) else 0
+        if math.isfinite(crf) and math.isclose(crf, rounded_crf):
+            measured.add(rounded_crf)
+    return measured
+
+
+def _measured_retry_candidate(
+        sample: SampleEncodeResult,
+        *,
+        trace: dict[str, Any],
+        crf: float,
+        non_video_bytes: int,
+        target_size_bytes: int,
+        source_cap_video_bytes: int | None,
+) -> dict[str, Any]:
+    target = object_dict(trace.get("target"))
+    tolerance = float_value(target.get("sample_projection_tolerance_percent"))
+    lower_bound_bytes, upper_bound_bytes = _bounds(target_size_bytes, tolerance)
+    predicted_total_bytes = sample.predicted_encode_size_bytes + non_video_bytes
+    attempts = [int_value(object_dict(candidate).get("attempt")) for candidate in trace.get("candidates", [])]
+    minimum_quality_score = float_value(object_dict(trace.get("quality_floor")).get("minimum"))
+    return {
+        "attempt": max(attempts, default=0) + 1,
+        "role": "final_retry_measurement",
+        "crf": crf,
+        "metric": sample.metric,
+        "metric_target": float_value(object_dict(trace.get("quality_floor")).get("target")),
+        "metric_score": sample.score,
+        "min_metric_score": minimum_quality_score,
+        "quality_floor_met": sample.score >= minimum_quality_score,
+        "sampled_clip_bytes": sample.sampled_clip_size_bytes,
+        "predicted_video_bytes": sample.predicted_encode_size_bytes,
+        "predicted_whole_episode_bytes": predicted_total_bytes,
+        "predicted_encode_percent": sample.predicted_encode_percent,
+        "predicted_encode_seconds": sample.predicted_encode_seconds,
+        "target_distance_bytes": abs(predicted_total_bytes - target_size_bytes),
+        "within_sample_band": lower_bound_bytes <= predicted_total_bytes <= upper_bound_bytes,
+        "violates_source_cap": (
+            source_cap_video_bytes is not None
+            and sample.predicted_encode_size_bytes > source_cap_video_bytes
+        ),
+    }
 
 
 def target_trace_with_actual_output(
@@ -389,11 +773,15 @@ def target_trace_with_actual_output(
     if not payload:
         return None
     payload = dict(payload)
-    payload["final_output"] = {
+    final_output = {
         **verification.to_payload(),
         "retry_count": retry_count,
         "max_retries": MAX_FINAL_OUTPUT_RETRIES,
     }
+    attempts = [dict(attempt) for attempt in payload.get("final_output_attempts", []) if isinstance(attempt, dict)]
+    attempts.append(final_output)
+    payload["final_output_attempts"] = attempts
+    payload["final_output"] = final_output
     return payload
 
 
@@ -695,11 +1083,6 @@ def _curve_shape(candidates: list[TargetSizeCandidate]) -> CurveShape:
 
 def _candidate_distance(candidate: TargetSizeCandidate) -> int:
     return candidate.target_distance_bytes if candidate.target_distance_bytes is not None else 10 ** 30
-
-
-def _distance(candidate: dict[str, Any]) -> float:
-    distance = float_value(candidate.get("target_distance_bytes"))
-    return distance if distance > 0 else 10 ** 30
 
 
 def _source_cap_blocker(ledger: StreamBudgetLedger) -> StreamBudgetProjectionBlocker | None:

--- a/tests/test_stream_budget.py
+++ b/tests/test_stream_budget.py
@@ -408,6 +408,47 @@ class StreamBudgetTests(unittest.TestCase):
         self.assertIn("-c:t", command)
         self.assertEqual(ledger.stream_plan.plan_id, StreamBudgetLedger.from_payload(ledger.to_payload()).stream_plan.plan_id)
 
+    def test_retry_measurement_reuses_quality_search_context(self) -> None:
+        sample = SampleEncodeResult(
+            metric="VMAF",
+            score=93.4,
+            predicted_encode_percent=30.5,
+            predicted_encode_seconds=120.0,
+            predicted_encode_size_bytes=240_000_000,
+            stdout="measured",
+        )
+        run_sample_encode = Mock(return_value=sample)
+        build_svt_params = Mock(return_value=["tune=0"])
+        effective_video_preset = Mock(return_value=5)
+
+        result = quality_search.measure_quality_candidate(
+            Path("/tmp/input.mkv"),
+            self._policy()["video"],
+            crf=36.0,
+            source_codec="h264",
+            width=3840,
+            height=2160,
+            host={"mode": "ssh", "media_access": "stream"},
+            quality_temp_dir=Path("/tmp/quality"),
+            host_media_access_for_host=Mock(return_value="stream"),
+            select_quality_metric=Mock(return_value=("vmaf", 95.0)),
+            build_svt_params=build_svt_params,
+            effective_video_preset=effective_video_preset,
+            run_sample_encode=run_sample_encode,
+        )
+
+        self.assertIs(result, sample)
+        build_svt_params.assert_called_once()
+        effective_video_preset.assert_called_once_with(self._policy()["video"], width=3840, height=2160)
+        call = run_sample_encode.call_args
+        self.assertEqual(call.args, (Path("/tmp/input.mkv"),))
+        self.assertEqual(call.kwargs["crf"], 36.0)
+        self.assertEqual(call.kwargs["preferred_metric"], "vmaf")
+        self.assertEqual(call.kwargs["preset"], 5)
+        self.assertEqual(call.kwargs["svt_params"], ["tune=0"])
+        self.assertEqual(call.kwargs["host"]["mode"], "local")
+        self.assertEqual(call.kwargs["quality_temp_dir"], Path("/tmp/quality"))
+
     def _ledger(
             self,
             *,

--- a/tests/test_target_size_production.py
+++ b/tests/test_target_size_production.py
@@ -14,7 +14,7 @@ from mediaforce.core.config import ConfigPaths, MediaforceConfig
 from mediaforce.core.db import DBClient, open_db
 from mediaforce.core.db_tables import item_events, library_items, staged_artifacts
 from mediaforce.core.models import ProbeSummary
-from mediaforce.encoding.quality import QualitySearchResult
+from mediaforce.encoding.quality import QualitySearchResult, SampleEncodeResult
 
 
 class TargetSizeProductionTests(unittest.TestCase):
@@ -42,7 +42,7 @@ class TargetSizeProductionTests(unittest.TestCase):
                 target_size_trace=self._trace(item, selected_crf=28.0),
             )
 
-            self._encode_with_output_sizes(connection, item, quality, [5_100_000])
+            build_calls, measure_calls = self._encode_with_output_sizes(connection, item, quality, [5_100_000])
 
             artifact = self._staged_artifact(connection, item_id, staged_artifacts.c.validation_json)
             assert artifact is not None
@@ -52,6 +52,8 @@ class TargetSizeProductionTests(unittest.TestCase):
             self.assertEqual(final_output["status"], "inside_target_band")
             self.assertEqual(final_output["actual_output_bytes"], 5_100_000)
             self.assertEqual(validation["target_size_trace"]["selected_candidate"]["predicted_whole_episode_bytes"], 5_000_000)
+            self.assertEqual(len(build_calls), 1)
+            self.assertEqual(measure_calls, [])
 
     def test_encode_uses_one_logged_retry_from_measured_candidate_for_final_miss(self) -> None:
         source_path = self._source_file("episode-target-retry.mkv")
@@ -69,7 +71,12 @@ class TargetSizeProductionTests(unittest.TestCase):
                 target_size_trace=self._trace(item, selected_crf=28.0, retry_crf=31.0),
             )
 
-            build_calls = self._encode_with_output_sizes(connection, item, quality, [5_400_000, 5_100_000])
+            build_calls, measure_calls = self._encode_with_output_sizes(
+                connection,
+                item,
+                quality,
+                [5_400_000, 5_100_000],
+            )
 
             artifact = self._staged_artifact(connection, item_id, staged_artifacts.c.validation_json)
             assert artifact is not None
@@ -81,6 +88,64 @@ class TargetSizeProductionTests(unittest.TestCase):
             self.assertEqual(final_output["actual_output_bytes"], 5_100_000)
             self.assertIn("encoding_target_size_retry", [event["event_type"] for event in events])
             self.assertEqual([call.kwargs["quality"].crf for call in build_calls], [28.0, 31.0])
+            self.assertEqual(measure_calls, [])
+
+    def test_encode_measures_interpolated_retry_before_second_full_encode(self) -> None:
+        source_path = self._source_file("episode-target-measured-retry.mkv")
+        staging_path = self._staging_path("episode-target-measured-retry.mkv")
+        with open_db(self.config.paths.db_path) as connection:
+            item_id = self._insert_item(connection, source_path)
+            item = self._manifest_item(item_id, source_path, staging_path)
+            self._attach_stream_budget(item)
+            quality = QualitySearchResult(
+                crf=34.0,
+                metric="VMAF",
+                target=85.0,
+                score=86.0,
+                stdout="target-size-search",
+                target_size_trace=self._trace(
+                    item,
+                    selected_crf=34.0,
+                    retry_crf=38.0,
+                    retry_predicted_total=4_200_000,
+                ),
+            )
+            retry_sample = SampleEncodeResult(
+                metric="VMAF",
+                score=84.5,
+                predicted_encode_percent=20.0,
+                predicted_encode_seconds=30.0,
+                predicted_encode_size_bytes=800_000,
+                stdout="measured retry",
+            )
+
+            build_calls, measure_calls = self._encode_with_output_sizes(
+                connection,
+                item,
+                quality,
+                [5_400_000, 5_100_000],
+                retry_sample=retry_sample,
+            )
+
+            artifact = self._staged_artifact(
+                connection,
+                item_id,
+                staged_artifacts.c.chosen_crf,
+                staged_artifacts.c.quality_score,
+                staged_artifacts.c.validation_json,
+            )
+            assert artifact is not None
+            validation = json.loads(cast(str, artifact["validation_json"]))
+            attempts = validation["target_size_trace"]["final_output_attempts"]
+            self.assertEqual([call.kwargs["quality"].crf for call in build_calls], [34.0, 35.0])
+            self.assertEqual([call.kwargs["crf"] for call in measure_calls], [35.0])
+            self.assertEqual(artifact["chosen_crf"], 35.0)
+            self.assertEqual(artifact["quality_score"], 84.5)
+            self.assertEqual([attempt["status"] for attempt in attempts], ["over_target", "inside_target_band"])
+            self.assertEqual(
+                validation["target_size_trace"]["selected_candidate"]["role"],
+                "final_retry_measurement",
+            )
 
     def test_encode_surfaces_needs_review_when_final_miss_has_no_measured_retry(self) -> None:
         source_path = self._source_file("episode-target-review.mkv")
@@ -110,13 +175,60 @@ class TargetSizeProductionTests(unittest.TestCase):
             self.assertEqual(failed_details["target_size_verification"]["status"], "over_target")
             self.assertFalse(staging_path.exists())
 
+    def test_encode_persists_rejected_retry_measurement_reason(self) -> None:
+        source_path = self._source_file("episode-target-retry-rejected.mkv")
+        staging_path = self._staging_path("episode-target-retry-rejected.mkv")
+        with open_db(self.config.paths.db_path) as connection:
+            item_id = self._insert_item(connection, source_path)
+            item = self._manifest_item(item_id, source_path, staging_path)
+            self._attach_stream_budget(item)
+            quality = QualitySearchResult(
+                crf=34.0,
+                metric="VMAF",
+                target=85.0,
+                score=86.0,
+                stdout="target-size-search",
+                target_size_trace=self._trace(
+                    item,
+                    selected_crf=34.0,
+                    retry_crf=38.0,
+                    retry_predicted_total=4_200_000,
+                ),
+            )
+            rejected_sample = SampleEncodeResult(
+                metric="VMAF",
+                score=79.5,
+                predicted_encode_percent=20.0,
+                predicted_encode_seconds=30.0,
+                predicted_encode_size_bytes=800_000,
+                stdout="below floor",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "Final output size missed"):
+                self._encode_with_output_sizes(
+                    connection,
+                    item,
+                    quality,
+                    [5_400_000],
+                    retry_sample=rejected_sample,
+                )
+
+            events = self._events(connection, item_id)
+            failed_details = json.loads(cast(str, events[-1]["details_json"]))
+            rejection_trace = failed_details["target_size_trace"]
+            self.assertEqual(rejection_trace["selection_reason"], "final_retry_measurement_below_quality_floor")
+            self.assertEqual(rejection_trace["final_retry_calibration"]["status"], "rejected")
+            self.assertFalse(staging_path.exists())
+
     def _encode_with_output_sizes(
             self,
             connection: DBClient,
             item: dict[str, Any],
             quality: QualitySearchResult,
             output_sizes: list[int],
-    ) -> list[Any]:
+            *,
+            retry_sample: SampleEncodeResult | None = None,
+    ) -> tuple[list[Any], list[Any]]:
         sizes = list(output_sizes)
 
         def run_encode_side_effect(*, temp_output: Path, **_: object) -> subprocess.CompletedProcess[str]:
@@ -141,9 +253,17 @@ class TargetSizeProductionTests(unittest.TestCase):
             audio_summary_json="[]",
             subtitle_summary_json="[]",
         )
+
+        def measure_retry_side_effect(*_args: object, **_kwargs: object) -> SampleEncodeResult:
+            if retry_sample is None:
+                self.fail("Retry measurement was not expected")
+            return retry_sample
+
         with patch("mediaforce.execution.resolve_item_source_path", return_value=Path(item["source_path"])), patch(
             "mediaforce.execution.resolve_item_staging_path", return_value=Path(item["staging_path"])
         ), patch("mediaforce.execution._search_quality", return_value=quality), patch(
+            "mediaforce.execution._measure_quality_candidate", side_effect=measure_retry_side_effect
+        ) as measure_mock, patch(
             "mediaforce.execution._build_ffmpeg_command", return_value=["ffmpeg", "-i", item["source_path"], item["staging_path"]]
         ) as command_mock, patch(
             "mediaforce.execution._run_encode_command", side_effect=run_encode_side_effect
@@ -159,7 +279,7 @@ class TargetSizeProductionTests(unittest.TestCase):
                 item,
                 overwrite=False,
             )
-            return list(command_mock.call_args_list)
+            return list(command_mock.call_args_list), list(measure_mock.call_args_list)
 
     def _attach_stream_budget(self, item: dict[str, Any]) -> None:
         item["stream_budget_ledger"] = execution.resolve_stream_budget_ledger(
@@ -175,12 +295,13 @@ class TargetSizeProductionTests(unittest.TestCase):
             *,
             selected_crf: float,
             retry_crf: float | None = None,
+            retry_predicted_total: int = 4_800_000,
     ) -> dict[str, Any]:
         ledger = item["stream_budget_ledger"]
         selected = self._candidate(selected_crf, predicted_total=5_000_000)
         candidates = [self._candidate(24.0, predicted_total=5_800_000), selected]
         if retry_crf is not None:
-            candidates.append(self._candidate(retry_crf, predicted_total=4_800_000))
+            candidates.append(self._candidate(retry_crf, predicted_total=retry_predicted_total))
         return {
             "schema_version": 1,
             "status": "selected",
@@ -192,8 +313,11 @@ class TargetSizeProductionTests(unittest.TestCase):
                 "total_target_bytes": 5_000_000,
                 "target_video_bytes": 1_000_000,
                 "non_video_bytes": 4_000_000,
+                "sample_projection_tolerance_percent": 10.0,
                 "final_output_tolerance_percent": 5.0,
             },
+            "source_cap": {"video_cap_bytes": 16_000_000},
+            "quality_floor": {"metric": "VMAF", "target": 85.0, "minimum": 80.0},
             "candidates": candidates,
             "selected_candidate": selected,
         }

--- a/tests/test_target_size_search.py
+++ b/tests/test_target_size_search.py
@@ -2,7 +2,7 @@ import unittest
 from pathlib import Path
 from typing import Any
 
-from mediaforce.encoding.quality import SampleEncodeResult
+from mediaforce.encoding.quality import QualitySearchResult, SampleEncodeResult
 from mediaforce.tuning.size_goals import SizeGoalIntent
 from mediaforce.tuning.stream_budget import StreamBudgetLedger, resolve_stream_budget_ledger
 from mediaforce.tuning.target_size_search import (
@@ -209,7 +209,7 @@ class TargetSizeSearchTests(unittest.TestCase):
         self.assertEqual(context.exception.trace["curve"]["shape"], "non_monotonic")
         self.assertEqual(len(context.exception.trace["candidates"]), 6)
 
-    def test_final_output_verification_allows_only_bounded_retry_from_measured_candidates(self) -> None:
+    def test_final_output_verification_allows_only_one_calibrated_retry(self) -> None:
         ledger = self._ledger(target_bytes=300_000_000, source_size_bytes=1_000_000_000)
         verification = verify_final_output_size(ledger, 330_000_000, retry_count=0)
         self.assertEqual(verification.status, "over_target")
@@ -244,13 +244,431 @@ class TargetSizeSearchTests(unittest.TestCase):
                 "",
             ),
         )
-        retry_quality = retry_quality_result_for_final_miss(quality, verification)
+        measured_crfs: list[float] = []
+
+        def measure_candidate(crf: float) -> SampleEncodeResult:
+            measured_crfs.append(crf)
+            predicted_video_bytes = 1_000_000_000 - 28_000_000 * int(crf)
+            return SampleEncodeResult(
+                "VMAF",
+                90.0,
+                predicted_video_bytes / 10_000_000,
+                30.0,
+                predicted_video_bytes,
+                "",
+            )
+
+        retry_quality = retry_quality_result_for_final_miss(
+            quality,
+            verification,
+            measure_candidate=measure_candidate,
+        )
 
         self.assertIsNotNone(retry_quality)
-        self.assertEqual(retry_quality.crf, 28.0)
+        assert retry_quality is not None
+        self.assertEqual(measured_crfs, [27.0])
+        self.assertEqual(retry_quality.crf, 27.0)
+        retry_curve = retry_quality.target_size_trace["curve"]
+        self.assertEqual(retry_curve["candidate_count"], retry_curve["search_candidate_count"] + 1)
+        self.assertEqual(retry_curve["final_retry_measurement_count"], 1)
         exhausted = verify_final_output_size(ledger, 330_000_000, retry_count=1)
         self.assertFalse(exhausted.retry_allowed)
-        self.assertIsNone(retry_quality_result_for_final_miss(quality, exhausted))
+        self.assertIsNone(retry_quality_result_for_final_miss(quality, exhausted, measure_candidate=measure_candidate))
+        self.assertEqual(measured_crfs, [27.0])
+
+    def test_final_output_retry_measures_interpolated_crf_from_actual_output(self) -> None:
+        target_size_bytes = 374_403_556
+        non_video_bytes = 66_775_402
+        selected = {
+            "attempt": 3,
+            "role": "refine",
+            "crf": 34.0,
+            "metric": "VMAF",
+            "metric_target": 85.0,
+            "metric_score": 93.9602279663086,
+            "quality_floor_met": True,
+            "predicted_video_bytes": 273_124_145,
+            "predicted_whole_episode_bytes": 339_899_547,
+            "violates_source_cap": False,
+        }
+        bracket = {
+            "attempt": 2,
+            "role": "refine",
+            "crf": 38.0,
+            "metric": "VMAF",
+            "metric_target": 85.0,
+            "metric_score": 92.91368865966797,
+            "quality_floor_met": True,
+            "predicted_video_bytes": 216_536_877,
+            "predicted_whole_episode_bytes": 283_312_279,
+            "violates_source_cap": False,
+        }
+        quality = QualitySearchResult(
+            crf=34.0,
+            metric="VMAF",
+            target=85.0,
+            score=93.9602279663086,
+            stdout="target-size-search",
+            target_size_trace={
+                "schema_version": 1,
+                "status": "selected",
+                "target": {
+                    "total_target_bytes": target_size_bytes,
+                    "non_video_bytes": non_video_bytes,
+                    "sample_projection_tolerance_percent": 10.0,
+                    "final_output_tolerance_percent": 5.0,
+                },
+                "source_cap": {"video_cap_bytes": 649_576_742},
+                "quality_floor": {"metric": "VMAF", "target": 85.0, "minimum": 80.0},
+                "candidates": [bracket, selected],
+                "selected_candidate": selected,
+            },
+        )
+        ledger = self._ledger(target_bytes=target_size_bytes, source_size_bytes=895_440_181)
+        verification = verify_final_output_size(ledger, 406_928_998, retry_count=0)
+        measured_crfs: list[float] = []
+
+        def measure_candidate(crf: float) -> SampleEncodeResult:
+            measured_crfs.append(crf)
+            return SampleEncodeResult(
+                metric="VMAF",
+                score=93.41461181640625,
+                predicted_encode_percent=30.53648895336881,
+                predicted_encode_seconds=7562.0,
+                predicted_encode_size_bytes=240_554_519,
+                stdout="crf 36 measured",
+            )
+
+        retry_quality = retry_quality_result_for_final_miss(
+            quality,
+            verification,
+            measure_candidate=measure_candidate,
+        )
+
+        self.assertIsNotNone(retry_quality)
+        assert retry_quality is not None
+        self.assertEqual(measured_crfs, [36.0])
+        self.assertEqual(retry_quality.crf, 36.0)
+        self.assertEqual(retry_quality.score, 93.41461181640625)
+        retry_trace = retry_quality.target_size_trace or {}
+        self.assertEqual(retry_trace["selection_reason"], "calibrated_final_size_retry_candidate")
+        self.assertEqual(
+            retry_trace["final_retry_calibration"]["calibrated_predicted_whole_episode_bytes"],
+            366_366_215,
+        )
+        self.assertEqual(retry_trace["selected_candidate"]["role"], "final_retry_measurement")
+
+    def test_final_output_retry_rejects_interpolated_sample_below_quality_floor(self) -> None:
+        selected = {
+            "crf": 30.0,
+            "metric": "VMAF",
+            "metric_target": 85.0,
+            "metric_score": 86.0,
+            "quality_floor_met": True,
+            "predicted_video_bytes": 1_000_000,
+            "predicted_whole_episode_bytes": 5_000_000,
+            "violates_source_cap": False,
+        }
+        bracket = {
+            "crf": 34.0,
+            "metric": "VMAF",
+            "metric_target": 85.0,
+            "metric_score": 82.0,
+            "quality_floor_met": True,
+            "predicted_video_bytes": 200_000,
+            "predicted_whole_episode_bytes": 4_200_000,
+            "violates_source_cap": False,
+        }
+        quality = QualitySearchResult(
+            crf=30.0,
+            metric="VMAF",
+            target=85.0,
+            score=86.0,
+            stdout="target-size-search",
+            target_size_trace={
+                "target": {
+                    "total_target_bytes": 5_000_000,
+                    "non_video_bytes": 4_000_000,
+                    "sample_projection_tolerance_percent": 10.0,
+                },
+                "source_cap": {"video_cap_bytes": 10_000_000},
+                "quality_floor": {"metric": "VMAF", "target": 85.0, "minimum": 80.0},
+                "candidates": [selected, bracket],
+                "selected_candidate": selected,
+            },
+        )
+        verification = verify_final_output_size(
+            self._ledger(target_bytes=5_000_000, source_size_bytes=20_000_000),
+            5_400_000,
+            retry_count=0,
+        )
+
+        retry_quality = retry_quality_result_for_final_miss(
+            quality,
+            verification,
+            measure_candidate=lambda _crf: SampleEncodeResult(
+                "VMAF", 79.9, 20.0, 30.0, 800_000, "below floor"
+            ),
+        )
+
+        self.assertIsNone(retry_quality)
+        rejection_trace = quality.target_size_trace or {}
+        self.assertEqual(rejection_trace["selection_reason"], "final_retry_measurement_below_quality_floor")
+        self.assertEqual(rejection_trace["final_retry_calibration"]["status"], "rejected")
+        self.assertEqual(rejection_trace["candidates"][-1]["role"], "final_retry_measurement")
+
+    def test_final_output_retry_interpolates_lower_crf_for_under_target_output(self) -> None:
+        selected = {
+            "crf": 34.0,
+            "metric": "VMAF",
+            "metric_target": 85.0,
+            "metric_score": 86.0,
+            "quality_floor_met": True,
+            "predicted_video_bytes": 1_000_000,
+            "predicted_whole_episode_bytes": 5_000_000,
+            "violates_source_cap": False,
+        }
+        bracket = {
+            "crf": 30.0,
+            "metric": "VMAF",
+            "metric_target": 85.0,
+            "metric_score": 86.5,
+            "quality_floor_met": True,
+            "predicted_video_bytes": 2_333_333,
+            "predicted_whole_episode_bytes": 6_333_333,
+            "violates_source_cap": True,
+        }
+        quality = QualitySearchResult(
+            crf=34.0,
+            metric="VMAF",
+            target=85.0,
+            score=86.0,
+            stdout="target-size-search",
+            target_size_trace={
+                "target": {
+                    "total_target_bytes": 5_000_000,
+                    "non_video_bytes": 4_000_000,
+                    "sample_projection_tolerance_percent": 10.0,
+                },
+                "source_cap": {"video_cap_bytes": 1_500_000},
+                "quality_floor": {"metric": "VMAF", "target": 85.0, "minimum": 80.0},
+                "candidates": [selected, bracket],
+                "selected_candidate": selected,
+            },
+        )
+        verification = verify_final_output_size(
+            self._ledger(target_bytes=5_000_000, source_size_bytes=20_000_000),
+            4_600_000,
+            retry_count=0,
+        )
+        measured_crfs: list[float] = []
+
+        def measure_candidate(crf: float) -> SampleEncodeResult:
+            measured_crfs.append(crf)
+            return SampleEncodeResult("VMAF", 86.2, 20.0, 30.0, 1_700_000, "measured")
+
+        retry_quality = retry_quality_result_for_final_miss(
+            quality,
+            verification,
+            measure_candidate=measure_candidate,
+        )
+
+        self.assertIsNotNone(retry_quality)
+        assert retry_quality is not None
+        self.assertEqual(measured_crfs, [32.0])
+        self.assertEqual(retry_quality.crf, 32.0)
+        self.assertEqual(
+            retry_quality.target_size_trace["final_retry_calibration"][
+                "calibrated_predicted_whole_episode_bytes"
+            ],
+            5_020_000,
+        )
+        self.assertTrue(retry_quality.target_size_trace["selected_candidate"]["sample_projection_violates_source_cap"])
+        self.assertFalse(retry_quality.target_size_trace["selected_candidate"]["violates_source_cap"])
+        self.assertTrue(retry_quality.target_size_trace["selected_candidate"]["within_calibrated_final_band"])
+
+    def test_final_output_retry_requires_a_bracket_with_an_intermediate_integer_crf(self) -> None:
+        selected = {
+            "crf": 34.0,
+            "metric": "VMAF",
+            "metric_target": 85.0,
+            "metric_score": 86.0,
+            "quality_floor_met": True,
+            "predicted_video_bytes": 1_000_000,
+            "predicted_whole_episode_bytes": 5_000_000,
+            "violates_source_cap": False,
+        }
+        verification = verify_final_output_size(
+            self._ledger(target_bytes=5_000_000, source_size_bytes=20_000_000),
+            5_400_000,
+            retry_count=0,
+        )
+        cases = (
+            (31.0, 900_000, "no corrected target bracket"),
+            (35.0, 500_000, "no intermediate integer crf"),
+        )
+        for bracket_crf, bracket_video_bytes, label in cases:
+            with self.subTest(label=label):
+                bracket = {
+                    "crf": bracket_crf,
+                    "metric": "VMAF",
+                    "metric_target": 85.0,
+                    "metric_score": 84.0,
+                    "quality_floor_met": True,
+                    "predicted_video_bytes": bracket_video_bytes,
+                    "predicted_whole_episode_bytes": bracket_video_bytes + 4_000_000,
+                    "violates_source_cap": False,
+                }
+                quality = QualitySearchResult(
+                    crf=34.0,
+                    metric="VMAF",
+                    target=85.0,
+                    score=86.0,
+                    stdout="target-size-search",
+                    target_size_trace={
+                        "target": {
+                            "total_target_bytes": 5_000_000,
+                            "non_video_bytes": 4_000_000,
+                            "sample_projection_tolerance_percent": 10.0,
+                        },
+                        "source_cap": {"video_cap_bytes": 10_000_000},
+                        "quality_floor": {"metric": "VMAF", "target": 85.0, "minimum": 80.0},
+                        "candidates": [selected, bracket],
+                        "selected_candidate": selected,
+                    },
+                )
+
+                retry_quality = retry_quality_result_for_final_miss(
+                    quality,
+                    verification,
+                    measure_candidate=lambda _crf: self.fail("Unsafe retries must not be measured"),
+                )
+
+                self.assertIsNone(retry_quality)
+
+    def test_final_output_retry_interpolation_respects_calibrated_source_cap(self) -> None:
+        selected = {
+            "crf": 30.0,
+            "metric": "VMAF",
+            "metric_target": 85.0,
+            "metric_score": 86.0,
+            "quality_floor_met": True,
+            "predicted_video_bytes": 800_000,
+            "predicted_whole_episode_bytes": 900_000,
+            "violates_source_cap": False,
+        }
+        bracket = {
+            "crf": 36.0,
+            "metric": "VMAF",
+            "metric_target": 85.0,
+            "metric_score": 82.0,
+            "quality_floor_met": True,
+            "predicted_video_bytes": 500_000,
+            "predicted_whole_episode_bytes": 600_000,
+            "violates_source_cap": False,
+        }
+        quality = QualitySearchResult(
+            crf=30.0,
+            metric="VMAF",
+            target=85.0,
+            score=86.0,
+            stdout="target-size-search",
+            target_size_trace={
+                "target": {
+                    "total_target_bytes": 1_000_000,
+                    "non_video_bytes": 100_000,
+                    "sample_projection_tolerance_percent": 10.0,
+                },
+                "source_cap": {"video_cap_bytes": 870_000},
+                "quality_floor": {"metric": "VMAF", "target": 85.0, "minimum": 80.0},
+                "candidates": [selected, bracket],
+                "selected_candidate": selected,
+            },
+        )
+        verification = verify_final_output_size(
+            self._ledger(target_bytes=1_000_000, source_size_bytes=2_000_000),
+            1_100_000,
+            retry_count=0,
+        )
+        measured_crfs: list[float] = []
+
+        def measure_candidate(crf: float) -> SampleEncodeResult:
+            measured_crfs.append(crf)
+            return SampleEncodeResult("VMAF", 84.0, 20.0, 30.0, 683_000, "measured")
+
+        retry_quality = retry_quality_result_for_final_miss(
+            quality,
+            verification,
+            measure_candidate=measure_candidate,
+        )
+
+        self.assertIsNotNone(retry_quality)
+        assert retry_quality is not None
+        self.assertEqual(measured_crfs, [32.0])
+        self.assertEqual(retry_quality.crf, 32.0)
+        self.assertLessEqual(
+            retry_quality.target_size_trace["selected_candidate"]["calibrated_predicted_video_bytes"],
+            870_000,
+        )
+
+    def test_final_output_retry_rejects_non_finite_quality_score(self) -> None:
+        selected = {
+            "crf": 30.0,
+            "metric": "VMAF",
+            "metric_target": 85.0,
+            "metric_score": 86.0,
+            "quality_floor_met": True,
+            "predicted_video_bytes": 1_000_000,
+            "predicted_whole_episode_bytes": 5_000_000,
+            "violates_source_cap": False,
+        }
+        bracket = {
+            "crf": 34.0,
+            "metric": "VMAF",
+            "metric_target": 85.0,
+            "metric_score": 82.0,
+            "quality_floor_met": True,
+            "predicted_video_bytes": 200_000,
+            "predicted_whole_episode_bytes": 4_200_000,
+            "violates_source_cap": False,
+        }
+        quality = QualitySearchResult(
+            crf=30.0,
+            metric="VMAF",
+            target=85.0,
+            score=86.0,
+            stdout="target-size-search",
+            target_size_trace={
+                "target": {
+                    "total_target_bytes": 5_000_000,
+                    "non_video_bytes": 4_000_000,
+                    "sample_projection_tolerance_percent": 10.0,
+                },
+                "source_cap": {"video_cap_bytes": 10_000_000},
+                "quality_floor": {"metric": "VMAF", "target": 85.0, "minimum": 80.0},
+                "candidates": [selected, bracket],
+                "selected_candidate": selected,
+            },
+        )
+        verification = verify_final_output_size(
+            self._ledger(target_bytes=5_000_000, source_size_bytes=20_000_000),
+            5_400_000,
+            retry_count=0,
+        )
+
+        retry_quality = retry_quality_result_for_final_miss(
+            quality,
+            verification,
+            measure_candidate=lambda _crf: SampleEncodeResult(
+                "VMAF", float("nan"), 20.0, 30.0, 800_000, "invalid score"
+            ),
+        )
+
+        self.assertIsNone(retry_quality)
+        self.assertEqual(
+            quality.target_size_trace["selection_reason"],
+            "final_retry_measurement_invalid_quality_score",
+        )
 
     def test_search_rejects_mutated_transform_plan_identity(self) -> None:
         transform_plan = self._transform_plan()


### PR DESCRIPTION
## Summary

- calibrate sample video-byte projections from the completed first full encode
- interpolate one bounded integer CRF and measure its real quality before a replacement encode
- preserve both final-size attempts and rejected measurement reasons in the target trace

## Real evidence

The controlled `movies/2101 (2014)` proof selected CRF 34, projected 339,899,547 bytes, and produced 406,928,998 bytes against a 355,683,378–393,123,734 byte final band. A targeted CRF 36 sample measured VMAF 93.4146 and calibrates to 366,366,215 bytes, inside the approved band. The preserved full-output retry is the final pre-merge dogfood step.

## Validation

- `uv run --with pytest pytest -q` — 917 passed, 8 subtests passed
- `bash scripts/pre-commit-check.sh` — passed
- `uv build` — passed
- `uv run ruff check --no-fix ...` — passed for changed Python files
- PyCharm changed-files inspection — GREEN, 0 findings

Closes #197