### PR TITLE
Stop routine reads and unchanged scans from launching media analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ On macOS, Mediaforce now prefers Homebrew's `ffmpeg-full` and `ffprobe` from
 changes and normal formula upgrades. You can override either binary with
 `MEDIAFORCE_FFMPEG` or `MEDIAFORCE_FFPROBE`.
 
-The web UI also auto-starts background catalog refreshes when the full library
-view is empty or stale, and it auto-refreshes the current folder before
-showing calibration actions when that folder's scan data is stale. A full scan
-also refreshes configured Plex and TMDB metadata; provider failures leave the
-last successful metadata in place and surface a warning instead of blocking the
-catalog scan.
+Web and API reads only report persisted catalog and job state; opening or
+polling a page does not start scans, host probes, or media analysis. Save a
+library-path change in Settings or run `mediaforce scan` when inventory should
+be reconciled. A full scan also refreshes configured Plex and TMDB metadata;
+provider failures leave the last successful metadata in place and surface a
+warning instead of blocking the catalog scan.
 
 The `/folders` index can browse either season folders or whole TV series
 prefixes. Use the Scope control there when an operation should cover an entire

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,3 +51,5 @@ Use this directory for guidance that should not live in `AGENTS.md`.
   contract for UI exploration and critique
 - `docs/development/browser-qa-matrix.md`: repeatable browser route, fixture,
   and narrow-layout validation matrix
+- `docs/development/catalog-refresh-benchmark.md`: generated catalog-scale
+  inventory benchmark and subprocess/resource metrics

--- a/docs/architecture/cadence-evidence.md
+++ b/docs/architecture/cadence-evidence.md
@@ -7,9 +7,13 @@
   allow-list.
 - `mediaforce/library/probe.py` records ffprobe stream metadata and runs bounded
   idet ranges only when frame order is not already known to be progressive.
+- `mediaforce/library/scanner.py` preserves cadence summaries while reconciling
+  unchanged catalog rows. Missing, malformed, old, or retryable cadence
+  remains non-current evidence and does not make routine inventory refresh
+  decode the source again.
 - `mediaforce/library/planner.py` binds persisted cadence facts to the source
-  fingerprint, cadence transform policy, and versioned evidence envelope carried by each
-  manifest item.
+  fingerprint, cadence transform policy, and versioned evidence envelope
+  carried by each manifest item.
 - `mediaforce/encoding/video_filters.py` is the only place that compiles a
   resolved cadence transform into an ffmpeg filter graph.
 
@@ -24,8 +28,8 @@ Cadence evidence version 1 persists:
 
 The manifest evidence ID includes the source fingerprint, cadence transform
 policy, measurement ranges, tool version, and derived decision. A source,
-transform-policy, or tool change therefore produces a different identity rather than
-silently reusing stale cadence facts.
+transform-policy, or tool change therefore produces a different identity
+rather than silently reusing stale cadence facts.
 
 ## Classification and gates
 
@@ -43,11 +47,12 @@ strings are never accepted.
 
 Mixed, unknown, low-coverage, and low-confidence results block sample search,
 bakeoff, and production before ffmpeg starts. The operator-visible error asks
-for a fresh scan or more evidence; the LLM cannot choose a cadence transform.
+for refreshed cadence analysis or more evidence; the LLM cannot choose a
+cadence transform.
 Sampling, preview clips, bakeoff plans, and production all call the same filter
 compiler, so the reviewed transform cannot drift before the final encode.
 
 New manifests built from catalog rows without cadence evidence remain blocked
-until those rows are reprobed. Already-written legacy manifests that predate the
-cadence contract remain runnable; rebuilding them opts them into the evidence
-gate instead of silently treating unknown material as progressive.
+until cadence analysis is refreshed. Already-written legacy manifests that
+predate the cadence contract remain runnable; rebuilding them opts them into the
+evidence gate instead of silently treating unknown material as progressive.

--- a/docs/architecture/media-fingerprint-evidence.md
+++ b/docs/architecture/media-fingerprint-evidence.md
@@ -7,10 +7,10 @@
   and low-confidence advisory gates.
 - `mediaforce/library/probe.py` records the persisted fingerprint summary during
   media probing alongside cadence evidence.
-- `mediaforce/library/scanner.py` treats missing, malformed, or old fingerprint
-  summaries as stale scan facts and records explicit unknown summaries for
-  failed probes. Failed-probe summaries carry a retry marker and never satisfy
-  the unchanged-row freshness check.
+- `mediaforce/library/scanner.py` preserves fingerprint summaries while
+  reconciling unchanged catalog rows, even when the summary is missing,
+  malformed, old, or retryable. New or content-changed files still receive the
+  existing full probe until the durable evidence worker owns refreshes.
 - `mediaforce/library/planner.py` binds persisted fingerprint facts to the
   current source fingerprint and carries the versioned envelope on manifest
   items.
@@ -36,6 +36,9 @@ The manifest envelope includes the source fingerprint, analyzer/tool version,
 policy hash, sampled ranges, aggregate measurements, audio probe facts, and the
 derived decision. A source fingerprint, analyzer, or policy change therefore
 creates a different evidence identity instead of silently reusing stale facts.
+Catalog freshness does not make stale fingerprint evidence current; malformed
+or missing summaries are projected as explicit unknown evidence at planning
+boundaries instead of forcing a catalog-wide media reread.
 
 ## Classification and gates
 

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -80,6 +80,8 @@ Guidance:
   - `folder_ai_tuning.py`
   - `dashboard_payloads.py`
   - `settings_payloads.py`
+  - `tool_capabilities.py`
+    - explicit-lifecycle ffmpeg capability snapshots used by read-only payloads
 - `serializers.py`
   - shared API payload shaping across routes
 
@@ -159,7 +161,8 @@ Guidance:
 - `probe.py`
   - ffprobe-based media inspection and audio, subtitle, attachment track summaries
 - `scanner.py`
-  - library scan orchestration and catalog updates
+  - library inventory orchestration and catalog updates
+  - unchanged inventory rows preserve evidence without launching deep analysis
 - `media_scopes.py`
   - canonical operator grouping for TV, movie, and generic media roots
   - exact-item versus descendant matching, SQL-safe boundaries, and API scope payloads

--- a/docs/development/catalog-refresh-benchmark.md
+++ b/docs/development/catalog-refresh-benchmark.md
@@ -1,0 +1,49 @@
+# Catalog Refresh Benchmark
+
+Use the generated benchmark to prove that an unchanged catalog refresh stays
+inside the inventory path and launches no media-analysis child processes.
+
+## Run
+
+```bash
+uv run scripts/benchmark_catalog_refresh.py
+```
+
+The default matrix covers 1,000 items, 10,000 items, the current catalog size,
+and twice the current catalog size. Each generated catalog is refreshed twice
+to catch work that only reappears on a later pass. Use `--sizes` or
+`--iterations` for a focused local run:
+
+```bash
+uv run scripts/benchmark_catalog_refresh.py --sizes 1000,10000
+```
+
+Use `--output` to retain point-in-time JSON outside the repository:
+
+```bash
+uv run scripts/benchmark_catalog_refresh.py \
+  --output ~/Desktop/mediaforce-catalog-refresh-benchmark.json
+```
+
+## Metrics
+
+Each generated catalog contains unchanged files whose cadence and fingerprint
+evidence is intentionally mixed between missing, malformed, and retryable
+states. A passing result records:
+
+- zero child-process launches
+- zero discovered or reprobed items
+- every generated item counted as unchanged
+- wall and CPU time
+- Python allocation peak and process peak RSS
+- database operation count and elapsed time
+- database calls over the lock-wait threshold and any SQLite busy/locked errors
+
+`db_lock_wait_events` counts database calls whose elapsed time meets the
+configured threshold. It is a conservative contention signal rather than an
+internal SQLite lock-wait counter. `db_lock_errors` records explicit busy or
+locked failures.
+
+The benchmark creates all media, database, and runtime state under a temporary
+directory and removes it after each case. It never writes review media or
+runtime state into the repository.

--- a/mediaforce/encoding/cadence.py
+++ b/mediaforce/encoding/cadence.py
@@ -305,7 +305,7 @@ def cadence_manifest_payload(
     ):
         decision = _unknown_decision(
             0.0,
-            "Cadence evidence uses an unsupported analyzer version; run a new scan before encoding.",
+            "Cadence evidence uses an unsupported analyzer version; refresh cadence analysis before encoding.",
         )
     else:
         decision = classify_cadence(
@@ -431,7 +431,7 @@ def _unknown_decision(coverage: float, rationale: str | None = None) -> dict[str
         confidence=0.0,
         coverage=coverage,
         transform=None,
-        rationale=rationale or "Cadence evidence is missing or inconclusive; run a new scan before encoding.",
+        rationale=rationale or "Cadence evidence is missing or inconclusive; refresh cadence analysis before encoding.",
     )
 
 

--- a/mediaforce/encoding/fingerprint.py
+++ b/mediaforce/encoding/fingerprint.py
@@ -287,7 +287,7 @@ def media_fingerprint_manifest_payload(
 ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
     summary_payload = object_dict(summary)
     if not summary_payload:
-        return None, _unknown_decision(0.0, "Media fingerprint evidence is missing; run a scan before review.")
+        return None, _unknown_decision(0.0, "Media fingerprint evidence is missing; refresh analysis before review.")
 
     analysis = object_dict(summary_payload.get("analysis"))
     tool = object_dict(analysis.get("tool"))
@@ -298,7 +298,7 @@ def media_fingerprint_manifest_payload(
     ):
         decision = _unknown_decision(
             0.0,
-            "Media fingerprint evidence uses an unsupported analyzer version; run a new scan before review.",
+            "Media fingerprint evidence uses an unsupported analyzer version; refresh analysis before review.",
         )
     else:
         decision = classify_media_fingerprint(analysis)

--- a/mediaforce/library/planner.py
+++ b/mediaforce/library/planner.py
@@ -86,8 +86,8 @@ def build_manifest_item(row: dict[str, Any], config: MediaforceConfig) -> dict[s
     subtitle_summary = json.loads(row["subtitle_summary_json"])
     attachment_summary_json = row.get("attachment_summary_json")
     attachment_summary = json.loads(attachment_summary_json) if attachment_summary_json else None
-    cadence_summary = json.loads(row["cadence_summary_json"]) if row.get("cadence_summary_json") else None
-    media_fingerprint = json.loads(row["media_fingerprint_json"]) if row.get("media_fingerprint_json") else None
+    cadence_summary = _evidence_summary(row.get("cadence_summary_json"))
+    media_fingerprint = _evidence_summary(row.get("media_fingerprint_json"))
     source_id = stable_source_id(row)
     cadence_evidence, cadence_decision = cadence_manifest_payload(
         cadence_summary,
@@ -149,3 +149,13 @@ def build_manifest_item(row: dict[str, Any], config: MediaforceConfig) -> dict[s
         prefer_persisted=False,
     ).to_payload()
     return item
+
+
+def _evidence_summary(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None

--- a/mediaforce/library/scanner.py
+++ b/mediaforce/library/scanner.py
@@ -18,22 +18,12 @@ from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.db_tables import scan_runs
 from mediaforce.core.models import ProbeSummary
-from mediaforce.encoding.cadence import (
-    CADENCE_SCHEMA_VERSION,
-    CADENCE_TOOL_NAME,
-    CADENCE_TOOL_VERSION,
-    unavailable_cadence_summary,
-)
-from mediaforce.encoding.fingerprint import (
-    MEDIA_FINGERPRINT_SCHEMA_VERSION,
-    MEDIA_FINGERPRINT_TOOL_NAME,
-    MEDIA_FINGERPRINT_TOOL_VERSION,
-    unavailable_media_fingerprint_summary,
-)
+from mediaforce.encoding.cadence import unavailable_cadence_summary
+from mediaforce.encoding.fingerprint import unavailable_media_fingerprint_summary
 from mediaforce.library.media_scopes import logical_library_rel_path, path_matches_scope
 from mediaforce.library.planner import recommend_item
 from mediaforce.library.probe import probe_media
-from mediaforce.core.type_defs import int_value, object_list
+from mediaforce.core.type_defs import float_value, int_value, object_list
 from mediaforce.core.utils import content_version_fingerprint, file_fingerprint, timestamp
 
 VIDEO_EXTENSIONS = {".avi", ".m4v", ".mkv", ".mp4", ".ts"}
@@ -131,15 +121,12 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
 
             if (
                     row
-                    and row["size_bytes"] == stat_result.st_size
-                    and row["mtime_ns"] == stat_result.st_mtime_ns
-                    and (
-                        row.get("content_version_fingerprint") is None
-                        or content_fingerprint is None
-                        or row["content_version_fingerprint"] == content_fingerprint
+                    and _source_content_unchanged(
+                        row,
+                        size_bytes=stat_result.st_size,
+                        mtime_ns=stat_result.st_mtime_ns,
+                        content_fingerprint=content_fingerprint,
                     )
-                    and _cadence_summary_present(row.get("cadence_summary_json"))
-                    and _media_fingerprint_present(row.get("media_fingerprint_json"))
             ):
                 connection.execute(
                     update(library_items)
@@ -151,6 +138,13 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
                         rel_path=rel_path,
                         media_root=root_name,
                         parent_dir=parent_dir,
+                        size_bytes=stat_result.st_size,
+                        mtime_ns=stat_result.st_mtime_ns,
+                        fingerprint=file_fingerprint(
+                            file_path=file_path,
+                            stat_result=stat_result,
+                            duration_seconds=float_value(row.get("duration_seconds")),
+                        ),
                         content_version_changed_at=case(
                             (library_items.c.status == "missing", started_at),
                             else_=library_items.c.content_version_changed_at,
@@ -333,6 +327,21 @@ def _content_version_changed(
     )
 
 
+def _source_content_unchanged(
+        row: Any,
+        *,
+        size_bytes: int,
+        mtime_ns: int,
+        content_fingerprint: str | None,
+) -> bool:
+    if int(row["size_bytes"] or 0) != size_bytes:
+        return False
+    previous_content_fingerprint = str(row.get("content_version_fingerprint") or "") or None
+    if previous_content_fingerprint and content_fingerprint:
+        return previous_content_fingerprint == content_fingerprint
+    return int(row["mtime_ns"] or 0) == mtime_ns
+
+
 def _flush_scan_progress(
         connection: DBClient,
         scan_id: str,
@@ -355,56 +364,6 @@ def _flush_scan_progress(
     )
     connection.commit()
     return 0
-
-
-def _cadence_summary_present(value: object) -> bool:
-    if not isinstance(value, str) or not value.strip():
-        return False
-    try:
-        payload = json.loads(value)
-    except json.JSONDecodeError:
-        return False
-    if (
-            not isinstance(payload, dict)
-            or payload.get("schema_version") != CADENCE_SCHEMA_VERSION
-            or payload.get("retry_required") is True
-    ):
-        return False
-    analysis = payload.get("analysis")
-    if not isinstance(analysis, dict):
-        return False
-    tool = analysis.get("tool")
-    return (
-        isinstance(payload.get("decision"), dict)
-        and isinstance(tool, dict)
-        and tool.get("name") == CADENCE_TOOL_NAME
-        and tool.get("version") == CADENCE_TOOL_VERSION
-    )
-
-
-def _media_fingerprint_present(value: object) -> bool:
-    if not isinstance(value, str) or not value.strip():
-        return False
-    try:
-        payload = json.loads(value)
-    except json.JSONDecodeError:
-        return False
-    if (
-            not isinstance(payload, dict)
-            or payload.get("schema_version") != MEDIA_FINGERPRINT_SCHEMA_VERSION
-            or payload.get("retry_required") is True
-    ):
-        return False
-    analysis = payload.get("analysis")
-    if not isinstance(analysis, dict):
-        return False
-    tool = analysis.get("tool")
-    return (
-        isinstance(payload.get("decision"), dict)
-        and isinstance(tool, dict)
-        and tool.get("name") == MEDIA_FINGERPRINT_TOOL_NAME
-        and tool.get("version") == MEDIA_FINGERPRINT_TOOL_VERSION
-    )
 
 
 def _failed_probe_summary(error: Exception) -> ProbeSummary:

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -109,7 +109,7 @@ from mediaforce.tuning.size_goals import guided_size_goal_options, operator_inte
 from mediaforce.core.type_defs import JSONValue, float_value, mapping_dict, object_dict, object_list
 from mediaforce.web.routes import register_completed_routes, register_dashboard_routes, register_folder_routes, \
     register_frontend_routes, register_host_routes, register_queue_routes, register_settings_routes
-from mediaforce.web.runtime import FolderCard, cached_folder_cards, dashboard_folders_payload, \
+from mediaforce.web.runtime import FolderCard, cached_folder_cards, cached_host_statuses, dashboard_folders_payload, \
     dashboard_library_payload, dashboard_summary_payload, default_sample_host_key, default_sample_host_key_from_statuses, \
     FolderAiTuneDeps, FolderStateDeps, FolderTuningRuntimeDeps, clear_pending_proposal, \
     archive_cleanup_summary, clear_archive_cleanup_action, \
@@ -174,7 +174,6 @@ from mediaforce.web.runtime.folder_tuning_advice import build_run_verdict_payloa
     calibration_draft_hash as runtime_calibration_draft_hash, \
     job_seed_metadata as runtime_job_seed_metadata, metric_status_copy as runtime_metric_status_copy, \
     matching_request_history as runtime_matching_request_history, \
-    metric_support as runtime_metric_support, \
     maybe_seed_baseline_policy as runtime_maybe_seed_baseline_policy, \
     operator_requested_experiment as runtime_operator_requested_experiment, \
     parse_audio_bitrate_kbps as runtime_parse_audio_bitrate_kbps, \
@@ -185,6 +184,8 @@ from mediaforce.web.runtime.folder_tuning_advice import build_run_verdict_payloa
     tuning_policy_focus as runtime_tuning_policy_focus, \
     tuning_policy_key_paths as runtime_tuning_policy_key_paths, \
     apply_policy_fragment as runtime_apply_policy_fragment
+from mediaforce.web.runtime.tool_capabilities import metric_support as runtime_metric_support, \
+    refresh_metric_support as runtime_refresh_metric_support
 from mediaforce.web.runtime.folder_tuning_helpers import size_budget_sample_analysis
 from mediaforce.web.runtime.catalog_signature import (
     catalog_signature_file as _catalog_signature_file,
@@ -201,6 +202,7 @@ from mediaforce.web.runtime.job_runtime import JobRuntimeDeps, active_scan_from_
     load_job_state as runtime_load_job_state, \
     load_overlapping_job_state as runtime_load_overlapping_job_state, \
     load_scan_job_state as runtime_load_scan_job_state, \
+    load_scan_status as runtime_load_scan_status, \
     maybe_schedule_scan as runtime_maybe_schedule_scan, \
     process_calibration_queue_once as runtime_process_calibration_queue_once, \
     run_scan_job as runtime_run_scan_job, save_job_state as runtime_save_job_state, \
@@ -422,6 +424,11 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             name="transient-cleanup",
             daemon=True,
         ).start()
+        threading.Thread(
+            target=_refresh_metric_support,
+            name="metric-support-refresh",
+            daemon=True,
+        ).start()
         with open_db(config.paths.db_path) as connection:
             repaired_host_rows = repair_persisted_encode_job_hosts(connection)
             if repaired_host_rows:
@@ -465,7 +472,8 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     async def periodic_cleanup(
             request: Request, call_next: Callable[[Request], Awaitable[Response]]
     ) -> Response:
-        _run_periodic_cleanup(config, cleanup_lock)
+        if _request_triggers_periodic_cleanup(request.method):
+            _run_periodic_cleanup(config, cleanup_lock)
         return await call_next(request)
 
     def _settings_page_payload(
@@ -505,11 +513,15 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             config,
             folder_card_cache_key=_folder_card_cache_key,
             preview_folder_cards=_preview_folder_cards,
-            maybe_schedule_scan=_maybe_schedule_scan,
+            load_scan_status=_load_scan_status,
             decorate_encode_queue_for_scheduler=_decorate_encode_queue_for_scheduler,
             library_color_map_for_config=_library_color_map_for_config,
             preview_limit=preview_limit,
         )
+
+    def _dashboard_scan_job_payload() -> dict[str, Any] | None:
+        with open_db(config.paths.db_path) as connection:
+            return _load_scan_status(connection, config, prefix=None)
 
     def _dashboard_folders_payload(include_series_folders: bool = True) -> dict[str, Any]:
         return dashboard_folders_payload(
@@ -654,7 +666,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             normalized_prefix,
             load_job_state=_load_overlapping_job_state,
             load_retryable_sample_job_state=_load_retryable_sample_job_state,
-            load_scan_job_state=_load_scan_job_state,
+            load_scan_status=_load_scan_status,
             load_active_encode_job_for_prefix=load_active_encode_job_for_prefix,
         )
 
@@ -796,13 +808,13 @@ def create_app(config_path: Path | None = None) -> FastAPI:
 
     def _hosts_payload(compact: int = 0) -> dict[str, Any]:
         with open_db(config.paths.db_path) as connection:
-            hosts = _host_runtime_rows(connection, config)
+            hosts = _host_runtime_rows(connection, config, collect_statuses=_cached_host_statuses)
         return {"compact": bool(compact), "hosts": hosts}
 
     register_dashboard_routes(
         app,
         dashboard_payload=_dashboard_api_payload,
-        dashboard_scan_job_payload=lambda: _load_scan_job_state(config, None),
+        dashboard_scan_job_payload=_dashboard_scan_job_payload,
         dashboard_folders_payload=_dashboard_folders_payload,
         dashboard_library_payload=_dashboard_library_payload,
         dashboard_library_details_payload=_dashboard_library_details_payload,
@@ -876,14 +888,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                     candidate_decisions=movie_decisions,
                 )
             calibration_job = _load_job_state(connection, config, normalized_prefix)
-            if calibration_job and calibration_job.get("status") in {"queued", "running"}:
-                existing_scan_job = _load_scan_job_state(config, normalized_prefix)
-                folder_scan_job = (
-                    existing_scan_job if existing_scan_job and existing_scan_job.get("status") in {"queued",
-                                                                                                   "running"} else None
-                )
-            else:
-                folder_scan_job = _maybe_schedule_scan(connection, config, prefix=normalized_prefix)
+            folder_scan_job = _load_scan_status(connection, config, prefix=normalized_prefix)
             summary = inspect_prefix(connection, config, normalized_prefix)
             metric_support = _metric_support()
             base_context: dict[str, Any] = {
@@ -980,13 +985,6 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             pending_proposal=pending_proposal_raw,
             summary=summary,
         )
-        advice_state = _backfill_multimodal_review_pack(
-            config,
-            normalized_prefix,
-            sample_item=sample_item,
-            calibration=calibration,
-            advice_state=advice_state,
-        )
         size_target_analysis = size_budget_sample_analysis(
             operator_request=object_dict(object_dict(advice_state).get("operator_request")) or None,
             calibration_payload=object_dict(calibration),
@@ -1047,7 +1045,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             ),
         )
         resolved_metric, _ = select_quality_metric(str(video_policy.get("quality_metric", "auto")))
-        sample_host_statuses = _sample_calibration_host_statuses(config)
+        sample_host_statuses = _cached_sample_calibration_host_statuses(config)
         sample_host_choices = _sample_host_options_from_statuses(config, sample_host_statuses)
         sample_host_key = _sample_host_key_from_choices(
             _default_sample_host_key_from_statuses(sample_host_statuses),
@@ -2148,6 +2146,10 @@ def _safe_collect_host_statuses(config: MediaforceConfig) -> list[HostStatus]:
     return safe_collect_host_statuses(config)
 
 
+def _cached_host_statuses(config: MediaforceConfig) -> list[HostStatus]:
+    return cached_host_statuses(config)
+
+
 def _folder_card_cache_key(config: MediaforceConfig) -> tuple[str, int, int]:
     return folder_card_cache_key(config)
 
@@ -2319,12 +2321,16 @@ def _attach_media_scopes(
 
 
 def _host_runtime_rows(
-        connection: DBClient, config: MediaforceConfig, *, now: datetime | None = None
+        connection: DBClient,
+        config: MediaforceConfig,
+        *,
+        collect_statuses: Any | None = None,
+        now: datetime | None = None,
 ) -> list[dict[str, Any]]:
     return host_runtime_rows(
         connection,
         config,
-        safe_collect_statuses=_safe_collect_host_statuses,
+        safe_collect_statuses=collect_statuses or _safe_collect_host_statuses,
         encode_queue_schedule_profiles=_encode_queue_schedule_profiles,
         host_max_parallel_encodes=_host_max_parallel_encodes,
         host_schedule_profile_key=_host_schedule_profile_key,
@@ -2389,6 +2395,10 @@ def _default_sample_host_key_from_statuses(statuses: list[HostStatus]) -> str:
 
 def _sample_calibration_host_statuses(config: MediaforceConfig) -> list[HostStatus]:
     return sample_calibration_host_statuses(config, safe_collect_statuses=_safe_collect_host_statuses)
+
+
+def _cached_sample_calibration_host_statuses(config: MediaforceConfig) -> list[HostStatus]:
+    return sample_calibration_host_statuses(config, safe_collect_statuses=_cached_host_statuses)
 
 
 def _sample_host_options(config: MediaforceConfig) -> list[dict[str, Any]]:
@@ -2709,6 +2719,7 @@ def _load_folder_staged_items(
 
 
 _metric_support = runtime_metric_support
+_refresh_metric_support = runtime_refresh_metric_support
 _metric_status_copy = runtime_metric_status_copy
 _tuning_policy_focus = runtime_tuning_policy_focus
 _tuning_policy_key_paths = runtime_tuning_policy_key_paths
@@ -2830,48 +2841,6 @@ def _multimodal_review_pack_public_view(
         review_pack: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
     return multimodal_review_pack_public_view(_folder_tuning_runtime_deps(), config, review_pack)
-
-
-def _backfill_multimodal_review_pack(
-        config: MediaforceConfig,
-        prefix: str,
-        *,
-        sample_item: dict[str, Any],
-        calibration: dict[str, Any] | None,
-        advice_state: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    calibration_payload = object_dict(calibration)
-    if not calibration_payload:
-        return advice_state
-    existing_pack = object_dict(object_dict(advice_state).get("multimodal_review_pack"))
-    if existing_pack:
-        if isinstance(calibration, dict):
-            calibration["advice"] = {**object_dict(calibration.get("advice")), "multimodal_review_pack": existing_pack}
-        return object_dict(advice_state) or advice_state
-    if not bool(calibration_payload.get("review_media_ready")):
-        return advice_state
-    stored_sample_item = object_dict(calibration_payload.get("sample_item")) or object_dict(sample_item)
-    if not stored_sample_item:
-        return advice_state
-    current_policy = object_dict(calibration_payload.get("policy")) or object_dict(stored_sample_item.get("resolved_policy"))
-    if not current_policy:
-        return advice_state
-    draft_hash = str(calibration_payload.get("draft_hash") or _calibration_draft_hash(calibration_payload)).strip()
-    request_id = f"legacy-{draft_hash[:12]}" if draft_hash else "legacy-review-pack"
-    review_pack = _build_multimodal_review_pack(
-        config=config,
-        sample_item=stored_sample_item,
-        current_policy=current_policy,
-        calibration=calibration_payload,
-        output_dir=_review_pack_dir(config, prefix, request_id),
-    )
-    public_review_pack = _multimodal_review_pack_public_view(config, review_pack)
-    if public_review_pack is None:
-        return advice_state
-    merged_advice_state = _merge_advice_state(config, prefix, {"multimodal_review_pack": public_review_pack})
-    if isinstance(calibration, dict):
-        calibration["advice"] = {**object_dict(calibration.get("advice")), "multimodal_review_pack": public_review_pack}
-    return merged_advice_state
 
 
 def _planned_audio_review_context(*, sample_item: dict[str, Any], current_policy: dict[str, Any]) -> dict[str, Any]:
@@ -3222,6 +3191,14 @@ def _expire_calibration_job(
 
 def _load_scan_job_state(config: MediaforceConfig, prefix: str | None) -> dict[str, Any] | None:
     return runtime_load_scan_job_state(config, prefix, _scan_job_file)
+
+
+def _load_scan_status(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str | None,
+) -> dict[str, Any] | None:
+    return runtime_load_scan_status(connection, config, prefix, _job_runtime_deps())
 
 
 def _save_scan_job_state(config: MediaforceConfig, prefix: str | None, payload: dict[str, Any]) -> None:
@@ -3939,6 +3916,10 @@ def _run_periodic_cleanup(config: MediaforceConfig, cleanup_lock: threading.Lock
         daemon=True,
     )
     thread.start()
+
+
+def _request_triggers_periodic_cleanup(method: str) -> bool:
+    return method.upper() not in {"GET", "HEAD", "OPTIONS"}
 
 
 def _run_periodic_cleanup_task(config: MediaforceConfig, cleanup_lock: threading.Lock) -> None:

--- a/mediaforce/web/runtime/__init__.py
+++ b/mediaforce/web/runtime/__init__.py
@@ -24,7 +24,7 @@ from mediaforce.web.runtime.host_runtime import default_sample_host_key, default
     host_lifecycle_start_timeout_seconds, host_lifecycle_stop_command, host_runtime_rows, \
     sample_calibration_host_statuses, sample_host_options, sample_host_options_from_statuses, \
     stop_encode_host_if_configured
-from mediaforce.web.runtime.host_status import refresh_host_status_cache, safe_collect_host_statuses
+from mediaforce.web.runtime.host_status import cached_host_statuses, refresh_host_status_cache, safe_collect_host_statuses
 from mediaforce.web.runtime.job_runtime import JobRuntimeDeps, active_scan_from_db, \
     calibration_job_belongs_to_current_process, expire_calibration_job, latest_scan_completed_at, \
     load_job_state, load_latest_failed_sample_job_state, load_latest_failed_target_size_job_state, \
@@ -68,6 +68,7 @@ __all__ = [
     "host_config_for_key",
     "active_scan_from_db",
     "calibration_job_belongs_to_current_process",
+    "cached_host_statuses",
     "expire_calibration_job",
     "latest_scan_completed_at",
     "load_calibration_state",

--- a/mediaforce/web/runtime/dashboard_payloads.py
+++ b/mediaforce/web/runtime/dashboard_payloads.py
@@ -19,7 +19,7 @@ def dashboard_summary_payload(
         *,
         folder_card_cache_key: Any,
         preview_folder_cards: Any,
-        maybe_schedule_scan: Any,
+        load_scan_status: Any,
         decorate_encode_queue_for_scheduler: Any,
         library_color_map_for_config: Any,
         preview_limit: int | None = None,
@@ -29,7 +29,7 @@ def dashboard_summary_payload(
 
     cache_key = folder_card_cache_key(config)
     with open_db(config.paths.db_path) as connection:
-        scan_job = maybe_schedule_scan(connection, config, prefix=None)
+        scan_job = load_scan_status(connection, config, prefix=None)
         preview_folders = [] if preview_limit == 0 else preview_folder_cards(config, connection)
         if preview_limit is not None and preview_limit > 0:
             preview_folders = preview_folders[:preview_limit]
@@ -102,7 +102,7 @@ def folder_status_payload(
         *,
         load_job_state: Any,
         load_retryable_sample_job_state: Any,
-        load_scan_job_state: Any,
+        load_scan_status: Any,
         load_active_encode_job_for_prefix: Any,
 ) -> dict[str, Any]:
     with open_db(config.paths.db_path) as connection:
@@ -114,7 +114,7 @@ def folder_status_payload(
         calibration_job = load_job_state(connection, config, normalized_prefix)
         retryable_sample_job = load_retryable_sample_job_state(connection, config, normalized_prefix)
         active_encode_job = load_active_encode_job_for_prefix(connection, normalized_prefix)
-        folder_scan_job = load_scan_job_state(config, normalized_prefix)
+        folder_scan_job = load_scan_status(connection, config, normalized_prefix)
         lifecycle_decisions = (
             project_candidates(connection, config, prefixes=[normalized_prefix])
             if media_scope.domain == "movie"

--- a/mediaforce/web/runtime/folder_tuning_advice.py
+++ b/mediaforce/web/runtime/folder_tuning_advice.py
@@ -1,5 +1,4 @@
 import json
-import subprocess
 import hashlib
 import re
 from decimal import Decimal, ROUND_HALF_UP
@@ -9,7 +8,6 @@ from typing import Any
 from mediaforce.advisor import apply_seed_policy, request_operator_note_parse, request_run_verdict, request_seed_policy
 from mediaforce.advising.policy import has_nonpositive_video_budget, merge_policy_fragments, policy_key_paths
 from mediaforce.advising.routing import AdvisorRouting, advisor_routing_from_config
-from mediaforce.core.binaries import ffmpeg_binary
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.type_defs import JSONValue, float_value, int_value, object_dict, object_list
@@ -32,6 +30,7 @@ from mediaforce.web.runtime.folder_tuning_helpers import (
     recent_tuning_sessions,
     size_budget_sample_analysis,
 )
+from mediaforce.web.runtime.tool_capabilities import metric_support
 
 MIN_RECOMMENDED_SAVINGS_BYTES = 100 * 1024 * 1024
 CALIBRATION_REVIEW_FIELDS = {
@@ -1085,20 +1084,6 @@ def record_run_verdict(
     if verdict.raw:
         verdict_payload["raw"] = verdict.raw
     merge_advice_state(prefix, {"run_verdict": verdict_payload})
-
-
-def metric_support() -> dict[str, bool]:
-    try:
-        result = subprocess.run([ffmpeg_binary(), "-hide_banner", "-filters"], check=True, capture_output=True, text=True)
-    except (OSError, subprocess.SubprocessError):
-        return {"vmaf": False, "xpsnr": False, "ssim": False, "psnr": False}
-    output = result.stdout.lower()
-    return {
-        "vmaf": "libvmaf" in output,
-        "xpsnr": "xpsnr" in output,
-        "ssim": "ssim" in output,
-        "psnr": " psnr " in output or "\n ts psnr" in output,
-    }
 
 
 def metric_status_copy(metric_support_payload: dict[str, bool]) -> str:

--- a/mediaforce/web/runtime/host_status.py
+++ b/mediaforce/web/runtime/host_status.py
@@ -20,20 +20,7 @@ def collect_host_statuses_with_fallback(config: MediaforceConfig) -> list[HostSt
     try:
         return collect_host_statuses(config)
     except (AttributeError, OSError, RuntimeError, TypeError, ValueError) as exc:
-        return [
-            HostStatus(
-                key="host-status-error",
-                label="Host status unavailable",
-                mode="ssh",
-                priority=0,
-                capabilities=[],
-                available=False,
-                message="Host checks could not load with the current runtime settings.",
-                missing_paths=[],
-                issues=["Review the runtime settings values and save the page again."],
-                detail=str(exc),
-            )
-        ]
+        return _host_status_error(str(exc))
 
 
 def refresh_host_status_cache(config: MediaforceConfig) -> list[HostStatus]:
@@ -69,6 +56,17 @@ def safe_collect_host_statuses(config: MediaforceConfig) -> list[HostStatus]:
     if _host_status_config_is_malformed(config):
         return collect_host_statuses_with_fallback(config)
     _schedule_host_status_refresh(config)
+    return _fallback_host_statuses(config)
+
+
+def cached_host_statuses(config: MediaforceConfig) -> list[HostStatus]:
+    _complete_host_status_refresh_if_ready()
+    cache_key = _host_status_cache_key(config)
+    with _HOST_STATUS_CACHE_LOCK:
+        if _HOST_STATUS_CACHE_KEY == cache_key and _HOST_STATUS_CACHE_VALUE:
+            return list(_HOST_STATUS_CACHE_VALUE)
+    if _host_status_config_is_malformed(config):
+        return _host_status_error(None)
     return _fallback_host_statuses(config)
 
 
@@ -121,6 +119,23 @@ def _fallback_host_statuses(config: MediaforceConfig) -> list[HostStatus]:
 
 def _host_status_config_is_malformed(config: MediaforceConfig) -> bool:
     return any(not isinstance(host, dict) for host in config.remote_hosts)
+
+
+def _host_status_error(detail: str | None) -> list[HostStatus]:
+    return [
+        HostStatus(
+            key="host-status-error",
+            label="Host status unavailable",
+            mode="ssh",
+            priority=0,
+            capabilities=[],
+            available=False,
+            message="Host checks could not load with the current runtime settings.",
+            missing_paths=[],
+            issues=["Review the runtime settings values and save the page again."],
+            detail=detail,
+        )
+    ]
 
 
 def _complete_host_status_refresh_if_ready() -> None:

--- a/mediaforce/web/runtime/job_runtime.py
+++ b/mediaforce/web/runtime/job_runtime.py
@@ -267,7 +267,7 @@ def maybe_schedule_scan(
         return job
     if not force and not scan_is_stale(connection, config, prefix, deps):
         return job
-    if job and job.get("status") == "failed":
+    if not force and job and job.get("status") == "failed":
         finished_at = deps.parse_iso(job.get("finished_at") or job.get("started_at"))
         interrupted_restart = str(job.get("error") or "") == deps.scan_interrupted_error
         if not interrupted_restart and finished_at and datetime.now(tz=UTC) - finished_at < deps.scan_retry_cooldown:
@@ -297,6 +297,22 @@ def maybe_schedule_scan(
     )
     thread.start()
     return job_payload
+
+
+def load_scan_status(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str | None,
+        deps: JobRuntimeDeps,
+) -> dict[str, Any] | None:
+    active_scan = active_scan_from_db(connection, config, prefix, deps, repair_stale=False)
+    if active_scan is not None:
+        return active_scan
+    if prefix is not None:
+        full_job = _scan_job_snapshot(config, None, deps)
+        if full_job and full_job.get("status") in {"queued", "running"}:
+            return full_job
+    return _scan_job_snapshot(config, prefix, deps)
 
 
 def run_scan_job(
@@ -541,6 +557,8 @@ def active_scan_from_db(
         config: MediaforceConfig,
         prefix: str | None,
         deps: JobRuntimeDeps,
+        *,
+        repair_stale: bool = True,
 ) -> dict[str, Any] | None:
     rows = connection.execute(
         select(
@@ -567,7 +585,15 @@ def active_scan_from_db(
         job_prefix = None if scope in {"full", "unknown"} else str(matched_prefix)
         job = deps.load_scan_job_state(config, job_prefix)
         if job and job.get("status") in {"queued", "running"} and not deps.scan_process_is_alive(job.get("owner_pid")):
-            job = _expire_scan_job(config, job_prefix, job, deps)
+            job = (
+                _expire_scan_job(config, job_prefix, job, deps)
+                if repair_stale
+                else _interrupted_scan_job(
+                    job,
+                    deps,
+                    finished_at=job.get("finished_at") or job.get("started_at") or job.get("created_at"),
+                )
+            )
 
         if deps.scan_process_is_alive(row["owner_pid"]):
             return {
@@ -596,7 +622,7 @@ def active_scan_from_db(
                 "stats": job.get("stats"),
             }
 
-        if job is not None:
+        if job is not None and repair_stale:
             _expire_scan_run(connection, str(row["scan_id"]))
     return None
 
@@ -695,14 +721,40 @@ def _expire_scan_job(
         job: dict[str, Any],
         deps: JobRuntimeDeps,
 ) -> dict[str, Any]:
-    expired = {
-        **job,
-        "status": "failed",
-        "finished_at": deps.now_iso(),
-        "error": deps.scan_interrupted_error,
-    }
+    expired = _interrupted_scan_job(job, deps, finished_at=deps.now_iso())
     deps.save_scan_job_state(config, prefix, expired)
     return expired
+
+
+def _scan_job_snapshot(
+        config: MediaforceConfig,
+        prefix: str | None,
+        deps: JobRuntimeDeps,
+) -> dict[str, Any] | None:
+    job = deps.load_scan_job_state(config, prefix)
+    if not job:
+        return None
+    if job.get("status") in {"queued", "running"} and not deps.scan_process_is_alive(job.get("owner_pid")):
+        return _interrupted_scan_job(
+            job,
+            deps,
+            finished_at=job.get("finished_at") or job.get("started_at") or job.get("created_at"),
+        )
+    return job
+
+
+def _interrupted_scan_job(
+        job: dict[str, Any],
+        deps: JobRuntimeDeps,
+        *,
+        finished_at: Any,
+) -> dict[str, Any]:
+    return {
+        **job,
+        "status": "failed",
+        "finished_at": finished_at,
+        "error": deps.scan_interrupted_error,
+    }
 
 
 def _now_iso() -> str:

--- a/mediaforce/web/runtime/tool_capabilities.py
+++ b/mediaforce/web/runtime/tool_capabilities.py
@@ -1,0 +1,64 @@
+import subprocess
+import threading
+from pathlib import Path
+
+from mediaforce.core.binaries import ffmpeg_binary
+
+_METRIC_SUPPORT_DEFAULTS = {"vmaf": False, "xpsnr": False, "ssim": False, "psnr": False}
+_METRIC_SUPPORT_LOCK = threading.Lock()
+_METRIC_SUPPORT_BY_BINARY: dict[tuple[str, int, int], dict[str, bool]] = {}
+_ACTIVE_METRIC_SUPPORT_IDENTITY: tuple[str, int, int] | None = None
+
+
+def metric_support() -> dict[str, bool]:
+    with _METRIC_SUPPORT_LOCK:
+        if _ACTIVE_METRIC_SUPPORT_IDENTITY is None:
+            return dict(_METRIC_SUPPORT_DEFAULTS)
+        return dict(_METRIC_SUPPORT_BY_BINARY.get(_ACTIVE_METRIC_SUPPORT_IDENTITY, _METRIC_SUPPORT_DEFAULTS))
+
+
+def refresh_metric_support() -> dict[str, bool]:
+    global _ACTIVE_METRIC_SUPPORT_IDENTITY
+
+    binary = ffmpeg_binary()
+    identity = _binary_identity(binary)
+    try:
+        result = subprocess.run(
+            [binary, "-hide_banner", "-filters"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        support = dict(_METRIC_SUPPORT_DEFAULTS)
+    else:
+        output = result.stdout.lower()
+        support = {
+            "vmaf": "libvmaf" in output,
+            "xpsnr": "xpsnr" in output,
+            "ssim": "ssim" in output,
+            "psnr": " psnr " in output or "\n ts psnr" in output,
+        }
+
+    with _METRIC_SUPPORT_LOCK:
+        _METRIC_SUPPORT_BY_BINARY[identity] = support
+        _ACTIVE_METRIC_SUPPORT_IDENTITY = identity
+    return dict(support)
+
+
+def reset_metric_support_cache() -> None:
+    global _ACTIVE_METRIC_SUPPORT_IDENTITY
+
+    with _METRIC_SUPPORT_LOCK:
+        _METRIC_SUPPORT_BY_BINARY.clear()
+        _ACTIVE_METRIC_SUPPORT_IDENTITY = None
+
+
+def _binary_identity(binary: str) -> tuple[str, int, int]:
+    path = Path(binary).expanduser()
+    try:
+        stat_result = path.stat()
+    except OSError:
+        return binary, -1, -1
+    return str(path.resolve()), stat_result.st_size, stat_result.st_mtime_ns

--- a/scripts/benchmark_catalog_refresh.py
+++ b/scripts/benchmark_catalog_refresh.py
@@ -1,0 +1,332 @@
+import argparse
+import json
+import resource
+import subprocess
+import sys
+import tempfile
+import time
+import tracemalloc
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import patch
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import OperationalError
+
+from mediaforce.core.config import DEFAULT_CONFIG_PATH, ConfigPaths, MediaforceConfig, load_config
+from mediaforce.core.db import DBClient, open_db, reset_engine_cache
+from mediaforce.core.db_tables import library_items
+from mediaforce.core.utils import content_version_fingerprint
+from mediaforce.library.scanner import scan_library
+
+
+@dataclass(slots=True)
+class BenchmarkResult:
+    item_count: int
+    iterations: int
+    wall_seconds: float
+    cpu_seconds: float
+    python_peak_bytes: int
+    process_peak_rss_bytes: int
+    child_process_count: int
+    discovered: int
+    reprobed: int
+    unchanged: int
+    db_operation_count: int
+    db_operation_seconds: float
+    db_lock_wait_events: int
+    db_lock_wait_seconds: float
+    db_lock_errors: int
+    passed: bool
+
+
+class _MeasuredConnection:
+    def __init__(self, connection: DBClient, lock_wait_threshold_seconds: float) -> None:
+        self.connection = connection
+        self.lock_wait_threshold_seconds = lock_wait_threshold_seconds
+        self.operation_count = 0
+        self.operation_seconds = 0.0
+        self.lock_wait_events = 0
+        self.lock_wait_seconds = 0.0
+        self.lock_errors = 0
+
+    def execute(self, *args: Any, **kwargs: Any) -> Any:
+        return self._measure(self.connection.execute, *args, **kwargs)
+
+    def commit(self) -> None:
+        self._measure(self.connection.commit)
+
+    def _measure(self, operation: Any, *args: Any, **kwargs: Any) -> Any:
+        started_at = time.perf_counter()
+        try:
+            return operation(*args, **kwargs)
+        except OperationalError as exc:
+            if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+                self.lock_errors += 1
+            raise
+        finally:
+            elapsed = time.perf_counter() - started_at
+            self.operation_count += 1
+            self.operation_seconds += elapsed
+            if elapsed >= self.lock_wait_threshold_seconds:
+                self.lock_wait_events += 1
+                self.lock_wait_seconds += elapsed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Benchmark unchanged catalog refreshes without launching media-analysis subprocesses."
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    parser.add_argument("--sizes", default="1000,10000,current,2x-current")
+    parser.add_argument("--iterations", type=int, default=2)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--lock-wait-threshold-ms", type=float, default=50.0)
+    args = parser.parse_args()
+
+    current_count = _current_catalog_count(args.config)
+    sizes, skipped = _resolve_sizes(args.sizes, current_count)
+    results = [
+        run_benchmark(
+            item_count,
+            iterations=args.iterations,
+            lock_wait_threshold_seconds=max(args.lock_wait_threshold_ms, 0.0) / 1000.0,
+        )
+        for item_count in sizes
+    ]
+    payload = {
+        "schema_version": 1,
+        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "current_catalog_count": current_count,
+        "requested_sizes": args.sizes,
+        "skipped": skipped,
+        "results": [asdict(result) for result in results],
+    }
+    encoded = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.expanduser().write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0 if all(result.passed for result in results) else 1
+
+
+def run_benchmark(
+        item_count: int,
+        *,
+        iterations: int = 2,
+        lock_wait_threshold_seconds: float = 0.05,
+) -> BenchmarkResult:
+    if item_count <= 0:
+        raise ValueError("item_count must be positive")
+    if iterations <= 0:
+        raise ValueError("iterations must be positive")
+
+    with tempfile.TemporaryDirectory(prefix="mediaforce-catalog-benchmark-") as temp_dir:
+        project_root = Path(temp_dir)
+        media_root = project_root / "library"
+        media_root.mkdir()
+        config = _benchmark_config(project_root, media_root)
+        _seed_fixture_catalog(config, media_root, item_count)
+
+        child_process_count = 0
+
+        def blocked_child_process(*_args: Any, **_kwargs: Any) -> None:
+            nonlocal child_process_count
+            child_process_count += 1
+            raise subprocess.SubprocessError("benchmark blocked unexpected child process")
+
+        usage_before = resource.getrusage(resource.RUSAGE_SELF)
+        tracemalloc.start()
+        started_at = time.perf_counter()
+        discovered = 0
+        reprobed = 0
+        unchanged = 0
+        try:
+            with open_db(config.paths.db_path) as connection:
+                measured_connection = _MeasuredConnection(connection, lock_wait_threshold_seconds)
+                with patch("subprocess.run", side_effect=blocked_child_process), patch(
+                    "subprocess.Popen",
+                    side_effect=blocked_child_process,
+                ):
+                    for _ in range(iterations):
+                        stats = scan_library(cast(DBClient, measured_connection), config)
+                        discovered += stats.discovered
+                        reprobed += stats.reprobed
+                        unchanged += stats.unchanged
+        finally:
+            wall_seconds = time.perf_counter() - started_at
+            _, python_peak_bytes = tracemalloc.get_traced_memory()
+            tracemalloc.stop()
+            usage_after = resource.getrusage(resource.RUSAGE_SELF)
+            reset_engine_cache()
+
+    cpu_seconds = (
+        usage_after.ru_utime - usage_before.ru_utime
+        + usage_after.ru_stime - usage_before.ru_stime
+    )
+    passed = (
+        child_process_count == 0
+        and discovered == 0
+        and reprobed == 0
+        and unchanged == item_count * iterations
+    )
+    return BenchmarkResult(
+        item_count=item_count,
+        iterations=iterations,
+        wall_seconds=round(wall_seconds, 6),
+        cpu_seconds=round(cpu_seconds, 6),
+        python_peak_bytes=python_peak_bytes,
+        process_peak_rss_bytes=_peak_rss_bytes(usage_after.ru_maxrss),
+        child_process_count=child_process_count,
+        discovered=discovered,
+        reprobed=reprobed,
+        unchanged=unchanged,
+        db_operation_count=measured_connection.operation_count,
+        db_operation_seconds=round(measured_connection.operation_seconds, 6),
+        db_lock_wait_events=measured_connection.lock_wait_events,
+        db_lock_wait_seconds=round(measured_connection.lock_wait_seconds, 6),
+        db_lock_errors=measured_connection.lock_errors,
+        passed=passed,
+    )
+
+
+def _benchmark_config(project_root: Path, media_root: Path) -> MediaforceConfig:
+    paths = ConfigPaths(
+        project_root=project_root,
+        config_path=project_root / "config.toml",
+        db_path=project_root / "library.sqlite3",
+        run_manifest_dir=project_root / "runs",
+        web_state_dir=project_root / "web",
+        review_dir=project_root / "review",
+        runtime_settings_path=project_root / "runtime-settings.json",
+    )
+    return MediaforceConfig(
+        raw={
+            "media": {
+                "libraries": [
+                    {
+                        "key": "benchmark",
+                        "label": "Benchmark",
+                        "path": str(media_root),
+                        "type": "other",
+                        "availability": "browse_only",
+                    }
+                ]
+            },
+            "video": {},
+            "audio": {},
+            "subtitle": {},
+            "planning": {},
+            "validation": {},
+            "overrides": [],
+            "remote_hosts": [],
+        },
+        paths=paths,
+    )
+
+
+def _seed_fixture_catalog(config: MediaforceConfig, media_root: Path, item_count: int) -> None:
+    payload = b"mediaforce-catalog-refresh-fixture\n"
+    now = datetime.now(UTC).isoformat(timespec="seconds")
+    rows: list[dict[str, Any]] = []
+    shared_content_fingerprint: str | None = None
+    evidence_values = (None, "not-json", '{"retry_required":true}')
+    with open_db(config.paths.db_path) as connection:
+        for index in range(item_count):
+            file_name = f"item-{index:08d}.mkv"
+            file_path = media_root / file_name
+            file_path.write_bytes(payload)
+            stat_result = file_path.stat()
+            if shared_content_fingerprint is None:
+                shared_content_fingerprint = content_version_fingerprint(file_path, stat_result)
+            rows.append(
+                {
+                    "source_path": str(file_path),
+                    "rel_path": f"benchmark/{file_name}",
+                    "media_root": "benchmark",
+                    "parent_dir": "benchmark",
+                    "file_name": file_name,
+                    "container": ".mkv",
+                    "size_bytes": stat_result.st_size,
+                    "mtime_ns": stat_result.st_mtime_ns,
+                    "fingerprint": f"fixture-{index}",
+                    "duration_seconds": 1.0,
+                    "video_codec": "h264",
+                    "audio_track_count": 1,
+                    "subtitle_track_count": 0,
+                    "english_audio_count": 1,
+                    "english_subtitle_count": 0,
+                    "audio_summary_json": "[]",
+                    "subtitle_summary_json": "[]",
+                    "attachment_summary_json": "[]",
+                    "cadence_summary_json": evidence_values[index % len(evidence_values)],
+                    "media_fingerprint_json": evidence_values[(index + 1) % len(evidence_values)],
+                    "content_version_changed_at": now,
+                    "content_version_fingerprint": shared_content_fingerprint,
+                    "status": "discovered",
+                    "priority_score": 0,
+                    "last_scan_id": "benchmark-seed",
+                    "discovered_at": now,
+                    "last_seen_at": now,
+                    "updated_at": now,
+                }
+            )
+            if len(rows) >= 1_000:
+                connection.execute(library_items.insert(), rows)
+                connection.commit()
+                rows.clear()
+        if rows:
+            connection.execute(library_items.insert(), rows)
+            connection.commit()
+    reset_engine_cache()
+
+
+def _current_catalog_count(config_path: Path) -> int:
+    try:
+        config = load_config(config_path.expanduser())
+        with open_db(config.paths.db_path) as connection:
+            return int(
+                connection.execute(
+                    select(func.count())
+                    .select_from(library_items)
+                    .where(library_items.c.status != "missing")
+                ).scalar_one()
+            )
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return 0
+
+
+def _resolve_sizes(raw_sizes: str, current_count: int) -> tuple[list[int], list[str]]:
+    sizes: list[int] = []
+    skipped: list[str] = []
+    for raw_token in raw_sizes.split(","):
+        token = raw_token.strip().lower()
+        if not token:
+            continue
+        if token == "current":
+            value = current_count
+        elif token == "2x-current":
+            value = current_count * 2
+        else:
+            try:
+                value = int(token.replace("_", ""))
+            except ValueError as exc:
+                raise ValueError(f"Unsupported size token: {raw_token}") from exc
+        if value <= 0:
+            skipped.append(raw_token.strip())
+            continue
+        if value not in sizes:
+            sizes.append(value)
+    if not sizes:
+        raise ValueError("No positive benchmark sizes were resolved")
+    return sizes, skipped
+
+
+def _peak_rss_bytes(raw_value: int | float) -> int:
+    value = int(raw_value)
+    return value if sys.platform == "darwin" else value * 1024
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_catalog_refresh_benchmark.py
+++ b/tests/test_catalog_refresh_benchmark.py
@@ -1,0 +1,20 @@
+import unittest
+
+from scripts.benchmark_catalog_refresh import run_benchmark
+
+
+class CatalogRefreshBenchmarkTests(unittest.TestCase):
+    def test_generated_unchanged_catalog_launches_no_child_processes(self) -> None:
+        result = run_benchmark(12)
+
+        self.assertTrue(result.passed)
+        self.assertEqual(result.child_process_count, 0)
+        self.assertEqual(result.iterations, 2)
+        self.assertEqual(result.discovered, 0)
+        self.assertEqual(result.reprobed, 0)
+        self.assertEqual(result.unchanged, 24)
+        self.assertEqual(result.db_lock_errors, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -3680,6 +3680,38 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(job["status"], "queued")
         fake_thread.start.assert_called_once()
 
+    def test_forced_scan_bypasses_recent_failure_cooldown(self) -> None:
+        now = web_app._now_iso()
+        web_app._save_scan_job_state(
+            self.config,
+            None,
+            {
+                "job_id": "recent-failure",
+                "status": "failed",
+                "scope": "full",
+                "prefix": None,
+                "owner_pid": os.getpid(),
+                "created_at": now,
+                "started_at": now,
+                "finished_at": now,
+                "error": "fixture failure",
+                "stats": None,
+            },
+        )
+        fake_thread = Mock()
+        with open_db(self.config.paths.db_path) as connection, patch.object(
+            web_app.threading,
+            "Thread",
+            return_value=fake_thread,
+        ):
+            job = web_app._maybe_schedule_scan(connection, self.config, prefix=None, force=True)
+
+        self.assertIsNotNone(job)
+        assert job is not None
+        self.assertEqual(job["status"], "queued")
+        self.assertNotEqual(job["job_id"], "recent-failure")
+        fake_thread.start.assert_called_once()
+
     def test_scheduler_uses_host_local_time_for_windows(self) -> None:
         policy = web_app._normalize_encode_queue_scheduler(
             {"mode": "night", "start_hour": 22, "end_hour": 6, "timezone": "host_local"}
@@ -12831,7 +12863,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         )
 
     def test_app_lifespan_does_not_wait_for_transient_cleanup(self) -> None:
-        cleanup_threads: list[Any] = []
+        startup_threads: list[Any] = []
 
         class FakeCleanupThread:
             def __init__(
@@ -12850,12 +12882,15 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 self.daemon = daemon
 
             def start(self) -> None:
-                cleanup_threads.append(self)
+                startup_threads.append(self)
 
         cleanup_mock = Mock(side_effect=AssertionError("cleanup should not run synchronously"))
+        metric_refresh_mock = Mock(side_effect=AssertionError("metric refresh should not run synchronously"))
         safe_collect_mock = Mock(return_value=[])
         with patch("mediaforce.web.app.load_config", return_value=self.config), patch(
                 "mediaforce.web.app.purge_transient_artifacts", cleanup_mock
+        ), patch(
+                "mediaforce.web.app._refresh_metric_support", metric_refresh_mock
         ), patch("mediaforce.web.app.threading.Thread", FakeCleanupThread), patch(
                 "mediaforce.web.app._start_calibration_queue_worker"
         ), patch("mediaforce.web.app._start_encode_queue_worker"), patch(
@@ -12870,14 +12905,20 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             asyncio.run(exercise_lifespan())
 
         cleanup_mock.assert_not_called()
+        metric_refresh_mock.assert_not_called()
         safe_collect_mock.assert_called_once_with(self.config)
-        self.assertEqual(len(cleanup_threads), 1)
-        cleanup_thread = cleanup_threads[0]
+        self.assertEqual(len(startup_threads), 2)
+        threads_by_name = {thread.name: thread for thread in startup_threads}
+        cleanup_thread = threads_by_name["transient-cleanup"]
         self.assertIs(cleanup_thread.target, cleanup_mock)
         self.assertEqual(cleanup_thread.args, (self.config,))
         self.assertEqual(cleanup_thread.kwargs, {"force": True})
-        self.assertEqual(cleanup_thread.name, "transient-cleanup")
         self.assertTrue(cleanup_thread.daemon)
+        metric_thread = threads_by_name["metric-support-refresh"]
+        self.assertIs(metric_thread.target, metric_refresh_mock)
+        self.assertEqual(metric_thread.args, ())
+        self.assertEqual(metric_thread.kwargs, {})
+        self.assertTrue(metric_thread.daemon)
 
     def test_folder_api_route_returns_payload_for_seeded_prefix(self) -> None:
         source_path = self._create_source_file("episode-folder.mkv")
@@ -12946,8 +12987,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             for route in app.router.routes
             if getattr(route, "path", "") == "/api/folders/{prefix:path}"
         )
-        with patch("mediaforce.web.app._maybe_schedule_scan", return_value=None), patch(
-                "mediaforce.web.app._sample_calibration_host_statuses", return_value=[]
+        with patch("mediaforce.web.app._load_scan_status", return_value=None), patch(
+                "mediaforce.web.app._cached_sample_calibration_host_statuses", return_value=[]
         ):
             response = folder_endpoint("tv/show")
         payload = json.loads(response.body)
@@ -13025,12 +13066,10 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             for route in app.router.routes
             if getattr(route, "path", "") == "/api/folders/{prefix:path}"
         )
-        with patch("mediaforce.web.app._maybe_schedule_scan", return_value=None), patch(
-                "mediaforce.web.app._sample_calibration_host_statuses", return_value=[]
+        with patch("mediaforce.web.app._load_scan_status", return_value=None), patch(
+                "mediaforce.web.app._cached_sample_calibration_host_statuses", return_value=[]
         ), patch("mediaforce.web.app._load_advice_state", return_value=advice_state), patch(
             "mediaforce.web.app._load_calibration_state", return_value=calibration
-        ), patch(
-            "mediaforce.web.app._backfill_multimodal_review_pack", return_value=advice_state
         ), patch("mediaforce.web.app._preview_hotspots", return_value=[]), patch(
             "mediaforce.web.app.describe_item_plan", return_value={}
         ):
@@ -13105,8 +13144,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             for route in app.router.routes
             if getattr(route, "path", "") == "/api/folders/{prefix:path}"
         )
-        with patch("mediaforce.web.app._maybe_schedule_scan", return_value=None), patch(
-                "mediaforce.web.app._sample_calibration_host_statuses", return_value=[]
+        with patch("mediaforce.web.app._load_scan_status", return_value=None), patch(
+                "mediaforce.web.app._cached_sample_calibration_host_statuses", return_value=[]
         ):
             response = folder_endpoint("tv/House/Season 5")
         payload = json.loads(response.body)
@@ -15284,7 +15323,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             "tv/show",
             load_job_state=web_app._load_overlapping_job_state,
             load_retryable_sample_job_state=web_app._load_retryable_sample_job_state,
-            load_scan_job_state=web_app._load_scan_job_state,
+            load_scan_status=web_app._load_scan_status,
             load_active_encode_job_for_prefix=load_active_encode_job_for_prefix,
         )
 
@@ -15316,7 +15355,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             "tv/show",
             load_job_state=web_app._load_overlapping_job_state,
             load_retryable_sample_job_state=web_app._load_retryable_sample_job_state,
-            load_scan_job_state=web_app._load_scan_job_state,
+            load_scan_status=web_app._load_scan_status,
             load_active_encode_job_for_prefix=load_active_encode_job_for_prefix,
         )
 
@@ -15419,7 +15458,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             "tv/show",
             load_job_state=web_app._load_job_state,
             load_retryable_sample_job_state=web_app._load_retryable_sample_job_state,
-            load_scan_job_state=web_app._load_scan_job_state,
+            load_scan_status=web_app._load_scan_status,
             load_active_encode_job_for_prefix=load_active_encode_job_for_prefix,
         )
 
@@ -15445,7 +15484,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             "other/Foo.mkv",
             load_job_state=lambda _connection, _config, _prefix: None,
             load_retryable_sample_job_state=lambda _connection, _config, _prefix: None,
-            load_scan_job_state=lambda _config, _prefix: None,
+            load_scan_status=lambda _connection, _config, _prefix: None,
             load_active_encode_job_for_prefix=lambda _connection, _prefix: None,
         )
 

--- a/tests/test_planner_evidence.py
+++ b/tests/test_planner_evidence.py
@@ -1,0 +1,15 @@
+import unittest
+
+from mediaforce.library.planner import _evidence_summary
+
+
+class PlannerEvidenceTests(unittest.TestCase):
+    def test_malformed_evidence_is_projected_as_missing(self) -> None:
+        self.assertIsNone(_evidence_summary(None))
+        self.assertIsNone(_evidence_summary("not-json"))
+        self.assertIsNone(_evidence_summary("[]"))
+        self.assertEqual(_evidence_summary('{"retry_required":true}'), {"retry_required": True})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_read_path_purity.py
+++ b/tests/test_read_path_purity.py
@@ -1,0 +1,201 @@
+import subprocess
+import tempfile
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from sqlalchemy import select
+
+from mediaforce.core.config import ConfigPaths, MediaforceConfig
+from mediaforce.core.db import open_db, reset_engine_cache
+from mediaforce.core.db_tables import scan_runs
+from mediaforce.web import app as web_app
+from mediaforce.web.runtime import tool_capabilities
+
+
+class ReadPathPurityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        tool_capabilities.reset_metric_support_cache()
+        self.tempdir = tempfile.TemporaryDirectory()
+        project_root = Path(self.tempdir.name)
+        media_root = project_root / "tv"
+        media_root.mkdir()
+        paths = ConfigPaths(
+            project_root=project_root,
+            config_path=project_root / "config.toml",
+            db_path=project_root / "library.sqlite3",
+            run_manifest_dir=project_root / "runs",
+            web_state_dir=project_root / "web",
+            review_dir=project_root / "review",
+            runtime_settings_path=project_root / "runtime-settings.json",
+        )
+        self.config = MediaforceConfig(
+            raw={
+                "media": {
+                    "libraries": [
+                        {
+                            "key": "tv",
+                            "label": "TV Shows",
+                            "path": str(media_root),
+                            "type": "tv",
+                            "availability": "browse_only",
+                        }
+                    ]
+                },
+                "video": {},
+                "audio": {},
+                "subtitle": {},
+                "planning": {},
+                "validation": {},
+                "overrides": [],
+                "remote_hosts": [],
+            },
+            paths=paths,
+        )
+
+    def tearDown(self) -> None:
+        tool_capabilities.reset_metric_support_cache()
+        reset_engine_cache()
+        self.tempdir.cleanup()
+
+    def test_metric_support_reads_never_probe_an_uninitialized_cache(self) -> None:
+        with patch("mediaforce.web.runtime.tool_capabilities.ffmpeg_binary") as binary_mock, patch(
+            "mediaforce.web.runtime.tool_capabilities.subprocess.run",
+        ) as run_mock:
+            support = tool_capabilities.metric_support()
+
+        self.assertEqual(
+            support,
+            {"vmaf": False, "xpsnr": False, "ssim": False, "psnr": False},
+        )
+        binary_mock.assert_not_called()
+        run_mock.assert_not_called()
+
+    def test_metric_support_refreshes_explicitly_and_reads_cached_snapshot(self) -> None:
+        binary = Path(self.tempdir.name) / "ffmpeg"
+        binary.write_text("fixture", encoding="utf-8")
+        completed = subprocess.CompletedProcess(
+            [str(binary), "-hide_banner", "-filters"],
+            0,
+            stdout=" T.. libvmaf\n T.. xpsnr\n TS. ssim\n TS. psnr ",
+            stderr="",
+        )
+        with patch(
+            "mediaforce.web.runtime.tool_capabilities.ffmpeg_binary",
+            return_value=str(binary),
+        ), patch(
+            "mediaforce.web.runtime.tool_capabilities.subprocess.run",
+            return_value=completed,
+        ) as run_mock:
+            refreshed = tool_capabilities.refresh_metric_support()
+            first_read = tool_capabilities.metric_support()
+            second_refresh = tool_capabilities.refresh_metric_support()
+
+        self.assertEqual(refreshed, {"vmaf": True, "xpsnr": True, "ssim": True, "psnr": True})
+        self.assertEqual(first_read, refreshed)
+        self.assertEqual(second_refresh, refreshed)
+        self.assertEqual(run_mock.call_count, 2)
+        self.assertEqual(run_mock.call_args.kwargs["timeout"], 10)
+
+    def test_reading_interrupted_scan_status_does_not_repair_persisted_state(self) -> None:
+        started_at = "2026-07-19T08:00:00+00:00"
+        web_app._save_scan_job_state(
+            self.config,
+            None,
+            {
+                "job_id": "scan-job",
+                "status": "running",
+                "scope": "full",
+                "prefix": None,
+                "owner_pid": 999_999,
+                "created_at": started_at,
+                "started_at": started_at,
+                "finished_at": None,
+                "error": None,
+                "stats": None,
+            },
+        )
+        with open_db(self.config.paths.db_path) as connection:
+            connection.execute(
+                scan_runs.insert().values(
+                    scan_id="scan-run",
+                    started_at=started_at,
+                    owner_pid=999_999,
+                    last_progress_at=started_at,
+                    roots_json='["tv"]',
+                    scope="full",
+                )
+            )
+            connection.commit()
+
+            with patch.object(web_app, "_scan_process_is_alive", return_value=False):
+                status = web_app._load_scan_status(connection, self.config, None)
+            scan_row = connection.execute(select(scan_runs)).mappings().one()
+
+        stored_job = web_app._load_scan_job_state(self.config, None)
+        self.assertIsNotNone(status)
+        assert status is not None
+        self.assertEqual(status["status"], "failed")
+        self.assertIsNone(scan_row["completed_at"])
+        self.assertIsNotNone(stored_job)
+        assert stored_job is not None
+        self.assertEqual(stored_job["status"], "running")
+
+    def test_dashboard_folder_status_and_host_reads_launch_no_work(self) -> None:
+        with patch("mediaforce.web.app.load_config", return_value=self.config):
+            app = web_app.create_app(self.config.paths.config_path)
+
+        dashboard_endpoint = self._endpoint(app, "/api/dashboard", "api_dashboard")
+        dashboard_scan_job_endpoint = self._endpoint(
+            app,
+            "/api/dashboard/scan-job",
+            "api_dashboard_scan_job",
+        )
+        folder_endpoint = self._endpoint(app, "/api/folders/{prefix:path}", "api_folder")
+        folder_status_endpoint = self._endpoint(
+            app,
+            "/api/folders/{prefix:path}/status",
+            "api_folder_status",
+        )
+        hosts_endpoint = self._endpoint(app, "/api/hosts", "api_hosts")
+
+        unexpected_process = AssertionError("GET request attempted to launch a child process")
+        with patch("subprocess.run", side_effect=unexpected_process) as run_mock, patch(
+            "subprocess.Popen",
+            side_effect=unexpected_process,
+        ) as popen_mock, patch(
+            "mediaforce.web.runtime.job_runtime.threading.Thread",
+        ) as scan_thread_mock, patch(
+            "mediaforce.web.runtime.host_status._schedule_host_status_refresh",
+        ) as host_refresh_mock:
+            dashboard_response = dashboard_endpoint(None)
+            dashboard_scan_job_response = dashboard_scan_job_endpoint()
+            folder_response = folder_endpoint("tv/missing")
+            folder_status_response = folder_status_endpoint("tv/missing")
+            hosts_response = hosts_endpoint(0)
+
+        self.assertEqual(dashboard_response.status_code, 200)
+        self.assertEqual(dashboard_scan_job_response.status_code, 200)
+        self.assertEqual(folder_response.status_code, 404)
+        self.assertEqual(folder_status_response.status_code, 200)
+        self.assertEqual(hosts_response.status_code, 200)
+        run_mock.assert_not_called()
+        popen_mock.assert_not_called()
+        scan_thread_mock.assert_not_called()
+        host_refresh_mock.assert_not_called()
+
+    @staticmethod
+    def _endpoint(app: FastAPI, path: str, name: str) -> Callable[..., Any]:
+        return next(
+            route.endpoint
+            for route in app.router.routes
+            if isinstance(route, APIRoute) and route.path == path and route.name == name
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scanner_runtime.py
+++ b/tests/test_scanner_runtime.py
@@ -13,14 +13,12 @@ from mediaforce.core.db import open_db, reset_engine_cache
 from mediaforce.core.db_tables import library_items, scan_runs
 from mediaforce.core.models import ProbeSummary
 from mediaforce.library.scanner import (
-    _cadence_summary_present,
     _content_version_changed,
     _failed_probe_summary,
     _iter_media_files,
-    _media_fingerprint_present,
     scan_library,
 )
-from mediaforce.core.utils import content_version_fingerprint
+from mediaforce.core.utils import content_version_fingerprint, file_fingerprint
 from mediaforce.web.runtime.job_runtime import _stats_payload
 
 
@@ -193,6 +191,134 @@ class ScannerRuntimeTests(unittest.TestCase):
 
         self.assertEqual(stats.discovered, 2)
         self.assertEqual(writer_errors, [])
+
+    def test_unchanged_inventory_preserves_noncurrent_evidence_without_probing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            movie = media_root / "Feature.mkv"
+            movie.write_bytes(b"movie")
+            config = self._config(project_root, {"movies": media_root})
+            retryable_summary = _failed_probe_summary(RuntimeError("fixture probe failure"))
+            stale_cadence = json.loads(retryable_summary.cadence_summary_json)
+            stale_cadence.pop("retry_required", None)
+            stale_cadence["analysis"]["tool"]["version"] = "0"
+            stale_fingerprint = json.loads(retryable_summary.media_fingerprint_json)
+            stale_fingerprint.pop("retry_required", None)
+            stale_fingerprint["analysis"]["tool"]["version"] = "0"
+
+            try:
+                with open_db(config.paths.db_path) as connection:
+                    with patch("mediaforce.library.scanner.probe_media", return_value=retryable_summary):
+                        scan_library(connection, config)
+
+                    evidence_cases = (
+                        (None, None),
+                        ("not-json", "not-json"),
+                        (json.dumps(stale_cadence), json.dumps(stale_fingerprint)),
+                        (retryable_summary.cadence_summary_json, retryable_summary.media_fingerprint_json),
+                    )
+                    for cadence_summary, media_fingerprint in evidence_cases:
+                        with self.subTest(cadence_summary=cadence_summary, media_fingerprint=media_fingerprint):
+                            connection.execute(
+                                update(library_items).values(
+                                    cadence_summary_json=cadence_summary,
+                                    media_fingerprint_json=media_fingerprint,
+                                )
+                            )
+                            connection.commit()
+                            with patch(
+                                "mediaforce.library.scanner.probe_media",
+                                return_value=retryable_summary,
+                            ) as probe_mock:
+                                stats = scan_library(connection, config)
+                            row = connection.execute(select(library_items)).mappings().one()
+
+                            probe_mock.assert_not_called()
+                            self.assertEqual(stats.unchanged, 1)
+                            self.assertEqual(stats.reprobed, 0)
+                            self.assertEqual(row["cadence_summary_json"], cadence_summary)
+                            self.assertEqual(row["media_fingerprint_json"], media_fingerprint)
+            finally:
+                reset_engine_cache()
+
+    def test_mtime_only_change_preserves_evidence_without_probing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            movie = media_root / "Feature.mkv"
+            movie.write_bytes(b"movie")
+            config = self._config(project_root, {"movies": media_root})
+            retryable_summary = _failed_probe_summary(RuntimeError("fixture probe failure"))
+
+            try:
+                with open_db(config.paths.db_path) as connection:
+                    with patch("mediaforce.library.scanner.probe_media", return_value=retryable_summary):
+                        scan_library(connection, config)
+                    original_row = dict(connection.execute(select(library_items)).mappings().one())
+                    original_stat = movie.stat()
+                    os.utime(
+                        movie,
+                        ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns + 1_000_000_000),
+                    )
+
+                    with patch(
+                        "mediaforce.library.scanner.probe_media",
+                        return_value=retryable_summary,
+                    ) as probe_mock:
+                        stats = scan_library(connection, config)
+                    refreshed_row = connection.execute(select(library_items)).mappings().one()
+                    expected_fingerprint = file_fingerprint(
+                        movie,
+                        movie.stat(),
+                        refreshed_row["duration_seconds"],
+                    )
+            finally:
+                reset_engine_cache()
+
+        probe_mock.assert_not_called()
+        self.assertEqual(stats.unchanged, 1)
+        self.assertEqual(stats.reprobed, 0)
+        self.assertNotEqual(refreshed_row["mtime_ns"], original_row["mtime_ns"])
+        self.assertNotEqual(refreshed_row["fingerprint"], original_row["fingerprint"])
+        self.assertEqual(
+            refreshed_row["fingerprint"],
+            expected_fingerprint,
+        )
+        self.assertEqual(refreshed_row["cadence_summary_json"], original_row["cadence_summary_json"])
+        self.assertEqual(refreshed_row["media_fingerprint_json"], original_row["media_fingerprint_json"])
+
+    def test_same_size_same_mtime_content_replacement_still_probes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            movie = media_root / "Feature.mkv"
+            movie.write_bytes(b"movie")
+            config = self._config(project_root, {"movies": media_root})
+            retryable_summary = _failed_probe_summary(RuntimeError("fixture probe failure"))
+
+            try:
+                with open_db(config.paths.db_path) as connection:
+                    with patch("mediaforce.library.scanner.probe_media", return_value=retryable_summary):
+                        scan_library(connection, config)
+                    original_stat = movie.stat()
+                    movie.write_bytes(b"other")
+                    os.utime(movie, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+
+                    with patch(
+                        "mediaforce.library.scanner.probe_media",
+                        return_value=retryable_summary,
+                    ) as probe_mock:
+                        stats = scan_library(connection, config)
+            finally:
+                reset_engine_cache()
+
+        probe_mock.assert_called_once_with(movie)
+        self.assertEqual(stats.unchanged, 0)
+        self.assertEqual(stats.reprobed, 1)
 
     def test_media_file_prefixes_use_the_configured_root_key(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -587,30 +713,12 @@ class ScannerRuntimeTests(unittest.TestCase):
     def test_failed_probe_becomes_blocked_unknown_evidence(self) -> None:
         summary = _failed_probe_summary(RuntimeError("corrupt media"))
 
-        self.assertFalse(_cadence_summary_present(summary.cadence_summary_json))
-        self.assertFalse(_media_fingerprint_present(summary.media_fingerprint_json))
         self.assertIn('"classification":"unknown"', summary.cadence_summary_json)
         self.assertIn("corrupt media", summary.cadence_summary_json)
         self.assertIn('"retry_required":true', summary.cadence_summary_json)
         self.assertIn('"status":"unknown"', summary.media_fingerprint_json)
         self.assertIn("corrupt media", summary.media_fingerprint_json)
         self.assertIn('"retry_required":true', summary.media_fingerprint_json)
-
-    def test_empty_or_malformed_cadence_summary_requires_reprobe(self) -> None:
-        self.assertFalse(_cadence_summary_present(None))
-        self.assertFalse(_cadence_summary_present("{}"))
-        self.assertFalse(_cadence_summary_present("not-json"))
-        old_summary = json.loads(_failed_probe_summary(RuntimeError("old")).cadence_summary_json)
-        old_summary["analysis"]["tool"]["version"] = "0"
-        self.assertFalse(_cadence_summary_present(json.dumps(old_summary)))
-
-    def test_empty_or_malformed_media_fingerprint_requires_reprobe(self) -> None:
-        self.assertFalse(_media_fingerprint_present(None))
-        self.assertFalse(_media_fingerprint_present("{}"))
-        self.assertFalse(_media_fingerprint_present("not-json"))
-        old_summary = json.loads(_failed_probe_summary(RuntimeError("old")).media_fingerprint_json)
-        old_summary["analysis"]["tool"]["version"] = "0"
-        self.assertFalse(_media_fingerprint_present(json.dumps(old_summary)))
 
 
 if __name__ == "__main__":

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -64,7 +64,6 @@ from mediaforce.tuning.calibration_jobs import load_latest_failed_target_size_sa
 from mediaforce.tuning.target_size_search import TargetSizeSearchError
 from mediaforce.web.app import (
     _advice_file,
-    _backfill_multimodal_review_pack,
     _build_multimodal_review_pack,
     _build_review_compare_video_from_pairs,
     _build_seed_policy_payload,
@@ -76,6 +75,7 @@ from mediaforce.web.app import (
     _calibration_file,
     _clear_folder_tuning_state,
     _folder_display_policy,
+    _request_triggers_periodic_cleanup,
     _run_periodic_cleanup,
     _review_compare_bundle_entries,
     _review_compare_pair_entries,
@@ -1210,7 +1210,7 @@ class TuningRuntimeTests(unittest.TestCase):
             self.config,
             folder_card_cache_key=lambda _config: ("empty", 0, 0),
             preview_folder_cards=lambda _config, _connection: [],
-            maybe_schedule_scan=lambda _connection, _config, prefix=None: None,
+            load_scan_status=lambda _connection, _config, prefix=None: None,
             decorate_encode_queue_for_scheduler=lambda _config, summary: summary,
             library_color_map_for_config=lambda _config: {},
         )
@@ -1227,7 +1227,7 @@ class TuningRuntimeTests(unittest.TestCase):
             self.config,
             folder_card_cache_key=lambda _config: ("one-item", 0, 0),
             preview_folder_cards=fail_preview_cards,
-            maybe_schedule_scan=lambda _connection, _config, prefix=None: None,
+            load_scan_status=lambda _connection, _config, prefix=None: None,
             decorate_encode_queue_for_scheduler=lambda _config, summary: summary,
             library_color_map_for_config=lambda _config: {},
             preview_limit=0,
@@ -1242,7 +1242,7 @@ class TuningRuntimeTests(unittest.TestCase):
                 self.config,
                 folder_card_cache_key=lambda _config: ("empty", 0, 0),
                 preview_folder_cards=lambda _config, _connection: [],
-                maybe_schedule_scan=lambda _connection, _config, prefix=None: None,
+                load_scan_status=lambda _connection, _config, prefix=None: None,
                 decorate_encode_queue_for_scheduler=lambda _config, summary: summary,
                 library_color_map_for_config=lambda _config: {},
                 preview_limit=-1,
@@ -2122,6 +2122,12 @@ class TuningRuntimeTests(unittest.TestCase):
                 time.sleep(0.01)
 
         self.assertFalse(cleanup_lock.locked())
+
+    def test_periodic_cleanup_ignores_safe_read_methods(self) -> None:
+        self.assertFalse(_request_triggers_periodic_cleanup("GET"))
+        self.assertFalse(_request_triggers_periodic_cleanup("HEAD"))
+        self.assertFalse(_request_triggers_periodic_cleanup("OPTIONS"))
+        self.assertTrue(_request_triggers_periodic_cleanup("POST"))
 
     def test_request_note_tuning_uses_multimodal_exec_when_review_pack_present(self) -> None:
         image_path = self.root / "review-pack.png"
@@ -6418,72 +6424,6 @@ class TuningRuntimeTests(unittest.TestCase):
             public_view["audio_plan"]["summary"],
             "Primary track eac3 is planned for Opus at 224k.",
         )
-
-    def test_backfill_multimodal_review_pack_restores_legacy_advice_with_retained_clips(self) -> None:
-        prefix = "movies/The Super Mario Galaxy Movie (2026)"
-        advice_path = _advice_file(self.config, prefix)
-        advice_path.parent.mkdir(parents=True, exist_ok=True)
-        advice_path.write_text(json.dumps({"summary": "Legacy draft without review pack."}) + "\n")
-
-        sample_item = {
-            "rel_path": f"{prefix}/The.Super.Mario.Galaxy.Movie.2026.mkv",
-            "source_path": str(self.root / "galaxy-source.mkv"),
-            "source_size_bytes": 2_519_516_042,
-            "video_codec": "h264",
-            "duration_seconds": 2561.35,
-            "audio_summary": [{"codec_name": "eac3", "channels": 6, "language": "eng", "default": 1, "index": 1}],
-            "subtitle_summary": [],
-            "resolved_policy": {
-                "video": {"quality_metric": "vmaf", "target_vmaf": 85.0},
-                "audio": {"convert_to_opus_codecs": ["eac3"], "surround_5_1_opus_bitrate": "224k"},
-            },
-        }
-
-        calibration = {
-            "draft_hash": "728b984563319b8f",
-            "review_media_ready": True,
-            "policy": sample_item["resolved_policy"],
-            "source_clips": [{"path": "/review-media/legacy-run/item-00/source-01.mp4", "timestamp_seconds": 345.0}],
-            "preview_clips": [{"path": "/review-media/legacy-run/item-00/encoded-01.mp4", "timestamp_seconds": 345.0}],
-            "compare_clips": [{"path": "/review-media/legacy-run/item-00/compare-01.mkv", "timestamp_seconds": 345.0}],
-        }
-
-        with patch(
-            "mediaforce.web.app._build_multimodal_review_pack",
-            return_value={"artifacts": [{"kind": "audio_spectrogram_compare"}]},
-        ), patch(
-            "mediaforce.web.app._multimodal_review_pack_public_view",
-            return_value={
-                "artifact_count": 3,
-                "artifacts": [
-                    {"kind": "video_compare_timeline", "image_url": "/review-media/review-compare.png"},
-                    {"kind": "video_contact_sheet", "image_url": "/review-media/review-video.png"},
-                    {"kind": "audio_spectrogram_compare", "image_url": "/review-media/review-audio.png"},
-                ],
-            },
-        ):
-            merged = _backfill_multimodal_review_pack(
-                self.config,
-                prefix,
-                sample_item=sample_item,
-                calibration=calibration,
-                advice_state={"summary": "Legacy draft without review pack."},
-            )
-
-        assert merged is not None
-        self.assertEqual(merged["summary"], "Legacy draft without review pack.")
-        pack = merged.get("multimodal_review_pack")
-        assert isinstance(pack, dict)
-        artifact_kinds = [artifact["kind"] for artifact in pack["artifacts"]]
-        self.assertIn("video_contact_sheet", artifact_kinds)
-        self.assertIn("video_compare_timeline", artifact_kinds)
-        self.assertIn("audio_spectrogram_compare", artifact_kinds)
-        calibration_advice = calibration.get("advice")
-        assert isinstance(calibration_advice, dict)
-        self.assertEqual(calibration_advice.get("multimodal_review_pack"), pack)
-        persisted_advice = json.loads(advice_path.read_text())
-        self.assertEqual(persisted_advice["summary"], "Legacy draft without review pack.")
-        self.assertEqual(persisted_advice["multimodal_review_pack"], pack)
 
     def test_build_multimodal_review_pack_includes_compare_timelines_and_moment_signals(self) -> None:
         sample_item = {


### PR DESCRIPTION
## Summary
- make dashboard, folder, scan-status, and host GET paths report cached/persisted state without scheduling scans, host probes, cleanup jobs, or media subprocesses
- separate inventory freshness from cadence/fingerprint evidence freshness so unchanged files preserve evidence without deep probing
- cache ffmpeg capability discovery behind startup/explicit lifecycle refresh and add generated catalog benchmarks

## Root cause
Mediaforce conflated three different concerns: reading operator state, reconciling file inventory, and refreshing expensive media evidence. GET polling could schedule work, and unchanged inventory rows were treated as probe candidates whenever evidence was missing, malformed, stale, or retryable.

## Validation
- `bash scripts/pre-commit-check.sh` — 970 backend tests plus frontend check/lint/test/build and full route smoke passed
- `uv build` — sdist and wheel passed
- PyCharm changed-files inspection — zero findings
- live headed browser review of dashboard and folder polling — stable, no console errors
- 600-second idle observation with 558 process samples — zero `ffmpeg` or `ffprobe` sightings
- valid one-second media regression — first scan discovered 1 item; unchanged second scan reported `reprobed=0 unchanged=1` with fail-fast ffmpeg/ffprobe sentinels untouched
- generated 1k, 10k, current (10,808), and doubled (21,616) fixtures — zero child processes, zero reprobes, zero DB lock errors in every case

## Review
An independent code review found one stale source-fingerprint edge on mtime-only changes; the fast path now recomputes the lightweight fingerprint while preserving cadence/fingerprint evidence.

Closes #215