### PR TITLE
Prevent unavailable roots from erasing catalog state

### DIFF
--- a/docs/architecture/typed-library-settings.md
+++ b/docs/architecture/typed-library-settings.md
@@ -87,3 +87,14 @@ a catalog scan. Label, color, ordering, profile, and policy changes do not alter
 filesystem membership. Metadata configuration changes continue through the
 metadata refresh performed by the scan runtime. Unrelated host, schedule,
 working-folder, and advanced runtime settings survive typed-library saves.
+
+Full scans reconcile each configured root independently. Mediaforce only marks
+files missing inside roots that were completely enumerated. If a configured
+root is absent, unreadable, only partially readable, or unexpectedly returns no
+media after previously containing active items, cached catalog state is
+preserved. The same circuit breaker applies when a previously populated root
+returns 20% or less of at least 25 active items. The scan reports an operator
+warning without exposing the local path. Disabling or removing a library in
+Settings remains the explicit action that accepts its disappearance and marks
+its former rows missing. Prefix scans only access roots named by their logical
+scope.

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -466,10 +466,24 @@ export interface DashboardScanJob {
 	finished_at: string | null;
 	error: string | null;
 	stats: {
-		items_seen: number;
-		updated_paths: number;
+		items_seen?: number;
+		updated_paths?: number;
 		unchanged: number;
+		scan_id?: string;
+		discovered?: number;
+		reprobed?: number;
+		missing?: number;
+		total_seen?: number;
+		warnings?: DashboardScanWarning[];
 	} | null;
+}
+
+export interface DashboardScanWarning {
+	code: string;
+	library_key: string;
+	label: string;
+	message: string;
+	preserved_item_count: number;
 }
 
 export interface ArchiveCleanupSummary {

--- a/frontend/src/lib/components/shell/AppShell.svelte
+++ b/frontend/src/lib/components/shell/AppShell.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
+	import { fetchJson } from '$lib/api/client';
+	import type { DashboardScanJob } from '$lib/api/types';
+	import { catalogWarningNotice } from '$lib/season/experience';
 	import type { Snippet } from 'svelte';
 	import ThemeToggle from './ThemeToggle.svelte';
 
 	let { children }: { children: Snippet } = $props();
+	let scanJob = $state<DashboardScanJob | null>(null);
+	let scanRequest = 0;
+	const catalogWarning = $derived(catalogWarningNotice(scanJob));
 
 	const navigation = [
 		{ label: 'Library', href: '/', icon: 'seasons' },
@@ -26,6 +32,22 @@
 				pathname.startsWith('/folders/')
 			);
 		return pathname === href || pathname.startsWith(`${href}/`);
+	}
+
+	$effect(() => {
+		const pathname = page.url.pathname;
+		void pathname;
+		void refreshScanJob();
+	});
+
+	async function refreshScanJob() {
+		const request = ++scanRequest;
+		try {
+			const payload = await fetchJson<DashboardScanJob | null>('/api/dashboard/scan-job');
+			if (request === scanRequest) scanJob = payload;
+		} catch {
+			// Library routes remain useful when scan status cannot be refreshed.
+		}
 	}
 </script>
 
@@ -70,6 +92,14 @@
 			<ThemeToggle />
 		</div>
 	</header>
+	{#if catalogWarning}
+		<aside class="catalog-warning" role="alert" aria-live="polite">
+			<div class="catalog-warning__inner">
+				<strong>{catalogWarning.title}</strong>
+				<span>{catalogWarning.detail}</span>
+			</div>
+		</aside>
+	{/if}
 
 	<div class="app-content">
 		{@render children()}
@@ -179,6 +209,26 @@
 		min-height: calc(100vh - 58px);
 	}
 
+	.catalog-warning {
+		background: var(--mf-wait-bg);
+		border-bottom: 1px solid var(--mf-wait-line);
+		color: var(--mf-wait-fg);
+	}
+
+	.catalog-warning__inner {
+		align-items: baseline;
+		display: flex;
+		font-size: 13px;
+		gap: 8px;
+		margin: 0 auto;
+		max-width: 1120px;
+		padding: 9px 24px;
+	}
+
+	.catalog-warning__inner strong {
+		white-space: nowrap;
+	}
+
 	@media (max-width: 680px) {
 		.app-header__inner {
 			height: 62px;
@@ -220,6 +270,17 @@
 
 		.app-content {
 			min-height: calc(100vh - 62px);
+		}
+
+		.catalog-warning__inner {
+			align-items: stretch;
+			flex-direction: column;
+			gap: 2px;
+			padding: 9px 14px;
+		}
+
+		.catalog-warning__inner strong {
+			white-space: normal;
 		}
 	}
 </style>

--- a/frontend/src/lib/season/experience.test.ts
+++ b/frontend/src/lib/season/experience.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import type {
+	DashboardScanJob,
+	DashboardScanWarning,
 	DashboardSummaryPayload,
 	FolderCard,
 	FolderPayload,
@@ -12,6 +14,7 @@ import type {
 import {
 	activeSeasonCards,
 	approvalGuardFromMessage,
+	catalogWarningNotice,
 	compareRiskSummary,
 	currentOperatorIntent,
 	detailSeasonState,
@@ -110,6 +113,140 @@ const status = {
 	calibration_job: null,
 	folder_scan_job: null
 } satisfies FolderStatusPayload;
+
+function scanJobWithWarnings(...warnings: DashboardScanWarning[]): DashboardScanJob {
+	return {
+		job_id: 'scan-warning',
+		status: 'completed',
+		scope: 'full',
+		prefix: null,
+		created_at: null,
+		started_at: null,
+		finished_at: null,
+		error: null,
+		stats: { unchanged: 0, warnings }
+	};
+}
+
+describe('catalog scan warnings', () => {
+	it('explains that cached catalog state was preserved for unavailable storage', () => {
+		const notice = catalogWarningNotice({
+			job_id: 'scan-1',
+			status: 'completed',
+			scope: 'full',
+			prefix: null,
+			created_at: null,
+			started_at: null,
+			finished_at: null,
+			error: null,
+			stats: {
+				unchanged: 24,
+				warnings: [
+					{
+						code: 'source_unavailable',
+						library_key: 'movies',
+						label: 'Movies',
+						message: 'Movies is unavailable. Cached catalog state was preserved.',
+						preserved_item_count: 24
+					}
+				]
+			}
+		});
+
+		expect(notice).toEqual({
+			title: 'Movies storage is unavailable.',
+			detail:
+				'Cached catalog state was preserved. Mediaforce will try this library again after storage returns.'
+		});
+		expect(JSON.stringify(notice)).not.toContain('/Volumes/');
+	});
+
+	it('explains the mass-disappearance circuit breaker', () => {
+		const notice = catalogWarningNotice({
+			job_id: 'scan-2',
+			status: 'completed',
+			scope: 'full',
+			prefix: null,
+			created_at: null,
+			started_at: null,
+			finished_at: null,
+			error: null,
+			stats: {
+				unchanged: 5,
+				warnings: [
+					{
+						code: 'source_mass_disappearance',
+						library_key: 'movies',
+						label: 'Movies',
+						message: 'Movies returned far fewer media items than expected.',
+						preserved_item_count: 25
+					}
+				]
+			}
+		});
+
+		expect(notice?.title).toBe('Movies returned far fewer items than expected.');
+		expect(notice?.detail).toBe(
+			'Cached catalog state was preserved so surviving workflow status remains unchanged.'
+		);
+	});
+
+	it('explains unexpectedly empty and incomplete library scans', () => {
+		const empty = catalogWarningNotice(
+			scanJobWithWarnings({
+				code: 'source_unexpectedly_empty',
+				library_key: 'movies',
+				label: 'Movies',
+				message: 'Movies returned no media.',
+				preserved_item_count: 24
+			})
+		);
+		const incomplete = catalogWarningNotice(
+			scanJobWithWarnings({
+				code: 'source_scan_incomplete',
+				library_key: 'other',
+				label: 'Other',
+				message: 'Other could not be fully read.',
+				preserved_item_count: 8
+			})
+		);
+
+		expect(empty?.title).toBe('Movies returned no media.');
+		expect(empty?.detail).toContain('Disable or remove the library in Settings');
+		expect(incomplete).toEqual({
+			title: 'Other could not be fully read.',
+			detail:
+				'Cached catalog state was preserved because the scan did not finish reading this library.'
+		});
+	});
+
+	it('uses accurate generic copy when multiple warning types are present', () => {
+		const notice = catalogWarningNotice(
+			scanJobWithWarnings(
+				{
+					code: 'source_scan_incomplete',
+					library_key: 'tv',
+					label: 'TV',
+					message: 'TV could not be fully read.',
+					preserved_item_count: 12
+				},
+				{
+					code: 'source_mass_disappearance',
+					library_key: 'movies',
+					label: 'Movies',
+					message: 'Movies returned far fewer media items than expected.',
+					preserved_item_count: 25
+				}
+			)
+		);
+
+		expect(notice).toEqual({
+			title: '2 libraries need attention.',
+			detail:
+				'Mediaforce could not safely reconcile these libraries, so their cached catalog state was preserved.'
+		});
+	});
+});
 
 function folder(overrides: Partial<FolderPayload> = {}): FolderPayload {
 	return {

--- a/frontend/src/lib/season/experience.ts
+++ b/frontend/src/lib/season/experience.ts
@@ -1,4 +1,5 @@
 import type {
+	DashboardScanJob,
 	DashboardSummaryPayload,
 	EncodeQueueJob,
 	FolderCard,
@@ -44,6 +45,11 @@ export interface SeasonIdentity {
 	show: string;
 	season: string;
 	showPrefix: string;
+}
+
+export interface CatalogWarningNotice {
+	title: string;
+	detail: string;
 }
 
 export interface SizeGoal {
@@ -140,6 +146,55 @@ export const REVIEW_CONCERNS: readonly ReviewConcern[] = [
 
 const ACTIVE_JOB_STATUSES = new Set(['queued', 'running', 'starting', 'retry_backoff', 'stopping']);
 const FAILURE_JOB_STATUSES = new Set(['failed', 'stopped', 'needs_attention']);
+
+export function catalogWarningNotice(
+	scanJob: DashboardScanJob | null
+): CatalogWarningNotice | null {
+	const warnings = scanJob?.stats?.warnings ?? [];
+	if (warnings.length === 0) return null;
+	if (warnings.length > 1) {
+		return {
+			title: `${warnings.length} libraries need attention.`,
+			detail:
+				'Mediaforce could not safely reconcile these libraries, so their cached catalog state was preserved.'
+		};
+	}
+
+	const warning = warnings[0];
+	if (warning.code === 'source_unexpectedly_empty') {
+		return {
+			title: `${warning.label} returned no media.`,
+			detail:
+				'Cached catalog state was preserved. Disable or remove the library in Settings if it was intentionally cleared.'
+		};
+	}
+	if (warning.code === 'source_scan_incomplete') {
+		return {
+			title: `${warning.label} could not be fully read.`,
+			detail:
+				'Cached catalog state was preserved because the scan did not finish reading this library.'
+		};
+	}
+	if (warning.code === 'source_mass_disappearance') {
+		return {
+			title: `${warning.label} returned far fewer items than expected.`,
+			detail: 'Cached catalog state was preserved so surviving workflow status remains unchanged.'
+		};
+	}
+	if (warning.code === 'source_unavailable') {
+		return {
+			title: `${warning.label} storage is unavailable.`,
+			detail:
+				'Cached catalog state was preserved. Mediaforce will try this library again after storage returns.'
+		};
+	}
+	return {
+		title: `${warning.label} needs attention.`,
+		detail:
+			warning.message ||
+			'Cached catalog state was preserved because this library could not be reconciled.'
+	};
+}
 
 function record(value: unknown): Record<string, unknown> {
 	return value && typeof value === 'object' && !Array.isArray(value)

--- a/mediaforce/library/scanner.py
+++ b/mediaforce/library/scanner.py
@@ -2,11 +2,12 @@ import json
 import os
 import subprocess
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterator
 
-from sqlalchemy import and_, case, or_
+from sqlalchemy import and_, case
+from sqlalchemy import func
 from sqlalchemy import insert
 from sqlalchemy import not_
 from sqlalchemy import select
@@ -37,6 +38,23 @@ from mediaforce.core.utils import content_version_fingerprint, file_fingerprint,
 
 VIDEO_EXTENSIONS = {".avi", ".m4v", ".mkv", ".mp4", ".ts"}
 SCAN_COMMIT_INTERVAL = 25
+MASS_DISAPPEARANCE_MIN_ITEMS = 25
+MASS_DISAPPEARANCE_MAX_REMAINING_PERCENT = 20
+
+
+@dataclass(frozen=True, slots=True)
+class ScanWarning:
+    code: str
+    library_key: str
+    label: str
+    message: str
+    preserved_item_count: int
+
+
+@dataclass(slots=True)
+class _RootEnumeration:
+    issue_code: str | None = None
+    matched_count: int = 0
 
 
 @dataclass(slots=True)
@@ -47,16 +65,20 @@ class ScanStats:
     unchanged: int = 0
     missing: int = 0
     total_seen: int = 0
+    warnings: list[ScanWarning] = field(default_factory=list)
 
 
 def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[str] | None = None,
                  limit: int | None = None) -> ScanStats:
     scan_id = uuid.uuid4().hex
     started_at = timestamp()
-    scan_source_roots = getattr(config, "scan_source_root_map", config.source_root_map)
-    roots_json = json.dumps(sorted(scan_source_roots.keys()))
     normalized_prefixes = sorted({prefix.strip("/") for prefix in object_list(prefixes) if str(prefix).strip("/")})
-    scope = "prefix" if normalized_prefixes else "full"
+    scan_source_roots = _scan_roots_for_prefixes(
+        getattr(config, "scan_source_root_map", config.source_root_map),
+        normalized_prefixes,
+    )
+    roots_json = json.dumps(sorted(scan_source_roots.keys()))
+    scope = "limited" if limit is not None else "prefix" if normalized_prefixes else "full"
     connection.execute(
         insert(scan_runs).values(
             scan_id=scan_id,
@@ -71,20 +93,34 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
     connection.commit()
 
     stats = ScanStats(scan_id=scan_id)
-    seen_paths: set[str] = set()
+    seen_paths_by_root: dict[str, set[str]] = {}
+    reconcilable_roots: set[str] = set()
     pending_writes = 0
+    full_scan = not normalized_prefixes and limit is None
 
     for root_name, root_path in scan_source_roots.items():
-        for file_path in _iter_media_files(root_name, root_path, prefixes=normalized_prefixes or None, limit=limit,
-                                           seen=stats.total_seen):
+        previous_item_count = _active_item_count(connection, root_name) if full_scan else 0
+        enumeration = _RootEnumeration()
+        root_seen_paths = seen_paths_by_root.setdefault(root_name, set())
+        for file_path in _iter_media_files(
+                root_name,
+                root_path,
+                prefixes=normalized_prefixes or None,
+                limit=limit,
+                seen=stats.total_seen,
+                enumeration=enumeration,
+        ):
             source_path = str(file_path)
             logical_path = logical_library_rel_path(root_name, root_path, file_path)
             rel_path = logical_path.as_posix()
             parent_dir = logical_path.parent.as_posix()
-            seen_paths.add(source_path)
+            try:
+                stat_result = file_path.stat()
+            except OSError:
+                enumeration.issue_code = "source_scan_incomplete"
+                continue
+            root_seen_paths.add(source_path)
             stats.total_seen += 1
-
-            stat_result = file_path.stat()
             try:
                 content_fingerprint = content_version_fingerprint(file_path, stat_result)
             except OSError:
@@ -216,30 +252,37 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
             if limit is not None and stats.total_seen >= limit:
                 break
 
+        if enumeration.issue_code:
+            stats.warnings.append(
+                _scan_warning(config, root_name, enumeration.issue_code, previous_item_count)
+            )
+        elif full_scan and previous_item_count > 0 and enumeration.matched_count == 0:
+            stats.warnings.append(
+                _scan_warning(config, root_name, "source_unexpectedly_empty", previous_item_count)
+            )
+        elif full_scan and _mass_disappearance_is_suspicious(previous_item_count, enumeration.matched_count):
+            stats.warnings.append(
+                _scan_warning(
+                    config,
+                    root_name,
+                    "source_mass_disappearance",
+                    max(previous_item_count - enumeration.matched_count, 0),
+                )
+            )
+        else:
+            reconcilable_roots.add(root_name)
+
         if limit is not None and stats.total_seen >= limit:
             break
 
-    full_scan = not normalized_prefixes and limit is None
     if full_scan:
-        active_roots = tuple(scan_source_roots.keys())
-        stale_filter = library_items.c.status != "missing"
-        if active_roots and seen_paths:
-            stale_filter = and_(
-                stale_filter,
-                or_(
-                    not_(library_items.c.media_root.in_(active_roots)),
-                    and_(
-                        library_items.c.media_root.in_(active_roots),
-                        not_(library_items.c.source_path.in_(tuple(seen_paths))),
-                    ),
-                ),
-            )
-        cursor = connection.execute(
-            update(library_items)
-            .where(stale_filter)
-            .values(status="missing", updated_at=started_at)
+        stats.missing = _reconcile_missing_items(
+            connection,
+            configured_roots=set(scan_source_roots),
+            reconcilable_roots=reconcilable_roots,
+            seen_paths_by_root=seen_paths_by_root,
+            updated_at=started_at,
         )
-        stats.missing = int_value(cursor.rowcount) if cursor.rowcount != -1 else 0
         pending_writes = _flush_scan_progress(connection, scan_id, stats, pending_writes + 1)
 
     _flush_scan_progress(connection, scan_id, stats, pending_writes, force=True)
@@ -391,23 +434,154 @@ def _failed_probe_summary(error: Exception) -> ProbeSummary:
     )
 
 
+def _active_item_count(connection: DBClient, root_name: str) -> int:
+    return int(
+        connection.execute(
+            select(func.count())
+            .select_from(library_items)
+            .where(
+                library_items.c.media_root == root_name,
+                library_items.c.status != "missing",
+            )
+        ).scalar_one()
+    )
+
+
+def _scan_roots_for_prefixes(
+        scan_source_roots: dict[str, Path],
+        normalized_prefixes: list[str],
+) -> dict[str, Path]:
+    if not normalized_prefixes:
+        return scan_source_roots
+    return {
+        root_name: root_path
+        for root_name, root_path in scan_source_roots.items()
+        if any(
+            prefix == root_name or prefix.startswith(f"{root_name}/")
+            for prefix in normalized_prefixes
+        )
+    }
+
+
+def _mass_disappearance_is_suspicious(previous_item_count: int, matched_count: int) -> bool:
+    return (
+        previous_item_count >= MASS_DISAPPEARANCE_MIN_ITEMS
+        and matched_count > 0
+        and matched_count * 100 <= previous_item_count * MASS_DISAPPEARANCE_MAX_REMAINING_PERCENT
+    )
+
+
+def _scan_warning(
+        config: MediaforceConfig,
+        root_name: str,
+        code: str,
+        preserved_item_count: int,
+) -> ScanWarning:
+    definitions = getattr(config, "library_definition_map", {})
+    definition = definitions.get(root_name, {}) if isinstance(definitions, dict) else {}
+    label = str(definition.get("label") or root_name.replace("_", " ").replace("-", " ").title())
+    if code == "source_unexpectedly_empty":
+        message = (
+            f"{label} returned no media. Cached catalog state was preserved; disable or remove the library "
+            "in Settings to accept the empty state."
+        )
+    elif code == "source_mass_disappearance":
+        message = (
+            f"{label} returned far fewer media items than expected. Cached catalog state was preserved so "
+            "surviving workflow status remains unchanged."
+        )
+    elif code == "source_scan_incomplete":
+        message = f"{label} could not be fully read. Cached catalog state was preserved."
+    else:
+        message = f"{label} is unavailable. Cached catalog state was preserved."
+    return ScanWarning(
+        code=code,
+        library_key=root_name,
+        label=label,
+        message=message,
+        preserved_item_count=preserved_item_count,
+    )
+
+
+def _reconcile_missing_items(
+        connection: DBClient,
+        *,
+        configured_roots: set[str],
+        reconcilable_roots: set[str],
+        seen_paths_by_root: dict[str, set[str]],
+        updated_at: str,
+) -> int:
+    missing_count = 0
+    removed_root_filter = library_items.c.status != "missing"
+    if configured_roots:
+        removed_root_filter = and_(
+            removed_root_filter,
+            not_(library_items.c.media_root.in_(tuple(sorted(configured_roots)))),
+        )
+    missing_count += _mark_items_missing(connection, removed_root_filter, updated_at)
+
+    for root_name in sorted(reconcilable_roots):
+        stale_filter = and_(
+            library_items.c.status != "missing",
+            library_items.c.media_root == root_name,
+        )
+        seen_paths = seen_paths_by_root.get(root_name, set())
+        if not seen_paths:
+            continue
+        stale_filter = and_(
+            stale_filter,
+            not_(library_items.c.source_path.in_(tuple(sorted(seen_paths)))),
+        )
+        missing_count += _mark_items_missing(connection, stale_filter, updated_at)
+    return missing_count
+
+
+def _mark_items_missing(connection: DBClient, stale_filter: Any, updated_at: str) -> int:
+    cursor = connection.execute(
+        update(library_items)
+        .where(stale_filter)
+        .values(status="missing", updated_at=updated_at)
+    )
+    return int_value(cursor.rowcount) if cursor.rowcount != -1 else 0
+
+
 def _iter_media_files(
         root_name: str,
         root_path: Path,
         prefixes: list[str] | None,
         limit: int | None,
         seen: int,
+        enumeration: _RootEnumeration | None = None,
 ) -> Iterator[Path]:
+    scan_state = enumeration or _RootEnumeration()
+    if limit is not None and seen >= limit:
+        return
+    try:
+        if not root_path.is_dir():
+            scan_state.issue_code = "source_unavailable"
+            return
+    except OSError:
+        scan_state.issue_code = "source_unavailable"
+        return
+
     matched = 0
-    for dirpath, _, filenames in os.walk(root_path):
-        for name in sorted(filenames):
-            file_path = Path(dirpath, name)
-            if file_path.suffix.lower() not in VIDEO_EXTENSIONS:
-                continue
-            rel_path = logical_library_rel_path(root_name, root_path, file_path).as_posix()
-            if prefixes and not any(path_matches_scope(rel_path, prefix) for prefix in prefixes):
-                continue
-            yield file_path
-            matched += 1
-            if limit is not None and seen + matched >= limit:
-                return
+
+    def _record_error(_error: OSError) -> None:
+        scan_state.issue_code = "source_scan_incomplete"
+
+    try:
+        for dirpath, _, filenames in os.walk(root_path, onerror=_record_error):
+            for name in sorted(filenames):
+                file_path = Path(dirpath, name)
+                if file_path.suffix.lower() not in VIDEO_EXTENSIONS:
+                    continue
+                rel_path = logical_library_rel_path(root_name, root_path, file_path).as_posix()
+                if prefixes and not any(path_matches_scope(rel_path, prefix) for prefix in prefixes):
+                    continue
+                matched += 1
+                scan_state.matched_count += 1
+                yield file_path
+                if limit is not None and seen + matched >= limit:
+                    return
+    except OSError:
+        scan_state.issue_code = "source_scan_incomplete"

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -802,6 +802,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     register_dashboard_routes(
         app,
         dashboard_payload=_dashboard_api_payload,
+        dashboard_scan_job_payload=lambda: _load_scan_job_state(config, None),
         dashboard_folders_payload=_dashboard_folders_payload,
         dashboard_library_payload=_dashboard_library_payload,
         dashboard_library_details_payload=_dashboard_library_details_payload,

--- a/mediaforce/web/routes/dashboard.py
+++ b/mediaforce/web/routes/dashboard.py
@@ -11,6 +11,7 @@ def register_dashboard_routes(
         app: FastAPI,
         *,
         dashboard_payload: Callable[[int | None], dict[str, Any]],
+        dashboard_scan_job_payload: Callable[[], dict[str, Any] | None],
         dashboard_folders_payload: Callable[[bool], dict[str, Any]],
         dashboard_library_payload: Callable[[], dict[str, Any]],
         dashboard_library_details_payload: Callable[[], dict[str, Any]],
@@ -22,6 +23,10 @@ def register_dashboard_routes(
     @app.get("/api/dashboard")
     def api_dashboard(preview_limit: PreviewLimit = None) -> JSONResponse:
         return JSONResponse(dashboard_payload(preview_limit))
+
+    @app.get("/api/dashboard/scan-job")
+    def api_dashboard_scan_job() -> JSONResponse:
+        return JSONResponse(dashboard_scan_job_payload())
 
     @app.get("/api/dashboard/folders")
     def api_dashboard_folders(include_series: int = 1) -> JSONResponse:

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -39,6 +39,7 @@ const APP_ROOT_SELECTOR = ".app-shell";
 
 const endpointChecks = [
   ["Dashboard summary", "/api/dashboard"],
+  ["Dashboard scan job", "/api/dashboard/scan-job"],
   ["Dashboard folders", "/api/dashboard/folders"],
   ["Library structure", "/api/dashboard/library"],
   ["Library details", "/api/dashboard/library/details"],
@@ -308,7 +309,7 @@ async function checkEndpoints(baseUrl, timeoutMs) {
 }
 
 async function checkRoutes(baseUrl, routeChecksForBrowser, timeoutMs) {
-  const browser = await chromium.launch();
+  const browser = await chromium.launch({ channel: "chromium" });
   try {
     const page = await browser.newPage({
       viewport: { width: 1440, height: 1000 },
@@ -417,7 +418,7 @@ async function checkLibraryStructureWithoutDashboard(
   expectedMarker,
   timeoutMs,
 ) {
-  const browser = await chromium.launch();
+  const browser = await chromium.launch({ channel: "chromium" });
   try {
     const page = await browser.newPage({
       viewport: { width: 1440, height: 1000 },
@@ -479,7 +480,7 @@ async function checkLibraryStructureWithoutDashboard(
 }
 
 async function checkLifecyclePolicyShowIsolation(baseUrl, timeoutMs) {
-  const browser = await chromium.launch();
+  const browser = await chromium.launch({ channel: "chromium" });
   try {
     const page = await browser.newPage({
       viewport: { width: 1440, height: 1000 },
@@ -550,7 +551,7 @@ async function checkLifecyclePolicyShowIsolation(baseUrl, timeoutMs) {
 }
 
 async function checkOlderSeasonConfirmation(baseUrl, timeoutMs) {
-  const browser = await chromium.launch();
+  const browser = await chromium.launch({ channel: "chromium" });
   try {
     const page = await browser.newPage({
       viewport: { width: 1440, height: 1000 },
@@ -602,7 +603,7 @@ async function checkOlderSeasonConfirmation(baseUrl, timeoutMs) {
 }
 
 async function checkNarrowRoutes(baseUrl, routeChecksForNarrow, timeoutMs) {
-  const browser = await chromium.launch();
+  const browser = await chromium.launch({ channel: "chromium" });
   try {
     const page = await browser.newPage({
       viewport: NARROW_VIEWPORT,

--- a/tests/test_scanner_runtime.py
+++ b/tests/test_scanner_runtime.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from mediaforce.core.config import ConfigPaths, MediaforceConfig
 from mediaforce.core.db import open_db, reset_engine_cache
-from mediaforce.core.db_tables import library_items
+from mediaforce.core.db_tables import library_items, scan_runs
 from mediaforce.core.models import ProbeSummary
 from mediaforce.library.scanner import (
     _cadence_summary_present,
@@ -21,6 +21,7 @@ from mediaforce.library.scanner import (
     scan_library,
 )
 from mediaforce.core.utils import content_version_fingerprint
+from mediaforce.web.runtime.job_runtime import _stats_payload
 
 
 class _FakeCursor:
@@ -53,6 +54,42 @@ class _FakeConfig:
 
 
 class ScannerRuntimeTests(unittest.TestCase):
+    @staticmethod
+    def _config(project_root: Path, roots: dict[str, Path], labels: dict[str, str] | None = None) -> MediaforceConfig:
+        paths = ConfigPaths(
+            project_root=project_root,
+            config_path=project_root / "config.toml",
+            db_path=project_root / "library.sqlite3",
+            run_manifest_dir=project_root / "runs",
+            web_state_dir=project_root / "web",
+            review_dir=project_root / "review",
+            runtime_settings_path=project_root / "runtime-settings.json",
+        )
+        return MediaforceConfig(
+            raw={
+                "media": {
+                    "libraries": [
+                        {
+                            "key": key,
+                            "label": (labels or {}).get(key, key.replace("_", " ").title()),
+                            "path": str(path),
+                            "type": "other",
+                            "availability": "browse_only",
+                        }
+                        for key, path in roots.items()
+                    ]
+                },
+                "video": {},
+                "audio": {},
+                "subtitle": {},
+                "planning": {},
+                "validation": {},
+                "overrides": [],
+                "remote_hosts": [],
+            },
+            paths=paths,
+        )
+
     def test_content_version_fingerprint_ignores_mtime_but_detects_same_size_replacement(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "episode.mkv"
@@ -221,6 +258,331 @@ class ScannerRuntimeTests(unittest.TestCase):
         self.assertEqual(row["media_root"], "films")
         self.assertEqual(row["rel_path"], "films/Example/Feature.mkv")
         self.assertEqual(row["parent_dir"], "films/Example")
+
+    def test_unavailable_root_preserves_catalog_rows_and_reports_redacted_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "Mounted Movies"
+            media_root.mkdir()
+            movie = media_root / "Feature.mkv"
+            movie.write_bytes(b"movie")
+            config = self._config(project_root, {"movies": media_root}, {"movies": "Movies"})
+
+            try:
+                with patch(
+                    "mediaforce.library.scanner.probe_media",
+                    return_value=_failed_probe_summary(RuntimeError("fixture probe")),
+                ):
+                    with open_db(config.paths.db_path) as connection:
+                        scan_library(connection, config)
+                        connection.execute(update(library_items).values(status="promoted"))
+                        connection.commit()
+                        before = connection.execute(select(library_items)).mappings().one()
+                        movie.unlink()
+                        media_root.rmdir()
+
+                        stats = scan_library(connection, config)
+                        after = connection.execute(select(library_items)).mappings().one()
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(after["status"], "promoted")
+        self.assertEqual(after["status"], before["status"])
+        self.assertEqual(after["last_scan_id"], before["last_scan_id"])
+        self.assertEqual(stats.missing, 0)
+        self.assertEqual([warning.code for warning in stats.warnings], ["source_unavailable"])
+        payload = _stats_payload(stats)
+        self.assertEqual(payload["warnings"][0]["label"], "Movies")
+        self.assertEqual(payload["warnings"][0]["preserved_item_count"], 1)
+        self.assertNotIn(str(media_root), json.dumps(payload))
+
+    def test_unexpectedly_empty_root_preserves_previous_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            movie = media_root / "Feature.mkv"
+            movie.write_bytes(b"movie")
+            config = self._config(project_root, {"movies": media_root})
+
+            try:
+                with patch(
+                    "mediaforce.library.scanner.probe_media",
+                    return_value=_failed_probe_summary(RuntimeError("fixture probe")),
+                ):
+                    with open_db(config.paths.db_path) as connection:
+                        scan_library(connection, config)
+                        movie.unlink()
+                        stats = scan_library(connection, config)
+                        row = connection.execute(select(library_items)).mappings().one()
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(row["status"], "discovered")
+        self.assertEqual(stats.missing, 0)
+        self.assertEqual([warning.code for warning in stats.warnings], ["source_unexpectedly_empty"])
+        self.assertIn("disable or remove", stats.warnings[0].message)
+
+    def test_healthy_root_reconciles_deletion_while_unavailable_root_is_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            healthy_root = project_root / "healthy"
+            unavailable_root = project_root / "unavailable"
+            healthy_root.mkdir()
+            unavailable_root.mkdir()
+            kept = healthy_root / "kept.mkv"
+            removed = healthy_root / "removed.mkv"
+            preserved = unavailable_root / "preserved.mkv"
+            kept.write_bytes(b"kept")
+            removed.write_bytes(b"removed")
+            preserved.write_bytes(b"preserved")
+            config = self._config(
+                project_root,
+                {"healthy": healthy_root, "archive": unavailable_root},
+                {"healthy": "Healthy", "archive": "Archive"},
+            )
+
+            try:
+                with patch(
+                    "mediaforce.library.scanner.probe_media",
+                    return_value=_failed_probe_summary(RuntimeError("fixture probe")),
+                ):
+                    with open_db(config.paths.db_path) as connection:
+                        scan_library(connection, config)
+                        removed.unlink()
+                        preserved.unlink()
+                        unavailable_root.rmdir()
+
+                        stats = scan_library(connection, config)
+                        rows = {
+                            row["file_name"]: row
+                            for row in connection.execute(select(library_items)).mappings().all()
+                        }
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(rows["kept.mkv"]["status"], "discovered")
+        self.assertEqual(rows["removed.mkv"]["status"], "missing")
+        self.assertEqual(rows["preserved.mkv"]["status"], "discovered")
+        self.assertEqual(stats.missing, 1)
+        self.assertEqual([warning.library_key for warning in stats.warnings], ["archive"])
+
+    def test_mass_disappearance_preserves_rows_and_reports_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            files = [media_root / f"Feature-{index:02d}.mkv" for index in range(30)]
+            for file_path in files:
+                file_path.write_bytes(file_path.name.encode())
+            config = self._config(project_root, {"movies": media_root}, {"movies": "Movies"})
+
+            try:
+                with patch(
+                    "mediaforce.library.scanner.probe_media",
+                    return_value=_failed_probe_summary(RuntimeError("fixture probe")),
+                ):
+                    with open_db(config.paths.db_path) as connection:
+                        scan_library(connection, config)
+                        for file_path in files[5:]:
+                            file_path.unlink()
+
+                        stats = scan_library(connection, config)
+                        statuses = connection.execute(select(library_items.c.status)).scalars().all()
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(set(statuses), {"discovered"})
+        self.assertEqual(stats.missing, 0)
+        self.assertEqual([warning.code for warning in stats.warnings], ["source_mass_disappearance"])
+        self.assertEqual(stats.warnings[0].preserved_item_count, 25)
+
+    def test_prefix_scan_does_not_touch_or_warn_about_unrelated_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            tv_root = project_root / "tv"
+            movie_root = project_root / "movies"
+            tv_root.mkdir()
+            movie_root.mkdir()
+            (tv_root / "Episode.mkv").write_bytes(b"episode")
+            movie = movie_root / "Feature.mkv"
+            movie.write_bytes(b"movie")
+            config = self._config(project_root, {"tv": tv_root, "movies": movie_root})
+
+            try:
+                with patch(
+                    "mediaforce.library.scanner.probe_media",
+                    return_value=_failed_probe_summary(RuntimeError("fixture probe")),
+                ):
+                    with open_db(config.paths.db_path) as connection:
+                        scan_library(connection, config)
+                        movie.unlink()
+                        movie_root.rmdir()
+
+                        stats = scan_library(connection, config, prefixes=["tv"])
+                        rows = {
+                            row["media_root"]: row
+                            for row in connection.execute(select(library_items)).mappings().all()
+                        }
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(stats.total_seen, 1)
+        self.assertEqual(stats.warnings, [])
+        self.assertEqual(rows["movies"]["status"], "discovered")
+
+    def test_prefix_scan_reports_target_root_unavailable_without_reconciling(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            movie = media_root / "Feature.mkv"
+            movie.write_bytes(b"movie")
+            config = self._config(project_root, {"movies": media_root}, {"movies": "Movies"})
+
+            try:
+                with patch(
+                    "mediaforce.library.scanner.probe_media",
+                    return_value=_failed_probe_summary(RuntimeError("fixture probe")),
+                ):
+                    with open_db(config.paths.db_path) as connection:
+                        scan_library(connection, config)
+                        movie.unlink()
+                        media_root.rmdir()
+
+                        stats = scan_library(connection, config, prefixes=["movies"])
+                        row = connection.execute(select(library_items)).mappings().one()
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(row["status"], "discovered")
+        self.assertEqual([warning.code for warning in stats.warnings], ["source_unavailable"])
+        self.assertNotIn(str(media_root), json.dumps(_stats_payload(stats)))
+
+    def test_new_empty_root_is_valid_without_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "empty"
+            media_root.mkdir()
+            config = self._config(project_root, {"empty": media_root})
+
+            try:
+                with open_db(config.paths.db_path) as connection:
+                    stats = scan_library(connection, config)
+                    rows = connection.execute(select(library_items)).mappings().all()
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(rows, [])
+        self.assertEqual(stats.missing, 0)
+        self.assertEqual(stats.warnings, [])
+
+    def test_removed_root_marks_previous_rows_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            (media_root / "Feature.mkv").write_bytes(b"movie")
+            configured = self._config(project_root, {"movies": media_root})
+            removed = self._config(project_root, {})
+
+            try:
+                with patch(
+                    "mediaforce.library.scanner.probe_media",
+                    return_value=_failed_probe_summary(RuntimeError("fixture probe")),
+                ):
+                    with open_db(configured.paths.db_path) as connection:
+                        scan_library(connection, configured)
+                        stats = scan_library(connection, removed)
+                        row = connection.execute(select(library_items)).mappings().one()
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(row["status"], "missing")
+        self.assertEqual(stats.missing, 1)
+        self.assertEqual(stats.warnings, [])
+
+    def test_enumeration_error_preserves_rows_without_exposing_error_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            (media_root / "Feature.mkv").write_bytes(b"movie")
+            config = self._config(project_root, {"movies": media_root}, {"movies": "Movies"})
+
+            def unreadable_walk(_root: Path, *, onerror: Any) -> Any:
+                onerror(PermissionError(str(media_root / "private")))
+                return iter(())
+
+            try:
+                with patch(
+                    "mediaforce.library.scanner.probe_media",
+                    return_value=_failed_probe_summary(RuntimeError("fixture probe")),
+                ):
+                    with open_db(config.paths.db_path) as connection:
+                        scan_library(connection, config)
+                        with patch("mediaforce.library.scanner.os.walk", side_effect=unreadable_walk):
+                            stats = scan_library(connection, config)
+                        row = connection.execute(select(library_items)).mappings().one()
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(row["status"], "discovered")
+        self.assertEqual([warning.code for warning in stats.warnings], ["source_scan_incomplete"])
+        self.assertNotIn(str(media_root), json.dumps(_stats_payload(stats)))
+
+    def test_file_stat_error_preserves_rows_without_exposing_file_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            movie = media_root / "Feature.mkv"
+            movie.write_bytes(b"movie")
+            config = self._config(project_root, {"movies": media_root}, {"movies": "Movies"})
+            original_stat = Path.stat
+
+            def flaky_stat(path: Path, *args: Any, **kwargs: Any) -> os.stat_result:
+                if path == movie:
+                    raise FileNotFoundError(str(path))
+                return original_stat(path, *args, **kwargs)
+
+            try:
+                with patch(
+                    "mediaforce.library.scanner.probe_media",
+                    return_value=_failed_probe_summary(RuntimeError("fixture probe")),
+                ):
+                    with open_db(config.paths.db_path) as connection:
+                        scan_library(connection, config)
+                        connection.execute(update(library_items).values(status="promoted"))
+                        connection.commit()
+                        with patch.object(Path, "stat", new=flaky_stat):
+                            stats = scan_library(connection, config)
+                        row = connection.execute(select(library_items)).mappings().one()
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(row["status"], "promoted")
+        self.assertEqual([warning.code for warning in stats.warnings], ["source_scan_incomplete"])
+        self.assertNotIn(str(movie), json.dumps(_stats_payload(stats)))
+
+    def test_limited_scan_is_not_recorded_as_a_full_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            (media_root / "Feature.mkv").write_bytes(b"movie")
+            config = self._config(project_root, {"movies": media_root})
+
+            try:
+                with open_db(config.paths.db_path) as connection:
+                    stats = scan_library(connection, config, limit=0)
+                    scan_row = connection.execute(select(scan_runs)).mappings().one()
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(stats.total_seen, 0)
+        self.assertEqual(scan_row["scope"], "limited")
+        self.assertEqual(scan_row["file_count"], 0)
 
     def test_failed_probe_becomes_blocked_unknown_evidence(self) -> None:
         summary = _failed_probe_summary(RuntimeError("corrupt media"))


### PR DESCRIPTION
## Summary
- reconcile full scans per configured root and preserve catalog/workflow state when a root is unavailable, incomplete, unexpectedly empty, or loses at least 80% of a previously populated catalog
- scope prefix scans to the addressed root, keep limited scans from satisfying full-scan freshness, and degrade file-level read races to redacted warnings
- expose completed scan warnings through a read-only endpoint and a global workstation banner across TV, Movies, Other, Activity, Finished, and Settings
- document the fail-safe contract and explicit disable/remove path for accepting a fully emptied root

## Validation
- `bash scripts/pre-commit-check.sh` — 962 backend tests, 207 frontend tests, CLI smoke, typecheck, lint, build, and desktop/narrow route smoke passed
- `uv build` — source distribution and wheel passed
- real-browser review at 1024px and 390px — warning remained visible across TV, Movies, and Other with no horizontal overflow or machine-local path exposure
- independent backend/frontend reviews completed; blocking and medium findings were addressed
- PyCharm changed-files inspection reported zero findings but an `UNKNOWN` verdict because the Svelte file was treated as plain text rather than semantically inspected

Closes #207