### PR TITLE
Add show-wide older-season processing

### DIFF
--- a/docs/architecture/library-lifecycle-policy.md
+++ b/docs/architecture/library-lifecycle-policy.md
@@ -87,11 +87,14 @@ tie breakers; they do not make an ineligible item runnable.
 
 ## Manual override
 
-Only an exact season prefix may bypass lifecycle holds. The operator must use the
-season surface and confirm the bypass; a series-wide queue action cannot silently
-override held seasons. Manual override bypasses current-season and acquisition
-holds only. Missing sources, active processing, staged-output consistency,
-validation, promotion, and other workflow safety rules still apply.
+An exact season prefix may bypass lifecycle holds from the season surface after
+the operator confirms the bypass. A separate show-level action may also process
+older numbered seasons with one approved setup. That action always excludes the
+highest numbered season, Specials, ambiguous season identities, and unsafe
+items; it does not change the show policy. Both override paths bypass only
+current-season and acquisition timing holds. Missing sources, active processing,
+staged-output consistency, validation, promotion, and other workflow safety
+rules still apply.
 
 ## Manifest provenance
 

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -86,6 +86,23 @@ export interface LifecycleState {
 	seasons: SeasonLifecycleState[];
 }
 
+export interface OlderSeasonOverridePayload {
+	schema_version: number;
+	mode: 'older_seasons';
+	available: boolean;
+	series_prefix: string;
+	latest_season_number?: number | null;
+	latest_season_label?: string | null;
+	latest_season_prefixes: string[];
+	included_season_prefixes: string[];
+	overridden_season_prefixes: string[];
+	season_count: number;
+	candidate_count: number;
+	overridden_candidate_count: number;
+	already_eligible_candidate_count: number;
+	current_size_bytes: number;
+}
+
 export type MediaScopeDomain = 'tv' | 'movie' | 'other';
 export type MediaScopeKind =
 	| 'library_root'
@@ -1069,6 +1086,7 @@ export interface FolderPayload {
 	encode_candidate_count?: number;
 	workflow_state?: FolderWorkflowState | null;
 	lifecycle?: LifecycleState | null;
+	older_season_override?: OlderSeasonOverridePayload | null;
 	movie_context?: MovieTitle | null;
 	other_context?: OtherScopeContext | null;
 }

--- a/frontend/src/lib/components/season/SeasonExperience.svelte
+++ b/frontend/src/lib/components/season/SeasonExperience.svelte
@@ -64,7 +64,7 @@
 	};
 
 	type SafetyDialog = {
-		kind: 'approval' | 'recovery' | 'lifecycle_override';
+		kind: 'approval' | 'recovery' | 'lifecycle_override' | 'older_seasons_override';
 		title: string;
 		detail: string;
 		primaryLabel: string;
@@ -123,6 +123,12 @@
 	);
 	const heldEpisodeCount = $derived(lifecycle?.held_candidate_count ?? 0);
 	const canOverrideLifecycleHolds = $derived(Boolean(lifecycle?.can_override_holds));
+	const olderSeasonOverride = $derived(
+		isSeriesScope ? (folder.older_season_override ?? null) : null
+	);
+	const canQueueOlderSeasons = $derived(
+		Boolean(olderSeasonOverride?.available && olderSeasonOverride.candidate_count > 0)
+	);
 	const lifecycleHoldReasons = $derived(currentSeasonLifecycle?.hold_reasons ?? []);
 	const lifecycleHold = $derived(lifecycleHoldReasons[0] ?? null);
 	const scopeTitle = $derived(
@@ -162,6 +168,15 @@
 	const productionEpisodeCount = $derived(isSeriesScope ? eligibleEpisodeCount : episodeCount);
 	const originalSeasonSize = $derived(folder.summary?.total_size_bytes ?? 0);
 	const expectedEpisodeBytes = $derived(predictedEpisodeSize(folder));
+	const olderSeasonProjectedSavingsBytes = $derived(
+		olderSeasonOverride && expectedEpisodeBytes > 0
+			? Math.max(
+					0,
+					olderSeasonOverride.current_size_bytes -
+						expectedEpisodeBytes * olderSeasonOverride.candidate_count
+				)
+			: null
+	);
 	const actualSampleSizes = $derived(reviewSampleSizes(folder));
 	const sizeTarget = $derived(folderSizeTargetAnalysis(folder));
 	const targetSummary = $derived(resolvedTargetSummary(folder));
@@ -470,6 +485,48 @@
 		await queueSeason(false);
 	}
 
+	async function queueOlderSeasons() {
+		await runAction('queueing', 'We couldn’t start the older seasons.', async () => {
+			ensureOk(
+				await postJson<ActionResponse>(endpoint('queue-older-seasons'), {
+					notes: 'Approved after reviewing the explicit older-season lifecycle override.',
+					bypass_schedule: false,
+					confirmed: true
+				}),
+				'We couldn’t start the older seasons.'
+			);
+		});
+	}
+
+	async function requestQueueOlderSeasons() {
+		const selection = olderSeasonOverride;
+		if (!selection?.available) return;
+		const latestSeason = selection.latest_season_label || 'The latest season';
+		const changes = [
+			`${selection.season_count} ${selection.season_count === 1 ? 'season' : 'seasons'} · ${selection.candidate_count} ${selection.candidate_count === 1 ? 'episode' : 'episodes'}.`,
+			`Current size: ${formatDecimalFileSize(selection.current_size_bytes)}.`,
+			olderSeasonProjectedSavingsBytes !== null
+				? `Projected savings: about ${formatDecimalFileSize(olderSeasonProjectedSavingsBytes)}.`
+				: 'Projected savings are not available for this setup.',
+			`${latestSeason} stays original.`,
+			selection.overridden_candidate_count > 0
+				? `${selection.overridden_candidate_count} ${selection.overridden_candidate_count === 1 ? 'episode bypasses' : 'episodes bypass'} lifecycle timing holds.`
+				: 'No lifecycle hold is bypassed; this action only excludes the latest season.',
+			selection.already_eligible_candidate_count > 0
+				? `${selection.already_eligible_candidate_count} already-eligible ${selection.already_eligible_candidate_count === 1 ? 'episode is' : 'episodes are'} included.`
+				: '',
+			'The current-season policy does not change.',
+			'Specials, ambiguous seasons, and unsafe items remain excluded.'
+		].filter(Boolean);
+		await openSafetyDialog({
+			kind: 'older_seasons_override',
+			title: `Process ${selection.season_count} older ${selection.season_count === 1 ? 'season' : 'seasons'} now?`,
+			detail: `This queues ${selection.candidate_count} ${selection.candidate_count === 1 ? 'episode' : 'episodes'} with the approved setup. Mediaforce will recheck the selection before anything starts.`,
+			primaryLabel: 'Process older seasons',
+			changes
+		});
+	}
+
 	async function checkOutputs() {
 		await runAction('checking', 'We couldn’t check the new episodes.', async () => {
 			ensureOk(
@@ -560,6 +617,10 @@
 		}
 		if (dialog.kind === 'lifecycle_override') {
 			await queueSeason(true);
+			return;
+		}
+		if (dialog.kind === 'older_seasons_override') {
+			await queueOlderSeasons();
 			return;
 		}
 		await performMeasuredRecovery();
@@ -653,7 +714,7 @@
 				detail: `Recording the test you chose and checking whether the ${scopeNoun} can start.`
 			},
 			queueing: {
-				title: isSeriesScope ? 'Starting every season' : 'Starting the season',
+				title: isSeriesScope ? 'Starting selected seasons' : 'Starting the season',
 				detail: 'Preparing the remaining episodes and finding available computers.'
 			},
 			checking: {
@@ -859,10 +920,21 @@
 								: lifecycleHold?.label || 'Season protected'}
 					</strong>
 					{#if isSeriesScope}
-						<p>
-							{eligibleEpisodeCount} episodes remain eligible for this show-level action. Protected seasons
-							stay visible and original.
-						</p>
+						{#if canQueueOlderSeasons && olderSeasonOverride}
+							<p>
+								{eligibleEpisodeCount} episodes are eligible normally. A separate confirmed action can
+								include {olderSeasonOverride.candidate_count}
+								{olderSeasonOverride.candidate_count === 1 ? 'episode' : 'episodes'} across
+								{olderSeasonOverride.season_count} older
+								{olderSeasonOverride.season_count === 1 ? 'season' : 'seasons'} while
+								{olderSeasonOverride.latest_season_label || 'the latest season'} stays original.
+							</p>
+						{:else}
+							<p>
+								{eligibleEpisodeCount} episodes remain eligible for this show-level action. Protected
+								seasons stay visible and original.
+							</p>
+						{/if}
 					{:else if lifecycleHoldReasons.length}
 						{#each lifecycleHoldReasons as reason (reason.code)}
 							<p><b>{reason.label}:</b> {reason.detail}</p>
@@ -1499,19 +1571,35 @@
 				<p class="eyebrow">Test approved</p>
 				<h1>
 					{isSeriesScope
-						? 'Ready to make the eligible seasons.'
+						? canQueueOlderSeasons
+							? eligibleEpisodeCount > 0
+								? 'Ready to choose which seasons to make.'
+								: 'Ready to process the older seasons.'
+							: 'Ready to make the eligible seasons.'
 						: heldEpisodeCount > 0
 							? 'This season is ready, but protected.'
 							: 'Ready to make the season.'}
 				</h1>
-				<p class="lede">
-					Mediaforce will make {productionEpisodeCount}
-					{productionEpisodeCount === 1 ? 'episode' : 'episodes'} with the same settings. {heldEpisodeCount >
-					0
-						? `${heldEpisodeCount} protected ${heldEpisodeCount === 1 ? 'episode stays' : 'episodes stay'} original unless you explicitly override this season.`
-						: 'New files stay separate until they pass their checks.'} Nothing is queued until you choose
-					the action below.
-				</p>
+				{#if isSeriesScope && canQueueOlderSeasons && olderSeasonOverride}
+					<p class="lede">
+						The approved setup can make {eligibleEpisodeCount} normally eligible
+						{eligibleEpisodeCount === 1 ? 'episode' : 'episodes'}. The older-season option can
+						include {olderSeasonOverride.candidate_count}
+						{olderSeasonOverride.candidate_count === 1 ? 'episode' : 'episodes'} across
+						{olderSeasonOverride.season_count} older
+						{olderSeasonOverride.season_count === 1 ? 'season' : 'seasons'} with explicit confirmation.
+						Nothing is queued until you choose an action.
+					</p>
+				{:else}
+					<p class="lede">
+						Mediaforce will make {productionEpisodeCount}
+						{productionEpisodeCount === 1 ? 'episode' : 'episodes'} with the same settings. {heldEpisodeCount >
+						0
+							? `${heldEpisodeCount} protected ${heldEpisodeCount === 1 ? 'episode stays' : 'episodes stay'} original unless you explicitly override this season.`
+							: 'New files stay separate until they pass their checks.'} Nothing is queued until you choose
+						the action below.
+					</p>
+				{/if}
 				<div class="ready-summary">
 					<div>
 						<span>{isSeriesScope ? 'Eligible episodes' : 'Episodes'}</span><strong
@@ -1534,16 +1622,47 @@
 						<small>Each episode gets its own runtime-derived target.</small>
 					</div>
 				</div>
-				<button
-					class="primary-button"
-					type="button"
-					onclick={requestQueueSeason}
-					disabled={(isSeriesScope && eligibleEpisodeCount === 0) ||
-						(!isSeriesScope && heldEpisodeCount > 0 && !canOverrideLifecycleHolds)}
-				>
-					{makeActionLabel}
-					<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 10h11M11 5l5 5-5 5" /></svg>
-				</button>
+				{#if isSeriesScope && canQueueOlderSeasons && olderSeasonOverride}
+					<div class="older-season-option">
+						<div>
+							<strong>Process older seasons</strong>
+							<p>
+								{olderSeasonOverride.latest_season_label || 'The latest season'} stays original.
+								{#if olderSeasonOverride.overridden_candidate_count > 0}
+									{olderSeasonOverride.overridden_candidate_count} protected
+									{olderSeasonOverride.overridden_candidate_count === 1 ? 'episode' : 'episodes'} will
+									bypass lifecycle timing holds; the policy itself stays unchanged.
+								{:else}
+									No lifecycle hold is bypassed; this action only keeps the latest season out of the
+									queue.
+								{/if}
+							</p>
+							<small>
+								{formatDecimalFileSize(olderSeasonOverride.current_size_bytes)} current
+								{#if olderSeasonProjectedSavingsBytes !== null}
+									· about {formatDecimalFileSize(olderSeasonProjectedSavingsBytes)} projected savings
+								{/if}
+							</small>
+						</div>
+						<button class="primary-button" type="button" onclick={requestQueueOlderSeasons}>
+							Process {olderSeasonOverride.season_count} older
+							{olderSeasonOverride.season_count === 1 ? 'season' : 'seasons'}
+							<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 10h11M11 5l5 5-5 5" /></svg>
+						</button>
+					</div>
+				{/if}
+				{#if !isSeriesScope || eligibleEpisodeCount > 0 || !canQueueOlderSeasons}
+					<button
+						class="primary-button"
+						type="button"
+						onclick={requestQueueSeason}
+						disabled={(isSeriesScope && eligibleEpisodeCount === 0) ||
+							(!isSeriesScope && heldEpisodeCount > 0 && !canOverrideLifecycleHolds)}
+					>
+						{makeActionLabel}
+						<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 10h11M11 5l5 5-5 5" /></svg>
+					</button>
+				{/if}
 			</section>
 		{:else if humanState.key === 'making_season'}
 			<section class="season-progress-room" aria-live="polite">
@@ -4926,6 +5045,47 @@
 		font-size: 10px;
 	}
 
+	.older-season-option {
+		align-items: center;
+		background: var(--mf-wait-bg);
+		border: 1px solid var(--mf-wait-line);
+		border-radius: var(--mf-radius-3);
+		display: flex;
+		gap: 20px;
+		justify-content: space-between;
+		margin-bottom: 16px;
+		max-width: 820px;
+		padding: 16px;
+		text-align: left;
+		width: 100%;
+	}
+
+	.older-season-option > div {
+		display: grid;
+		gap: 4px;
+	}
+
+	.older-season-option strong {
+		color: var(--mf-wait-fg);
+		font-size: 14px;
+	}
+
+	.older-season-option p {
+		color: var(--mf-fg-secondary);
+		font-size: 12px;
+		margin: 0;
+	}
+
+	.older-season-option small {
+		color: var(--mf-fg-tertiary);
+		font-size: 11px;
+	}
+
+	.older-season-option .primary-button {
+		flex: 0 0 auto;
+		white-space: nowrap;
+	}
+
 	.detail-error {
 		background: var(--mf-wait-bg);
 		border: 1px solid var(--mf-wait-line);
@@ -4979,6 +5139,11 @@
 		.active-facts,
 		.ready-summary {
 			grid-template-columns: 1fr;
+		}
+
+		.older-season-option {
+			align-items: stretch;
+			flex-direction: column;
 		}
 
 		.active-facts div,

--- a/frontend/src/lib/components/season/SeasonLibrary.svelte
+++ b/frontend/src/lib/components/season/SeasonLibrary.svelte
@@ -19,6 +19,7 @@
 	import {
 		buildShowCards,
 		filterShowCards,
+		olderSeasonLibraryAction,
 		savingsPercent,
 		seasonsByShow,
 		sortShowCards,
@@ -74,6 +75,9 @@
 			: []
 	);
 	const selectedLifecycle = $derived(selectedShow?.lifecycle ?? null);
+	const olderSeasonAction = $derived(
+		selectedLifecycle ? olderSeasonLibraryAction(selectedLifecycle) : null
+	);
 	const displayedLifecycleMode = $derived<LifecycleMode>(
 		pendingLifecycleMode?.prefix === selectedShow?.prefix
 			? pendingLifecycleMode.mode
@@ -454,7 +458,26 @@
 						{/if}
 					</div>
 
-					{#if selectedShow && selectedSeasons.length > 1}
+					{#if selectedShow && olderSeasonAction}
+						<div class="show-action show-action--override">
+							<div>
+								<strong>Process older seasons with one setup</strong>
+								<span>
+									Include {olderSeasonAction.episodeCount}
+									{olderSeasonAction.episodeCount === 1 ? 'episode' : 'episodes'} across
+									{olderSeasonAction.seasonCount} older
+									{olderSeasonAction.seasonCount === 1 ? 'season' : 'seasons'}.
+									{olderSeasonAction.latestSeasonLabel} stays original, and the current-season policy
+									does not change. Recent-acquisition holds are bypassed only after confirmation.
+								</span>
+							</div>
+							<a class="primary-button" href={resolve(folderHref(selectedShow.prefix))}
+								>Set up older seasons</a
+							>
+						</div>
+					{/if}
+
+					{#if selectedShow && selectedSeasons.length > 1 && (!lifecycleAvailable || eligibleEpisodeCount > 0 || !olderSeasonAction)}
 						<div class="show-action">
 							<div>
 								<strong>Use one setup for eligible seasons</strong>
@@ -999,6 +1022,15 @@
 	.show-action span {
 		color: var(--mf-fg-secondary);
 		font-size: 12px;
+	}
+
+	.show-action--override {
+		background: var(--mf-wait-bg);
+		border-color: var(--mf-wait-line);
+	}
+
+	.show-action--override strong {
+		color: var(--mf-wait-fg);
 	}
 
 	.show-action .primary-button {

--- a/frontend/src/lib/season/library.test.ts
+++ b/frontend/src/lib/season/library.test.ts
@@ -7,6 +7,7 @@ import {
 	buildShowCards,
 	filterShowCards,
 	mergeFolderPayloads,
+	olderSeasonLibraryAction,
 	savingsPercent,
 	seasonsByShow,
 	sortShowCards
@@ -219,6 +220,96 @@ describe('season library grouping', () => {
 			eligible_candidate_count: 10,
 			held_candidate_count: 0,
 			hold_reason_counts: {}
+		});
+	});
+
+	it('offers one older-season action while preserving the latest season', () => {
+		const heldOlderSeason = {
+			...seasonLifecycle('tv/Alpha/Season 1', 10),
+			is_current_season: false,
+			hold_reasons: [
+				{ code: 'current_season', label: 'Current season', detail: 'Protected.' },
+				{ code: 'recent_acquisition', label: 'Recent acquisition', detail: 'Waiting.' }
+			]
+		};
+		const eligibleSeason = {
+			...seasonLifecycle('tv/Alpha/Season 2', 0),
+			is_current_season: false
+		};
+		const latestSeason = {
+			...seasonLifecycle('tv/Alpha/Season 3', 10),
+			is_current_season: true,
+			hold_reasons: [
+				{ code: 'recent_acquisition', label: 'Recent acquisition', detail: 'Waiting.' },
+				{ code: 'current_season', label: 'Current season', detail: 'Protected.' }
+			]
+		};
+		const action = olderSeasonLibraryAction({
+			...lifecycle('on', 0),
+			candidate_count: 30,
+			eligible_candidate_count: 10,
+			held_candidate_count: 20,
+			seasons: [heldOlderSeason, eligibleSeason, latestSeason]
+		});
+
+		expect(action).toEqual({
+			latestSeasonLabel: 'Season 3',
+			seasonCount: 2,
+			episodeCount: 20,
+			overriddenSeasonCount: 1,
+			overriddenEpisodeCount: 10
+		});
+	});
+
+	it('does not offer the action for ambiguous or non-overrideable older seasons', () => {
+		const action = olderSeasonLibraryAction({
+			...lifecycle('on', 0),
+			candidate_count: 20,
+			eligible_candidate_count: 0,
+			held_candidate_count: 20,
+			seasons: [
+				{
+					...seasonLifecycle('tv/Alpha/Season 1', 10),
+					ambiguous: true,
+					is_current_season: false,
+					hold_reasons: [
+						{ code: 'recent_acquisition', label: 'Recent acquisition', detail: 'Waiting.' }
+					]
+				},
+				{
+					...seasonLifecycle('tv/Alpha/Season 2', 10),
+					is_current_season: false,
+					hold_reasons: [{ code: 'content_age_unknown', label: 'Age unknown', detail: 'Unknown.' }]
+				},
+				{
+					...seasonLifecycle('tv/Alpha/Season 3', 0),
+					is_current_season: true
+				}
+			]
+		});
+
+		expect(action).toBeNull();
+	});
+
+	it('offers the older-season scope even when no lifecycle hold needs bypassing', () => {
+		const action = olderSeasonLibraryAction({
+			...lifecycle('off', 20),
+			candidate_count: 30,
+			eligible_candidate_count: 30,
+			held_candidate_count: 0,
+			seasons: [
+				seasonLifecycle('tv/Alpha/Season 1', 0),
+				seasonLifecycle('tv/Alpha/Season 2', 0),
+				seasonLifecycle('tv/Alpha/Season 3', 0)
+			]
+		});
+
+		expect(action).toEqual({
+			latestSeasonLabel: 'Season 3',
+			seasonCount: 2,
+			episodeCount: 20,
+			overriddenSeasonCount: 0,
+			overriddenEpisodeCount: 0
 		});
 	});
 });

--- a/frontend/src/lib/season/library.ts
+++ b/frontend/src/lib/season/library.ts
@@ -9,6 +9,16 @@ import { seasonIdentity } from './experience';
 
 export type LibrarySort = 'savings' | 'size' | 'seasons' | 'name';
 
+export interface OlderSeasonLibraryAction {
+	latestSeasonLabel: string;
+	seasonCount: number;
+	episodeCount: number;
+	overriddenSeasonCount: number;
+	overriddenEpisodeCount: number;
+}
+
+const OVERRIDEABLE_HOLD_CODES = new Set(['current_season', 'recent_acquisition']);
+
 export function mergeFolderPayloads(
 	structure: DashboardFoldersPayload,
 	details: DashboardFoldersPayload
@@ -69,6 +79,54 @@ export function applySeriesLifecycle(
 		...payload,
 		folders: payload.folders.map(updateCard),
 		series_folders: payload.series_folders?.map(updateCard)
+	};
+}
+
+export function olderSeasonLibraryAction(
+	lifecycle: LifecycleState
+): OlderSeasonLibraryAction | null {
+	const numberedSeasons = lifecycle.seasons.filter(
+		(season) =>
+			!season.is_special &&
+			Number.isInteger(season.season_number) &&
+			Number(season.season_number) > 0
+	);
+	const latestSeasonNumber = Math.max(
+		...numberedSeasons.map((season) => Number(season.season_number)),
+		0
+	);
+	if (latestSeasonNumber <= 0) return null;
+	const prefixCountByNumber = new Map<number, number>();
+	for (const season of numberedSeasons) {
+		const seasonNumber = Number(season.season_number);
+		prefixCountByNumber.set(seasonNumber, (prefixCountByNumber.get(seasonNumber) ?? 0) + 1);
+	}
+	const included = numberedSeasons.filter((season) => {
+		const seasonNumber = Number(season.season_number);
+		if (
+			seasonNumber >= latestSeasonNumber ||
+			season.ambiguous ||
+			(prefixCountByNumber.get(seasonNumber) ?? 0) > 1 ||
+			season.candidate_count <= 0
+		)
+			return false;
+		if (season.held_candidate_count <= 0) return season.eligible_candidate_count > 0;
+		return (
+			season.hold_reasons.length > 0 &&
+			season.hold_reasons.every((reason) => OVERRIDEABLE_HOLD_CODES.has(reason.code))
+		);
+	});
+	const overridden = included.filter((season) => season.held_candidate_count > 0);
+	if (!included.length) return null;
+	return {
+		latestSeasonLabel: `Season ${latestSeasonNumber}`,
+		seasonCount: included.length,
+		episodeCount: included.reduce((total, season) => total + season.candidate_count, 0),
+		overriddenSeasonCount: overridden.length,
+		overriddenEpisodeCount: overridden.reduce(
+			(total, season) => total + season.held_candidate_count,
+			0
+		)
 	};
 }
 

--- a/mediaforce/library/candidate_selection.py
+++ b/mediaforce/library/candidate_selection.py
@@ -1,6 +1,6 @@
 import re
 from collections import Counter, defaultdict
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -160,6 +160,46 @@ class CandidateDecision:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class OlderSeasonOverrideSelection:
+    series_prefix: str
+    latest_season_number: int | None
+    latest_season_prefixes: tuple[str, ...]
+    included_season_prefixes: tuple[str, ...]
+    overridden_season_prefixes: tuple[str, ...]
+    candidate_count: int
+    overridden_candidate_count: int
+    current_size_bytes: int
+
+    @property
+    def available(self) -> bool:
+        return bool(self.included_season_prefixes)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "mode": "older_seasons",
+            "available": self.available,
+            "series_prefix": self.series_prefix,
+            "latest_season_number": self.latest_season_number,
+            "latest_season_label": (
+                f"Season {self.latest_season_number}"
+                if self.latest_season_number is not None
+                else None
+            ),
+            "latest_season_prefixes": list(self.latest_season_prefixes),
+            "included_season_prefixes": list(self.included_season_prefixes),
+            "overridden_season_prefixes": list(self.overridden_season_prefixes),
+            "season_count": len(self.included_season_prefixes),
+            "candidate_count": self.candidate_count,
+            "overridden_candidate_count": self.overridden_candidate_count,
+            "already_eligible_candidate_count": (
+                self.candidate_count - self.overridden_candidate_count
+            ),
+            "current_size_bytes": self.current_size_bytes,
+        }
+
+
 def project_candidates(
         connection: DBClient,
         config: MediaforceConfig,
@@ -168,6 +208,7 @@ def project_candidates(
         statuses: set[str] | frozenset[str] | None = None,
         now: datetime | None = None,
         manual_override_prefix: str | None = None,
+        manual_override_prefixes: Collection[str] | None = None,
 ) -> list[CandidateDecision]:
     current_time = (now or datetime.now(tz=UTC)).astimezone(UTC)
     library_types = config.library_type_map
@@ -179,7 +220,11 @@ def project_candidates(
     )
     query_scopes = (
         resolved_scopes
-        if resolved_scopes and all(scope.domain == "other" for scope in resolved_scopes)
+        if resolved_scopes
+        and all(
+            scope.domain == "other" or scope.kind == "tv_series"
+            for scope in resolved_scopes
+        )
         else []
     )
     rows = _load_rows(connection, scopes=query_scopes)
@@ -238,7 +283,14 @@ def project_candidates(
             )
         else:
             other_group_blockers[group_prefix] = profile_blockers[0] if profile_blockers else None
+    normalized_overrides = {
+        normalize_scope_prefix(prefix)
+        for prefix in (manual_override_prefixes or ())
+        if normalize_scope_prefix(prefix)
+    }
     normalized_override = normalize_scope_prefix(manual_override_prefix or "")
+    if normalized_override:
+        normalized_overrides.add(normalized_override)
     decisions: list[CandidateDecision] = []
     production_roots = set(config.source_root_map)
     scan_roots = set(config.scan_source_root_map)
@@ -344,9 +396,9 @@ def project_candidates(
         activity_at = season_activity.get(season.season_prefix) if season is not None else None
         rank_age = season_rank_age.get(season.season_prefix, _media_age(row)) if season is not None else _media_age(row)
         manual_override = bool(
-            normalized_override
+            normalized_overrides
             and season is not None
-            and season.season_prefix == normalized_override
+            and season.season_prefix in normalized_overrides
         )
         hold_reasons = _hold_reasons(
             season=season,
@@ -393,6 +445,7 @@ def encode_candidate_decisions(
         prefixes: list[str],
         now: datetime | None = None,
         manual_override_prefix: str | None = None,
+        manual_override_prefixes: Collection[str] | None = None,
 ) -> list[CandidateDecision]:
     return project_candidates(
         connection,
@@ -401,6 +454,107 @@ def encode_candidate_decisions(
         statuses=ENCODE_CANDIDATE_STATUSES,
         now=now,
         manual_override_prefix=manual_override_prefix,
+        manual_override_prefixes=manual_override_prefixes,
+    )
+
+
+def older_season_override_selection(
+        decisions: list[CandidateDecision],
+        series_prefix: str,
+) -> OlderSeasonOverrideSelection:
+    normalized_series = normalize_scope_prefix(series_prefix)
+    scoped = [
+        decision
+        for decision in decisions
+        if decision.season is not None
+        and decision.season.series_prefix == normalized_series
+    ]
+    prefixes_by_number: dict[int, set[str]] = defaultdict(set)
+    for decision in scoped:
+        season = decision.season
+        if season is None or season.season_number is None or season.season_number <= 0:
+            continue
+        prefixes_by_number[season.season_number].add(season.season_prefix)
+    latest_season_number = max(prefixes_by_number, default=None)
+    if latest_season_number is None:
+        return OlderSeasonOverrideSelection(
+            series_prefix=normalized_series,
+            latest_season_number=None,
+            latest_season_prefixes=(),
+            included_season_prefixes=(),
+            overridden_season_prefixes=(),
+            candidate_count=0,
+            overridden_candidate_count=0,
+            current_size_bytes=0,
+        )
+
+    candidates_by_prefix: dict[str, list[CandidateDecision]] = defaultdict(list)
+    season_number_by_prefix: dict[str, int] = {}
+    for decision in scoped:
+        season = decision.season
+        if (
+            season is None
+            or season.season_number is None
+            or season.season_number <= 0
+            or decision.workflow_lane != "encode"
+        ):
+            continue
+        candidates_by_prefix[season.season_prefix].append(decision)
+        season_number_by_prefix[season.season_prefix] = season.season_number
+
+    duplicate_numbers = {
+        season_number
+        for season_number, prefixes in prefixes_by_number.items()
+        if len(prefixes) > 1
+    }
+    included: list[str] = []
+    overridden: list[str] = []
+    candidate_count = 0
+    overridden_candidate_count = 0
+    current_size_bytes = 0
+    for season_prefix, season_decisions in sorted(
+            candidates_by_prefix.items(),
+            key=lambda item: (season_number_by_prefix[item[0]], item[0]),
+    ):
+        season_number = season_number_by_prefix[season_prefix]
+        if season_number >= latest_season_number or season_number in duplicate_numbers:
+            continue
+        if any(
+            decision.season is None
+            or decision.season.ambiguous
+            or decision.season.is_special
+            or decision.season.season_number != season_number
+            or not decision.production_included
+            or decision.profile_blocker is not None
+            or decision.target_size_blocker is not None
+            for decision in season_decisions
+        ):
+            continue
+        if any(
+            any(reason.code not in OVERRIDEABLE_HOLD_CODES for reason in decision.hold_reasons)
+            for decision in season_decisions
+        ):
+            continue
+        included.append(season_prefix)
+        held_count = sum(bool(decision.hold_reasons) for decision in season_decisions)
+        if held_count:
+            overridden.append(season_prefix)
+            overridden_candidate_count += held_count
+        candidate_count += len(season_decisions)
+        current_size_bytes += sum(
+            max(0, int(decision.row.get("size_bytes") or 0))
+            for decision in season_decisions
+        )
+
+    return OlderSeasonOverrideSelection(
+        series_prefix=normalized_series,
+        latest_season_number=latest_season_number,
+        latest_season_prefixes=tuple(sorted(prefixes_by_number[latest_season_number])),
+        included_season_prefixes=tuple(included),
+        overridden_season_prefixes=tuple(overridden),
+        candidate_count=candidate_count,
+        overridden_candidate_count=overridden_candidate_count,
+        current_size_bytes=current_size_bytes,
     )
 
 

--- a/mediaforce/library/run_manifests.py
+++ b/mediaforce/library/run_manifests.py
@@ -18,7 +18,7 @@ from mediaforce.core.db_tables import staged_artifacts
 from mediaforce.library.workflow_state import ENCODE_CANDIDATE_STATUSES
 from mediaforce.library.workflow_state import derive_item_workflow_state
 from mediaforce.core.type_defs import object_dict
-from mediaforce.library.candidate_selection import candidate_rank_key, project_candidates
+from mediaforce.library.candidate_selection import OlderSeasonOverrideSelection, candidate_rank_key, project_candidates
 from mediaforce.library.media_scopes import resolve_media_scope, resolve_media_scopes, scope_rel_path_filter
 from mediaforce.library.planner import build_manifest_item, recommend_item
 from mediaforce.library.scanner import scan_library
@@ -52,6 +52,7 @@ def select_candidates(
         buckets: list[str] | None = None,
         require_encode_lane: bool = False,
         manual_override_prefix: str | None = None,
+        manual_override_prefixes: list[str] | tuple[str, ...] | None = None,
 ) -> list[dict[str, Any]]:
     if require_encode_lane:
         projected = project_candidates(
@@ -60,6 +61,7 @@ def select_candidates(
             prefixes=prefixes,
             statuses=set(statuses),
             manual_override_prefix=manual_override_prefix,
+            manual_override_prefixes=manual_override_prefixes,
         )
         ranked: list[tuple[Any, dict[str, Any]]] = []
         for decision in projected:
@@ -137,6 +139,7 @@ def select_encode_candidates(
         limit: int | None,
         buckets: list[str] | None = None,
         manual_override_prefix: str | None = None,
+        manual_override_prefixes: list[str] | tuple[str, ...] | None = None,
 ) -> list[dict[str, Any]]:
     return select_candidates(
         connection,
@@ -147,6 +150,7 @@ def select_encode_candidates(
         buckets=buckets,
         require_encode_lane=True,
         manual_override_prefix=manual_override_prefix,
+        manual_override_prefixes=manual_override_prefixes,
     )
 
 
@@ -240,18 +244,33 @@ def create_folder_manifest(
         limit: int | None = None,
         scan_first: bool = False,
         manual_override_prefix: str | None = None,
+        older_season_override: OlderSeasonOverrideSelection | None = None,
 ) -> tuple[dict[str, Any], Path]:
+    if manual_override_prefix and older_season_override is not None:
+        raise ValueError("Exact-season and older-season lifecycle overrides cannot be combined")
     if scan_first:
         scan_library(connection, config, prefixes=[prefix])
     scope = resolve_media_scope(connection, prefix, library_types=config.library_type_map)
+    selection_prefixes = (
+        list(older_season_override.included_season_prefixes)
+        if older_season_override is not None
+        else [prefix]
+    )
     rows = select_encode_candidates(
         connection,
         config,
-        prefixes=[prefix],
+        prefixes=selection_prefixes,
         limit=limit,
         manual_override_prefix=manual_override_prefix,
+        manual_override_prefixes=(
+            older_season_override.overridden_season_prefixes
+            if older_season_override is not None
+            else None
+        ),
     )
     manifest = build_run_manifest(rows, config)
     manifest["selection"]["media_scope"] = scope.to_payload()
+    if older_season_override is not None:
+        manifest["selection"]["lifecycle_override"] = older_season_override.to_payload()
     manifest_path = write_manifest(connection, config, manifest)
     return manifest, manifest_path

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -71,8 +71,9 @@ from mediaforce.library.planner import build_manifest_item
 from mediaforce.library.representatives import RepresentativeSelection, load_representative_selection, \
     public_representative_item
 from mediaforce.library.run_manifests import select_encode_candidates
-from mediaforce.library.candidate_selection import CandidateDecision, encode_candidate_decisions, project_candidates, \
-    scope_lifecycle_payload_from_decisions, workflow_eligibility
+from mediaforce.library.candidate_selection import CandidateDecision, encode_candidate_decisions, \
+    older_season_override_selection, project_candidates, scope_lifecycle_payload_from_decisions, \
+    workflow_eligibility
 from mediaforce.hosts.types import HostSetupResult
 from mediaforce.hosts.config import configured_remote_host_execution_mode
 from mediaforce.core.process_control import ManagedProcessController
@@ -839,6 +840,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
 
     def _folder_content_payload(normalized_prefix: str) -> tuple[dict[str, Any], int]:
         latest_failed_sample_job_payload: dict[str, Any] | None = None
+        older_season_override: dict[str, Any] | None = None
         with open_db(config.paths.db_path) as connection:
             media_scope = resolve_media_scope(
                 connection,
@@ -935,7 +937,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             encode_queue_summary = _encode_queue_summary_copy(encode_queue, encode_queue_state, encode_job)
             lifecycle_decisions = (
                 project_candidates(connection, config, prefixes=[normalized_prefix])
-                if media_scope.domain == "movie"
+                if media_scope.domain == "movie" or media_scope.kind == "tv_series"
                 else encode_candidate_decisions(connection, config, prefixes=[normalized_prefix])
             )
             lifecycle = (
@@ -943,6 +945,11 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 if media_scope.domain == "tv"
                 else None
             )
+            if media_scope.kind == "tv_series":
+                older_season_override = older_season_override_selection(
+                    lifecycle_decisions,
+                    normalized_prefix,
+                ).to_payload()
             if media_scope.domain == "other":
                 other_context = load_other_scope_payload(
                     connection,
@@ -1075,6 +1082,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 "encode_candidate_count": encode_candidate_count,
                 "workflow_state": workflow_state,
                 "lifecycle": lifecycle,
+                "older_season_override": older_season_override,
                 "series_context": series_context,
                 "resolved_metric": resolved_metric.upper(),
                 "sample_host_key": sample_host_key,
@@ -1295,11 +1303,13 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             proposal_id,
         )
 
-    def _queue_folder_encode_action(
+    def _queue_encode_action(
             normalized_prefix: str,
             notes: str,
             bypass_schedule: bool,
             override_policy_holds: bool = False,
+            override_older_seasons: bool = False,
+            older_seasons_confirmed: bool = False,
             scope_membership_token: str = "",
     ) -> ActionPayload:
         return queue_folder_encode_action(
@@ -1308,6 +1318,8 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             notes,
             bypass_schedule,
             override_policy_holds,
+            override_older_seasons=override_older_seasons,
+            older_seasons_confirmed=older_seasons_confirmed,
             now_iso=_now_iso,
             load_job_state=_load_job_state,
             load_calibration_state=_load_calibration_state,
@@ -1329,6 +1341,42 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 prefix,
                 membership_token=scope_membership_token,
             ),
+        )
+
+    def _queue_folder_encode_action(
+            normalized_prefix: str,
+            notes: str,
+            bypass_schedule: bool,
+            override_policy_holds: bool = False,
+            scope_membership_token: str = "",
+    ) -> ActionPayload:
+        return _queue_encode_action(
+            normalized_prefix,
+            notes,
+            bypass_schedule,
+            override_policy_holds=override_policy_holds,
+            scope_membership_token=scope_membership_token,
+        )
+
+    def _queue_older_seasons_encode_action(
+            normalized_prefix: str,
+            notes: str,
+            bypass_schedule: bool,
+            confirmed: bool,
+            scope_membership_token: str = "",
+    ) -> ActionPayload:
+        if not confirmed:
+            raise HTTPException(
+                status_code=400,
+                detail="Confirm the older-season selection before starting production.",
+            )
+        return _queue_encode_action(
+            normalized_prefix,
+            notes,
+            bypass_schedule,
+            override_older_seasons=True,
+            older_seasons_confirmed=confirmed,
+            scope_membership_token=scope_membership_token,
         )
 
     def _approve_measured_encode_recovery_action(
@@ -1554,6 +1602,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         save_series_lifecycle_action=_save_series_lifecycle_action,
         approve_measured_encode_recovery_action=_approve_measured_encode_recovery_action,
         queue_folder_encode_action=_queue_folder_encode_action,
+        queue_older_seasons_encode_action=_queue_older_seasons_encode_action,
         validate_folder_outputs_action=_validate_folder_outputs_action,
         promote_folder_outputs_action=_promote_folder_outputs_action,
         save_profile_action=_save_profile_action,

--- a/mediaforce/web/routes/folders.py
+++ b/mediaforce/web/routes/folders.py
@@ -36,6 +36,7 @@ def register_folder_routes(
         save_series_lifecycle_action: Callable[[str, str], dict[str, Any]],
         approve_measured_encode_recovery_action: Callable[[str, str], dict[str, Any]],
         queue_folder_encode_action: Callable[[str, str, bool, bool, str], dict[str, Any]],
+        queue_older_seasons_encode_action: Callable[[str, str, bool, bool, str], dict[str, Any]],
         validate_folder_outputs_action: Callable[[str, str], dict[str, Any]],
         promote_folder_outputs_action: Callable[[str, str], dict[str, Any]],
         save_profile_action: Callable[[str, bool, bool, str, str], dict[str, Any]],
@@ -123,6 +124,19 @@ def register_folder_routes(
         result = await run_in_threadpool(
             approve_measured_encode_recovery_action,
             prefix.strip("/"),
+            str(body.get("scope_membership_token", "")),
+        )
+        return JSONResponse(result, status_code=200 if result.get("ok") else 409)
+
+    @app.post("/api/folders/{prefix:path}/queue-older-seasons")
+    async def api_folder_queue_older_seasons(prefix: str, request: Request) -> JSONResponse:
+        body = await _request_body(request)
+        result = await run_in_threadpool(
+            queue_older_seasons_encode_action,
+            prefix.strip("/"),
+            str(body.get("notes", "")),
+            _request_flag(body, "bypass_schedule"),
+            _request_flag(body, "confirmed"),
             str(body.get("scope_membership_token", "")),
         )
         return JSONResponse(result, status_code=200 if result.get("ok") else 409)

--- a/mediaforce/web/runtime/folder_actions.py
+++ b/mediaforce/web/runtime/folder_actions.py
@@ -23,8 +23,8 @@ from mediaforce.library.media_scopes import MediaScope, path_matches_scope, reso
 from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
 from mediaforce.library.workflow_state import build_folder_workflow_state
 from mediaforce.library.run_manifests import create_folder_manifest
-from mediaforce.library.candidate_selection import encode_candidate_decisions, scope_lifecycle_payload_from_decisions, \
-    scope_target_size_blocker, workflow_eligibility
+from mediaforce.library.candidate_selection import encode_candidate_decisions, older_season_override_selection, \
+    project_candidates, scope_lifecycle_payload_from_decisions, scope_target_size_blocker, workflow_eligibility
 from mediaforce.tuning.quality_risk import build_quality_risk_contract
 from mediaforce.tuning.quality_risk import append_quality_risk_record
 from mediaforce.tuning.size_goals import operator_intent_from_policy
@@ -202,6 +202,8 @@ def queue_folder_encode_action(
         bypass_schedule: bool,
         override_policy_holds: bool = False,
         *,
+        override_older_seasons: bool = False,
+        older_seasons_confirmed: bool = False,
         now_iso: NowIsoFn,
         load_job_state: LoadJobStateFn,
         load_calibration_state: LoadCalibrationStateFn,
@@ -229,8 +231,20 @@ def queue_folder_encode_action(
             normalized_prefix,
             library_types=config.library_type_map,
         )
+        if override_policy_holds and override_older_seasons:
+            raise HTTPException(status_code=400, detail="Choose one lifecycle override mode.")
         if override_policy_holds and scope.kind != "tv_season":
             raise HTTPException(status_code=400, detail="Lifecycle holds can only be overridden for one season at a time.")
+        if override_older_seasons and scope.kind != "tv_series":
+            raise HTTPException(
+                status_code=400,
+                detail="Older-season holds can only be overridden for one TV series.",
+            )
+        if override_older_seasons and not older_seasons_confirmed:
+            raise HTTPException(
+                status_code=400,
+                detail="Confirm the older-season selection before starting production.",
+            )
         existing_job = load_job_state(connection, config, normalized_prefix)
         if existing_job and existing_job.get("status") in {"queued", "running", "pending_review"}:
             return {"ok": False, "message": "A calibration job is already active for this folder."}
@@ -376,10 +390,34 @@ def queue_folder_encode_action(
         upsert_override(saved_profile_path, normalized_prefix, calibration_policy)
         refreshed_config = load_config(config.paths.config_path)
         manifest_kwargs: dict[str, Any] = {"prefix": normalized_prefix}
+        older_season_selection = None
         if override_policy_holds:
             manifest_kwargs["manual_override_prefix"] = normalized_prefix
+        elif override_older_seasons:
+            older_season_selection = older_season_override_selection(
+                project_candidates(
+                    connection,
+                    refreshed_config,
+                    prefixes=[normalized_prefix],
+                ),
+                normalized_prefix,
+            )
+            if not older_season_selection.available:
+                raise HTTPException(
+                    status_code=409,
+                    detail="No safe older-season candidates remain for this show.",
+                )
+            manifest_kwargs["older_season_override"] = older_season_selection
         manifest, manifest_path = create_folder_manifest(connection, refreshed_config, **manifest_kwargs)
         if not manifest["items"]:
+            if older_season_selection is not None:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        "The safe older-season selection changed before it could be queued. "
+                        "Reload the show and review it again."
+                    ),
+                )
             lifecycle_decisions = encode_candidate_decisions(
                 connection,
                 refreshed_config,
@@ -465,9 +503,24 @@ def queue_folder_encode_action(
             )
     return {
         "ok": True,
-        "message": "Queued the eligible folder encode.",
+        "message": (
+            "Queued the older seasons."
+            if older_season_selection is not None
+            else "Queued the eligible folder encode."
+        ),
         "job": queue_job,
-        "policy_holds_overridden": override_policy_holds,
+        "policy_holds_overridden": bool(
+            override_policy_holds
+            or (
+                older_season_selection is not None
+                and older_season_selection.overridden_season_prefixes
+            )
+        ),
+        "older_season_override": (
+            older_season_selection.to_payload()
+            if older_season_selection is not None
+            else None
+        ),
     }
 
 

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -65,6 +65,7 @@ CURRENT_PREVIOUS_PREFIX = "tv/Current Season/Season 1"
 CURRENT_SEASON_PREFIX = "tv/Current Season/Season 2"
 CURRENT_SERIES_PREFIX = "tv/Current Season"
 PROTECTED_READY_PREFIX = "tv/Protected Ready/Season 2"
+PROTECTED_READY_PREVIOUS_PREFIX = "tv/Protected Ready/Season 1"
 PROTECTED_READY_SERIES_PREFIX = "tv/Protected Ready"
 FIXTURE_PREFIXES = (
     FOLDER_PREFIX,
@@ -98,6 +99,7 @@ FIXTURE_PREFIXES = (
     OTHER_PROMOTION_PREFIX,
     CURRENT_PREVIOUS_PREFIX,
     CURRENT_SEASON_PREFIX,
+    PROTECTED_READY_PREVIOUS_PREFIX,
     PROTECTED_READY_PREFIX,
 )
 
@@ -646,6 +648,16 @@ def _write_review_states(config: Any, rows_by_prefix: dict[str, dict[str, Any]])
     _write_review_sample_state(
         config,
         rows_by_prefix,
+        prefix=PROTECTED_READY_SERIES_PREFIX,
+        job_id="web-smoke-protected-ready-series",
+        review_slug="web-smoke-protected-ready-series",
+        predicted_total_size_bytes=396_000_000,
+        quality_score=94.8,
+        accepted=True,
+    )
+    _write_review_sample_state(
+        config,
+        rows_by_prefix,
         prefix=MISSED_TARGET_PREFIX,
         job_id="web-smoke-overshoot",
         review_slug="web-smoke-overshoot",
@@ -999,6 +1011,18 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
             _library_item(
                 project_root=project_root,
                 media_root="tv",
+                rel_path="tv/Protected Ready/Season 1/Episode 01.mkv",
+                size_bytes=7 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=83,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture older season requires an explicit lifecycle override.",
+                age_days=5,
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
                 rel_path="tv/Protected Ready/Season 2/Episode 01.mkv",
                 size_bytes=8 * 1024**3,
                 status="discovered",
@@ -1221,6 +1245,7 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
             )
         )
         rows_by_prefix = {str(row["parent_dir"]): row for row in rows}
+        rows_by_prefix[PROTECTED_READY_SERIES_PREFIX] = rows_by_prefix[PROTECTED_READY_PREFIX]
         ids_by_rel_path = {
             str(row["rel_path"]): item_id
             for row, item_id in zip(rows, inserted_ids, strict=True)
@@ -1682,6 +1707,12 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 "route": "/folders/tv/Protected%20Ready/Season%202",
                 "marker": "Protected Ready",
                 "stageMarker": "This season is ready, but protected",
+            },
+            {
+                "label": "Folder Studio older-season override fixture",
+                "route": "/folders/tv/Protected%20Ready",
+                "marker": "Protected Ready",
+                "stageMarker": "Ready to process the older seasons",
             },
             {
                 "label": "Folder Studio missed-target fixture",

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -549,6 +549,58 @@ async function checkLifecyclePolicyShowIsolation(baseUrl, timeoutMs) {
   }
 }
 
+async function checkOlderSeasonConfirmation(baseUrl, timeoutMs) {
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage({
+      viewport: { width: 1440, height: 1000 },
+    });
+    let queueRequests = 0;
+    page.on("request", (request) => {
+      if (request.url().includes("/queue-older-seasons")) {
+        queueRequests += 1;
+      }
+    });
+    await page.goto(`${baseUrl}/folders/tv/Protected%20Ready`, {
+      waitUntil: "domcontentloaded",
+      timeout: timeoutMs,
+    });
+    const action = page.getByRole("button", {
+      name: "Process 1 older season",
+    });
+    await action.waitFor({ state: "visible", timeout: timeoutMs });
+    await action.click();
+    const dialog = page.getByRole("alertdialog");
+    await dialog.waitFor({ state: "visible", timeout: timeoutMs });
+    const dialogText = await dialog.innerText();
+    for (const marker of [
+      "1 season · 1 episode",
+      "Current size:",
+      "Projected savings: about",
+      "Season 2 stays original",
+      "current-season policy does not change",
+    ]) {
+      if (!dialogText.includes(marker)) {
+        throw new Error(
+          `Older-season confirmation missed ${JSON.stringify(marker)}: ${dialogText}`,
+        );
+      }
+    }
+    await dialog.getByRole("button", { name: "Go back" }).click();
+    await dialog.waitFor({ state: "hidden", timeout: timeoutMs });
+    if (queueRequests !== 0) {
+      throw new Error(
+        "Canceling the older-season confirmation queued production.",
+      );
+    }
+    console.log(
+      "route ok: Older-season confirmation is explicit and cancel-safe",
+    );
+  } finally {
+    await browser.close();
+  }
+}
+
 async function checkNarrowRoutes(baseUrl, routeChecksForNarrow, timeoutMs) {
   const browser = await chromium.launch();
   try {
@@ -730,6 +782,7 @@ async function main() {
         args.routeTimeoutMs,
       );
       await checkLifecyclePolicyShowIsolation(targetUrl, args.routeTimeoutMs);
+      await checkOlderSeasonConfirmation(targetUrl, args.routeTimeoutMs);
     }
     if (args.narrow) {
       await checkNarrowRoutes(

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import errno
 import io
 import json
@@ -9,6 +10,7 @@ import sqlite3
 import subprocess
 import tempfile
 import threading
+import tomllib
 import unittest
 from collections.abc import Mapping
 from dataclasses import replace
@@ -15068,6 +15070,129 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
         self.assertEqual(raised.exception.status_code, 400)
         self.assertIn("one season at a time", str(raised.exception.detail))
+
+    def test_older_season_override_rejects_non_series_scope(self) -> None:
+        source = self._create_source_file("older-season-scope.mkv")
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_library_item(
+                connection,
+                source,
+                rel_path="tv/show/Season 1/older-season-scope.mkv",
+            )
+
+        with self.assertRaises(HTTPException) as raised:
+            folder_actions_runtime.queue_folder_encode_action(
+                self.config,
+                "tv/show/Season 1",
+                "",
+                False,
+                override_older_seasons=True,
+                now_iso=web_app._now_iso,
+                load_job_state=Mock(),
+                load_calibration_state=Mock(),
+                review_gate=Mock(),
+                upsert_override=Mock(),
+                load_active_encode_job_for_prefix_fn=Mock(),
+                clear_terminal_encode_jobs_for_prefix_fn=Mock(),
+                prepare_terminal_encode_job_for_requeue_fn=Mock(),
+                save_encode_job=Mock(),
+            )
+
+        self.assertEqual(raised.exception.status_code, 400)
+        self.assertIn("one TV series", str(raised.exception.detail))
+
+    def test_older_season_override_requires_explicit_confirmation(self) -> None:
+        source = self._create_source_file("older-season-confirmation.mkv")
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_library_item(
+                connection,
+                source,
+                rel_path="tv/show/Season 1/older-season-confirmation.mkv",
+            )
+
+        with self.assertRaises(HTTPException) as raised:
+            folder_actions_runtime.queue_folder_encode_action(
+                self.config,
+                "tv/show",
+                "",
+                False,
+                override_older_seasons=True,
+                now_iso=web_app._now_iso,
+                load_job_state=Mock(),
+                load_calibration_state=Mock(),
+                review_gate=Mock(),
+                upsert_override=Mock(),
+                load_active_encode_job_for_prefix_fn=Mock(),
+                clear_terminal_encode_jobs_for_prefix_fn=Mock(),
+                prepare_terminal_encode_job_for_requeue_fn=Mock(),
+                save_encode_job=Mock(),
+            )
+
+        self.assertEqual(raised.exception.status_code, 400)
+        self.assertIn("Confirm the older-season selection", str(raised.exception.detail))
+
+    def test_queue_older_seasons_freezes_server_selected_manifest(self) -> None:
+        with config_runtime.DEFAULT_CONFIG_PATH.open("rb") as handle:
+            complete_raw = copy.deepcopy(tomllib.load(handle))
+        complete_raw["media"].update(self.config.raw["media"])
+        complete_raw["remote_hosts"] = []
+        complete_raw["encode_queue"] = self.config.raw["encode_queue"]
+        queue_config = MediaforceConfig(raw=complete_raw, paths=self.config.paths)
+        with open_db(self.config.paths.db_path) as connection:
+            for rel_path in (
+                    "tv/show/Season 1/Episode 1.mkv",
+                    "tv/show/Season 2/Episode 1.mkv",
+                    "tv/show/Season 3/Episode 1.mkv",
+                    "tv/show/Specials/Aftershow.mkv",
+            ):
+                source = self._create_source_file(rel_path.replace("/", "-"))
+                self._insert_library_item(connection, source, rel_path=rel_path)
+
+        saved_jobs: list[dict[str, Any]] = []
+        calibration = {
+            "policy": {},
+            "accepted_at": web_app._now_iso(),
+            "draft_hash": "approved-draft",
+        }
+        with patch.object(folder_actions_runtime, "load_config", return_value=queue_config):
+            result = folder_actions_runtime.queue_folder_encode_action(
+                queue_config,
+                "tv/show",
+                "Approved older seasons after comparing the representative test.",
+                False,
+                override_older_seasons=True,
+                older_seasons_confirmed=True,
+                now_iso=web_app._now_iso,
+                load_job_state=self._noop_load_job_state,
+                load_calibration_state=lambda *_args, **_kwargs: calibration,
+                review_gate=self._accepted_review_gate,
+                upsert_override=self._noop_upsert_override,
+                load_active_encode_job_for_prefix_fn=lambda *_args, **_kwargs: None,
+                clear_terminal_encode_jobs_for_prefix_fn=lambda *_args, **_kwargs: None,
+                prepare_terminal_encode_job_for_requeue_fn=lambda *_args, **_kwargs: None,
+                save_encode_job=lambda _connection, job: saved_jobs.append(dict(job)),
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["policy_holds_overridden"])
+        self.assertEqual(result["older_season_override"]["latest_season_number"], 3)
+        parent_job = next(job for job in saved_jobs if job["job_kind"] == "folder")
+        manifest = json.loads(Path(parent_job["manifest_path"]).read_text())
+        self.assertEqual(
+            {
+                item["selection_provenance"]["season_prefix"]
+                for item in manifest["items"]
+            },
+            {"tv/show/Season 1", "tv/show/Season 2"},
+        )
+        self.assertEqual(
+            manifest["selection"]["lifecycle_override"]["latest_season_prefixes"],
+            ["tv/show/Season 3"],
+        )
+        self.assertNotIn(
+            "tv/show/Season 3",
+            manifest["selection"]["lifecycle_override"]["included_season_prefixes"],
+        )
 
     def test_validate_folder_outputs_action_uses_only_validate_lane_outputs(self) -> None:
         encoded_source = self._create_source_file("episode-encoded-validate.mkv")

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -15177,21 +15177,21 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertTrue(result["policy_holds_overridden"])
         self.assertEqual(result["older_season_override"]["latest_season_number"], 3)
         parent_job = next(job for job in saved_jobs if job["job_kind"] == "folder")
-        manifest = json.loads(Path(parent_job["manifest_path"]).read_text())
+        queued_manifest = json.loads(Path(parent_job["manifest_path"]).read_text())
         self.assertEqual(
             {
                 item["selection_provenance"]["season_prefix"]
-                for item in manifest["items"]
+                for item in queued_manifest["items"]
             },
             {"tv/show/Season 1", "tv/show/Season 2"},
         )
         self.assertEqual(
-            manifest["selection"]["lifecycle_override"]["latest_season_prefixes"],
+            queued_manifest["selection"]["lifecycle_override"]["latest_season_prefixes"],
             ["tv/show/Season 3"],
         )
         self.assertNotIn(
             "tv/show/Season 3",
-            manifest["selection"]["lifecycle_override"]["included_season_prefixes"],
+            queued_manifest["selection"]["lifecycle_override"]["included_season_prefixes"],
         )
 
     def test_validate_folder_outputs_action_uses_only_validate_lane_outputs(self) -> None:

--- a/tests/test_library_lifecycle.py
+++ b/tests/test_library_lifecycle.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from mediaforce.core.config import ConfigPaths, DEFAULT_CONFIG_PATH, MediaforceConfig
 from mediaforce.core.db import DBClient, open_db, reset_engine_cache
 from mediaforce.core.db_tables import library_items, plex_item_metadata, series_metadata
-from mediaforce.library.candidate_selection import project_candidates, season_identity
+from mediaforce.library.candidate_selection import older_season_override_selection, project_candidates, season_identity
 from mediaforce.library.run_manifests import build_run_manifest, create_folder_manifest, select_encode_candidates
 from mediaforce.library.workflow_state import EncodeEligibility, build_folder_workflow_state, derive_item_workflow_state
 from mediaforce.web.routes.folders import _request_flag
@@ -188,6 +188,65 @@ class LibraryLifecycleTests(unittest.TestCase):
         self.assertTrue(override_by_season[2].eligible)
         self.assertTrue(override_by_season[2].manual_override)
 
+    def test_older_season_override_excludes_latest_even_when_policy_is_off(self) -> None:
+        config = self._config(mode="off")
+        with open_db(config.paths.db_path) as connection:
+            self._insert_item(connection, "tv/Show/Season 1/Episode 01.mkv", age_days=5)
+            self._insert_item(connection, "tv/Show/Season 2/Episode 01.mkv", age_days=100)
+            self._insert_item(connection, "tv/Show/Season 3/Episode 01.mkv", age_days=5)
+            self._insert_item(connection, "tv/Show/Specials/Aftershow.mkv", age_days=5)
+
+            selection = older_season_override_selection(
+                project_candidates(connection, config, prefixes=["tv/Show"], now=NOW),
+                "tv/Show",
+            )
+
+        self.assertTrue(selection.available)
+        self.assertEqual(selection.latest_season_number, 3)
+        self.assertEqual(selection.latest_season_prefixes, ("tv/Show/Season 3",))
+        self.assertEqual(
+            selection.included_season_prefixes,
+            ("tv/Show/Season 1", "tv/Show/Season 2"),
+        )
+        self.assertEqual(selection.overridden_season_prefixes, ("tv/Show/Season 1",))
+        self.assertEqual(selection.candidate_count, 2)
+        self.assertEqual(selection.overridden_candidate_count, 1)
+
+    def test_older_season_override_excludes_ambiguous_and_unknown_age_seasons(self) -> None:
+        config = self._config(mode="off")
+        with open_db(config.paths.db_path) as connection:
+            unknown_id = self._insert_item(
+                connection,
+                "tv/Show/Season 1/Episode 01.mkv",
+                age_days=100,
+            )
+            ambiguous_id = self._insert_item(
+                connection,
+                "tv/Show/Season 2/Episode 01.mkv",
+                age_days=100,
+            )
+            self._insert_item(connection, "tv/Show/Season 3/Episode 01.mkv", age_days=100)
+            connection.execute(
+                library_items.update()
+                .where(library_items.c.id == unknown_id)
+                .values(discovered_at="unknown", content_version_changed_at=None)
+            )
+            self._insert_plex_metadata(
+                connection,
+                ambiguous_id,
+                added_at=NOW - timedelta(days=100),
+                season_index=9,
+            )
+
+            selection = older_season_override_selection(
+                project_candidates(connection, config, prefixes=["tv/Show"], now=NOW),
+                "tv/Show",
+            )
+
+        self.assertFalse(selection.available)
+        self.assertEqual(selection.latest_season_number, 3)
+        self.assertEqual(selection.included_season_prefixes, ())
+
     def test_selection_ranks_plex_age_then_mediaforce_discovery(self) -> None:
         config = self._config(mode="off")
         with open_db(config.paths.db_path) as connection:
@@ -271,6 +330,55 @@ class LibraryLifecycleTests(unittest.TestCase):
             {"recent_acquisition", "current_season"},
         )
         self.assertTrue(provenance["override_applied"])
+
+    def test_older_season_manifest_freezes_exact_scope_and_override_provenance(self) -> None:
+        config = self._config(mode="off")
+        with open_db(config.paths.db_path) as connection:
+            first_id = self._insert_item(
+                connection,
+                "tv/Show/Season 1/Episode 01.mkv",
+                age_days=5,
+            )
+            second_id = self._insert_item(
+                connection,
+                "tv/Show/Season 2/Episode 01.mkv",
+                age_days=100,
+            )
+            self._insert_item(connection, "tv/Show/Season 3/Episode 01.mkv", age_days=5)
+            self._insert_item(connection, "tv/Show/Specials/Aftershow.mkv", age_days=5)
+            selection = older_season_override_selection(
+                project_candidates(connection, config, prefixes=["tv/Show"], now=NOW),
+                "tv/Show",
+            )
+
+            manifest, _ = create_folder_manifest(
+                connection,
+                config,
+                prefix="tv/Show",
+                older_season_override=selection,
+            )
+
+        self.assertEqual(
+            [item["library_item_id"] for item in manifest["items"]],
+            [second_id, first_id],
+        )
+        override = manifest["selection"]["lifecycle_override"]
+        self.assertEqual(
+            override["included_season_prefixes"],
+            ["tv/Show/Season 1", "tv/Show/Season 2"],
+        )
+        self.assertEqual(
+            override["overridden_season_prefixes"],
+            ["tv/Show/Season 1"],
+        )
+        provenance_by_season = {
+            item["selection_provenance"]["season_number"]: item["selection_provenance"]
+            for item in manifest["items"]
+        }
+        self.assertTrue(provenance_by_season[1]["manual_override"])
+        self.assertTrue(provenance_by_season[1]["override_applied"])
+        self.assertFalse(provenance_by_season[2]["manual_override"])
+        self.assertFalse(provenance_by_season[2]["override_applied"])
 
     def test_manifest_exact_root_movie_excludes_similarly_named_sibling(self) -> None:
         config = self._config(mode="off")

--- a/tests/test_web_route_security.py
+++ b/tests/test_web_route_security.py
@@ -73,6 +73,7 @@ class WebRouteSecurityTests(unittest.TestCase):
             save_series_lifecycle_action=lambda _prefix, _mode: {"ok": True},
             approve_measured_encode_recovery_action=lambda _prefix, _membership_token: {},
             queue_folder_encode_action=lambda _prefix, _notes, _bypass_schedule, _override_policy_holds, _membership_token: {},
+            queue_older_seasons_encode_action=lambda _prefix, _notes, _bypass, _confirmed, _token: {},
             validate_folder_outputs_action=lambda _prefix, _membership_token: {},
             promote_folder_outputs_action=lambda _prefix, _membership_token: {},
             save_profile_action=lambda _prefix, _profile, _approve, _notes, _membership_token: {},
@@ -131,15 +132,22 @@ class WebRouteSecurityTests(unittest.TestCase):
             save_series_lifecycle_action=lambda _prefix, _mode: {},
             approve_measured_encode_recovery_action=lambda _prefix, token: capture("recovery", token),
             queue_folder_encode_action=lambda _prefix, _notes, _bypass, _override, token: capture("queue", token),
+            queue_older_seasons_encode_action=lambda _prefix, _notes, _bypass, confirmed, token: capture(
+                "older-confirmed" if confirmed else "older-unconfirmed",
+                token,
+            ),
             validate_folder_outputs_action=lambda _prefix, token: capture("validate", token),
             promote_folder_outputs_action=lambda _prefix, token: capture("promote", token),
             save_profile_action=lambda _prefix, _high, _size, _hash, token: capture("save", token),
         )
-        request = lambda: _json_request({"scope_membership_token": "membership-v2"})
+        request = lambda **extra: _json_request({"scope_membership_token": "membership-v2", **extra})
 
         async def exercise() -> None:
             await _route_endpoint(app, "/api/folders/{prefix:path}/queue-encode", "POST")(
                 "other/Batch", request()
+            )
+            await _route_endpoint(app, "/api/folders/{prefix:path}/queue-older-seasons", "POST")(
+                "tv/Show", request(confirmed=True)
             )
             await _route_endpoint(app, "/api/folders/{prefix:path}/approve-recovery", "POST")(
                 "other/Batch", request()
@@ -160,6 +168,7 @@ class WebRouteSecurityTests(unittest.TestCase):
             captured,
             [
                 ("queue", "membership-v2"),
+                ("older-confirmed", "membership-v2"),
                 ("recovery", "membership-v2"),
                 ("validate", "membership-v2"),
                 ("promote", "membership-v2"),
@@ -181,6 +190,7 @@ class WebRouteSecurityTests(unittest.TestCase):
             save_series_lifecycle_action=lambda _prefix, _mode: {},
             approve_measured_encode_recovery_action=lambda _prefix, _membership_token: {},
             queue_folder_encode_action=lambda *_args: {},
+            queue_older_seasons_encode_action=lambda *_args: {},
             validate_folder_outputs_action=lambda _prefix, _membership_token: {},
             promote_folder_outputs_action=lambda _prefix, _membership_token: {},
             save_profile_action=lambda *_args: {


### PR DESCRIPTION
## Summary
- add a server-derived older-season selection that always excludes the highest positive-numbered season, Specials, ambiguous identities, and unsafe candidates
- add an explicit show-level setup and confirmation flow without changing the durable current-season policy
- freeze exact included and overridden season prefixes in manifest selection provenance
- show season/episode impact, current size, projected savings, and the excluded latest season before queueing

## Safety
- requires explicit confirmation at both the API wrapper and queue runtime
- recomputes the selection server-side immediately before manifest creation
- keeps normal eligible-season and exact-season override paths unchanged
- canceling the confirmation sends no queue request

## Validation
- `bash scripts/pre-commit-check.sh`
  - 951 backend tests
  - CLI smoke
  - frontend check, lint, unit tests, and production build
  - desktop and narrow web-route smoke
- `uv build`
- live browser review on Big Brother at desktop and narrow widths
- seeded browser regression opens the older-season confirmation, checks impact/savings/latest-season copy, and verifies cancel safety
- independent Antigravity and Claude review; findings addressed
- PyCharm 2026.1.4 offline inspection completed in an isolated config; the actionable changed-line warning was fixed, leaving only the Playwright `domcontentloaded` technical literal

Closes #211