### PR TITLE
Add bounded Other library workflow

### DIFF
--- a/config/web-smoke.toml
+++ b/config/web-smoke.toml
@@ -17,7 +17,47 @@ output_container = "mkv"
 
 [media.source_roots]
 movies = "scratch/web-smoke/source/movies"
+other = "scratch/web-smoke/source/other"
 tv = "scratch/web-smoke/source/tv"
+
+[[media.libraries]]
+key = "movies"
+label = "Movies"
+path = "scratch/web-smoke/source/movies"
+type = "movie"
+availability = "production"
+default_profile = "movie_balanced"
+
+[media.libraries.policy]
+grouping = "title"
+editions = "separate"
+extras = "exclude"
+ranking = "oldest_added_first"
+
+[[media.libraries]]
+key = "tv"
+label = "TV"
+path = "scratch/web-smoke/source/tv"
+type = "tv"
+availability = "production"
+default_profile = "inherit_defaults"
+
+[media.libraries.policy]
+series_lifecycle_mode = "auto"
+current_season_inactive_days = 365
+season_acquisition_hold_days = 30
+series_metadata_stale_days = 7
+
+[[media.libraries]]
+key = "other"
+label = "Other"
+path = "scratch/web-smoke/source/other"
+type = "other"
+availability = "production"
+default_profile = "other_conservative"
+
+[media.libraries.policy]
+grouping = "folder"
 
 [video]
 encoder = "libsvtav1"

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -166,6 +166,13 @@ Guidance:
 - `library_settings.py`
   - ordered typed-root schema, legacy inference, safe availability defaults,
     type-specific policies, and profile registries
+- `other_profiles.py`
+  - generic Other profile probe requirements, canonical scope boundaries, and
+    bounded folder/catalog limits
+- `other_library.py`
+  - Other folder/file grouping, Library payloads, exact scope membership, and
+    processing confirmation guards; action callers consume membership tokens
+    rather than minting replacements
 - `folder_profiles.py`
   - folder inspection and suggested override shaping
 - `run_manifests.py`

--- a/docs/architecture/typed-library-settings.md
+++ b/docs/architecture/typed-library-settings.md
@@ -38,12 +38,18 @@ first typed save.
 - `disabled`: neither scan nor process; a full scan marks former catalog rows
   missing
 
-TV and Movies are production-enabled types. Movies keeps extras and uncertain
-nested files out of title-wide production by default while exact-file actions
-remain deliberate. Other remains Browse only until its bounded generic workflow
-is complete. Spatial media remains safety-blocked
-until the 3D/VR qualification plan proves geometry, stream, metadata, audio,
-and target-device playback invariants.
+TV, Movies, and Other are production-enabled types. Movies keeps extras and
+uncertain nested files out of title-wide production by default while exact-file
+actions remain deliberate. Other uses an explicit generic profile, exact
+root-level files, and bounded top-level folder scopes; folders above the
+membership limit must be split or switched to exact-file grouping before
+processing. Every non-empty folder scope requires a current membership token,
+and unscoped candidate selection excludes Other items. Library responses cap one
+catalog window at 5,000 indexed items and 500 work units so a generic root cannot
+exhaust the operator process; truncated catalogs remain non-actionable until the
+configured roots are narrowed. Spatial media remains safety-blocked until the
+3D/VR qualification plan proves geometry, stream, metadata, audio, and
+target-device playback invariants.
 
 ## Type policies
 
@@ -52,10 +58,11 @@ and series-status freshness. These values layer above global planning defaults
 and below explicit folder overrides.
 
 Movies records title grouping, separate editions, extras inclusion, and ranking
-intent. Other records a bounded folder or exact-file work unit. Spatial records
-the playback target, stereo layout, projection, source-preserving geometry, and
-an unqualified container state. Controls that do not apply to the selected type
-are structurally absent from Settings.
+intent. Other records a bounded top-level folder or exact-file work unit and
+requires operators to review folder membership before sampling or queueing.
+Spatial records the playback target, stereo layout, projection,
+source-preserving geometry, and an unqualified container state. Controls that do
+not apply to the selected type are structurally absent from Settings.
 
 ## Type changes
 

--- a/docs/development/browser-qa-matrix.md
+++ b/docs/development/browser-qa-matrix.md
@@ -187,6 +187,16 @@ and that narrow layouts replace the long show rail with a show picker. Opening a
 multi-season show must clearly state that one representative test and one size
 choice apply to all seasons before any full encode can be queued.
 
+On Other Library, verify that root-level files are exact work units and nested
+media is grouped by the configured bounded folder or file policy. Every row must
+show reachable file count, stored size, workflow state, and profile readiness.
+Other Studio must list exact membership before sampling or queueing, require an
+explicit membership acknowledgement for every non-empty folder, block incomplete
+probe/profile requirements, and never show TV, movie, edition, extras, or spatial
+terminology. Cover the empty root, root-level file, nested folder, scope above the
+250-file limit, catalog-window warning, unsupported media, active processing,
+validation, and promotion states at 1024px and 390px without horizontal overflow.
+
 For `Current Season`, verify that `Auto`, `On`, and `Off` are understandable as
 current-season policy rather than queue controls; saving a mode must retain the
 selected show. Eligible and held totals must agree between the show view and its

--- a/frontend/src/lib/api/placeholders.ts
+++ b/frontend/src/lib/api/placeholders.ts
@@ -7,6 +7,7 @@ import type {
 	HostsPayload,
 	MediaScopePayload,
 	MovieLibraryPayload,
+	OtherLibraryPayload,
 	QueueLane
 } from './types';
 
@@ -55,6 +56,17 @@ export const initialMovieLibrary: MovieLibraryPayload = {
 	libraries: [],
 	titles: [],
 	catalog_empty: false,
+	details_loading: true
+};
+
+export const initialOtherLibrary: OtherLibraryPayload = {
+	schema_version: 1,
+	libraries: [],
+	work_units: [],
+	catalog_empty: false,
+	catalog_truncated: false,
+	catalog_item_limit: 5000,
+	catalog_work_unit_limit: 500,
 	details_loading: true
 };
 

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -232,6 +232,107 @@ export interface MovieLibraryPayload {
 	details_loading: boolean;
 }
 
+export interface OtherProfileReadiness {
+	state: 'ready' | 'blocked' | 'browse_only';
+	label: string;
+	detail: string;
+	profile: string;
+	profile_label: string;
+	blockers: string[];
+}
+
+export interface OtherWorkflowItemState {
+	item_id: number;
+	rel_path: string;
+	status: string;
+	state: string;
+	lane: WorkflowLane;
+	has_staged_output: boolean;
+	blocker?: string | null;
+}
+
+export interface OtherMember {
+	item_id: number;
+	prefix: string;
+	rel_path: string;
+	label: string;
+	status: string;
+	size_bytes: number;
+	duration_seconds?: number | null;
+	video_codec?: string | null;
+	width?: number | null;
+	height?: number | null;
+	profile_supported: boolean;
+	profile_blocker?: string | null;
+	workflow_state?: OtherWorkflowItemState | null;
+}
+
+export interface OtherLibraryRoot {
+	key: string;
+	label: string;
+	availability: 'production' | 'browse_only';
+	default_profile: string;
+	policy: Record<string, unknown>;
+}
+
+export interface OtherWorkUnit {
+	prefix: string;
+	root: string;
+	library_label: string;
+	availability: 'production' | 'browse_only';
+	default_profile: string;
+	policy: Record<string, unknown>;
+	title: string;
+	subtitle: string;
+	scope_label: string;
+	scope_mode: 'exact_file' | 'folder';
+	media_scope: MediaScopePayload;
+	item_count: number;
+	total_size_bytes: number;
+	eligible_item_count?: number | null;
+	blocked_item_count: number;
+	statuses: Record<string, number>;
+	video_codecs: Record<string, number>;
+	projected_reclaim_bytes?: number | null;
+	estimate_unavailable_count?: number | null;
+	profile_readiness: OtherProfileReadiness;
+	workflow_state?: FolderWorkflowState | null;
+	membership_requires_confirmation: boolean;
+	details_loading: boolean;
+}
+
+export interface OtherLibraryPayload {
+	schema_version: number;
+	libraries: OtherLibraryRoot[];
+	work_units: OtherWorkUnit[];
+	catalog_empty: boolean;
+	catalog_truncated: boolean;
+	catalog_item_limit: number;
+	catalog_work_unit_limit: number;
+	details_loading: boolean;
+}
+
+export interface OtherScopeContext {
+	schema_version: number;
+	prefix: string;
+	root: string;
+	library_label: string;
+	availability: 'production' | 'browse_only';
+	default_profile: string;
+	policy: Record<string, unknown>;
+	media_scope: MediaScopePayload;
+	item_count: number;
+	eligible_item_count: number;
+	blocked_item_count: number;
+	total_size_bytes: number;
+	membership_complete: boolean;
+	membership_limit: number;
+	membership_requires_confirmation: boolean;
+	membership_token: string;
+	profile_readiness: OtherProfileReadiness;
+	members: OtherMember[];
+}
+
 export interface QueueLane {
 	running: Array<Record<string, unknown>>;
 	queued: Array<Record<string, unknown>>;
@@ -969,6 +1070,7 @@ export interface FolderPayload {
 	workflow_state?: FolderWorkflowState | null;
 	lifecycle?: LifecycleState | null;
 	movie_context?: MovieTitle | null;
+	other_context?: OtherScopeContext | null;
 }
 
 export interface FolderBenchPreviewResponse {

--- a/frontend/src/lib/components/settings/LibraryRootsPanel.svelte
+++ b/frontend/src/lib/components/settings/LibraryRootsPanel.svelte
@@ -201,7 +201,9 @@
 						onchange={(event) =>
 							patchSelected({ availability: selectValue(event) as LibraryAvailability })}
 					>
-						<option value="production" disabled={selected.library_type !== 'tv'}>Production</option>
+						<option value="production" disabled={selected.library_type === 'spatial'}
+							>Production</option
+						>
 						<option value="browse_only">Browse only</option>
 						<option value="disabled">Disabled</option>
 					</select>

--- a/frontend/src/lib/components/shell/AppShell.svelte
+++ b/frontend/src/lib/components/shell/AppShell.svelte
@@ -20,6 +20,8 @@
 				pathname === '/' ||
 				pathname === '/movies' ||
 				pathname.startsWith('/movies/') ||
+				pathname === '/other' ||
+				pathname.startsWith('/other/') ||
 				pathname === '/folders' ||
 				pathname.startsWith('/folders/')
 			);

--- a/frontend/src/lib/components/workstation/LibraryModeNav.svelte
+++ b/frontend/src/lib/components/workstation/LibraryModeNav.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 
-	let { active }: { active: 'tv' | 'movie' } = $props();
+	let { active }: { active: 'tv' | 'movie' | 'other' } = $props();
 </script>
 
 <nav class="library-mode-nav" aria-label="Library type">
@@ -14,6 +14,11 @@
 		href={resolve('/movies')}
 		class:active={active === 'movie'}
 		aria-current={active === 'movie' ? 'page' : undefined}>Movies</a
+	>
+	<a
+		href={resolve('/other')}
+		class:active={active === 'other'}
+		aria-current={active === 'other' ? 'page' : undefined}>Other</a
 	>
 </nav>
 

--- a/frontend/src/lib/components/workstation/OtherLibraryPage.svelte
+++ b/frontend/src/lib/components/workstation/OtherLibraryPage.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	import { fetchJson } from '$lib/api/client';
+	import { initialOtherLibrary } from '$lib/api/placeholders';
+	import type { OtherLibraryPayload } from '$lib/api/types';
+	import { mergeOtherLibraryPayloads } from '$lib/other/library';
+	import OtherLibraryView from './OtherLibraryView.svelte';
+
+	let structure = $state<OtherLibraryPayload>(initialOtherLibrary);
+	let details = $state<OtherLibraryPayload>(initialOtherLibrary);
+	const payload = $derived(mergeOtherLibraryPayloads(structure, details));
+	let structurePending = $state(true);
+	let detailsPending = $state(true);
+	let loadError = $state('');
+	let detailsError = $state('');
+	let disposed = false;
+
+	onMount(() => {
+		disposed = false;
+		let refreshTimer: number | undefined;
+		void hydrateStructure().finally(async () => {
+			if (disposed) return;
+			await hydrateDetails();
+			if (!disposed) scheduleRefresh();
+		});
+
+		function scheduleRefresh() {
+			refreshTimer = window.setTimeout(async () => {
+				await Promise.all([hydrateStructure(true), hydrateDetails(true)]);
+				if (!disposed) scheduleRefresh();
+			}, 7000);
+		}
+
+		return () => {
+			disposed = true;
+			if (refreshTimer) window.clearTimeout(refreshTimer);
+		};
+	});
+
+	async function hydrateStructure(background = false) {
+		if (!background) structurePending = true;
+		try {
+			const response = await fetchJson<OtherLibraryPayload>('/api/dashboard/library/other');
+			if (disposed) return;
+			structure = response;
+			loadError = '';
+		} catch (error) {
+			if (disposed) return;
+			loadError =
+				error instanceof Error ? error.message : 'The Other library index could not open.';
+		} finally {
+			if (!disposed) structurePending = false;
+		}
+	}
+
+	async function hydrateDetails(background = false) {
+		if (!background) detailsPending = true;
+		try {
+			const response = await fetchJson<OtherLibraryPayload>('/api/dashboard/library/other/details');
+			if (disposed) return;
+			details = response;
+			detailsError = '';
+		} catch (error) {
+			if (disposed) return;
+			detailsError =
+				error instanceof Error ? error.message : 'Other workflow details could not load.';
+		} finally {
+			if (!disposed) detailsPending = false;
+		}
+	}
+</script>
+
+<OtherLibraryView {payload} {structurePending} {detailsPending} {loadError} {detailsError} />

--- a/frontend/src/lib/components/workstation/OtherLibraryView.svelte
+++ b/frontend/src/lib/components/workstation/OtherLibraryView.svelte
@@ -1,0 +1,814 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	import type { OtherLibraryPayload, OtherWorkUnit } from '$lib/api/types';
+	import { folderRoutePath } from '$lib/folder-display';
+	import LibraryModeNav from './LibraryModeNav.svelte';
+
+	let {
+		payload,
+		structurePending = false,
+		detailsPending = false,
+		loadError = '',
+		detailsError = ''
+	}: {
+		payload: OtherLibraryPayload;
+		structurePending?: boolean;
+		detailsPending?: boolean;
+		loadError?: string;
+		detailsError?: string;
+	} = $props();
+
+	let query = $state('');
+	let rootFilter = $state('all');
+	let stateFilter = $state<'all' | 'ready' | 'blocked' | 'browse_only' | 'active'>('all');
+	let sortMode = $state<'name' | 'size' | 'files' | 'reclaim'>('name');
+	let selectedPrefix = $state('');
+
+	const workUnits = $derived.by(() => {
+		const normalizedQuery = query.trim().toLocaleLowerCase();
+		const filtered = payload.work_units.filter((unit) => {
+			if (rootFilter !== 'all' && unit.root !== rootFilter) return false;
+			if (normalizedQuery) {
+				const haystack = `${unit.title} ${unit.prefix} ${unit.library_label}`.toLocaleLowerCase();
+				if (!haystack.includes(normalizedQuery)) return false;
+			}
+			if (stateFilter === 'ready') return unit.profile_readiness.state === 'ready';
+			if (stateFilter === 'blocked') return unit.profile_readiness.state === 'blocked';
+			if (stateFilter === 'browse_only') return unit.profile_readiness.state === 'browse_only';
+			if (stateFilter === 'active') {
+				return ['processing', 'validate', 'promote', 'attention'].includes(
+					unit.workflow_state?.primary_lane ?? ''
+				);
+			}
+			return true;
+		});
+		return [...filtered].sort((left, right) => compareUnits(left, right, sortMode));
+	});
+
+	const selectedUnit = $derived(
+		workUnits.find((unit) => unit.prefix === selectedPrefix) ?? workUnits[0] ?? null
+	);
+	const totalFiles = $derived(
+		payload.work_units.reduce((total, unit) => total + unit.item_count, 0)
+	);
+	const totalSize = $derived(
+		payload.work_units.reduce((total, unit) => total + unit.total_size_bytes, 0)
+	);
+	const readyCount = $derived(
+		payload.work_units.filter((unit) => unit.profile_readiness.state === 'ready').length
+	);
+	const projectedReclaim = $derived(
+		payload.work_units.reduce((total, unit) => total + (unit.projected_reclaim_bytes ?? 0), 0)
+	);
+	const reclaimCoverage = $derived(
+		payload.work_units.filter((unit) => unit.projected_reclaim_bytes != null).length
+	);
+	const reclaimHasUnknowns = $derived(
+		payload.work_units.some(
+			(unit) => unit.projected_reclaim_bytes == null || (unit.estimate_unavailable_count ?? 0) > 0
+		)
+	);
+
+	$effect(() => {
+		if (selectedUnit && selectedPrefix !== selectedUnit.prefix)
+			selectedPrefix = selectedUnit.prefix;
+	});
+
+	function compareUnits(left: OtherWorkUnit, right: OtherWorkUnit, mode: typeof sortMode): number {
+		if (mode === 'size') return right.total_size_bytes - left.total_size_bytes;
+		if (mode === 'files') return right.item_count - left.item_count;
+		if (mode === 'reclaim')
+			return (right.projected_reclaim_bytes ?? -1) - (left.projected_reclaim_bytes ?? -1);
+		return left.title.localeCompare(right.title, undefined, { numeric: true, sensitivity: 'base' });
+	}
+
+	function formatBytes(value: number | null | undefined): string {
+		if (value == null) return 'Pending';
+		if (value < 1024) return `${value} B`;
+		const units = ['KB', 'MB', 'GB', 'TB', 'PB'];
+		let current = value / 1024;
+		let unit = 0;
+		while (current >= 1024 && unit < units.length - 1) {
+			current /= 1024;
+			unit += 1;
+		}
+		return `${current >= 10 ? current.toFixed(0) : current.toFixed(1)} ${units[unit]}`;
+	}
+
+	function workflowTone(unit: OtherWorkUnit): string {
+		if (unit.profile_readiness.state === 'blocked') return 'fail';
+		if (unit.profile_readiness.state === 'browse_only') return 'wait';
+		const lane = unit.workflow_state?.primary_lane;
+		if (lane === 'processing') return 'active';
+		if (lane === 'validate' || lane === 'promote' || lane === 'encode') return 'ready';
+		if (lane === 'attention' || lane === 'blocked') return 'fail';
+		return 'idle';
+	}
+
+	function statusLabel(unit: OtherWorkUnit): string {
+		if (unit.profile_readiness.state !== 'ready') return unit.profile_readiness.label;
+		return unit.workflow_state?.label ?? (unit.details_loading ? 'Loading details' : 'Ready');
+	}
+</script>
+
+<svelte:head>
+	<title>Other Library · Mediaforce</title>
+</svelte:head>
+
+<main class="other-library">
+	<LibraryModeNav active="other" />
+
+	<header class="page-heading">
+		<div class="page-heading__copy">
+			<span class="eyebrow">Library workstation</span>
+			<h1>Other Library</h1>
+			<p>Bounded folders and files use explicit profiles without guessed media semantics.</p>
+		</div>
+		<div class="library-totals" aria-label="Other library totals">
+			<div><strong>{payload.work_units.length}</strong><span>Work units</span></div>
+			<div><strong>{totalFiles}</strong><span>Files</span></div>
+			<div><strong>{formatBytes(totalSize)}</strong><span>Stored</span></div>
+			<div><strong>{readyCount}</strong><span>Profile ready</span></div>
+		</div>
+	</header>
+
+	{#if loadError}
+		<div class="notice notice--danger" role="alert">
+			<strong>Other Library could not open</strong><span>{loadError}</span>
+		</div>
+	{/if}
+	{#if detailsError}
+		<div class="notice" role="status">
+			<strong>Workflow details are unavailable</strong>
+			<span>The library index remains usable. {detailsError}</span>
+		</div>
+	{/if}
+	{#if payload.catalog_truncated}
+		<div class="notice" role="status">
+			<strong>Safe catalog window reached</strong>
+			<span
+				>Showing at most {payload.catalog_work_unit_limit} work units from the first {payload.catalog_item_limit.toLocaleString()}
+				indexed items. Narrow the configured roots to expose more bounded work; hidden items cannot be
+				queued from this view.</span
+			>
+		</div>
+	{/if}
+
+	<section class="library-workstation" aria-label="Other library work units">
+		<div class="toolbar">
+			<label class="search-field">
+				<span class="sr-only">Search folders and files</span>
+				<input bind:value={query} type="search" placeholder="Search folders and files" />
+			</label>
+			<label>
+				<span>Library</span>
+				<select bind:value={rootFilter}>
+					<option value="all">All roots</option>
+					{#each payload.libraries as library (library.key)}
+						<option value={library.key}>{library.label}</option>
+					{/each}
+				</select>
+			</label>
+			<label>
+				<span>State</span>
+				<select bind:value={stateFilter}>
+					<option value="all">All states</option>
+					<option value="ready">Profile ready</option>
+					<option value="blocked">Blocked</option>
+					<option value="browse_only">Browse only</option>
+					<option value="active">Active work</option>
+				</select>
+			</label>
+			<label>
+				<span>Sort</span>
+				<select bind:value={sortMode}>
+					<option value="name">Name</option>
+					<option value="size">Stored size</option>
+					<option value="files">File count</option>
+					<option value="reclaim">Projected reclaim</option>
+				</select>
+			</label>
+		</div>
+
+		{#if structurePending && payload.work_units.length === 0}
+			<div class="empty-state" role="status">
+				<strong>Reading Other roots</strong>
+				<span>Building bounded folder and exact-file work units.</span>
+			</div>
+		{:else if payload.catalog_empty || payload.work_units.length === 0}
+			<div class="empty-state">
+				<strong>No Other media is indexed</strong>
+				<span
+					>Add or scan an Other root in Settings. Root-level files and nested folders will appear
+					here.</span
+				>
+				<a href={resolve('/settings')}>Open Settings</a>
+			</div>
+		{:else if workUnits.length === 0}
+			<div class="empty-state">
+				<strong>No work units match these filters</strong>
+				<span>Clear search or choose a broader state and library filter.</span>
+			</div>
+		{:else}
+			<div class="workbench">
+				<div class="unit-list" aria-label="Other work units">
+					<div class="unit-list__head" aria-hidden="true">
+						<span>Scope</span><span>Files</span><span>Stored</span><span>Workflow</span>
+					</div>
+					{#each workUnits as unit (unit.prefix)}
+						<button
+							type="button"
+							class="unit-row"
+							class:is-selected={selectedUnit?.prefix === unit.prefix}
+							aria-pressed={selectedUnit?.prefix === unit.prefix}
+							onclick={() => (selectedPrefix = unit.prefix)}
+						>
+							<span class="unit-identity">
+								<strong>{unit.title}</strong>
+								<small
+									>{unit.scope_mode === 'exact_file' ? 'Exact file' : 'Bounded folder'} · {unit.library_label}</small
+								>
+							</span>
+							<span data-label="Files"><span class="sr-only">Files: </span>{unit.item_count}</span>
+							<span data-label="Stored"
+								><span class="sr-only">Stored: </span>{formatBytes(unit.total_size_bytes)}</span
+							>
+							<span class="state-badge" data-tone={workflowTone(unit)}>{statusLabel(unit)}</span>
+						</button>
+					{/each}
+				</div>
+
+				{#if selectedUnit}
+					<aside class="inspector" aria-label={`${selectedUnit.title} details`}>
+						<header class="inspector-heading">
+							<div>
+								<span class="eyebrow">{selectedUnit.scope_label}</span>
+								<h2>{selectedUnit.title}</h2>
+								<p>{selectedUnit.prefix}</p>
+							</div>
+							<span class="state-badge" data-tone={workflowTone(selectedUnit)}
+								>{statusLabel(selectedUnit)}</span
+							>
+						</header>
+
+						<div class="inspector-facts">
+							<div>
+								<span>Membership</span><strong
+									>{selectedUnit.item_count}
+									{selectedUnit.item_count === 1 ? 'file' : 'files'}</strong
+								>
+							</div>
+							<div>
+								<span>Stored</span><strong>{formatBytes(selectedUnit.total_size_bytes)}</strong>
+							</div>
+							<div>
+								<span>Projected reclaim</span><strong
+									>{formatBytes(selectedUnit.projected_reclaim_bytes)}</strong
+								>
+							</div>
+							<div>
+								<span>Work unit</span><strong
+									>{selectedUnit.scope_mode === 'exact_file'
+										? 'Exact file'
+										: 'Folder descendants'}</strong
+								>
+							</div>
+						</div>
+
+						<section class="readiness" data-state={selectedUnit.profile_readiness.state}>
+							<span>Processing profile</span>
+							<strong>{selectedUnit.profile_readiness.profile_label}</strong>
+							<p>{selectedUnit.profile_readiness.detail}</p>
+							{#if selectedUnit.profile_readiness.blockers.length}
+								<ul>
+									{#each selectedUnit.profile_readiness.blockers as blocker (blocker)}
+										<li>{blocker}</li>
+									{/each}
+								</ul>
+							{/if}
+						</section>
+
+						<div class="policy-strip" aria-label="Other library policy">
+							<span
+								>{selectedUnit.scope_mode === 'exact_file'
+									? 'Exact-file grouping'
+									: 'Folder grouping'}</span
+							>
+							<span>No inferred media semantics</span>
+							{#if selectedUnit.membership_requires_confirmation}<span
+									>Membership confirmation required</span
+								>{/if}
+						</div>
+
+						<footer class="inspector-actions">
+							<a class="primary-link" href={resolve(folderRoutePath(selectedUnit.prefix))}>
+								Open {selectedUnit.scope_mode === 'exact_file' ? 'File' : 'Folder'} Studio
+							</a>
+							<span>Studio lists exact membership before sampling or queueing.</span>
+						</footer>
+					</aside>
+				{/if}
+			</div>
+		{/if}
+
+		<footer class="workstation-footer">
+			<span>{workUnits.length} of {payload.work_units.length} work units shown</span>
+			<span
+				>{detailsPending || reclaimCoverage === 0
+					? 'Refreshing workflow details…'
+					: `${formatBytes(projectedReclaim)} projected reclaim${reclaimHasUnknowns ? ' · lower bound' : ''}`}</span
+			>
+		</footer>
+	</section>
+</main>
+
+<style>
+	.other-library {
+		margin: 0 auto;
+		max-width: 1400px;
+		padding: 24px 28px 54px;
+	}
+
+	h1,
+	h2,
+	p {
+		margin: 0;
+	}
+
+	.page-heading {
+		align-items: center;
+		display: flex;
+		gap: 28px;
+		justify-content: space-between;
+		margin-bottom: 14px;
+	}
+
+	.page-heading__copy {
+		max-width: 610px;
+	}
+
+	.eyebrow {
+		color: var(--mf-fg-muted);
+		font-size: 11px;
+		font-weight: 800;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+	}
+
+	h1 {
+		font-size: clamp(24px, 3vw, 30px);
+		letter-spacing: -0.03em;
+		margin-top: 2px;
+	}
+
+	.page-heading p,
+	.inspector-heading p,
+	.inspector-actions span,
+	.readiness p,
+	.readiness li {
+		color: var(--mf-fg-secondary);
+		font-size: 12px;
+		line-height: 1.55;
+	}
+
+	.library-totals {
+		border-bottom: 1px solid var(--mf-line);
+		border-top: 1px solid var(--mf-line);
+		display: grid;
+		grid-template-columns: repeat(4, minmax(88px, 1fr));
+		min-width: min(100%, 430px);
+	}
+
+	.library-totals div {
+		border-left: 1px solid var(--mf-line);
+		padding: 9px 12px;
+	}
+
+	.library-totals div:first-child {
+		border-left: 0;
+	}
+
+	.library-totals strong,
+	.library-totals span {
+		display: block;
+	}
+
+	.library-totals strong {
+		font-size: 15px;
+	}
+
+	.library-totals span,
+	.toolbar label > span,
+	.inspector-facts span,
+	.readiness > span {
+		color: var(--mf-fg-muted);
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		margin-top: 3px;
+		text-transform: uppercase;
+	}
+
+	.notice {
+		background: var(--mf-bg-panel);
+		border: 1px solid var(--mf-line);
+		border-left: 3px solid var(--mf-wait-fg);
+		display: grid;
+		gap: 3px;
+		margin-bottom: 14px;
+		padding: 12px 14px;
+	}
+
+	.notice--danger {
+		border-left-color: var(--mf-fail-fg);
+	}
+
+	.notice span {
+		color: var(--mf-fg-secondary);
+		font-size: 12px;
+	}
+
+	.library-workstation {
+		background: var(--mf-bg-panel);
+		border: 1px solid var(--mf-line);
+	}
+
+	.toolbar {
+		align-items: end;
+		border-bottom: 1px solid var(--mf-line);
+		display: grid;
+		gap: 12px;
+		grid-template-columns: minmax(220px, 1.6fr) repeat(3, minmax(130px, 0.7fr));
+		padding: 14px;
+	}
+
+	.toolbar label {
+		display: grid;
+		gap: 5px;
+	}
+
+	.toolbar input,
+	.toolbar select {
+		background: var(--mf-bg-input);
+		border: 1px solid var(--mf-line-strong);
+		border-radius: 0;
+		color: var(--mf-fg-primary);
+		font: inherit;
+		font-size: 13px;
+		height: 36px;
+		padding: 0 10px;
+	}
+
+	.workbench {
+		display: grid;
+		grid-template-columns: minmax(0, 1.35fr) minmax(320px, 0.65fr);
+		min-height: 480px;
+	}
+
+	.unit-list {
+		border-right: 1px solid var(--mf-line);
+		min-width: 0;
+	}
+
+	.unit-list__head,
+	.unit-row {
+		display: grid;
+		gap: 12px;
+		grid-template-columns: minmax(180px, 1fr) 64px 92px minmax(112px, 0.65fr);
+	}
+
+	.unit-list__head {
+		background: var(--mf-bg-subtle);
+		border-bottom: 1px solid var(--mf-line);
+		color: var(--mf-fg-muted);
+		font-size: 10px;
+		font-weight: 800;
+		letter-spacing: 0.06em;
+		padding: 10px 14px;
+		text-transform: uppercase;
+	}
+
+	.unit-row {
+		align-items: center;
+		background: transparent;
+		border: 0;
+		border-bottom: 1px solid var(--mf-line);
+		color: var(--mf-fg-primary);
+		cursor: pointer;
+		font: inherit;
+		padding: 13px 14px;
+		text-align: left;
+		width: 100%;
+	}
+
+	.unit-row:hover,
+	.unit-row.is-selected {
+		background: var(--mf-bg-subtle);
+	}
+
+	.unit-row.is-selected {
+		box-shadow: inset 3px 0 0 var(--mf-lib-other);
+	}
+
+	.unit-identity,
+	.unit-identity strong,
+	.unit-identity small {
+		display: block;
+		min-width: 0;
+	}
+
+	.unit-identity strong,
+	.unit-identity small,
+	.inspector-heading p {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.unit-identity small {
+		color: var(--mf-fg-secondary);
+		font-size: 11px;
+		margin-top: 3px;
+	}
+
+	.state-badge {
+		border: 1px solid var(--mf-line-strong);
+		color: var(--mf-fg-secondary);
+		font-size: 10px;
+		font-weight: 800;
+		justify-self: start;
+		letter-spacing: 0.04em;
+		padding: 4px 6px;
+		text-transform: uppercase;
+	}
+
+	.state-badge[data-tone='ready'] {
+		border-color: var(--mf-ready-fg);
+		color: var(--mf-ready-fg);
+	}
+
+	.state-badge[data-tone='active'] {
+		background: var(--mf-active-bg-strong);
+		border-color: var(--mf-active-fg);
+		color: var(--mf-active-fg-bright);
+	}
+
+	.state-badge[data-tone='wait'] {
+		border-color: var(--mf-wait-fg);
+		color: var(--mf-wait-fg);
+	}
+
+	.state-badge[data-tone='fail'] {
+		border-color: var(--mf-fail-fg);
+		color: var(--mf-fail-fg);
+	}
+
+	.inspector {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		padding: 20px;
+	}
+
+	.inspector-heading {
+		align-items: start;
+		display: flex;
+		gap: 16px;
+		justify-content: space-between;
+	}
+
+	.inspector-heading > div {
+		min-width: 0;
+	}
+
+	.inspector-heading h2 {
+		font-size: 22px;
+		letter-spacing: -0.025em;
+		margin-top: 4px;
+	}
+
+	.inspector-facts {
+		border: 1px solid var(--mf-line);
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		margin-top: 18px;
+	}
+
+	.inspector-facts div {
+		border-bottom: 1px solid var(--mf-line);
+		padding: 12px;
+	}
+
+	.inspector-facts div:nth-child(odd) {
+		border-right: 1px solid var(--mf-line);
+	}
+
+	.inspector-facts div:nth-last-child(-n + 2) {
+		border-bottom: 0;
+	}
+
+	.inspector-facts strong,
+	.inspector-facts span {
+		display: block;
+	}
+
+	.inspector-facts strong {
+		font-size: 13px;
+		margin-top: 4px;
+	}
+
+	.readiness {
+		border-left: 3px solid var(--mf-ready-fg);
+		margin-top: 16px;
+		padding: 4px 0 4px 12px;
+	}
+
+	.readiness[data-state='blocked'] {
+		border-left-color: var(--mf-fail-fg);
+	}
+
+	.readiness[data-state='browse_only'] {
+		border-left-color: var(--mf-wait-fg);
+	}
+
+	.readiness strong,
+	.readiness p {
+		display: block;
+	}
+
+	.readiness p {
+		margin-top: 4px;
+	}
+
+	.readiness ul {
+		margin: 8px 0 0;
+		padding-left: 18px;
+	}
+
+	.policy-strip {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px;
+		margin-top: 16px;
+	}
+
+	.policy-strip span {
+		background: var(--mf-bg-subtle);
+		border: 1px solid var(--mf-line);
+		color: var(--mf-fg-secondary);
+		font-size: 10px;
+		font-weight: 700;
+		padding: 5px 7px;
+		text-transform: uppercase;
+	}
+
+	.inspector-actions {
+		align-items: start;
+		border-top: 1px solid var(--mf-line);
+		display: grid;
+		gap: 8px;
+		margin-top: auto;
+		padding-top: 18px;
+	}
+
+	.primary-link,
+	.empty-state a {
+		background: var(--mf-active-fg);
+		color: var(--mf-active-contrast);
+		font-size: 13px;
+		font-weight: 800;
+		justify-self: start;
+		padding: 9px 12px;
+		text-decoration: none;
+	}
+
+	.empty-state {
+		align-items: center;
+		display: grid;
+		gap: 8px;
+		justify-items: center;
+		min-height: 360px;
+		padding: 36px;
+		text-align: center;
+	}
+
+	.empty-state span {
+		color: var(--mf-fg-secondary);
+		font-size: 13px;
+		max-width: 520px;
+	}
+
+	.workstation-footer {
+		border-top: 1px solid var(--mf-line);
+		color: var(--mf-fg-muted);
+		display: flex;
+		font-size: 11px;
+		justify-content: space-between;
+		padding: 10px 14px;
+	}
+
+	.sr-only {
+		height: 1px;
+		overflow: hidden;
+		position: absolute;
+		width: 1px;
+		clip: rect(0 0 0 0);
+	}
+
+	@media (max-width: 980px) {
+		.page-heading {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.toolbar {
+			grid-template-columns: 1fr 1fr;
+		}
+
+		.search-field {
+			grid-column: 1 / -1;
+		}
+
+		.workbench {
+			grid-template-columns: 1fr;
+		}
+
+		.unit-list {
+			border-right: 0;
+		}
+
+		.inspector {
+			border-top: 1px solid var(--mf-line);
+			min-height: 420px;
+		}
+	}
+
+	@media (max-width: 680px) {
+		.other-library {
+			padding: 22px 14px 40px;
+		}
+
+		.library-totals {
+			grid-template-columns: 1fr 1fr;
+			min-width: 0;
+		}
+
+		.library-totals div:nth-child(3) {
+			border-left: 0;
+			border-top: 1px solid var(--mf-line);
+		}
+
+		.library-totals div:nth-child(4) {
+			border-top: 1px solid var(--mf-line);
+		}
+
+		.toolbar {
+			grid-template-columns: 1fr;
+		}
+
+		.search-field {
+			grid-column: auto;
+		}
+
+		.unit-list__head {
+			display: none;
+		}
+
+		.unit-row {
+			gap: 7px 12px;
+			grid-template-columns: 1fr auto;
+		}
+
+		.unit-identity {
+			grid-column: 1 / -1;
+		}
+
+		.unit-row > span[data-label]::before {
+			color: var(--mf-fg-muted);
+			content: attr(data-label) ' ';
+			font-size: 9px;
+			font-weight: 800;
+			text-transform: uppercase;
+		}
+
+		.state-badge {
+			grid-column: 1 / -1;
+		}
+
+		.inspector {
+			padding: 16px;
+		}
+
+		.inspector-heading {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.workstation-footer {
+			align-items: flex-start;
+			flex-direction: column;
+			gap: 4px;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/workstation/OtherStudioView.svelte
+++ b/frontend/src/lib/components/workstation/OtherStudioView.svelte
@@ -1,0 +1,1104 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+
+	import { apiDownloadHref, postJson } from '$lib/api/client';
+	import type {
+		FolderBenchConfirmResponse,
+		FolderBenchPreviewResponse,
+		FolderPayload,
+		FolderStatusPayload,
+		HostsPayload,
+		OtherMember
+	} from '$lib/api/types';
+	import { folderRoutePath, folderRoutePrefix } from '$lib/folder-display';
+
+	let {
+		folder,
+		status,
+		hosts,
+		folderPending = false,
+		onMutate = async () => {},
+		loadError = null
+	}: {
+		folder: FolderPayload;
+		status: FolderStatusPayload;
+		hosts: HostsPayload;
+		folderPending?: boolean;
+		onMutate?: () => Promise<void>;
+		loadError?: string | null;
+	} = $props();
+
+	let note = $state('');
+	let selectedHostKey = $state('');
+	let membershipConfirmed = $state(false);
+	let pendingAction = $state('');
+	let actionMessage = $state('');
+	let actionError = $state('');
+	let confirmedMembershipToken = $state('');
+
+	const context = $derived(folder.other_context ?? null);
+	const workflow = $derived(status.workflow_state ?? folder.workflow_state ?? null);
+	const calibration = $derived(asRecord(folder.calibration));
+	const pendingProposal = $derived(asRecord(folder.pending_proposal));
+	const pendingProposalCanQueue = $derived(pendingProposal.can_queue === true);
+	const calibrationJob = $derived(asRecord(folder.calibration_job));
+	const encodeJob = $derived(folder.encode_job ?? null);
+	const hostOptions = $derived(
+		(folder.sample_host_options ?? [])
+			.map((host) => asRecord(host))
+			.filter((host) => asText(host.key) && host.available !== false)
+	);
+	const title = $derived(
+		context?.media_scope.title ??
+			folder.media_scope.title ??
+			folder.prefix.split('/').at(-1) ??
+			'Other media'
+	);
+	const readiness = $derived(context?.profile_readiness ?? null);
+	const isBrowseOnly = $derived(context?.availability === 'browse_only');
+	const requiresMembershipConfirmation = $derived(
+		context?.membership_requires_confirmation === true
+	);
+	const membershipComplete = $derived(context?.membership_complete !== false);
+	const scopeReady = $derived(readiness?.state === 'ready' && membershipComplete);
+	const actionReady = $derived(
+		scopeReady && !isBrowseOnly && (!requiresMembershipConfirmation || membershipConfirmed)
+	);
+	const isBusy = $derived(Boolean(pendingAction));
+	const activeWorkerCount = $derived(hosts.hosts.filter((host) => host.available).length);
+	const reviewReady = $derived(
+		Boolean(
+			calibration.review_media_ready ||
+			calibration.browser_review_ready ||
+			calibration.compare_clips
+		)
+	);
+	const approved = $derived(Boolean(calibration.accepted_at));
+	const scopeNoun = $derived(folder.media_scope.match === 'exact_item' ? 'file' : 'folder');
+	const reviewPackHref = $derived(
+		apiDownloadHref(`/api/folders/${folderRoutePrefix(folder.prefix)}/review-compare/download`)
+	);
+	const workflowDetail = $derived(
+		normalizeWorkflowDetail(
+			workflow?.detail ?? 'Workflow details are loading.',
+			context?.item_count ?? 0
+		)
+	);
+	const decisionTitle = $derived.by(() => {
+		if (workflow?.primary_lane === 'processing') return 'Encoding in progress';
+		if (workflow?.primary_lane === 'validate') return 'Validate encoded output';
+		if (workflow?.primary_lane === 'promote') return 'Promote validated output';
+		if (['blocked', 'attention'].includes(workflow?.primary_lane ?? ''))
+			return 'Resolve the workflow blocker';
+		return `Prepare and deliver this ${scopeNoun}`;
+	});
+	const activeOperationCopy = $derived.by(() => {
+		const host = asRecord(encodeJob?.host);
+		const worker =
+			asText(host.label) ||
+			asText(host.key) ||
+			encodeJob?.progress?.active_host_labels?.[0] ||
+			'Unassigned';
+		const percent = encodeJob?.progress?.percent_complete;
+		const parts = [
+			percent != null ? `${Math.round(percent)}% complete` : 'Progress pending',
+			`Worker: ${worker}`,
+			formatElapsed(encodeJob?.created_at)
+		].filter(Boolean);
+		return parts.join(' · ');
+	});
+	const showSampleControls = $derived(
+		scopeReady &&
+			!isBrowseOnly &&
+			!pendingProposalCanQueue &&
+			!reviewReady &&
+			!approved &&
+			!['failed', 'stopped'].includes(asText(calibrationJob.status)) &&
+			!['processing', 'validate', 'promote'].includes(workflow?.primary_lane ?? '')
+	);
+
+	$effect(() => {
+		if (confirmedMembershipToken && confirmedMembershipToken !== context?.membership_token) {
+			confirmedMembershipToken = '';
+			membershipConfirmed = false;
+		}
+		const folderHostKey = String(folder.sample_host_key ?? '').trim();
+		if (!selectedHostKey || !hostOptions.some((host) => asText(host.key) === selectedHostKey)) {
+			selectedHostKey = folderHostKey || asText(hostOptions[0]?.key);
+		}
+	});
+
+	async function prepareSample() {
+		if (!actionReady || isBusy) return;
+		await runAction('prepare-sample', async () => {
+			const response = await postJson<FolderBenchPreviewResponse>(
+				`/api/folders/${folderRoutePrefix(folder.prefix)}/ai-tune/preview`,
+				{
+					note:
+						note.trim() ||
+						`Prepare a representative sample for this bounded ${scopeNoun} using the selected Other profile.`,
+					host_key: selectedHostKey,
+					scope_membership_token: scopeMembershipToken()
+				}
+			);
+			if (!response.ok)
+				throw new Error(response.message || 'This scope is not ready for sampling.');
+			note = '';
+			return response.message || 'Sample plan ready. Review it before starting work.';
+		});
+	}
+
+	async function startSample() {
+		if (!actionReady || isBusy || !pendingProposalCanQueue) return;
+		await runAction('start-sample', async () => {
+			const response = await postJson<FolderBenchConfirmResponse>(
+				`/api/folders/${folderRoutePrefix(folder.prefix)}/ai-tune/confirm`,
+				{
+					proposal_id: asText(pendingProposal.proposal_id),
+					scope_membership_token: scopeMembershipToken()
+				}
+			);
+			if (!response.ok) throw new Error(response.message || 'The sample could not start.');
+			return response.message || 'Sample run queued.';
+		});
+	}
+
+	async function retrySample() {
+		if (!actionReady || isBusy) return;
+		await runAction('retry-sample', async () => {
+			const response = await postJson<FolderBenchConfirmResponse>(
+				`/api/folders/${folderRoutePrefix(folder.prefix)}/ai-tune/confirm`,
+				{
+					proposal_id: '',
+					scope_membership_token: scopeMembershipToken()
+				}
+			);
+			if (!response.ok) throw new Error(response.message || 'The sample could not restart.');
+			return response.message || 'Sample retry queued.';
+		});
+	}
+
+	async function approveSample() {
+		if (!actionReady || isBusy) return;
+		await runAction('approve-sample', async () => {
+			const response = await postJson<{ ok: boolean; message?: string }>(
+				`/api/folders/${folderRoutePrefix(folder.prefix)}/save-profile`,
+				{
+					confirm_high_impact: true,
+					confirm_size_tradeoff: true,
+					reviewed_draft_hash: asText(calibration.draft_hash),
+					scope_membership_token: scopeMembershipToken()
+				}
+			);
+			if (!response.ok)
+				throw new Error(response.message || 'The sample approval could not be saved.');
+			return response.message || `Approved the sample for this ${scopeNoun}.`;
+		});
+	}
+
+	function openReviewPack() {
+		window.location.assign(reviewPackHref);
+	}
+
+	async function queueApproved() {
+		if (!actionReady || isBusy) return;
+		await runAction('queue-work', async () => {
+			const response = await postJson<{ ok: boolean; message?: string }>(
+				`/api/folders/${folderRoutePrefix(folder.prefix)}/queue-encode`,
+				{
+					notes: '',
+					bypass_schedule: false,
+					scope_membership_token: scopeMembershipToken()
+				}
+			);
+			if (!response.ok) throw new Error(response.message || 'This work could not be queued.');
+			return response.message || `Queued this ${scopeNoun}.`;
+		});
+	}
+
+	async function validateOutputs() {
+		await folderAction('validate-outputs', 'Validated the ready Other output.');
+	}
+
+	async function promoteOutputs() {
+		await folderAction('promote-outputs', 'Promoted the validated Other output.');
+	}
+
+	async function folderAction(action: string, successMessage: string) {
+		if (isBusy) return;
+		await runAction(action, async () => {
+			const response = await postJson<{ ok: boolean; message?: string }>(
+				`/api/folders/${folderRoutePrefix(folder.prefix)}/${action}`,
+				{ scope_membership_token: scopeMembershipToken() }
+			);
+			if (!response.ok) throw new Error(response.message || `${action} failed.`);
+			return response.message || successMessage;
+		});
+	}
+
+	async function runAction(action: string, execute: () => Promise<string>) {
+		pendingAction = action;
+		actionMessage = '';
+		actionError = '';
+		try {
+			actionMessage = await execute();
+			await onMutate();
+		} catch (error) {
+			actionError = error instanceof Error ? error.message : 'The action could not complete.';
+		} finally {
+			pendingAction = '';
+		}
+	}
+
+	function asRecord(value: unknown): Record<string, unknown> {
+		return value && typeof value === 'object' && !Array.isArray(value)
+			? (value as Record<string, unknown>)
+			: {};
+	}
+
+	function asText(value: unknown): string {
+		return typeof value === 'string' ? value : '';
+	}
+
+	function formatBytes(value: number | null | undefined): string {
+		if (value == null) return 'Unknown';
+		if (value < 1024) return `${value} B`;
+		const units = ['KB', 'MB', 'GB', 'TB', 'PB'];
+		let current = value / 1024;
+		let unit = 0;
+		while (current >= 1024 && unit < units.length - 1) {
+			current /= 1024;
+			unit += 1;
+		}
+		return `${current >= 10 ? current.toFixed(0) : current.toFixed(1)} ${units[unit]}`;
+	}
+
+	function formatElapsed(timestamp: string | null | undefined): string {
+		if (!timestamp) return '';
+		const startedAt = Date.parse(timestamp);
+		if (!Number.isFinite(startedAt)) return '';
+		const elapsedSeconds = Math.max(Math.floor((Date.now() - startedAt) / 1000), 0);
+		if (elapsedSeconds < 60) return `Active for ${elapsedSeconds}s`;
+		const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+		if (elapsedMinutes < 60) return `Active for ${elapsedMinutes}m`;
+		return `Active for ${Math.floor(elapsedMinutes / 60)}h ${elapsedMinutes % 60}m`;
+	}
+
+	function workflowTone(): string {
+		if (readiness?.state === 'blocked') return 'fail';
+		if (isBrowseOnly) return 'wait';
+		if (workflow?.primary_lane === 'processing') return 'active';
+		if (['encode', 'validate', 'promote'].includes(workflow?.primary_lane ?? '')) return 'ready';
+		if (['blocked', 'attention'].includes(workflow?.primary_lane ?? '')) return 'fail';
+		return 'idle';
+	}
+
+	function memberState(member: OtherMember): string {
+		if (workflow?.primary_lane === 'processing') return 'processing';
+		return member.workflow_state?.state.replaceAll('_', ' ') ?? member.status.replaceAll('_', ' ');
+	}
+
+	function scopeMembershipToken(): string {
+		return membershipConfirmed || !requiresMembershipConfirmation
+			? (context?.membership_token ?? '')
+			: '';
+	}
+
+	function updateMembershipConfirmation(checked: boolean) {
+		membershipConfirmed = checked;
+		confirmedMembershipToken = checked ? (context?.membership_token ?? '') : '';
+	}
+
+	function normalizeWorkflowDetail(detail: string, itemCount: number): string {
+		if (itemCount !== 1) {
+			return detail.replace('item(s)', 'items').replace('output(s)', 'outputs');
+		}
+		return detail
+			.replace('item(s)', 'item')
+			.replace('output(s)', 'output')
+			.replace(' output need ', ' output needs ')
+			.replace(' output are ', ' output is ');
+	}
+</script>
+
+<svelte:head>
+	<title>{title} · Other Studio · Mediaforce</title>
+</svelte:head>
+
+<main class="other-studio" data-folder-ready-marker={title}>
+	<header class="studio-header">
+		<div class="studio-header__identity">
+			<a href={resolve('/other')}>← Other Library</a>
+			<div>
+				<span class="eyebrow"
+					>{folder.media_scope.match === 'exact_item' ? 'Exact file' : 'Bounded folder'}</span
+				>
+				<h1>{title}</h1>
+				<p>{folder.prefix}</p>
+			</div>
+		</div>
+		<span class="state-badge" data-tone={workflowTone()}>
+			{readiness?.state === 'ready'
+				? (workflow?.label ?? 'Ready')
+				: (readiness?.label ?? 'Loading')}
+		</span>
+	</header>
+
+	<section class="status-strip" aria-label="Other Studio status">
+		<div>
+			<span>Scope</span><strong
+				>{context?.item_count ?? 0} {context?.item_count === 1 ? 'file' : 'files'}</strong
+			>
+		</div>
+		<div><span>Profile</span><strong>{readiness?.profile_label ?? 'Loading'}</strong></div>
+		<div><span>Workflow</span><strong>{workflow?.label ?? 'Loading'}</strong></div>
+		<div>
+			<span>Sample</span><strong
+				>{reviewReady
+					? approved
+						? 'Approved'
+						: 'Review ready'
+					: asText(calibrationJob.status) || 'Not started'}</strong
+			>
+		</div>
+		<div>
+			<span>Processing</span><strong>{encodeJob?.status?.replaceAll('_', ' ') ?? 'Idle'}</strong>
+		</div>
+		<div><span>Workers online</span><strong>{activeWorkerCount}</strong></div>
+	</section>
+
+	{#if loadError}
+		<div class="notice notice--danger" role="alert">
+			<strong>Studio update failed</strong><span>{loadError}</span>
+		</div>
+	{/if}
+	{#if actionError}
+		<div class="notice notice--danger" role="alert">
+			<strong>Action failed</strong><span>{actionError}</span>
+		</div>
+	{/if}
+	{#if actionMessage}
+		<div class="notice notice--success" role="status">
+			<strong>Updated</strong><span>{actionMessage}</span>
+		</div>
+	{/if}
+	{#if isBrowseOnly}
+		<div class="notice">
+			<strong>Browse only</strong><span
+				>Enable Production for this root in Settings before sampling or queueing work.</span
+			>
+		</div>
+	{:else if readiness?.state === 'blocked'}
+		<div class="notice notice--danger">
+			<strong>{readiness.label}</strong><span>{readiness.detail}</span>
+			{#if readiness.blockers.length}
+				<ul>
+					{#each readiness.blockers as blocker (blocker)}<li>{blocker}</li>{/each}
+				</ul>
+			{/if}
+		</div>
+	{/if}
+
+	<div class="studio-grid">
+		<section class="decision-panel">
+			<header class="panel-heading">
+				<div>
+					<span class="eyebrow">Decision</span>
+					<h2>{decisionTitle}</h2>
+				</div>
+				<span>{folderPending ? 'Refreshing…' : workflowDetail}</span>
+			</header>
+
+			<div class="scope-contract">
+				<div>
+					<span>Exact membership</span><strong
+						>{context?.membership_complete
+							? `${context.item_count} indexed ${context.item_count === 1 ? 'file' : 'files'}`
+							: `More than ${context?.membership_limit ?? 250} files`}</strong
+					>
+				</div>
+				<div><span>Stored size</span><strong>{formatBytes(context?.total_size_bytes)}</strong></div>
+				<div>
+					<span>Grouping</span><strong
+						>{folder.media_scope.match === 'exact_item'
+							? 'One exact file'
+							: 'All descendants'}</strong
+					>
+				</div>
+				<div>
+					<span>Semantics</span><strong>No title, season, edition, or spatial inference</strong>
+				</div>
+			</div>
+
+			{#if requiresMembershipConfirmation}
+				<label class="confirmation" class:is-disabled={!scopeReady}>
+					<input
+						type="checkbox"
+						checked={membershipConfirmed}
+						disabled={!scopeReady}
+						onchange={(event) =>
+							updateMembershipConfirmation((event.currentTarget as HTMLInputElement).checked)}
+					/>
+					<span>
+						<strong>I reviewed all {context?.item_count ?? 0} files in this folder scope.</strong>
+						<small>Sampling and production apply to every eligible file listed in Membership.</small
+						>
+					</span>
+				</label>
+			{/if}
+
+			{#if showSampleControls}
+				<div class="sample-form">
+					<label>
+						<span>Sample note</span>
+						<textarea
+							bind:value={note}
+							rows="3"
+							placeholder="Optional quality or size direction for this scope"></textarea>
+					</label>
+					<label>
+						<span>Worker</span>
+						<select bind:value={selectedHostKey} disabled={!hostOptions.length}>
+							{#if !hostOptions.length}<option value="">No sample worker available</option>{/if}
+							{#each hostOptions as host (asText(host.key))}
+								<option value={asText(host.key)}>{asText(host.label) || asText(host.key)}</option>
+							{/each}
+						</select>
+					</label>
+				</div>
+			{/if}
+
+			<div class="action-row">
+				{#if workflow?.primary_lane === 'processing'}
+					<span class="operation-state"
+						><strong>Production is active.</strong>{activeOperationCopy}</span
+					>
+				{:else if workflow?.primary_lane === 'validate'}
+					<button class="primary" disabled={isBusy || isBrowseOnly} onclick={validateOutputs}
+						>Validate ready output</button
+					>
+				{:else if workflow?.primary_lane === 'promote'}
+					<button class="primary" disabled={isBusy || isBrowseOnly} onclick={promoteOutputs}
+						>Promote validated output</button
+					>
+				{:else if reviewReady && !approved}
+					<button class="secondary" type="button" onclick={openReviewPack}>Open review pack</button>
+					<button class="primary" disabled={!actionReady || isBusy} onclick={approveSample}
+						>Approve reviewed sample</button
+					>
+				{:else if approved && workflow?.primary_lane === 'encode'}
+					<button class="primary" disabled={!actionReady || isBusy} onclick={queueApproved}
+						>Queue {context?.eligible_item_count ?? 0} eligible files</button
+					>
+				{:else if pendingProposalCanQueue}
+					<button class="primary" disabled={!actionReady || isBusy} onclick={startSample}
+						>Start proposed sample</button
+					>
+				{:else if ['failed', 'stopped'].includes(asText(calibrationJob.status))}
+					<button class="primary" disabled={!actionReady || isBusy} onclick={retrySample}
+						>Retry sample</button
+					>
+				{:else}
+					<button
+						class="primary"
+						disabled={!actionReady || isBusy || !hostOptions.length}
+						onclick={prepareSample}>Prepare representative sample</button
+					>
+				{/if}
+				{#if requiresMembershipConfirmation && !membershipConfirmed}
+					<span class="action-help"
+						>{hostOptions.length
+							? 'Confirm membership to enable sample and queue actions.'
+							: 'Confirm membership and bring a sample-capable worker online to prepare a sample.'}</span
+					>
+				{:else if readiness?.state !== 'ready'}
+					<span class="action-help">Resolve profile readiness before starting work.</span>
+				{:else if showSampleControls && !hostOptions.length && !reviewReady}
+					<span class="action-help">Bring a sample-capable worker online.</span>
+				{/if}
+			</div>
+		</section>
+
+		<aside class="membership-panel">
+			<header class="panel-heading">
+				<div>
+					<span class="eyebrow">Membership</span>
+					<h2>{context?.item_count === 1 ? 'File in this scope' : 'Files in this scope'}</h2>
+				</div>
+				<span
+					>{context?.members.length ?? 0}{context?.membership_complete === false ? '+' : ''} shown</span
+				>
+			</header>
+
+			{#if context?.membership_complete === false}
+				<div class="membership-warning">
+					<strong>Scope exceeds the safe membership limit.</strong>
+					<span
+						>Switch this root to exact-file grouping or split the source folder before processing.</span
+					>
+				</div>
+			{/if}
+
+			<div class="member-list">
+				{#each context?.members ?? [] as member (member.item_id)}
+					<div class="member-row" data-supported={member.profile_supported}>
+						<div>
+							<strong>{member.label}</strong>
+							<code>{member.rel_path}</code>
+							<small>
+								{formatBytes(member.size_bytes)}
+								{#if member.video_codec}
+									· {member.video_codec.toUpperCase()}{/if}
+								{#if member.width && member.height}
+									· {member.width}×{member.height}{/if}
+							</small>
+							{#if member.profile_blocker}<span class="member-blocker"
+									>{member.profile_blocker}</span
+								>{/if}
+						</div>
+						<div class="member-row__actions">
+							<span>{memberState(member)}</span>
+							<a href={resolve(folderRoutePath(member.prefix))}>Open exact file</a>
+						</div>
+					</div>
+				{/each}
+			</div>
+		</aside>
+	</div>
+</main>
+
+<style>
+	.other-studio {
+		margin: 0 auto;
+		max-width: 1440px;
+		padding: 24px 28px 54px;
+	}
+
+	h1,
+	h2,
+	p {
+		margin: 0;
+	}
+
+	.studio-header {
+		align-items: end;
+		display: flex;
+		gap: 24px;
+		justify-content: space-between;
+	}
+
+	.studio-header__identity {
+		align-items: end;
+		display: flex;
+		gap: 18px;
+		min-width: 0;
+	}
+
+	.studio-header__identity > a {
+		color: var(--mf-fg-secondary);
+		font-size: 12px;
+		font-weight: 700;
+		padding-bottom: 6px;
+		text-decoration: none;
+		white-space: nowrap;
+	}
+
+	.studio-header__identity > div {
+		min-width: 0;
+	}
+
+	.eyebrow,
+	.scope-contract span,
+	.sample-form label > span,
+	.status-strip span {
+		color: var(--mf-fg-muted);
+		font-size: 10px;
+		font-weight: 800;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	h1 {
+		font-size: clamp(28px, 4vw, 42px);
+		letter-spacing: -0.04em;
+		margin-top: 3px;
+	}
+
+	.studio-header p {
+		color: var(--mf-fg-secondary);
+		font-family: var(--mf-font-mono);
+		font-size: 12px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.state-badge {
+		border: 1px solid var(--mf-line-strong);
+		color: var(--mf-fg-secondary);
+		font-size: 10px;
+		font-weight: 800;
+		letter-spacing: 0.05em;
+		padding: 5px 7px;
+		text-transform: uppercase;
+	}
+
+	.state-badge[data-tone='ready'] {
+		border-color: var(--mf-ready-fg);
+		color: var(--mf-ready-fg);
+	}
+
+	.state-badge[data-tone='active'] {
+		background: var(--mf-active-bg-strong);
+		border-color: var(--mf-active-fg);
+		color: var(--mf-active-fg-bright);
+	}
+
+	.state-badge[data-tone='wait'] {
+		border-color: var(--mf-wait-fg);
+		color: var(--mf-wait-fg);
+	}
+
+	.state-badge[data-tone='fail'] {
+		border-color: var(--mf-fail-fg);
+		color: var(--mf-fail-fg);
+	}
+
+	.status-strip {
+		background: var(--mf-bg-panel);
+		border: 1px solid var(--mf-line);
+		display: grid;
+		grid-template-columns: repeat(6, minmax(110px, 1fr));
+		margin-top: 18px;
+	}
+
+	.status-strip div {
+		border-left: 1px solid var(--mf-line);
+		padding: 11px 12px;
+	}
+
+	.status-strip div:first-child {
+		border-left: 0;
+	}
+
+	.status-strip span,
+	.status-strip strong {
+		display: block;
+	}
+
+	.status-strip strong {
+		font-size: 12px;
+		margin-top: 3px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		text-transform: capitalize;
+		white-space: nowrap;
+	}
+
+	.notice {
+		background: var(--mf-bg-panel);
+		border: 1px solid var(--mf-line);
+		border-left: 3px solid var(--mf-wait-fg);
+		display: grid;
+		gap: 3px;
+		margin-top: 12px;
+		padding: 11px 13px;
+	}
+
+	.notice--danger {
+		border-left-color: var(--mf-fail-fg);
+	}
+
+	.notice--success {
+		border-left-color: var(--mf-ready-fg);
+	}
+
+	.notice span,
+	.notice li {
+		color: var(--mf-fg-secondary);
+		font-size: 12px;
+		line-height: 1.5;
+	}
+
+	.notice ul {
+		margin: 5px 0 0;
+		padding-left: 18px;
+	}
+
+	.studio-grid {
+		display: grid;
+		gap: 14px;
+		grid-template-columns: minmax(0, 1.15fr) minmax(360px, 0.85fr);
+		margin-top: 14px;
+	}
+
+	.decision-panel,
+	.membership-panel {
+		background: var(--mf-bg-panel);
+		border: 1px solid var(--mf-line);
+		min-width: 0;
+	}
+
+	.decision-panel {
+		padding: 20px;
+	}
+
+	.panel-heading {
+		align-items: start;
+		display: flex;
+		gap: 18px;
+		justify-content: space-between;
+	}
+
+	.panel-heading h2 {
+		font-size: 20px;
+		letter-spacing: -0.02em;
+		margin-top: 3px;
+	}
+
+	.panel-heading > span {
+		color: var(--mf-fg-secondary);
+		font-size: 11px;
+		line-height: 1.45;
+		max-width: 260px;
+		text-align: right;
+	}
+
+	.scope-contract {
+		border: 1px solid var(--mf-line);
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		margin-top: 18px;
+	}
+
+	.scope-contract div {
+		border-bottom: 1px solid var(--mf-line);
+		padding: 12px;
+	}
+
+	.scope-contract div:nth-child(odd) {
+		border-right: 1px solid var(--mf-line);
+	}
+
+	.scope-contract div:nth-last-child(-n + 2) {
+		border-bottom: 0;
+	}
+
+	.scope-contract span,
+	.scope-contract strong {
+		display: block;
+	}
+
+	.scope-contract strong {
+		font-size: 13px;
+		margin-top: 4px;
+	}
+
+	.confirmation {
+		align-items: start;
+		background: var(--mf-bg-subtle);
+		border: 1px solid var(--mf-line-strong);
+		cursor: pointer;
+		display: flex;
+		gap: 10px;
+		margin-top: 16px;
+		padding: 12px;
+	}
+
+	.confirmation.is-disabled {
+		cursor: not-allowed;
+		opacity: 0.65;
+	}
+
+	.confirmation input {
+		margin-top: 2px;
+	}
+
+	.confirmation strong,
+	.confirmation small {
+		display: block;
+	}
+
+	.confirmation small {
+		color: var(--mf-fg-secondary);
+		font-size: 11px;
+		line-height: 1.45;
+		margin-top: 3px;
+	}
+
+	.sample-form {
+		display: grid;
+		gap: 12px;
+		grid-template-columns: 1fr 190px;
+		margin-top: 16px;
+	}
+
+	.sample-form label {
+		display: grid;
+		gap: 5px;
+	}
+
+	.sample-form textarea,
+	.sample-form select {
+		background: var(--mf-bg-input);
+		border: 1px solid var(--mf-line-strong);
+		border-radius: 0;
+		color: var(--mf-fg-primary);
+		font: inherit;
+		font-size: 13px;
+		padding: 9px 10px;
+	}
+
+	.sample-form select {
+		height: 38px;
+	}
+
+	.action-row {
+		align-items: center;
+		border-top: 1px solid var(--mf-line);
+		display: flex;
+		flex-wrap: wrap;
+		gap: 9px;
+		margin-top: 18px;
+		padding-top: 16px;
+	}
+
+	.primary,
+	.secondary {
+		border: 1px solid var(--mf-active-fg);
+		border-radius: 0;
+		font: inherit;
+		font-size: 12px;
+		font-weight: 800;
+		padding: 9px 12px;
+		text-decoration: none;
+	}
+
+	.primary {
+		background: var(--mf-active-fg);
+		color: var(--mf-active-contrast);
+		cursor: pointer;
+	}
+
+	.primary:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	.secondary {
+		background: transparent;
+		color: var(--mf-active-fg);
+	}
+
+	.action-help {
+		color: var(--mf-fg-secondary);
+		font-size: 11px;
+	}
+
+	.operation-state {
+		border-left: 3px solid var(--mf-active-fg);
+		color: var(--mf-fg-secondary);
+		display: grid;
+		font-size: 12px;
+		gap: 2px;
+		line-height: 1.5;
+		padding: 5px 0 5px 10px;
+	}
+
+	.operation-state strong {
+		color: var(--mf-fg-primary);
+	}
+
+	.membership-panel {
+		display: flex;
+		flex-direction: column;
+		max-height: 720px;
+	}
+
+	.membership-panel > .panel-heading {
+		border-bottom: 1px solid var(--mf-line);
+		padding: 18px;
+	}
+
+	.membership-warning {
+		border-bottom: 1px solid var(--mf-line);
+		border-left: 3px solid var(--mf-fail-fg);
+		display: grid;
+		gap: 4px;
+		padding: 11px 13px;
+	}
+
+	.membership-warning span {
+		color: var(--mf-fg-secondary);
+		font-size: 11px;
+		line-height: 1.45;
+	}
+
+	.member-list {
+		overflow: auto;
+	}
+
+	.member-row {
+		align-items: start;
+		border-bottom: 1px solid var(--mf-line);
+		display: grid;
+		gap: 12px;
+		grid-template-columns: minmax(0, 1fr) auto;
+		padding: 12px 14px;
+	}
+
+	.member-row[data-supported='false'] {
+		box-shadow: inset 3px 0 0 var(--mf-fail-fg);
+	}
+
+	.member-row > div:first-child {
+		min-width: 0;
+	}
+
+	.member-row strong,
+	.member-row code,
+	.member-row small,
+	.member-blocker {
+		display: block;
+	}
+
+	.member-row strong {
+		font-size: 13px;
+	}
+
+	.member-row code {
+		color: var(--mf-fg-secondary);
+		font-size: 10px;
+		margin-top: 3px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.member-row small {
+		color: var(--mf-fg-muted);
+		font-size: 10px;
+		margin-top: 4px;
+	}
+
+	.member-blocker {
+		color: var(--mf-fail-fg);
+		font-size: 10px;
+		line-height: 1.4;
+		margin-top: 5px;
+	}
+
+	.member-row__actions {
+		align-items: end;
+		display: grid;
+		gap: 5px;
+		justify-items: end;
+	}
+
+	.member-row__actions span {
+		color: var(--mf-fg-muted);
+		font-size: 9px;
+		font-weight: 800;
+		text-transform: uppercase;
+	}
+
+	.member-row__actions a {
+		color: var(--mf-active-fg);
+		font-size: 10px;
+		font-weight: 700;
+		text-decoration: none;
+	}
+
+	@media (max-width: 1020px) {
+		.status-strip {
+			grid-template-columns: repeat(3, 1fr);
+		}
+
+		.status-strip div:nth-child(4) {
+			border-left: 0;
+			border-top: 1px solid var(--mf-line);
+		}
+
+		.status-strip div:nth-child(n + 5) {
+			border-top: 1px solid var(--mf-line);
+		}
+
+		.studio-grid {
+			grid-template-columns: 1fr;
+		}
+
+		.membership-panel {
+			max-height: none;
+		}
+	}
+
+	@media (max-width: 680px) {
+		.other-studio {
+			padding: 20px 14px 40px;
+		}
+
+		.studio-header,
+		.studio-header__identity {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.studio-header__identity {
+			gap: 10px;
+		}
+
+		.state-badge {
+			align-self: flex-start;
+		}
+
+		.status-strip {
+			grid-template-columns: 1fr 1fr;
+		}
+
+		.status-strip div:nth-child(odd) {
+			border-left: 0;
+		}
+
+		.status-strip div:nth-child(n + 3) {
+			border-top: 1px solid var(--mf-line);
+		}
+
+		.decision-panel {
+			padding: 16px;
+		}
+
+		.panel-heading {
+			flex-direction: column;
+		}
+
+		.panel-heading > span {
+			max-width: none;
+			text-align: left;
+		}
+
+		.scope-contract,
+		.sample-form {
+			grid-template-columns: 1fr;
+		}
+
+		.scope-contract div,
+		.scope-contract div:nth-child(odd),
+		.scope-contract div:nth-last-child(-n + 2) {
+			border-bottom: 1px solid var(--mf-line);
+			border-right: 0;
+		}
+
+		.scope-contract div:last-child {
+			border-bottom: 0;
+		}
+
+		.member-row {
+			grid-template-columns: 1fr;
+		}
+
+		.member-row__actions {
+			align-items: start;
+			justify-items: start;
+		}
+	}
+</style>

--- a/frontend/src/lib/other/library.test.ts
+++ b/frontend/src/lib/other/library.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import type { OtherLibraryPayload, OtherWorkUnit } from '$lib/api/types';
+import { mergeOtherLibraryPayloads } from './library';
+
+const workUnit: OtherWorkUnit = {
+	prefix: 'other/Collection',
+	root: 'other',
+	library_label: 'Other',
+	availability: 'production',
+	default_profile: 'other_conservative',
+	policy: { grouping: 'folder' },
+	title: 'Collection',
+	subtitle: 'Other',
+	scope_label: 'Folder',
+	scope_mode: 'folder',
+	media_scope: {
+		schema_version: 1,
+		prefix: 'other/Collection',
+		root: 'other',
+		domain: 'other',
+		kind: 'media_folder',
+		match: 'descendants',
+		title: 'Collection',
+		subtitle: 'Other',
+		scope_label: 'Folder',
+		parent: { prefix: 'other', title: 'Other' }
+	},
+	item_count: 2,
+	total_size_bytes: 100,
+	blocked_item_count: 0,
+	statuses: { discovered: 2 },
+	video_codecs: { h264: 2 },
+	profile_readiness: {
+		state: 'ready',
+		label: 'Profile ready',
+		detail: 'All files are ready.',
+		profile: 'other_conservative',
+		profile_label: 'Conservative',
+		blockers: []
+	},
+	membership_requires_confirmation: true,
+	details_loading: true
+};
+
+function payload(unit: OtherWorkUnit): OtherLibraryPayload {
+	return {
+		schema_version: 1,
+		libraries: [],
+		work_units: [unit],
+		catalog_empty: false,
+		catalog_truncated: false,
+		catalog_item_limit: 5000,
+		catalog_work_unit_limit: 500,
+		details_loading: unit.details_loading
+	};
+}
+
+describe('mergeOtherLibraryPayloads', () => {
+	it('keeps structure order while hydrating workflow and reclaim details', () => {
+		const merged = mergeOtherLibraryPayloads(
+			payload(workUnit),
+			payload({
+				...workUnit,
+				projected_reclaim_bytes: 40,
+				workflow_state: {
+					prefix: workUnit.prefix,
+					state: 'encode_candidates',
+					primary_lane: 'encode',
+					label: 'Ready to encode',
+					tone: 'ready',
+					detail: '2 files are ready.',
+					counts: { total: 2 },
+					lane_counts: { encode: 2 },
+					state_counts: { encode_candidate: 2 },
+					next_action: {
+						kind: 'queue_encode',
+						label: 'Queue encode',
+						enabled: true,
+						target_prefix: workUnit.prefix
+					},
+					blockers: []
+				},
+				details_loading: false
+			})
+		);
+
+		expect(merged.work_units[0]?.projected_reclaim_bytes).toBe(40);
+		expect(merged.work_units[0]?.workflow_state?.primary_lane).toBe('encode');
+		expect(merged.work_units[0]?.details_loading).toBe(false);
+	});
+});

--- a/frontend/src/lib/other/library.ts
+++ b/frontend/src/lib/other/library.ts
@@ -1,0 +1,32 @@
+import type { OtherLibraryPayload, OtherWorkUnit } from '$lib/api/types';
+
+export function mergeOtherLibraryPayloads(
+	structure: OtherLibraryPayload,
+	details: OtherLibraryPayload
+): OtherLibraryPayload {
+	const detailsByPrefix = new Map(details.work_units.map((unit) => [unit.prefix, unit]));
+	const structurePrefixes = new Set(structure.work_units.map((unit) => unit.prefix));
+	const workUnits = structure.work_units.map((unit) =>
+		mergeOtherWorkUnit(unit, detailsByPrefix.get(unit.prefix))
+	);
+	for (const unit of details.work_units) {
+		if (!structurePrefixes.has(unit.prefix)) workUnits.push(unit);
+	}
+	return {
+		schema_version: Math.max(structure.schema_version, details.schema_version),
+		libraries: details.libraries.length ? details.libraries : structure.libraries,
+		work_units: workUnits,
+		catalog_empty: structure.catalog_empty && details.catalog_empty,
+		catalog_truncated: structure.catalog_truncated || details.catalog_truncated,
+		catalog_item_limit: Math.min(structure.catalog_item_limit, details.catalog_item_limit),
+		catalog_work_unit_limit: Math.min(
+			structure.catalog_work_unit_limit,
+			details.catalog_work_unit_limit
+		),
+		details_loading: details.details_loading
+	};
+}
+
+function mergeOtherWorkUnit(structure: OtherWorkUnit, details?: OtherWorkUnit): OtherWorkUnit {
+	return details ? { ...structure, ...details } : structure;
+}

--- a/frontend/src/lib/settings/editor.test.ts
+++ b/frontend/src/lib/settings/editor.test.ts
@@ -296,6 +296,25 @@ describe('settings draft helpers', () => {
 		expect(spatial && libraryReadiness(spatial).state).toBe('incomplete');
 	});
 
+	it('allows an Other root into production with an explicit profile', () => {
+		const other = {
+			...payload.libraries[0],
+			key: 'other',
+			label: 'Other',
+			path: '/Volumes/Other',
+			library_type: 'other' as const,
+			availability: 'production' as const,
+			default_profile: 'other_conservative',
+			policy: { grouping: 'folder' as const }
+		};
+
+		expect(libraryReadiness(other)).toEqual({
+			state: 'ready',
+			label: 'Ready',
+			detail: 'Generic file and folder scopes use the selected profile and require probe readiness.'
+		});
+	});
+
 	it('uses the saved transcode root for destructive archive cleanup', () => {
 		const draft = draftFromSettings(payload);
 		draft.transcode_root = '/Volumes/UnsavedTranscode';

--- a/frontend/src/lib/settings/editor.ts
+++ b/frontend/src/lib/settings/editor.ts
@@ -303,7 +303,8 @@ export function libraryReadiness(
 	library: Pick<
 		SettingsLibrary,
 		'key' | 'label' | 'path' | 'library_type' | 'availability' | 'policy'
-	>
+	> &
+		Partial<Pick<SettingsLibrary, 'default_profile'>>
 ): LibraryReadiness {
 	if (!library.key.trim() || !library.label.trim() || !library.path.trim()) {
 		return {
@@ -345,11 +346,25 @@ export function libraryReadiness(
 			detail: 'Mediaforce scans and shows this library but never processes it.'
 		};
 	}
-	if (!['tv', 'movie'].includes(library.library_type)) {
+	if (!['tv', 'movie', 'other'].includes(library.library_type)) {
 		return {
 			state: 'blocked',
 			label: 'Workflow blocked',
 			detail: 'Production is not available for this library type yet.'
+		};
+	}
+	if (library.library_type === 'other') {
+		if (!library.default_profile?.trim()) {
+			return {
+				state: 'incomplete',
+				label: 'Profile needed',
+				detail: 'Choose an explicit Other processing profile before enabling Production.'
+			};
+		}
+		return {
+			state: 'ready',
+			label: 'Ready',
+			detail: 'Generic file and folder scopes use the selected profile and require probe readiness.'
 		};
 	}
 	return {

--- a/frontend/src/routes/folders/[...prefix]/+page.svelte
+++ b/frontend/src/routes/folders/[...prefix]/+page.svelte
@@ -17,6 +17,7 @@
 	import SeasonExperience from '$lib/components/season/SeasonExperience.svelte';
 	import SeasonLibrary from '$lib/components/season/SeasonLibrary.svelte';
 	import MovieStudioView from '$lib/components/workstation/MovieStudioView.svelte';
+	import OtherStudioView from '$lib/components/workstation/OtherStudioView.svelte';
 
 	let { data }: { data: { mode: 'directory' | 'studio'; prefix: string } } = $props();
 	const mode = $derived(data.mode);
@@ -126,7 +127,7 @@
 <svelte:head>
 	<title
 		>{mode === 'studio'
-			? `${prefix.split('/').at(-1)} · ${folder.pending ? 'Studio' : folder.media_scope.domain === 'movie' ? 'Movie Studio' : 'Mediaforce'}`
+			? `${prefix.split('/').at(-1)} · ${folder.pending ? 'Studio' : folder.media_scope.domain === 'movie' ? 'Movie Studio' : folder.media_scope.domain === 'other' ? 'Other Studio' : 'Mediaforce'}`
 			: 'Make a TV season smaller · Mediaforce'}</title
 	>
 </svelte:head>
@@ -145,6 +146,15 @@
 		</div>
 	{:else if folder.media_scope.domain === 'movie'}
 		<MovieStudioView
+			{folder}
+			{status}
+			{hosts}
+			{folderPending}
+			loadError={loadError ?? undefined}
+			onMutate={refreshStudio}
+		/>
+	{:else if folder.media_scope.domain === 'other'}
+		<OtherStudioView
 			{folder}
 			{status}
 			{hosts}

--- a/frontend/src/routes/other/+page.svelte
+++ b/frontend/src/routes/other/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import OtherLibraryPage from '$lib/components/workstation/OtherLibraryPage.svelte';
+</script>
+
+<OtherLibraryPage />

--- a/mediaforce/library/candidate_selection.py
+++ b/mediaforce/library/candidate_selection.py
@@ -1,20 +1,31 @@
 import re
-from collections import Counter
+from collections import Counter, defaultdict
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal
 
-from sqlalchemy import outerjoin, select
+from sqlalchemy import or_, outerjoin, select
 
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items, plex_item_metadata, series_metadata, staged_artifacts
 from mediaforce.core.type_defs import object_dict
 from mediaforce.library.library_settings import normalize_library_policy, normalize_library_type
-from mediaforce.library.media_scopes import normalize_scope_prefix, path_matches_scope, resolve_media_scopes
+from mediaforce.library.media_scopes import (
+    MediaScope,
+    normalize_scope_prefix,
+    path_matches_scope,
+    resolve_media_scopes,
+    scope_rel_path_filter,
+)
 from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
+from mediaforce.library.other_profiles import (
+    OTHER_FOLDER_SCOPE_MAX_ITEMS,
+    other_group_scope_for_rel_path,
+    other_item_profile_blocker,
+)
 from mediaforce.library.planner import build_manifest_item
 from mediaforce.library.workflow_state import ENCODE_CANDIDATE_STATUSES, EncodeEligibility, derive_item_workflow_state
 from mediaforce.tuning.stream_budget import (
@@ -85,6 +96,7 @@ class CandidateDecision:
     media_role: str | None
     production_included: bool
     production_blocker: str | None
+    profile_blocker: str | None
     target_size_blocker: StreamBudgetProjectionBlocker | None
     ranking_mode: str
     media_domain: str
@@ -129,6 +141,7 @@ class CandidateDecision:
             "media_role": self.media_role,
             "production_included": self.production_included,
             "production_blocker": self.production_blocker,
+            "profile_blocker": self.profile_blocker,
             "target_size_blocker": (
                 self.target_size_blocker.to_payload()
                 if self.target_size_blocker is not None
@@ -157,11 +170,17 @@ def project_candidates(
         manual_override_prefix: str | None = None,
 ) -> list[CandidateDecision]:
     current_time = (now or datetime.now(tz=UTC)).astimezone(UTC)
-    rows = _load_rows(connection)
-    metadata_by_series = {
-        str(row["series_prefix"]): object_dict(row)
-        for row in connection.execute(select(series_metadata)).mappings().fetchall()
-    }
+    resolved_scopes = resolve_media_scopes(
+        connection,
+        prefixes or [],
+        library_types=config.library_type_map,
+    )
+    query_scopes = (
+        resolved_scopes
+        if resolved_scopes and all(scope.domain == "other" for scope in resolved_scopes)
+        else []
+    )
+    rows = _load_rows(connection, scopes=query_scopes)
     season_by_item: dict[int, SeasonIdentity | None] = {}
     season_rows: dict[str, list[dict[str, Any]]] = {}
     numbered_by_series: dict[str, set[int]] = {}
@@ -175,6 +194,15 @@ def project_candidates(
         if season.season_number is not None:
             numbered_by_series.setdefault(season.series_prefix, set()).add(season.season_number)
 
+    metadata_by_series = (
+        {
+            str(row["series_prefix"]): object_dict(row)
+            for row in connection.execute(select(series_metadata)).mappings().fetchall()
+        }
+        if season_rows
+        else {}
+    )
+
     season_activity = {
         season_prefix: _latest_timestamp(_content_activity_at(row) for row in grouped_rows)
         for season_prefix, grouped_rows in season_rows.items()
@@ -183,11 +211,31 @@ def project_candidates(
         season_prefix: _newest_age_evidence(_media_age(row) for row in grouped_rows)
         for season_prefix, grouped_rows in season_rows.items()
     }
-    resolved_scopes = resolve_media_scopes(
-        connection,
-        prefixes or [],
-        library_types=config.library_type_map,
-    )
+    explicit_scope_keys = {(scope.prefix, scope.match) for scope in resolved_scopes}
+    other_rows_by_prefix: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        media_root = str(row.get("media_root") or "")
+        library = config.library_definition_map.get(media_root, {})
+        if normalize_library_type(library.get("type"), key=media_root) != "other":
+            continue
+        group_scope = other_group_scope_for_rel_path(str(row.get("rel_path") or ""), config)
+        if group_scope is not None:
+            other_rows_by_prefix[group_scope.prefix].append(row)
+    other_group_blockers: dict[str, str | None] = {}
+    for group_prefix, grouped_rows in other_rows_by_prefix.items():
+        library = config.library_definition_map.get(str(grouped_rows[0].get("media_root") or ""), {})
+        profile_blockers = [
+            blocker
+            for row in grouped_rows
+            if (blocker := other_item_profile_blocker(row, library)) is not None
+        ]
+        if len(grouped_rows) > OTHER_FOLDER_SCOPE_MAX_ITEMS:
+            other_group_blockers[group_prefix] = (
+                f"This Other folder contains more than {OTHER_FOLDER_SCOPE_MAX_ITEMS} files. "
+                "Split it or use exact-file grouping before processing."
+            )
+        else:
+            other_group_blockers[group_prefix] = profile_blockers[0] if profile_blockers else None
     normalized_override = normalize_scope_prefix(manual_override_prefix or "")
     decisions: list[CandidateDecision] = []
     production_roots = set(config.source_root_map)
@@ -221,9 +269,18 @@ def project_candidates(
             if membership is not None
             else (True, None)
         )
+        profile_blocker = None
+        if library_type == "other":
+            group_scope = other_group_scope_for_rel_path(rel_path, config)
+            if group_scope is None or (group_scope.prefix, group_scope.match) not in explicit_scope_keys:
+                profile_blocker = (
+                    "Open this item through its bounded Other Library work unit before processing."
+                )
+            else:
+                profile_blocker = other_group_blockers.get(group_scope.prefix)
         production_enabled = media_root in production_roots
-        production_included = production_enabled and member_included
-        production_blocker = member_blocker
+        production_included = production_enabled and member_included and profile_blocker is None
+        production_blocker = profile_blocker or member_blocker
         if not production_enabled:
             label = str(library.get("label") or media_root or "This library")
             production_blocker = f"{label} is browse only; set its availability to Production before processing."
@@ -307,6 +364,7 @@ def project_candidates(
                 media_role=membership.role if membership is not None else None,
                 production_included=production_included,
                 production_blocker=production_blocker,
+                profile_blocker=profile_blocker,
                 target_size_blocker=target_size_blocker,
                 ranking_mode=ranking_mode,
                 media_domain=library_type,
@@ -358,7 +416,7 @@ def workflow_eligibility(decisions: list[CandidateDecision]) -> dict[int, Encode
                 or (decision.target_size_blocker.message if decision.target_size_blocker is not None else None)
                 or (decision.hold_reasons[0].detail if decision.hold_reasons else None)
             ),
-            blocked=decision.target_size_blocker is not None,
+            blocked=decision.profile_blocker is not None or decision.target_size_blocker is not None,
         )
         for decision in decisions
     }
@@ -512,7 +570,11 @@ def candidate_rank_key(decision: CandidateDecision, *, recommendation_score: flo
     )
 
 
-def _load_rows(connection: DBClient) -> list[dict[str, Any]]:
+def _load_rows(
+        connection: DBClient,
+        *,
+        scopes: list[MediaScope] | None = None,
+) -> list[dict[str, Any]]:
     joined = outerjoin(
         outerjoin(
             library_items,
@@ -543,6 +605,10 @@ def _load_rows(connection: DBClient) -> list[dict[str, Any]]:
         .select_from(joined)
         .where(library_items.c.status != "missing")
     )
+    if scopes:
+        query = query.where(
+            or_(*(scope_rel_path_filter(library_items.c.rel_path, scope) for scope in scopes))
+        )
     return [object_dict(row) for row in connection.execute(query).mappings().fetchall()]
 
 

--- a/mediaforce/library/library_settings.py
+++ b/mediaforce/library/library_settings.py
@@ -168,4 +168,4 @@ def library_type_label(library_type: str) -> str:
 
 
 def library_production_supported(library_type: str) -> bool:
-    return library_type in {"tv", "movie"}
+    return library_type in {"tv", "movie", "other"}

--- a/mediaforce/library/other_library.py
+++ b/mediaforce/library/other_library.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+import hashlib
+from collections import Counter, defaultdict
+from collections.abc import Mapping
+from pathlib import PurePosixPath
+from typing import Any
+
+from sqlalchemy import func, outerjoin, select
+
+from mediaforce.core.config import MediaforceConfig
+from mediaforce.core.db import DBClient
+from mediaforce.core.db_tables import library_items, staged_artifacts
+from mediaforce.core.type_defs import mapping_dict, object_dict
+from mediaforce.library.candidate_selection import CandidateDecision, project_candidates, workflow_eligibility
+from mediaforce.library.media_scopes import MediaScope, resolve_media_scope, scope_rel_path_filter
+from mediaforce.library.other_profiles import (
+    OTHER_FOLDER_SCOPE_MAX_ITEMS,
+    OTHER_LIBRARY_CATALOG_MAX_ITEMS,
+    OTHER_LIBRARY_CATALOG_MAX_WORK_UNITS,
+    other_group_scope_for_rel_path,
+    other_item_profile_blocker,
+    other_profile_readiness,
+    other_scope_boundary_blocker,
+)
+from mediaforce.library.workflow_state import build_folder_workflow_states, derive_item_workflow_state
+
+OtherMetrics = Mapping[str, Mapping[str, Any]]
+
+
+def load_other_library_payload(
+        connection: DBClient,
+        config: MediaforceConfig,
+        *,
+        include_details: bool,
+        metrics_by_prefix: OtherMetrics | None = None,
+        candidate_decisions: list[CandidateDecision] | None = None,
+) -> dict[str, Any]:
+    libraries = _other_libraries(config)
+    library_by_root = {str(library["key"]): library for library in libraries}
+    if not library_by_root:
+        return {
+            "schema_version": 1,
+            "libraries": [],
+            "work_units": [],
+            "catalog_empty": True,
+            "catalog_truncated": False,
+            "catalog_item_limit": OTHER_LIBRARY_CATALOG_MAX_ITEMS,
+            "catalog_work_unit_limit": OTHER_LIBRARY_CATALOG_MAX_WORK_UNITS,
+            "details_loading": not include_details,
+        }
+    catalog_rows = [
+        mapping_dict(row)
+        for row in connection.execute(
+            select(library_items)
+            .where(library_items.c.media_root.in_(tuple(library_by_root)))
+            .where(library_items.c.status != "missing")
+            .order_by(library_items.c.rel_path.asc())
+            .limit(OTHER_LIBRARY_CATALOG_MAX_ITEMS + 1)
+        ).mappings().fetchall()
+    ]
+    rows = catalog_rows[:OTHER_LIBRARY_CATALOG_MAX_ITEMS]
+    item_limit_reached = len(catalog_rows) > OTHER_LIBRARY_CATALOG_MAX_ITEMS
+    grouped_rows: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    scopes: dict[str, MediaScope] = {}
+    for row in rows:
+        scope = other_group_scope_for_rel_path(str(row["rel_path"]), config)
+        if scope is None:
+            continue
+        scopes[scope.prefix] = scope
+        grouped_rows[scope.prefix].append(row)
+    ordered_prefixes = sorted(grouped_rows)
+    visible_prefixes = ordered_prefixes[:OTHER_LIBRARY_CATALOG_MAX_WORK_UNITS]
+    work_unit_limit_reached = len(ordered_prefixes) > OTHER_LIBRARY_CATALOG_MAX_WORK_UNITS
+    incomplete_prefix = ""
+    if item_limit_reached and rows:
+        last_scope = other_group_scope_for_rel_path(str(rows[-1]["rel_path"]), config)
+        next_scope = other_group_scope_for_rel_path(
+            str(catalog_rows[OTHER_LIBRARY_CATALOG_MAX_ITEMS]["rel_path"]),
+            config,
+        )
+        if last_scope is not None and next_scope is not None and last_scope.prefix == next_scope.prefix:
+            incomplete_prefix = last_scope.prefix
+    visible_rows = {prefix: grouped_rows[prefix] for prefix in visible_prefixes}
+    decisions = (
+        candidate_decisions
+        if include_details and candidate_decisions is not None
+        else project_candidates(
+            connection,
+            config,
+            prefixes=[prefix for prefix in visible_prefixes if prefix != incomplete_prefix],
+        )
+        if include_details and visible_prefixes
+        else []
+    )
+    decisions_by_item = {decision.item_id: decision for decision in decisions}
+    workflows = (
+        build_folder_workflow_states(
+            connection,
+            visible_prefixes,
+            candidate_eligibility=workflow_eligibility(decisions),
+            library_types=config.library_type_map,
+        )
+        if include_details and visible_prefixes
+        else {}
+    )
+    metrics = metrics_by_prefix or {}
+    work_units = []
+    for prefix in visible_prefixes:
+        grouped = visible_rows[prefix]
+        member_count = len(grouped)
+        total_size_bytes = sum(int(row.get("size_bytes") or 0) for row in grouped)
+        membership_complete = prefix != incomplete_prefix
+        if not membership_complete:
+            member_count, total_size_bytes = connection.execute(
+                select(func.count(), func.coalesce(func.sum(library_items.c.size_bytes), 0))
+                .select_from(library_items)
+                .where(library_items.c.status != "missing")
+                .where(scope_rel_path_filter(library_items.c.rel_path, scopes[prefix]))
+            ).one()
+        work_units.append(_work_unit_payload(
+            scope=scopes[prefix],
+            rows=grouped,
+            library=library_by_root[scopes[prefix].root],
+            decisions_by_item=decisions_by_item,
+            workflow=workflows.get(prefix),
+            metrics=object_dict(metrics.get(prefix)),
+            metrics_available=prefix in metrics,
+            include_details=include_details,
+            member_count=int(member_count),
+            total_size_bytes=int(total_size_bytes or 0),
+            membership_complete=membership_complete,
+        ))
+    work_units.sort(key=lambda unit: (str(unit["title"]).casefold(), str(unit["prefix"])))
+    return {
+        "schema_version": 1,
+        "libraries": libraries,
+        "work_units": work_units,
+        "catalog_empty": not rows,
+        "catalog_truncated": item_limit_reached or work_unit_limit_reached,
+        "catalog_item_limit": OTHER_LIBRARY_CATALOG_MAX_ITEMS,
+        "catalog_work_unit_limit": OTHER_LIBRARY_CATALOG_MAX_WORK_UNITS,
+        "details_loading": not include_details,
+    }
+
+
+def load_other_scope_payload(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+        *,
+        candidate_decisions: list[CandidateDecision] | None = None,
+) -> dict[str, Any] | None:
+    scope = resolve_media_scope(connection, prefix, library_types=config.library_type_map)
+    if scope.domain != "other":
+        return None
+    library = config.library_definition_map.get(scope.root)
+    if library is None or str(library.get("type") or "") != "other":
+        return None
+    if other_scope_boundary_blocker(scope, library) is not None:
+        return None
+    member_count, total_size_bytes = connection.execute(
+            select(func.count(), func.coalesce(func.sum(library_items.c.size_bytes), 0))
+            .select_from(library_items)
+            .where(library_items.c.status != "missing")
+            .where(scope_rel_path_filter(library_items.c.rel_path, scope))
+        ).one()
+    member_count = int(member_count)
+    rows = [
+        mapping_dict(row)
+        for row in connection.execute(
+            _other_member_query(scope).limit(OTHER_FOLDER_SCOPE_MAX_ITEMS)
+        ).mappings().fetchall()
+    ]
+    membership_complete = member_count <= OTHER_FOLDER_SCOPE_MAX_ITEMS
+    decisions = (
+        candidate_decisions or project_candidates(connection, config, prefixes=[scope.prefix])
+        if membership_complete
+        else []
+    )
+    decisions_by_item = {decision.item_id: decision for decision in decisions}
+    eligible_item_count = sum(decision.eligible for decision in decisions)
+    blocked_item_count = (
+        sum(
+            decision.profile_blocker is not None or decision.target_size_blocker is not None
+            for decision in decisions
+        )
+        if membership_complete
+        else member_count
+    )
+    blockers = [
+        blocker
+        for row in rows
+        if (blocker := other_item_profile_blocker(row, library)) is not None
+    ]
+    membership_token = _membership_token(rows) if membership_complete else ""
+    readiness = other_profile_readiness(
+        library,
+        item_count=member_count,
+        blockers=blockers,
+        membership_complete=membership_complete,
+    )
+    members = [
+        _member_payload(row, decisions_by_item.get(int(row["item_id"])), library=library)
+        for row in rows
+    ]
+    return {
+        "schema_version": 1,
+        "prefix": scope.prefix,
+        "root": scope.root,
+        "library_label": str(library.get("label") or scope.root),
+        "availability": str(library.get("availability") or "browse_only"),
+        "default_profile": str(library.get("default_profile") or ""),
+        "policy": object_dict(library.get("policy")),
+        "media_scope": scope.to_payload(),
+        "item_count": member_count,
+        "eligible_item_count": eligible_item_count,
+        "blocked_item_count": blocked_item_count,
+        "total_size_bytes": int(total_size_bytes or 0),
+        "membership_complete": membership_complete,
+        "membership_limit": OTHER_FOLDER_SCOPE_MAX_ITEMS,
+        "membership_requires_confirmation": scope.match == "descendants" and member_count > 0,
+        "membership_token": membership_token,
+        "profile_readiness": readiness,
+        "members": members,
+    }
+
+
+def other_scope_action_blocker(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+        *,
+        membership_token: str,
+) -> dict[str, Any] | None:
+    scope = resolve_media_scope(connection, prefix, library_types=config.library_type_map)
+    if scope.domain != "other":
+        return None
+    library = config.library_definition_map.get(scope.root)
+    if library is None or str(library.get("type") or "") != "other":
+        return None
+    boundary_blocker = other_scope_boundary_blocker(scope, library)
+    if boundary_blocker is not None:
+        return {
+            "ok": False,
+            "code": "other_scope_not_bounded",
+            "message": boundary_blocker,
+        }
+    context = load_other_scope_payload(connection, config, prefix)
+    if context is None:
+        return None
+    readiness = object_dict(context.get("profile_readiness"))
+    if readiness.get("state") != "ready":
+        return {
+            "ok": False,
+            "code": "other_profile_not_ready",
+            "message": str(readiness.get("detail") or "This Other scope is not ready for processing."),
+        }
+    if (
+            bool(context.get("membership_requires_confirmation"))
+            and membership_token != str(context.get("membership_token") or "")
+    ):
+        return {
+            "ok": False,
+            "code": "other_scope_confirmation_required",
+            "message": (
+                f"Review and confirm all {context['item_count']} files in this folder scope before sampling "
+                "or queueing work."
+            ),
+        }
+    return None
+
+
+def _membership_token(rows: list[dict[str, Any]]) -> str:
+    membership = "\n".join(
+        (
+            f"{int(row['item_id'])}:{row.get('rel_path') or ''}:{row.get('fingerprint') or ''}:"
+            f"{int(row.get('size_bytes') or 0)}:{int(row.get('mtime_ns') or 0)}"
+        )
+        for row in rows
+    )
+    return hashlib.sha256(membership.encode("utf-8")).hexdigest()
+
+
+def _other_libraries(config: MediaforceConfig) -> list[dict[str, Any]]:
+    return [
+        {
+            "key": str(definition["key"]),
+            "label": str(definition.get("label") or definition["key"]),
+            "availability": str(definition.get("availability") or "browse_only"),
+            "default_profile": str(definition.get("default_profile") or ""),
+            "policy": object_dict(definition.get("policy")),
+        }
+        for definition in config.library_definitions
+        if str(definition.get("type") or "") == "other"
+        and str(definition.get("availability") or "") != "disabled"
+    ]
+
+
+def _work_unit_payload(
+        *,
+        scope: MediaScope,
+        rows: list[dict[str, Any]],
+        library: Mapping[str, Any],
+        decisions_by_item: Mapping[int, CandidateDecision],
+        workflow: Any,
+        metrics: dict[str, Any],
+        metrics_available: bool,
+        include_details: bool,
+        member_count: int,
+        total_size_bytes: int,
+        membership_complete: bool,
+) -> dict[str, Any]:
+    blockers = [
+        blocker
+        for row in rows
+        if (blocker := other_item_profile_blocker(row, library)) is not None
+    ]
+    membership_complete = membership_complete and member_count <= OTHER_FOLDER_SCOPE_MAX_ITEMS
+    readiness = other_profile_readiness(
+        library,
+        item_count=member_count,
+        blockers=blockers,
+        membership_complete=membership_complete,
+    )
+    statuses = Counter(str(row.get("status") or "unknown") for row in rows)
+    video_codecs = Counter(str(row.get("video_codec") or "unknown") for row in rows)
+    eligible_count = sum(
+        decision.eligible
+        for row in rows
+        if (decision := decisions_by_item.get(int(row["id"]))) is not None
+    )
+    return {
+        "prefix": scope.prefix,
+        "root": scope.root,
+        "library_label": str(library.get("label") or scope.root),
+        "availability": str(library.get("availability") or "browse_only"),
+        "default_profile": str(library.get("default_profile") or ""),
+        "policy": object_dict(library.get("policy")),
+        "title": scope.title,
+        "subtitle": scope.subtitle,
+        "scope_label": scope.scope_label,
+        "scope_mode": "exact_file" if scope.match == "exact_item" else "folder",
+        "media_scope": scope.to_payload(),
+        "item_count": member_count,
+        "total_size_bytes": total_size_bytes,
+        "eligible_item_count": eligible_count if include_details else None,
+        "blocked_item_count": len(blockers) if membership_complete else member_count,
+        "statuses": dict(statuses),
+        "video_codecs": dict(video_codecs),
+        "projected_reclaim_bytes": (
+            int(metrics.get("projected_reclaim_bytes") or 0) if metrics_available else None
+        ),
+        "estimate_unavailable_count": (
+            int(metrics.get("estimate_unavailable_count") or 0) if metrics_available else None
+        ),
+        "profile_readiness": readiness,
+        "workflow_state": workflow.to_payload() if workflow is not None else None,
+        "membership_requires_confirmation": scope.match == "descendants" and member_count > 0,
+        "details_loading": not include_details,
+    }
+
+
+def _other_member_query(scope: MediaScope) -> Any:
+    return (
+        select(
+            library_items,
+            library_items.c.id.label("item_id"),
+            staged_artifacts.c.library_item_id.label("staged_library_item_id"),
+            staged_artifacts.c.staging_path,
+            staged_artifacts.c.promoted_at,
+        )
+        .select_from(
+            outerjoin(
+                library_items,
+                staged_artifacts,
+                staged_artifacts.c.library_item_id == library_items.c.id,
+            )
+        )
+        .where(library_items.c.status != "missing")
+        .where(scope_rel_path_filter(library_items.c.rel_path, scope))
+        .order_by(library_items.c.rel_path.asc())
+    )
+
+
+def _member_payload(
+        row: dict[str, Any],
+        decision: CandidateDecision | None,
+        *,
+        library: Mapping[str, Any],
+) -> dict[str, Any]:
+    profile_blocker = other_item_profile_blocker(row, library)
+    if decision is None:
+        workflow_state = derive_item_workflow_state(
+            row,
+            encode_eligible=profile_blocker is None,
+            policy_blocker=profile_blocker,
+            encode_blocked=profile_blocker is not None,
+        )
+    else:
+        workflow_state = derive_item_workflow_state(
+            row,
+            encode_eligible=(
+                decision.eligible
+                if decision.workflow_lane == "encode"
+                else decision.production_included
+            ),
+            policy_blocker=(
+                decision.production_blocker
+                or (
+                    decision.target_size_blocker.message
+                    if decision.target_size_blocker is not None
+                    else None
+                )
+            ),
+            encode_blocked=(
+                decision.profile_blocker is not None
+                or decision.target_size_blocker is not None
+            ),
+        )
+    rel_path = str(row.get("rel_path") or "")
+    return {
+        "item_id": int(row["item_id"]),
+        "prefix": rel_path,
+        "rel_path": rel_path,
+        "label": PurePosixPath(rel_path).name,
+        "status": str(row.get("status") or "unknown"),
+        "size_bytes": int(row.get("size_bytes") or 0),
+        "duration_seconds": float(row.get("duration_seconds") or 0),
+        "video_codec": str(row.get("video_codec") or "") or None,
+        "width": int(row.get("width") or 0) or None,
+        "height": int(row.get("height") or 0) or None,
+        "profile_supported": profile_blocker is None,
+        "profile_blocker": profile_blocker,
+        "workflow_state": workflow_state.to_payload(),
+    }

--- a/mediaforce/library/other_profiles.py
+++ b/mediaforce/library/other_profiles.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import PurePosixPath
+from typing import Any
+
+from mediaforce.core.config import MediaforceConfig
+from mediaforce.core.type_defs import object_dict
+from mediaforce.library.library_settings import LIBRARY_PROFILE_OPTIONS
+from mediaforce.library.media_scopes import MediaScope, media_scope_from_prefix
+
+OTHER_FOLDER_SCOPE_MAX_ITEMS = 250
+OTHER_LIBRARY_CATALOG_MAX_ITEMS = 5_000
+OTHER_LIBRARY_CATALOG_MAX_WORK_UNITS = 500
+
+
+def other_group_scope_for_rel_path(rel_path: str, config: MediaforceConfig) -> MediaScope | None:
+    normalized = str(rel_path or "").strip().strip("/")
+    parts = PurePosixPath(normalized).parts
+    if len(parts) < 2:
+        return None
+    root = parts[0]
+    library = config.library_definition_map.get(root, {})
+    if str(library.get("type") or "") != "other":
+        return None
+    grouping = str(object_dict(library.get("policy")).get("grouping") or "folder")
+    if grouping == "file" or len(parts) == 2:
+        return media_scope_from_prefix(
+            normalized,
+            match="exact_item",
+            library_types=config.library_type_map,
+        )
+    return media_scope_from_prefix(
+        "/".join(parts[:2]),
+        match="descendants",
+        library_types=config.library_type_map,
+    )
+
+
+def other_scope_boundary_blocker(
+        scope: MediaScope,
+        library: Mapping[str, Any],
+) -> str | None:
+    parts = PurePosixPath(scope.prefix).parts
+    if len(parts) < 2:
+        return "Choose one bounded folder or exact file from the Other Library before processing."
+    grouping = str(object_dict(library.get("policy")).get("grouping") or "folder")
+    if grouping == "file":
+        if scope.match != "exact_item":
+            return "This Other root uses exact-file grouping. Open one file before processing."
+        return None
+    if len(parts) != 2:
+        return "This Other root uses top-level folder grouping. Open the bounded folder from Other Library."
+    if scope.match not in {"descendants", "exact_item"}:
+        return "Choose one bounded folder or exact file from the Other Library before processing."
+    return None
+
+
+def other_profile_label(profile: str) -> str:
+    return next(
+        (
+            option["label"]
+            for option in LIBRARY_PROFILE_OPTIONS["other"]
+            if option["key"] == profile
+        ),
+        "Unconfigured profile",
+    )
+
+
+def other_item_profile_blocker(
+        row: Mapping[str, Any],
+        library: Mapping[str, Any],
+) -> str | None:
+    profile = str(library.get("default_profile") or "").strip()
+    valid_profiles = {option["key"] for option in LIBRARY_PROFILE_OPTIONS["other"]}
+    if profile not in valid_profiles:
+        return "Choose a supported Other processing profile in Settings."
+    video_codec = str(row.get("video_codec") or "").strip().lower()
+    if not video_codec or video_codec == "unknown":
+        return f"{other_profile_label(profile)} requires a detected video stream."
+    if _positive_float(row.get("duration_seconds")) <= 0:
+        return f"{other_profile_label(profile)} requires a measured media duration."
+    if _positive_int(row.get("width")) <= 0 or _positive_int(row.get("height")) <= 0:
+        return f"{other_profile_label(profile)} requires measured frame dimensions."
+    return None
+
+
+def other_profile_readiness(
+        library: Mapping[str, Any],
+        *,
+        item_count: int,
+        blockers: list[str],
+        membership_complete: bool,
+) -> dict[str, Any]:
+    availability = str(library.get("availability") or "browse_only")
+    profile = str(library.get("default_profile") or "")
+    profile_label = other_profile_label(profile)
+    if availability != "production":
+        return {
+            "state": "browse_only",
+            "label": "Browse only",
+            "detail": "Enable Production in Settings before sampling or queueing this scope.",
+            "profile": profile,
+            "profile_label": profile_label,
+            "blockers": [],
+        }
+    if not membership_complete:
+        return {
+            "state": "blocked",
+            "label": "Scope too large",
+            "detail": (
+                f"This folder contains more than {OTHER_FOLDER_SCOPE_MAX_ITEMS} files. "
+                "Choose exact-file grouping or split the source folder before processing."
+            ),
+            "profile": profile,
+            "profile_label": profile_label,
+            "blockers": ["The complete membership cannot be reviewed as one bounded work unit."],
+        }
+    unique_blockers = list(dict.fromkeys(blockers))
+    if unique_blockers:
+        blocked_count = len(blockers)
+        return {
+            "state": "blocked",
+            "label": "Profile blocked",
+            "detail": (
+                f"{blocked_count} of {item_count} files do not meet the {profile_label} requirements. "
+                f"{unique_blockers[0]}"
+            ),
+            "profile": profile,
+            "profile_label": profile_label,
+            "blockers": unique_blockers,
+        }
+    return {
+        "state": "ready",
+        "label": "Profile ready",
+        "detail": (
+            f"All {item_count} indexed files meet the {profile_label} probe requirements."
+            if item_count
+            else f"{profile_label} is selected; this root is currently empty."
+        ),
+        "profile": profile,
+        "profile_label": profile_label,
+        "blockers": [],
+    }
+
+
+def _positive_float(value: Any) -> float:
+    try:
+        return max(float(value or 0), 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _positive_int(value: Any) -> int:
+    try:
+        return max(int(value or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -64,6 +64,9 @@ from mediaforce.library.media_scopes import media_group_scope_for_rel_path, reso
     scope_rel_path_filter, series_context_for_prefix, tv_series_scope_for_rel_path
 from mediaforce.library.movie_library import load_movie_library_payload, load_movie_scope_payload
 from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
+from mediaforce.library.other_library import load_other_library_payload, load_other_scope_payload, \
+    other_group_scope_for_rel_path, other_scope_action_blocker
+from mediaforce.library.other_profiles import OTHER_FOLDER_SCOPE_MAX_ITEMS
 from mediaforce.library.planner import build_manifest_item
 from mediaforce.library.representatives import RepresentativeSelection, load_representative_selection, \
     public_representative_item
@@ -575,6 +578,67 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 candidate_decisions=decisions,
             )
 
+    def _dashboard_other_library_payload() -> dict[str, Any]:
+        with open_db(config.paths.db_path) as connection:
+            return load_other_library_payload(
+                connection,
+                config,
+                include_details=False,
+            )
+
+    def _dashboard_other_library_details_payload() -> dict[str, Any]:
+        with open_db(config.paths.db_path) as connection:
+            other_roots = {
+                root
+                for root, library_type in config.library_type_map.items()
+                if library_type == "other"
+            }
+            if not other_roots:
+                return load_other_library_payload(
+                    connection,
+                    config,
+                    include_details=True,
+                    candidate_decisions=[],
+                )
+            structure = load_other_library_payload(
+                connection,
+                config,
+                include_details=False,
+            )
+            work_unit_prefixes = [
+                str(unit.get("prefix") or "")
+                for unit in structure["work_units"]
+                if str(unit.get("prefix") or "")
+                and int(unit.get("item_count") or 0) <= OTHER_FOLDER_SCOPE_MAX_ITEMS
+            ]
+            decisions = (
+                project_candidates(connection, config, prefixes=work_unit_prefixes)
+                if work_unit_prefixes
+                else []
+            )
+            cards = _folder_cards_for_group(
+                config,
+                connection,
+                folder_group=lambda rel_path: (
+                    scope.group_tuple()
+                    if (scope := other_group_scope_for_rel_path(rel_path, config)) is not None
+                    else None
+                ),
+                minimum_recommended_savings_bytes=None,
+                media_roots=other_roots,
+                candidate_decisions=decisions,
+                restrict_to_candidate_items=True,
+                include_lifecycle=False,
+                include_workflow_states=False,
+            )
+            return load_other_library_payload(
+                connection,
+                config,
+                include_details=True,
+                metrics_by_prefix={card.prefix: asdict(card) for card in cards},
+                candidate_decisions=decisions,
+            )
+
     def _dashboard_api_payload(preview_limit: int | None = None) -> dict[str, Any]:
         metric_support = _metric_support()
         return {
@@ -742,6 +806,8 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         dashboard_library_details_payload=_dashboard_library_details_payload,
         dashboard_movie_library_payload=_dashboard_movie_library_payload,
         dashboard_movie_library_details_payload=_dashboard_movie_library_details_payload,
+        dashboard_other_library_payload=_dashboard_other_library_payload,
+        dashboard_other_library_details_payload=_dashboard_other_library_details_payload,
     )
     register_settings_routes(
         app,
@@ -780,6 +846,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 library_types=config.library_type_map,
             )
             movie_context = None
+            other_context = None
             if media_scope.domain == "movie":
                 membership = classify_movie_path(normalized_prefix, root=media_scope.root)
                 movie_title_prefix = membership.title_prefix if membership is not None else normalized_prefix
@@ -820,6 +887,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 "prefix": normalized_prefix,
                 "media_scope": media_scope.to_payload(),
                 "movie_context": movie_context,
+                "other_context": other_context,
                 "calibration_job": calibration_job,
                 "folder_scan_job": folder_scan_job,
                 "metric_support": metric_support,
@@ -875,6 +943,14 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 if media_scope.domain == "tv"
                 else None
             )
+            if media_scope.domain == "other":
+                other_context = load_other_scope_payload(
+                    connection,
+                    config,
+                    normalized_prefix,
+                    candidate_decisions=lifecycle_decisions,
+                )
+                base_context["other_context"] = other_context
             encode_candidate_count = sum(decision.eligible for decision in lifecycle_decisions)
             workflow_state = build_folder_workflow_state(
                 connection,
@@ -1162,8 +1238,12 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             note: str,
             host_key: str,
             operator_intent: dict[str, Any] | None = None,
+            scope_membership_token: str = "",
     ) -> dict[str, Any]:
         blocker = production_action_blocker(config, normalized_prefix)
+        if blocker is not None:
+            return blocker
+        blocker = _other_scope_action_blocker(normalized_prefix, scope_membership_token)
         if blocker is not None:
             return blocker
         return folder_ai_tune_preview_action(
@@ -1180,8 +1260,12 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             note: str,
             host_key: str,
             operator_intent: dict[str, Any] | None = None,
+            scope_membership_token: str = "",
     ) -> dict[str, Any]:
         blocker = production_action_blocker(config, normalized_prefix)
+        if blocker is not None:
+            return blocker
+        blocker = _other_scope_action_blocker(normalized_prefix, scope_membership_token)
         if blocker is not None:
             return blocker
         return folder_ai_tune_action(
@@ -1193,8 +1277,15 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             operator_intent,
         )
 
-    def _folder_ai_tune_confirm_action(normalized_prefix: str, proposal_id: str) -> dict[str, Any]:
+    def _folder_ai_tune_confirm_action(
+            normalized_prefix: str,
+            proposal_id: str,
+            scope_membership_token: str = "",
+    ) -> dict[str, Any]:
         blocker = production_action_blocker(config, normalized_prefix)
+        if blocker is not None:
+            return blocker
+        blocker = _other_scope_action_blocker(normalized_prefix, scope_membership_token)
         if blocker is not None:
             return blocker
         return folder_ai_tune_confirm_action(
@@ -1209,6 +1300,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             notes: str,
             bypass_schedule: bool,
             override_policy_holds: bool = False,
+            scope_membership_token: str = "",
     ) -> ActionPayload:
         return queue_folder_encode_action(
             config,
@@ -1231,10 +1323,22 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             save_encode_job=save_encode_job,
             load_advice_state=_load_advice_state_for_queue,
             load_latest_failed_target_size_job_state=_load_latest_failed_target_size_job_state,
+            validate_scope_action=lambda connection, prefix: other_scope_action_blocker(
+                connection,
+                config,
+                prefix,
+                membership_token=scope_membership_token,
+            ),
         )
 
-    def _approve_measured_encode_recovery_action(normalized_prefix: str) -> ActionPayload:
+    def _approve_measured_encode_recovery_action(
+            normalized_prefix: str,
+            scope_membership_token: str = "",
+    ) -> ActionPayload:
         blocker = production_action_blocker(config, normalized_prefix)
+        if blocker is not None:
+            return blocker
+        blocker = _other_scope_action_blocker(normalized_prefix, scope_membership_token)
         if blocker is not None:
             return blocker
         return approve_measured_encode_recovery_action(
@@ -1246,25 +1350,49 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             save_calibration_state=_save_calibration_state,
             review_gate=_review_gate,
             upsert_override=_upsert_override,
-            queue_folder_encode_action=_queue_folder_encode_action,
+            queue_folder_encode_action=lambda prefix, notes, bypass_schedule: _queue_folder_encode_action(
+                prefix,
+                notes,
+                bypass_schedule,
+                False,
+                scope_membership_token,
+            ),
         )
 
-    def _validate_folder_outputs_action(normalized_prefix: str) -> ActionPayload:
+    def _validate_folder_outputs_action(
+            normalized_prefix: str,
+            scope_membership_token: str = "",
+    ) -> ActionPayload:
         return validate_folder_outputs_action(
             config,
             normalized_prefix,
             load_active_encode_job_for_prefix_fn=load_active_encode_job_for_prefix,
             load_folder_staged_items_fn=_load_folder_staged_items,
             validate_manifest_items_fn=validate_manifest_items,
+            validate_scope_action=lambda connection, prefix: other_scope_action_blocker(
+                connection,
+                config,
+                prefix,
+                membership_token=scope_membership_token,
+            ),
         )
 
-    def _promote_folder_outputs_action(normalized_prefix: str) -> ActionPayload:
+    def _promote_folder_outputs_action(
+            normalized_prefix: str,
+            scope_membership_token: str = "",
+    ) -> ActionPayload:
         return promote_folder_outputs_action(
             config,
             normalized_prefix,
             load_active_encode_job_for_prefix_fn=load_active_encode_job_for_prefix,
             load_folder_staged_items_fn=_load_folder_staged_items,
             promote_manifest_items_fn=promote_manifest_items,
+            validate_scope_action=lambda connection, prefix: other_scope_action_blocker(
+                connection,
+                config,
+                prefix,
+                membership_token=scope_membership_token,
+            ),
         )
 
     def _save_profile_action(
@@ -1272,7 +1400,11 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             confirm_high_impact: bool,
             confirm_size_tradeoff: bool,
             reviewed_draft_hash: str,
+            scope_membership_token: str = "",
     ) -> ActionPayload:
+        blocker = _other_scope_action_blocker(normalized_prefix, scope_membership_token)
+        if blocker is not None:
+            return blocker
         return save_profile_action(
             config,
             normalized_prefix,
@@ -1289,6 +1421,18 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             confirm_size_tradeoff=confirm_size_tradeoff,
             reviewed_draft_hash=reviewed_draft_hash,
         )
+
+    def _other_scope_action_blocker(
+            normalized_prefix: str,
+            membership_token: str,
+    ) -> dict[str, Any] | None:
+        with open_db(config.paths.db_path) as connection:
+            return other_scope_action_blocker(
+                connection,
+                config,
+                normalized_prefix,
+                membership_token=membership_token,
+            )
 
     def _pause_encode_queue_action() -> dict[str, Any]:
         return pause_encode_queue_action(
@@ -1323,14 +1467,23 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             queue_folder_encode_action=_queue_folder_encode_action,
         )
 
-    def _retry_failed_encode_prefix_action(prefix: str) -> dict[str, Any]:
+    def _retry_failed_encode_prefix_action(
+            prefix: str,
+            scope_membership_token: str = "",
+    ) -> dict[str, Any]:
         return retry_failed_encode_prefix_action(
             connection_factory=lambda: open_db(config.paths.db_path),
             config=config,
             prefix=prefix,
             load_calibration_state=_load_calibration_state,
             review_gate=_review_gate,
-            queue_folder_encode_action=_queue_folder_encode_action,
+            queue_folder_encode_action=lambda normalized_prefix, notes, bypass_schedule: _queue_folder_encode_action(
+                normalized_prefix,
+                notes,
+                bypass_schedule,
+                False,
+                scope_membership_token,
+            ),
         )
 
     def _stop_calibration_queue_action() -> dict[str, Any]:
@@ -2035,6 +2188,7 @@ def _folder_cards_for_group(
         rel_path_root: str | None = None,
         media_roots: set[str] | None = None,
         candidate_decisions: list[CandidateDecision] | None = None,
+        restrict_to_candidate_items: bool = False,
         include_lifecycle: bool = True,
         include_workflow_states: bool = True,
 ) -> list[FolderCard]:
@@ -2073,6 +2227,7 @@ def _folder_cards_for_group(
         rel_path_root=rel_path_root,
         media_roots=media_roots,
         candidate_decisions=candidate_decisions,
+        restrict_to_candidate_items=restrict_to_candidate_items,
         include_lifecycle=include_lifecycle,
         include_workflow_states=include_workflow_states,
     )

--- a/mediaforce/web/routes/dashboard.py
+++ b/mediaforce/web/routes/dashboard.py
@@ -16,6 +16,8 @@ def register_dashboard_routes(
         dashboard_library_details_payload: Callable[[], dict[str, Any]],
         dashboard_movie_library_payload: Callable[[], dict[str, Any]],
         dashboard_movie_library_details_payload: Callable[[], dict[str, Any]],
+        dashboard_other_library_payload: Callable[[], dict[str, Any]],
+        dashboard_other_library_details_payload: Callable[[], dict[str, Any]],
 ) -> None:
     @app.get("/api/dashboard")
     def api_dashboard(preview_limit: PreviewLimit = None) -> JSONResponse:
@@ -40,3 +42,11 @@ def register_dashboard_routes(
     @app.get("/api/dashboard/library/movies/details")
     def api_dashboard_movie_library_details() -> JSONResponse:
         return JSONResponse(dashboard_movie_library_details_payload())
+
+    @app.get("/api/dashboard/library/other")
+    def api_dashboard_other_library() -> JSONResponse:
+        return JSONResponse(dashboard_other_library_payload())
+
+    @app.get("/api/dashboard/library/other/details")
+    def api_dashboard_other_library_details() -> JSONResponse:
+        return JSONResponse(dashboard_other_library_details_payload())

--- a/mediaforce/web/routes/folders.py
+++ b/mediaforce/web/routes/folders.py
@@ -15,22 +15,30 @@ def _request_flag(body: object, key: str) -> bool:
     return isinstance(body, dict) and body.get(key) is True
 
 
+async def _request_body(request: Request) -> dict[str, Any]:
+    try:
+        body = await request.json()
+    except Exception:
+        return {}
+    return body if isinstance(body, dict) else {}
+
+
 def register_folder_routes(
         app: FastAPI,
         *,
         folder_status_payload: Callable[[str], dict[str, Any]],
         folder_content_payload: Callable[[str], tuple[dict[str, Any], int]],
         download_review_compare_action: Callable[[str], FileResponse],
-        folder_ai_tune_action: Callable[[str, str, str, dict[str, Any] | None], dict[str, Any]],
-        folder_ai_tune_preview_action: Callable[[str, str, str, dict[str, Any] | None], dict[str, Any]],
-        folder_ai_tune_confirm_action: Callable[[str, str], dict[str, Any]],
+        folder_ai_tune_action: Callable[[str, str, str, dict[str, Any] | None, str], dict[str, Any]],
+        folder_ai_tune_preview_action: Callable[[str, str, str, dict[str, Any] | None, str], dict[str, Any]],
+        folder_ai_tune_confirm_action: Callable[[str, str, str], dict[str, Any]],
         clear_folder_tuning_action: Callable[[str], dict[str, Any]],
         save_series_lifecycle_action: Callable[[str, str], dict[str, Any]],
-        approve_measured_encode_recovery_action: Callable[[str], dict[str, Any]],
-        queue_folder_encode_action: Callable[[str, str, bool, bool], dict[str, Any]],
-        validate_folder_outputs_action: Callable[[str], dict[str, Any]],
-        promote_folder_outputs_action: Callable[[str], dict[str, Any]],
-        save_profile_action: Callable[[str, bool, bool, str], dict[str, Any]],
+        approve_measured_encode_recovery_action: Callable[[str, str], dict[str, Any]],
+        queue_folder_encode_action: Callable[[str, str, bool, bool, str], dict[str, Any]],
+        validate_folder_outputs_action: Callable[[str, str], dict[str, Any]],
+        promote_folder_outputs_action: Callable[[str, str], dict[str, Any]],
+        save_profile_action: Callable[[str, bool, bool, str, str], dict[str, Any]],
 ) -> None:
     @app.get("/api/folders/{prefix:path}/status")
     def api_folder_status(prefix: str) -> JSONResponse:
@@ -47,35 +55,38 @@ def register_folder_routes(
 
     @app.post("/api/folders/{prefix:path}/ai-tune")
     async def api_folder_ai_tune(prefix: str, request: Request) -> JSONResponse:
-        body = await request.json()
+        body = await _request_body(request)
         result = await run_in_threadpool(
             folder_ai_tune_action,
             prefix.strip("/"),
             str(body.get("note", "")),
             str(body.get("host_key", "")),
             object_dict_or_none(body.get("operator_intent")),
+            str(body.get("scope_membership_token", "")),
         )
         return JSONResponse(result, status_code=200 if result.get("ok") else 409)
 
     @app.post("/api/folders/{prefix:path}/ai-tune/preview")
     async def api_folder_ai_tune_preview(prefix: str, request: Request) -> JSONResponse:
-        body = await request.json()
+        body = await _request_body(request)
         result = await run_in_threadpool(
             folder_ai_tune_preview_action,
             prefix.strip("/"),
             str(body.get("note", "")),
             str(body.get("host_key", "")),
             object_dict_or_none(body.get("operator_intent")),
+            str(body.get("scope_membership_token", "")),
         )
         return JSONResponse(result, status_code=200 if result.get("ok") else 409)
 
     @app.post("/api/folders/{prefix:path}/ai-tune/confirm")
     async def api_folder_ai_tune_confirm(prefix: str, request: Request) -> JSONResponse:
-        body = await request.json()
+        body = await _request_body(request)
         result = await run_in_threadpool(
             folder_ai_tune_confirm_action,
             prefix.strip("/"),
             str(body.get("proposal_id", "")),
+            str(body.get("scope_membership_token", "")),
         )
         return JSONResponse(result, status_code=200 if result.get("ok") else 409)
 
@@ -86,7 +97,7 @@ def register_folder_routes(
 
     @app.post("/api/folders/{prefix:path}/series-lifecycle")
     async def api_folder_series_lifecycle(prefix: str, request: Request) -> JSONResponse:
-        body = await request.json()
+        body = await _request_body(request)
         result = save_series_lifecycle_action(
             prefix.strip("/"),
             str(body.get("mode", "")),
@@ -95,39 +106,56 @@ def register_folder_routes(
 
     @app.post("/api/folders/{prefix:path}/queue-encode")
     async def api_folder_queue_encode(prefix: str, request: Request) -> JSONResponse:
-        body = await request.json()
-        result = queue_folder_encode_action(
+        body = await _request_body(request)
+        result = await run_in_threadpool(
+            queue_folder_encode_action,
             prefix.strip("/"),
             str(body.get("notes", "")),
             _request_flag(body, "bypass_schedule"),
             _request_flag(body, "override_policy_holds"),
+            str(body.get("scope_membership_token", "")),
         )
         return JSONResponse(result, status_code=200 if result.get("ok") else 409)
 
     @app.post("/api/folders/{prefix:path}/approve-recovery")
-    def api_folder_approve_recovery(prefix: str) -> JSONResponse:
-        result = approve_measured_encode_recovery_action(prefix.strip("/"))
+    async def api_folder_approve_recovery(prefix: str, request: Request) -> JSONResponse:
+        body = await _request_body(request)
+        result = await run_in_threadpool(
+            approve_measured_encode_recovery_action,
+            prefix.strip("/"),
+            str(body.get("scope_membership_token", "")),
+        )
         return JSONResponse(result, status_code=200 if result.get("ok") else 409)
 
     @app.post("/api/folders/{prefix:path}/validate-outputs")
-    def api_folder_validate_outputs(prefix: str) -> JSONResponse:
-        result = validate_folder_outputs_action(prefix.strip("/"))
+    async def api_folder_validate_outputs(prefix: str, request: Request) -> JSONResponse:
+        body = await _request_body(request)
+        result = await run_in_threadpool(
+            validate_folder_outputs_action,
+            prefix.strip("/"),
+            str(body.get("scope_membership_token", "")),
+        )
         return JSONResponse(result, status_code=200 if result.get("ok") else 409)
 
     @app.post("/api/folders/{prefix:path}/promote-outputs")
-    def api_folder_promote_outputs(prefix: str) -> JSONResponse:
-        result = promote_folder_outputs_action(prefix.strip("/"))
+    async def api_folder_promote_outputs(prefix: str, request: Request) -> JSONResponse:
+        body = await _request_body(request)
+        result = await run_in_threadpool(
+            promote_folder_outputs_action,
+            prefix.strip("/"),
+            str(body.get("scope_membership_token", "")),
+        )
         return JSONResponse(result, status_code=200 if result.get("ok") else 409)
+
     @app.post("/api/folders/{prefix:path}/save-profile")
     async def api_folder_save_profile(prefix: str, request: Request) -> JSONResponse:
-        try:
-            body = await request.json()
-        except Exception:
-            body = {}
-        result = save_profile_action(
+        body = await _request_body(request)
+        result = await run_in_threadpool(
+            save_profile_action,
             prefix.strip("/"),
             bool(body.get("confirm_high_impact", False)),
             bool(body.get("confirm_size_tradeoff", False)),
             str(body.get("reviewed_draft_hash", "")),
+            str(body.get("scope_membership_token", "")),
         )
         return JSONResponse(result, status_code=200 if result.get("ok") else 409)

--- a/mediaforce/web/routes/queues.py
+++ b/mediaforce/web/routes/queues.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
 
 
 def register_queue_routes(
@@ -11,7 +12,7 @@ def register_queue_routes(
         pause_encode_queue_action: Callable[[], dict[str, Any]],
         resume_encode_queue_action: Callable[[], dict[str, Any]],
         retry_failed_encode_queue_action: Callable[[], dict[str, Any]],
-        retry_failed_encode_prefix_action: Callable[[str], dict[str, Any]],
+        retry_failed_encode_prefix_action: Callable[[str, str], dict[str, Any]],
         stop_encode_queue_action: Callable[[], dict[str, Any]],
         stop_calibration_queue_action: Callable[[], dict[str, Any]],
 ) -> None:
@@ -30,7 +31,12 @@ def register_queue_routes(
     @app.post("/api/encode-queue/retry-prefix")
     async def api_retry_failed_encode_prefix(request: Request) -> JSONResponse:
         body = await request.json()
-        return JSONResponse(retry_failed_encode_prefix_action(str(body.get("prefix", "")).strip()))
+        result = await run_in_threadpool(
+            retry_failed_encode_prefix_action,
+            str(body.get("prefix", "")).strip(),
+            str(body.get("scope_membership_token", "")),
+        )
+        return JSONResponse(result)
 
     @app.post("/api/encode-queue/stop")
     def api_stop_encode_queue() -> JSONResponse:

--- a/mediaforce/web/runtime/folder_actions.py
+++ b/mediaforce/web/runtime/folder_actions.py
@@ -56,6 +56,7 @@ LoadAdviceStateFn: TypeAlias = Callable[[MediaforceConfig, str], ActionPayload |
 MergeAdviceStateFn: TypeAlias = Callable[[MediaforceConfig, str, ActionPayload], ActionPayload]
 LoadSampleItemFn: TypeAlias = Callable[[DBClient, MediaforceConfig, str], FolderItem | None]
 QueueFolderEncodeActionFn: TypeAlias = Callable[[str, str, bool], ActionPayload]
+ValidateScopeActionFn: TypeAlias = Callable[[DBClient, str], ActionPayload | None]
 
 
 def _calibration_policy_hash(payload: ActionPayload) -> str:
@@ -212,11 +213,17 @@ def queue_folder_encode_action(
         save_encode_job: SaveEncodeJobFn,
         load_advice_state: LoadAdviceStateFn | None = None,
         load_latest_failed_target_size_job_state: LoadJobStateFn | None = None,
+        validate_scope_action: ValidateScopeActionFn | None = None,
 ) -> ActionPayload:
     production_blocker = production_action_blocker(config, normalized_prefix)
     if production_blocker is not None:
         return production_blocker
     with open_db(config.paths.db_path) as connection:
+        if validate_scope_action is not None:
+            connection.exec_driver_sql("BEGIN IMMEDIATE")
+            scope_blocker = validate_scope_action(connection, normalized_prefix)
+            if scope_blocker is not None:
+                return scope_blocker
         scope = resolve_media_scope(
             connection,
             normalized_prefix,
@@ -629,6 +636,7 @@ def validate_folder_outputs_action(
         load_active_encode_job_for_prefix_fn: LoadActiveEncodeJobFn | None = None,
         load_folder_staged_items_fn: LoadFolderStagedItemsFn,
         validate_manifest_items_fn: ValidateManifestItemsFn,
+        validate_scope_action: ValidateScopeActionFn | None = None,
 ) -> ActionPayload:
     production_blocker = production_action_blocker(config, normalized_prefix)
     if production_blocker is not None:
@@ -636,6 +644,11 @@ def validate_folder_outputs_action(
     if load_active_encode_job_for_prefix_fn is None:
         load_active_encode_job_for_prefix_fn = _no_active_encode_job
     with open_db(config.paths.db_path) as connection:
+        if validate_scope_action is not None:
+            connection.exec_driver_sql("BEGIN")
+            scope_blocker = validate_scope_action(connection, normalized_prefix)
+            if scope_blocker is not None:
+                return scope_blocker
         active_encode_job = load_active_encode_job_for_prefix_fn(connection, normalized_prefix)
         encode_blocked = _validate_delivery_blocked_by_active_encode(active_encode_job)
         if encode_blocked is not None:
@@ -691,6 +704,7 @@ def promote_folder_outputs_action(
         load_active_encode_job_for_prefix_fn: LoadActiveEncodeJobFn | None = None,
         load_folder_staged_items_fn: LoadFolderStagedItemsFn,
         promote_manifest_items_fn: PromoteManifestItemsFn,
+        validate_scope_action: ValidateScopeActionFn | None = None,
 ) -> ActionPayload:
     production_blocker = production_action_blocker(config, normalized_prefix)
     if production_blocker is not None:
@@ -698,6 +712,11 @@ def promote_folder_outputs_action(
     if load_active_encode_job_for_prefix_fn is None:
         load_active_encode_job_for_prefix_fn = _no_active_encode_job
     with open_db(config.paths.db_path) as connection:
+        if validate_scope_action is not None:
+            connection.exec_driver_sql("BEGIN")
+            scope_blocker = validate_scope_action(connection, normalized_prefix)
+            if scope_blocker is not None:
+                return scope_blocker
         active_encode_job = load_active_encode_job_for_prefix_fn(connection, normalized_prefix)
         encode_blocked = _validate_delivery_blocked_by_active_encode(active_encode_job)
         if encode_blocked is not None:

--- a/mediaforce/web/runtime/folder_cards.py
+++ b/mediaforce/web/runtime/folder_cards.py
@@ -340,6 +340,7 @@ def list_folder_cards(
         rel_path_root: str | None = None,
         media_roots: set[str] | None = None,
         candidate_decisions: list[CandidateDecision] | None = None,
+        restrict_to_candidate_items: bool = False,
         include_lifecycle: bool = True,
         include_workflow_states: bool = True,
 ) -> list[FolderCard]:
@@ -382,6 +383,11 @@ def list_folder_cards(
         if not media_roots:
             return []
         query = query.where(library_items.c.media_root.in_(tuple(media_roots)))
+    if restrict_to_candidate_items:
+        candidate_item_ids = tuple(decision.item_id for decision in candidate_decisions)
+        if not candidate_item_ids:
+            return []
+        query = query.where(library_items.c.id.in_(candidate_item_ids))
     rows = connection.execute(query.order_by(library_items.c.rel_path)).mappings().fetchall()
     grouped: dict[str, FolderCard] = {}
     for row in rows:

--- a/mediaforce/web/settings_runtime.py
+++ b/mediaforce/web/settings_runtime.py
@@ -144,6 +144,7 @@ def index_settings_library_rows(rows: list[dict[str, Any]], *, min_rows: int = 1
                     path=str(row.get("path") or ""),
                     library_type=library_type,
                     availability=str(definition["availability"]),
+                    default_profile=str(definition["default_profile"]),
                     policy=dict(definition["policy"]),
                 ),
                 "type_change_confirmation": "",
@@ -179,6 +180,7 @@ def library_readiness(
         path: str,
         library_type: str,
         availability: str,
+        default_profile: str,
         policy: dict[str, Any],
 ) -> dict[str, str]:
     if not key or not label.strip() or not path.strip():
@@ -215,6 +217,19 @@ def library_readiness(
             "state": "blocked",
             "label": "Workflow blocked",
             "detail": f"{library_type_label(library_type)} production is not available yet.",
+        }
+    if library_type == "other":
+        valid_profiles = {option["key"] for option in LIBRARY_PROFILE_OPTIONS["other"]}
+        if default_profile not in valid_profiles:
+            return {
+                "state": "incomplete",
+                "label": "Profile needed",
+                "detail": "Choose an explicit Other processing profile before enabling Production.",
+            }
+        return {
+            "state": "ready",
+            "label": "Ready",
+            "detail": "Generic file and folder scopes use the selected profile and require probe readiness.",
         }
     return {"state": "ready", "label": "Ready", "detail": "Scanning and production processing are enabled."}
 

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -54,6 +54,13 @@ MOVIE_LOOSE_PREFIX = "movies/Loose Feature.mkv"
 MOVIE_EDITIONS_PREFIX = "movies/Editions Showcase"
 MOVIE_CONFLICT_PREFIX = "movies/Promotion Conflict"
 MOVIE_TARGET_BLOCKED_PREFIX = "movies/Target Too Large"
+OTHER_FOLDER_PREFIX = "other/Field Notes"
+OTHER_ROOT_FILE_PREFIX = "other/Loose Capture.mkv"
+OTHER_BLOCKED_PREFIX = "other/Needs Probe"
+OTHER_OVERSIZED_PREFIX = "other/Oversized Intake"
+OTHER_ACTIVE_PREFIX = "other/Active Batch"
+OTHER_VALIDATION_PREFIX = "other/Validation Ready"
+OTHER_PROMOTION_PREFIX = "other/Promotion Ready"
 CURRENT_PREVIOUS_PREFIX = "tv/Current Season/Season 1"
 CURRENT_SEASON_PREFIX = "tv/Current Season/Season 2"
 CURRENT_SERIES_PREFIX = "tv/Current Season"
@@ -82,6 +89,13 @@ FIXTURE_PREFIXES = (
     MOVIE_EDITIONS_PREFIX,
     MOVIE_CONFLICT_PREFIX,
     MOVIE_TARGET_BLOCKED_PREFIX,
+    OTHER_FOLDER_PREFIX,
+    OTHER_ROOT_FILE_PREFIX,
+    OTHER_BLOCKED_PREFIX,
+    OTHER_OVERSIZED_PREFIX,
+    OTHER_ACTIVE_PREFIX,
+    OTHER_VALIDATION_PREFIX,
+    OTHER_PROMOTION_PREFIX,
     CURRENT_PREVIOUS_PREFIX,
     CURRENT_SEASON_PREFIX,
     PROTECTED_READY_PREFIX,
@@ -113,6 +127,8 @@ def _library_item(
     recommendation_reason: str,
     duration_seconds: float = 3_600.0,
     age_days: int = 730,
+    width: int | None = 1920,
+    height: int | None = 1080,
 ) -> dict[str, Any]:
     timestamp = (datetime.now(UTC) - timedelta(days=age_days)).isoformat(timespec="seconds")
     source_path = _resolve_under_project(
@@ -217,8 +233,8 @@ def _library_item(
         "duration_seconds": duration_seconds,
         "video_codec": video_codec,
         "video_bitrate": 8_000_000 if video_codec == "h264" else 4_500_000,
-        "width": 1920,
-        "height": 1080,
+        "width": width,
+        "height": height,
         "pix_fmt": "yuv420p",
         "audio_track_count": 1,
         "subtitle_track_count": 1,
@@ -1077,7 +1093,108 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 recommendation_reason="Fixture movie promotion collision for browser QA.",
                 age_days=900,
             ),
+            _library_item(
+                project_root=project_root,
+                media_root="other",
+                rel_path="other/Field Notes/Camera A.mkv",
+                size_bytes=4 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=69,
+                recommendation="review_encode",
+                recommendation_reason="Fixture bounded Other folder member for browser QA.",
+                age_days=820,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="other",
+                rel_path="other/Field Notes/Nested/Camera B.mkv",
+                size_bytes=3 * 1024**3,
+                status="planned",
+                video_codec="hevc",
+                priority_score=61,
+                recommendation="review_encode",
+                recommendation_reason="Fixture nested Other folder member for membership review.",
+                age_days=810,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="other",
+                rel_path=OTHER_ROOT_FILE_PREFIX,
+                size_bytes=5 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=67,
+                recommendation="review_encode",
+                recommendation_reason="Fixture root-level exact Other file for browser QA.",
+                age_days=800,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="other",
+                rel_path="other/Needs Probe/Unknown Stream.mkv",
+                size_bytes=2 * 1024**3,
+                status="discovered",
+                video_codec="",
+                priority_score=30,
+                recommendation="review_encode",
+                recommendation_reason="Fixture unsupported Other profile state for browser QA.",
+                age_days=790,
+                width=None,
+                height=None,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="other",
+                rel_path="other/Active Batch/Camera C.mkv",
+                size_bytes=6 * 1024**3,
+                status="encoding",
+                video_codec="h264",
+                priority_score=65,
+                recommendation="review_encode",
+                recommendation_reason="Fixture active Other processing state for browser QA.",
+                age_days=780,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="other",
+                rel_path="other/Validation Ready/Camera D.mkv",
+                size_bytes=5 * 1024**3,
+                status="encoded",
+                video_codec="h264",
+                priority_score=64,
+                recommendation="review_encode",
+                recommendation_reason="Fixture Other validation state for browser QA.",
+                age_days=770,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="other",
+                rel_path="other/Promotion Ready/Camera E.mkv",
+                size_bytes=5 * 1024**3,
+                status="validated",
+                video_codec="hevc",
+                priority_score=63,
+                recommendation="review_encode",
+                recommendation_reason="Fixture Other promotion state for browser QA.",
+                age_days=760,
+            ),
         ]
+        rows.extend(
+            _library_item(
+                project_root=project_root,
+                media_root="other",
+                rel_path=f"{OTHER_OVERSIZED_PREFIX}/Clip-{index:03d}.mkv",
+                size_bytes=32 * 1024**2,
+                status="discovered",
+                video_codec="h264",
+                priority_score=25,
+                recommendation="review_encode",
+                recommendation_reason="Fixture oversized Other scope for browser safety coverage.",
+                age_days=700,
+            )
+            for index in range(251)
+        )
         inserted_ids: list[int] = []
         for row in rows:
             result = connection.execute(library_items.insert().values(**row))
@@ -1225,6 +1342,8 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
         for prefix, validated_at in (
             (VALIDATION_PREFIX, None),
             (PROMOTION_PREFIX, timestamp),
+            (OTHER_VALIDATION_PREFIX, None),
+            (OTHER_PROMOTION_PREFIX, timestamp),
         ):
             row = rows_by_prefix[prefix]
             item_id = ids_by_rel_path[str(row["rel_path"])]
@@ -1395,6 +1514,25 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 status="queued",
                 waiting_reason="No configured host is available for queued encode work.",
             ),
+            _encode_job(
+                project_root=project_root,
+                job_id="web-smoke-other-running",
+                prefix=OTHER_ACTIVE_PREFIX,
+                rel_path="other/Active Batch/Camera C.mkv",
+                status="running",
+                progress={
+                    "total_duration_seconds": 3600.0,
+                    "overall_completed_duration_seconds": 900.0,
+                    "remaining_duration_seconds": 2700.0,
+                    "percent_complete": 25,
+                    "fps": 76.0,
+                    "speed": 1.55,
+                    "current_item_number": 1,
+                    "total_item_count": 1,
+                    "current_item_rel_path": "other/Active Batch/Camera C.mkv",
+                    "progress_state": "encoding",
+                },
+            ),
         ]
         for row in encode_rows:
             connection.execute(encode_jobs.insert().values(**row))
@@ -1416,6 +1554,53 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
         "folderPrefix": FOLDER_PREFIX,
         "folderRoute": "/folders/tv/Example%20Show/Season%201",
         "folderRoutes": [
+            {
+                "label": "Other Library fixture",
+                "route": "/other",
+                "marker": "Field Notes",
+            },
+            {
+                "label": "Other Studio bounded-folder fixture",
+                "route": "/folders/other/Field%20Notes",
+                "marker": "Field Notes",
+                "stageMarker": "Files in this scope",
+            },
+            {
+                "label": "Other Studio exact-file fixture",
+                "route": "/folders/other/Loose%20Capture.mkv",
+                "marker": "Loose Capture",
+                "stageMarker": "One exact file",
+            },
+            {
+                "label": "Other Studio profile-blocked fixture",
+                "route": "/folders/other/Needs%20Probe",
+                "marker": "Needs Probe",
+                "stageMarker": "Profile blocked",
+            },
+            {
+                "label": "Other Studio oversized-scope fixture",
+                "route": "/folders/other/Oversized%20Intake",
+                "marker": "Oversized Intake",
+                "stageMarker": "More than 250 files",
+            },
+            {
+                "label": "Other Studio active-processing fixture",
+                "route": "/folders/other/Active%20Batch",
+                "marker": "Active Batch",
+                "stageMarker": "Production is active.",
+            },
+            {
+                "label": "Other Studio validation fixture",
+                "route": "/folders/other/Validation%20Ready",
+                "marker": "Validation Ready",
+                "stageMarker": "Validate ready output",
+            },
+            {
+                "label": "Other Studio promotion fixture",
+                "route": "/folders/other/Promotion%20Ready",
+                "marker": "Promotion Ready",
+                "stageMarker": "Promote validated output",
+            },
             {
                 "label": "Folder Studio waiting fixture",
                 "route": "/folders/tv/Example%20Show/Season%201",
@@ -1555,7 +1740,7 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
         ],
         "completedPrefix": COMPLETED_PREFIX,
         "libraryItems": len(rows),
-        "encodeJobs": 3,
+        "encodeJobs": 4,
     }
 
 

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -44,6 +44,8 @@ const endpointChecks = [
   ["Library details", "/api/dashboard/library/details"],
   ["Movie library structure", "/api/dashboard/library/movies"],
   ["Movie library details", "/api/dashboard/library/movies/details"],
+  ["Other library structure", "/api/dashboard/library/other"],
+  ["Other library details", "/api/dashboard/library/other/details"],
   ["Host status", "/api/hosts?compact=1"],
   ["Settings initial payload", "/api/settings?include_archive_cleanup=0"],
   ["Completed payload", "/api/completed"],
@@ -52,6 +54,7 @@ const endpointChecks = [
 const routeChecks = [
   ["Library", "/", "Your library"],
   ["Movies Library", "/movies", "MOVIE WORKSTATION"],
+  ["Other Library", "/other", "Other Library"],
   ["Folders compatibility", "/folders", "Your library"],
   ["Activity", "/ops", "What’s happening"],
   ["Settings", "/settings", "Library and working space"],
@@ -607,6 +610,7 @@ async function checkEmptyFixtureRoutes(baseUrl, configPath, timeoutMs, narrow) {
   const emptyRouteChecks = [
     ["Empty Library", "/", "Point Mediaforce at your TV folder"],
     ["Empty Folders", "/folders", "Point Mediaforce at your TV folder"],
+    ["Empty Other Library", "/other", "No Other media is indexed"],
     ["Empty Activity", "/ops", "Nothing is running right now"],
     ["Empty Finished", "/completed", "No finished seasons match this search"],
   ];
@@ -643,9 +647,15 @@ async function main() {
     await checkEndpoints(targetUrl, args.endpointTimeoutMs);
     await checkRoutes(targetUrl, browserRouteChecks, args.routeTimeoutMs);
     if (fixtures?.folderRoutes?.length) {
+      const libraryFixture = fixtures.folderRoutes.find((fixtureRoute) =>
+        fixtureRoute.route.startsWith("/folders/tv/"),
+      );
+      if (!libraryFixture) {
+        throw new Error("Fixture payload did not include a TV library route.");
+      }
       await checkLibraryStructureWithoutDashboard(
         targetUrl,
-        fixtures.folderRoutes[0].marker,
+        libraryFixture.marker,
         args.routeTimeoutMs,
       );
     }

--- a/tests/test_movie_workflow.py
+++ b/tests/test_movie_workflow.py
@@ -174,7 +174,7 @@ class MovieWorkflowTests(unittest.TestCase):
         self.assertEqual(oldest_sorted[0].age.source, "plex")
         self.assertEqual(largest_sorted[0].item_id, larger_id)
 
-    def test_typed_movie_root_can_enter_production_while_other_and_spatial_remain_blocked(self) -> None:
+    def test_typed_movie_and_other_roots_can_enter_production_while_spatial_remains_blocked(self) -> None:
         config = self._config(
             extras="exclude",
             additional_libraries=[
@@ -192,7 +192,7 @@ class MovieWorkflowTests(unittest.TestCase):
                 },
             ],
         )
-        self.assertEqual(set(config.source_root_map), {"films"})
+        self.assertEqual(set(config.source_root_map), {"films", "other"})
 
     def test_movie_library_payload_keeps_editions_extras_age_and_conflicts_visible(self) -> None:
         with open_db(self.config.paths.db_path) as connection:

--- a/tests/test_other_workflow.py
+++ b/tests/test_other_workflow.py
@@ -1,0 +1,384 @@
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+from mediaforce.core.config import ConfigPaths, MediaforceConfig
+from mediaforce.core.db import DBClient, open_db, reset_engine_cache
+from mediaforce.core.db_tables import library_items
+from mediaforce.library.candidate_selection import project_candidates, workflow_eligibility
+from mediaforce.library.other_library import load_other_library_payload, load_other_scope_payload, \
+    other_group_scope_for_rel_path, other_scope_action_blocker
+from mediaforce.library.workflow_state import build_folder_workflow_state
+from mediaforce.web.runtime.folder_actions import (
+    promote_folder_outputs_action,
+    queue_folder_encode_action,
+    validate_folder_outputs_action,
+)
+
+
+class OtherWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+
+    def tearDown(self) -> None:
+        reset_engine_cache()
+        self.temp_dir.cleanup()
+
+    def test_folder_grouping_uses_exact_root_files_and_bounded_top_level_folders(self) -> None:
+        config = self._config(grouping="folder")
+
+        root_file = other_group_scope_for_rel_path("other/Loose.mkv", config)
+        nested = other_group_scope_for_rel_path("other/Collection/Nested/Clip.mkv", config)
+
+        self.assertEqual(
+            (root_file.prefix, root_file.match, root_file.scope_label),
+            ("other/Loose.mkv", "exact_item", "File"),
+        )
+        self.assertEqual(
+            (nested.prefix, nested.match, nested.scope_label),
+            ("other/Collection", "descendants", "Folder"),
+        )
+
+    def test_file_grouping_keeps_every_item_exact(self) -> None:
+        config = self._config(grouping="file")
+
+        nested = other_group_scope_for_rel_path("other/Collection/Nested/Clip.mkv", config)
+
+        self.assertEqual(
+            (nested.prefix, nested.match, nested.scope_label),
+            ("other/Collection/Nested/Clip.mkv", "exact_item", "File"),
+        )
+
+    def test_profile_probe_requirements_block_the_whole_bounded_scope(self) -> None:
+        config = self._config(grouping="folder")
+        with open_db(config.paths.db_path) as connection:
+            ready_id = self._insert_item(connection, "other/Collection/Ready.mkv")
+            blocked_id = self._insert_item(
+                connection,
+                "other/Collection/Unprobed.mkv",
+                width=None,
+                height=None,
+            )
+            decisions = project_candidates(connection, config, prefixes=["other/Collection"])
+            workflow = build_folder_workflow_state(
+                connection,
+                "other/Collection",
+                candidate_eligibility=workflow_eligibility(decisions),
+                library_types=config.library_type_map,
+            )
+
+        by_id = {decision.item_id: decision for decision in decisions}
+        self.assertFalse(by_id[ready_id].eligible)
+        self.assertIn("frame dimensions", by_id[ready_id].profile_blocker)
+        self.assertFalse(by_id[blocked_id].eligible)
+        self.assertIn("frame dimensions", by_id[blocked_id].profile_blocker)
+        self.assertEqual(workflow.primary_lane, "blocked")
+        self.assertIn("frame dimensions", workflow.blockers[0])
+
+    def test_library_and_scope_payloads_keep_membership_and_confirmation_explicit(self) -> None:
+        config = self._config(grouping="folder")
+        with open_db(config.paths.db_path) as connection:
+            self._insert_item(connection, "other/Collection/One.mkv", size_bytes=1_000)
+            self._insert_item(connection, "other/Collection/Two.mkv", size_bytes=2_000)
+            self._insert_item(connection, "other/Loose.mkv", size_bytes=3_000)
+            payload = load_other_library_payload(connection, config, include_details=True)
+            context = load_other_scope_payload(connection, config, "other/Collection")
+            blocked = other_scope_action_blocker(
+                connection,
+                config,
+                "other/Collection",
+                membership_token="",
+            )
+            allowed = other_scope_action_blocker(
+                connection,
+                config,
+                "other/Collection",
+                membership_token=str(context["membership_token"]),
+            )
+
+        units = {unit["prefix"]: unit for unit in payload["work_units"]}
+        folder = units["other/Collection"]
+        self.assertEqual(folder["item_count"], 2)
+        self.assertEqual(folder["total_size_bytes"], 3_000)
+        self.assertEqual(folder["profile_readiness"]["state"], "ready")
+        self.assertTrue(folder["membership_requires_confirmation"])
+        self.assertEqual(
+            [member["prefix"] for member in context["members"]],
+            ["other/Collection/One.mkv", "other/Collection/Two.mkv"],
+        )
+        self.assertTrue(context["membership_complete"])
+        self.assertEqual(blocked["code"], "other_scope_confirmation_required")
+        self.assertIsNone(allowed)
+
+    def test_single_member_folder_still_requires_membership_confirmation(self) -> None:
+        config = self._config(grouping="folder")
+        with open_db(config.paths.db_path) as connection:
+            self._insert_item(connection, "other/Collection/Only.mkv")
+            context = load_other_scope_payload(connection, config, "other/Collection")
+            blocker = other_scope_action_blocker(
+                connection,
+                config,
+                "other/Collection",
+                membership_token="",
+            )
+
+        self.assertTrue(context["membership_requires_confirmation"])
+        self.assertEqual(blocker["code"], "other_scope_confirmation_required")
+
+    def test_server_rejects_noncanonical_other_scopes(self) -> None:
+        folder_config = self._config(grouping="folder")
+        with open_db(folder_config.paths.db_path) as connection:
+            self._insert_item(connection, "other/Collection/Nested/Clip.mkv")
+            nested_file = other_scope_action_blocker(
+                connection,
+                folder_config,
+                "other/Collection/Nested/Clip.mkv",
+                membership_token="",
+            )
+            root_scope = other_scope_action_blocker(
+                connection,
+                folder_config,
+                "other",
+                membership_token="",
+            )
+
+        file_config = self._config(grouping="file")
+        with open_db(file_config.paths.db_path) as connection:
+            folder_scope = other_scope_action_blocker(
+                connection,
+                file_config,
+                "other/Collection",
+                membership_token="",
+            )
+
+        self.assertEqual(nested_file["code"], "other_scope_not_bounded")
+        self.assertEqual(root_scope["code"], "other_scope_not_bounded")
+        self.assertEqual(folder_scope["code"], "other_scope_not_bounded")
+
+    def test_unscoped_other_candidates_are_not_production_eligible(self) -> None:
+        config = self._config(grouping="folder")
+        with open_db(config.paths.db_path) as connection:
+            item_id = self._insert_item(connection, "other/Collection/Clip.mkv")
+            unscoped = project_candidates(connection, config)
+            scoped = project_candidates(connection, config, prefixes=["other/Collection"])
+
+        self.assertFalse({decision.item_id: decision for decision in unscoped}[item_id].eligible)
+        self.assertTrue({decision.item_id: decision for decision in scoped}[item_id].eligible)
+
+    def test_membership_confirmation_expires_when_the_scope_changes(self) -> None:
+        config = self._config(grouping="folder")
+        with open_db(config.paths.db_path) as connection:
+            self._insert_item(connection, "other/Collection/One.mkv")
+            self._insert_item(connection, "other/Collection/Two.mkv")
+            context = load_other_scope_payload(connection, config, "other/Collection")
+            reviewed_token = str(context["membership_token"])
+            self._insert_item(connection, "other/Collection/Three.mkv")
+            blocker = other_scope_action_blocker(
+                connection,
+                config,
+                "other/Collection",
+                membership_token=reviewed_token,
+            )
+
+        self.assertEqual(blocker["code"], "other_scope_confirmation_required")
+        self.assertIn("all 3 files", blocker["message"])
+
+    def test_oversized_folder_scope_is_blocked_before_processing(self) -> None:
+        config = self._config(grouping="folder")
+        with open_db(config.paths.db_path) as connection:
+            for index in range(251):
+                self._insert_item(connection, f"other/Large/Clip-{index:03d}.mkv")
+            with patch(
+                "mediaforce.library.other_library.project_candidates",
+                side_effect=AssertionError("oversized scopes must short-circuit candidate projection"),
+            ):
+                context = load_other_scope_payload(connection, config, "other/Large")
+                blocker = other_scope_action_blocker(
+                    connection,
+                    config,
+                    "other/Large",
+                    membership_token="ignored-for-oversized-scope",
+                )
+
+        self.assertEqual(context["item_count"], 251)
+        self.assertFalse(context["membership_complete"])
+        self.assertEqual(context["profile_readiness"]["label"], "Scope too large")
+        self.assertEqual(blocker["code"], "other_profile_not_ready")
+
+    def test_other_library_catalog_is_bounded_and_reports_truncation(self) -> None:
+        config = self._config(grouping="file")
+        with open_db(config.paths.db_path) as connection:
+            for index in range(3):
+                self._insert_item(connection, f"other/Clip-{index}.mkv")
+            with patch("mediaforce.library.other_library.OTHER_LIBRARY_CATALOG_MAX_ITEMS", 2):
+                payload = load_other_library_payload(connection, config, include_details=False)
+
+        self.assertTrue(payload["catalog_truncated"])
+        self.assertEqual(payload["catalog_item_limit"], 2)
+        self.assertEqual(len(payload["work_units"]), 2)
+
+    def test_other_scope_can_validate_and_promote_without_media_type_assumptions(self) -> None:
+        config = self._config(grouping="folder")
+        source_path = self.root / "other" / "Delivery" / "Clip.mp4"
+        staging_path = self.root / "staging" / "other" / "Delivery" / "Clip.mkv"
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        staging_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_bytes(b"source")
+        staging_path.write_bytes(b"staged")
+        item = {
+            "source_path": str(source_path),
+            "rel_path": "other/Delivery/Clip.mp4",
+            "staging_path": str(staging_path),
+        }
+
+        validated = validate_folder_outputs_action(
+            config,
+            "other/Delivery",
+            load_folder_staged_items_fn=lambda *_args, **_kwargs: [item],
+            validate_manifest_items_fn=lambda *_args, **_kwargs: [{"passed": True}],
+        )
+        promoted = promote_folder_outputs_action(
+            config,
+            "other/Delivery",
+            load_folder_staged_items_fn=lambda *_args, **_kwargs: [item],
+            promote_manifest_items_fn=lambda *_args, **_kwargs: [source_path.with_suffix(".mkv")],
+        )
+
+        self.assertEqual(validated["validated_count"], 1)
+        self.assertEqual(promoted["promoted_count"], 1)
+
+    def test_queue_validates_membership_inside_an_immediate_transaction(self) -> None:
+        config = self._config(grouping="folder")
+        transaction_states: list[bool] = []
+
+        def validate_scope(connection: DBClient, _prefix: str) -> dict[str, object]:
+            transaction_states.append(bool(connection.connection.driver_connection.in_transaction))
+            return {"ok": False, "code": "blocked", "message": "Membership changed."}
+
+        result = queue_folder_encode_action(
+            config,
+            "other/Collection",
+            "",
+            False,
+            now_iso=lambda: "2026-07-14T00:00:00+00:00",
+            load_job_state=lambda *_args: None,
+            load_calibration_state=lambda *_args: None,
+            review_gate=lambda *_args: {},
+            upsert_override=lambda *_args: None,
+            load_active_encode_job_for_prefix_fn=lambda *_args: None,
+            clear_terminal_encode_jobs_for_prefix_fn=lambda *_args: None,
+            prepare_terminal_encode_job_for_requeue_fn=lambda *_args: None,
+            save_encode_job=lambda *_args: None,
+            validate_scope_action=validate_scope,
+        )
+
+        self.assertEqual(result["code"], "blocked")
+        self.assertEqual(transaction_states, [True])
+
+    def test_delivery_actions_validate_membership_inside_their_database_transaction(self) -> None:
+        config = self._config(grouping="folder")
+        transaction_states: list[bool] = []
+
+        def validate_scope(connection: DBClient, _prefix: str) -> dict[str, object]:
+            transaction_states.append(bool(connection.connection.driver_connection.in_transaction))
+            return {"ok": False, "code": "blocked", "message": "Membership changed."}
+
+        validated = validate_folder_outputs_action(
+            config,
+            "other/Collection",
+            load_folder_staged_items_fn=lambda *_args, **_kwargs: [],
+            validate_manifest_items_fn=lambda *_args, **_kwargs: [],
+            validate_scope_action=validate_scope,
+        )
+        promoted = promote_folder_outputs_action(
+            config,
+            "other/Collection",
+            load_folder_staged_items_fn=lambda *_args, **_kwargs: [],
+            promote_manifest_items_fn=lambda *_args, **_kwargs: [],
+            validate_scope_action=validate_scope,
+        )
+
+        self.assertEqual(validated["code"], "blocked")
+        self.assertEqual(promoted["code"], "blocked")
+        self.assertEqual(transaction_states, [True, True])
+
+    def _config(self, *, grouping: str, availability: str = "production") -> MediaforceConfig:
+        return MediaforceConfig(
+            raw={
+                "media": {
+                    "libraries": [
+                        {
+                            "key": "other",
+                            "label": "Other",
+                            "path": str(self.root / "other"),
+                            "type": "other",
+                            "availability": availability,
+                            "default_profile": "other_conservative",
+                            "policy": {"grouping": grouping},
+                        }
+                    ],
+                    "output_container": "mkv",
+                    "staging_root": str(self.root / "staging"),
+                    "archive_root": str(self.root / "archive"),
+                },
+                "video": {},
+                "audio": {},
+                "subtitle": {},
+                "planning": {},
+                "validation": {},
+                "overrides": [],
+                "remote_hosts": [],
+            },
+            paths=ConfigPaths(
+                project_root=self.root,
+                config_path=self.root / "config.toml",
+                db_path=self.root / "library.sqlite3",
+                run_manifest_dir=self.root / "runs",
+                web_state_dir=self.root / "web",
+                review_dir=self.root / "review",
+                runtime_settings_path=self.root / "runtime-settings.json",
+            ),
+        )
+
+    @staticmethod
+    def _insert_item(
+            connection: DBClient,
+            rel_path: str,
+            *,
+            size_bytes: int = 1_024,
+            width: int | None = 1_920,
+            height: int | None = 1_080,
+    ) -> int:
+        timestamp = datetime.now(tz=UTC).isoformat(timespec="seconds")
+        path = Path(rel_path)
+        result = connection.execute(
+            library_items.insert().values(
+                source_path=f"/media/{rel_path}",
+                rel_path=rel_path,
+                media_root=path.parts[0],
+                parent_dir=str(path.parent),
+                file_name=path.name,
+                container=path.suffix.lstrip(".") or "mkv",
+                size_bytes=size_bytes,
+                mtime_ns=1_700_000_000_000_000_000,
+                fingerprint=f"other-{rel_path}",
+                duration_seconds=3_600.0,
+                video_codec="h264",
+                width=width,
+                height=height,
+                audio_summary_json="[]",
+                subtitle_summary_json="[]",
+                status="discovered",
+                priority_score=50,
+                recommendation="priority_encode",
+                recommendation_reason="Other workflow fixture.",
+                last_scan_id="other-scan",
+                discovered_at=timestamp,
+                last_seen_at=timestamp,
+                updated_at=timestamp,
+            )
+        )
+        return int(result.inserted_primary_key[0])

--- a/tests/test_web_route_security.py
+++ b/tests/test_web_route_security.py
@@ -11,6 +11,7 @@ from starlette.routing import Route
 
 from mediaforce.web.routes.completed import COMPLETED_CLEANUP_ERROR_MESSAGE, register_completed_routes
 from mediaforce.web.routes.folders import register_folder_routes
+from mediaforce.web.routes.queues import register_queue_routes
 from mediaforce.web.routes.settings import SETTINGS_SAVE_ERROR_MESSAGE, register_settings_routes
 from mediaforce.web.settings_runtime import SettingsValidationError
 
@@ -45,15 +46,18 @@ class WebRouteSecurityTests(unittest.TestCase):
         preview_started = threading.Event()
         release_preview = threading.Event()
         captured_intents: list[dict[str, Any] | None] = []
+        captured_membership_tokens: list[str] = []
 
         def slow_preview(
                 prefix: str,
                 note: str,
                 host_key: str,
                 operator_intent: dict[str, Any] | None,
+                _scope_membership_token: str,
         ) -> dict[str, Any]:
             preview_started.set()
             captured_intents.append(operator_intent)
+            captured_membership_tokens.append(_scope_membership_token)
             release_preview.wait(timeout=1.0)
             return {"ok": True, "prefix": prefix, "note": note, "host_key": host_key}
 
@@ -64,14 +68,14 @@ class WebRouteSecurityTests(unittest.TestCase):
             download_review_compare_action=lambda _prefix: None,
             folder_ai_tune_action=slow_preview,
             folder_ai_tune_preview_action=slow_preview,
-            folder_ai_tune_confirm_action=lambda _prefix, _proposal_id: {"ok": True},
+            folder_ai_tune_confirm_action=lambda _prefix, _proposal_id, _membership_token: {"ok": True},
             clear_folder_tuning_action=lambda _prefix: {},
             save_series_lifecycle_action=lambda _prefix, _mode: {"ok": True},
-            approve_measured_encode_recovery_action=lambda _prefix: {},
-            queue_folder_encode_action=lambda _prefix, _notes, _bypass_schedule, _override_policy_holds: {},
-            validate_folder_outputs_action=lambda _prefix: {},
-            promote_folder_outputs_action=lambda _prefix: {},
-            save_profile_action=lambda _prefix, _profile, _approve, _notes: {},
+            approve_measured_encode_recovery_action=lambda _prefix, _membership_token: {},
+            queue_folder_encode_action=lambda _prefix, _notes, _bypass_schedule, _override_policy_holds, _membership_token: {},
+            validate_folder_outputs_action=lambda _prefix, _membership_token: {},
+            promote_folder_outputs_action=lambda _prefix, _membership_token: {},
+            save_profile_action=lambda _prefix, _profile, _approve, _notes, _membership_token: {},
         )
         endpoint = _route_endpoint(app, "/api/folders/{prefix:path}/ai-tune/preview", "POST")
 
@@ -89,6 +93,7 @@ class WebRouteSecurityTests(unittest.TestCase):
                                 "size_goal": {"mode": "absolute", "value_mb": 225},
                                 "resolution": {"mode": "source"},
                             },
+                            "scope_membership_token": "membership-v1",
                         }
                     ),
                 )
@@ -104,6 +109,63 @@ class WebRouteSecurityTests(unittest.TestCase):
         self.assertLess(elapsed, 0.2)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(captured_intents[0]["size_goal"]["mode"], "absolute")
+        self.assertEqual(captured_membership_tokens, ["membership-v1"])
+
+    def test_folder_lifecycle_routes_forward_scope_membership_token(self) -> None:
+        app = FastAPI()
+        captured: list[tuple[str, str]] = []
+
+        def capture(action: str, token: str) -> dict[str, Any]:
+            captured.append((action, token))
+            return {"ok": True}
+
+        register_folder_routes(
+            app,
+            folder_status_payload=lambda _prefix: {},
+            folder_content_payload=lambda _prefix: ({}, 200),
+            download_review_compare_action=lambda _prefix: None,
+            folder_ai_tune_action=lambda *_args: {"ok": True},
+            folder_ai_tune_preview_action=lambda *_args: {"ok": True},
+            folder_ai_tune_confirm_action=lambda *_args: {"ok": True},
+            clear_folder_tuning_action=lambda _prefix: {},
+            save_series_lifecycle_action=lambda _prefix, _mode: {},
+            approve_measured_encode_recovery_action=lambda _prefix, token: capture("recovery", token),
+            queue_folder_encode_action=lambda _prefix, _notes, _bypass, _override, token: capture("queue", token),
+            validate_folder_outputs_action=lambda _prefix, token: capture("validate", token),
+            promote_folder_outputs_action=lambda _prefix, token: capture("promote", token),
+            save_profile_action=lambda _prefix, _high, _size, _hash, token: capture("save", token),
+        )
+        request = lambda: _json_request({"scope_membership_token": "membership-v2"})
+
+        async def exercise() -> None:
+            await _route_endpoint(app, "/api/folders/{prefix:path}/queue-encode", "POST")(
+                "other/Batch", request()
+            )
+            await _route_endpoint(app, "/api/folders/{prefix:path}/approve-recovery", "POST")(
+                "other/Batch", request()
+            )
+            await _route_endpoint(app, "/api/folders/{prefix:path}/validate-outputs", "POST")(
+                "other/Batch", request()
+            )
+            await _route_endpoint(app, "/api/folders/{prefix:path}/promote-outputs", "POST")(
+                "other/Batch", request()
+            )
+            await _route_endpoint(app, "/api/folders/{prefix:path}/save-profile", "POST")(
+                "other/Batch", request()
+            )
+
+        asyncio.run(exercise())
+
+        self.assertEqual(
+            captured,
+            [
+                ("queue", "membership-v2"),
+                ("recovery", "membership-v2"),
+                ("validate", "membership-v2"),
+                ("promote", "membership-v2"),
+                ("save", "membership-v2"),
+            ],
+        )
 
     def test_folder_save_profile_failure_returns_conflict_status(self) -> None:
         app = FastAPI()
@@ -117,10 +179,10 @@ class WebRouteSecurityTests(unittest.TestCase):
             folder_ai_tune_confirm_action=lambda *_args: {},
             clear_folder_tuning_action=lambda _prefix: {},
             save_series_lifecycle_action=lambda _prefix, _mode: {},
-            approve_measured_encode_recovery_action=lambda _prefix: {},
+            approve_measured_encode_recovery_action=lambda _prefix, _membership_token: {},
             queue_folder_encode_action=lambda *_args: {},
-            validate_folder_outputs_action=lambda _prefix: {},
-            promote_folder_outputs_action=lambda _prefix: {},
+            validate_folder_outputs_action=lambda _prefix, _membership_token: {},
+            promote_folder_outputs_action=lambda _prefix, _membership_token: {},
             save_profile_action=lambda *_args: {
                 "ok": False,
                 "code": "library_not_production",
@@ -133,6 +195,35 @@ class WebRouteSecurityTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 409)
         self.assertEqual(json.loads(response.body)["code"], "library_not_production")
+
+    def test_retry_prefix_forwards_scope_membership_token(self) -> None:
+        app = FastAPI()
+        captured: list[tuple[str, str]] = []
+        register_queue_routes(
+            app,
+            pause_encode_queue_action=lambda: {},
+            resume_encode_queue_action=lambda: {},
+            retry_failed_encode_queue_action=lambda: {},
+            retry_failed_encode_prefix_action=lambda prefix, token: (
+                captured.append((prefix, token)) or {"ok": True}
+            ),
+            stop_encode_queue_action=lambda: {},
+            stop_calibration_queue_action=lambda: {},
+        )
+
+        response = asyncio.run(
+            _route_endpoint(app, "/api/encode-queue/retry-prefix", "POST")(
+                _json_request(
+                    {
+                        "prefix": "other/Batch",
+                        "scope_membership_token": "membership-v3",
+                    }
+                )
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(captured, [("other/Batch", "membership-v3")])
 
     def test_settings_save_hides_internal_validation_detail(self) -> None:
         app = FastAPI()


### PR DESCRIPTION
## Summary

- add a dedicated Other Library and Other Studio for exact root files and bounded top-level folders
- require explicit generic profiles, canonical work-unit scopes, current membership confirmation, and conservative catalog/scope limits
- carry Other items through prepare, queue, validate, and promote without TV, movie, edition, extras, or spatial semantics
- add Settings support, API contracts, regression coverage, and desktop/narrow browser fixtures including a 251-file blocked scope

## Safety

- unscoped and noncanonical Other candidates remain ineligible for production
- retries and measured recovery no longer mint replacement membership tokens
- queue membership validation runs in an immediate database transaction; validation and promotion validate against the same database transaction used to select staged outputs
- catalog responses are bounded to 5,000 indexed items and 500 work units

## Validation

- `bash scripts/pre-commit-check.sh`
- `uv build`
- PyCharm changed-files inspection: GREEN, 0 findings
- headed browser review at 1024px and 390px with no horizontal overflow
- independent frontend, backend, and Gemini-family correctness reviews; actionable findings addressed

Closes #189
Closes #200
Closes #201
Closes #202