### PR TITLE
Persist reusable per-item evidence state

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ Use this directory for guidance that should not live in `AGENTS.md`.
   versioned evidence, and safe allow-listed transforms
 - `docs/architecture/media-fingerprint-evidence.md`: measured visual/audio
   complexity, versioned media fingerprint evidence, and review-moment selection
+- `docs/architecture/evidence-state.md`: additive per-item cadence/fingerprint
+  lifecycle state, identities, retry foundation, and media-free rebuilds
 - `docs/architecture/stream-budget-ledger.md`: production stream selection,
   non-video overhead, uncertainty, and deterministic size feasibility
 - `docs/architecture/quality-risk-contract.md`: versioned quality-risk facts,

--- a/docs/architecture/cadence-evidence.md
+++ b/docs/architecture/cadence-evidence.md
@@ -11,6 +11,9 @@
   unchanged catalog rows. Missing, malformed, old, or retryable cadence
   remains non-current evidence and does not make routine inventory refresh
   decode the source again.
+- `mediaforce/library/evidence_state.py` projects canonical cadence JSON into
+  independently queryable current, analysis-required, or
+  classification-required state without changing the payload.
 - `mediaforce/library/planner.py` binds persisted cadence facts to the source
   fingerprint, cadence transform policy, and versioned evidence envelope
   carried by each manifest item.

--- a/docs/architecture/evidence-state.md
+++ b/docs/architecture/evidence-state.md
@@ -1,0 +1,96 @@
+# Rebuildable Per-Item Evidence State
+
+## Ownership
+
+- `library_items.cadence_summary_json` and
+  `library_items.media_fingerprint_json` remain the canonical measured evidence.
+- `mediaforce/library/evidence_state.py` projects those payloads into compact,
+  queryable lifecycle state without running media tools.
+- `library_item_evidence_state` stores one row per library item and evidence
+  kind. It is additive, disposable, and rebuildable from canonical catalog
+  state.
+- `mediaforce/library/scanner.py` refreshes projection rows when a new or
+  content-changed item receives a new canonical payload. It also performs the
+  one-time source-identity upgrade for unchanged legacy rows without rebinding
+  their policy identity or running media analysis.
+- Planner, representative-selection, review, and manifest code continue to
+  consume canonical JSON. Projection rows never authorize an encode decision.
+
+## State contract
+
+Evidence kinds are independent:
+
+- `cadence_analysis`
+- `media_fingerprint`
+
+Each row has one lifecycle state:
+
+- `current`: the canonical payload has the supported schema and analyzer and
+  does not request another analysis pass.
+- `analysis_required`: media measurement is required before the evidence can be
+  current.
+- `classification_required`: stored measurements remain reusable, but current
+  policy must reclassify them without rereading media.
+
+Non-current reasons are compact and machine-readable:
+
+- `missing`
+- `malformed`
+- `retry_required`
+- `schema_changed`
+- `tool_changed`
+- `unknown`
+- `source_changed`
+- `policy_changed`
+
+Valid blocked or mixed cadence remains current measured evidence. An explicit
+unknown cadence or fingerprint result is non-current because it cannot satisfy
+the next decision that needs that evidence.
+
+## Identities
+
+Projection rows record:
+
+- the exact canonical JSON SHA-256 without normalizing or rewriting the payload
+- the source content fingerprint, falling back to the legacy file fingerprint
+  when no content fingerprint exists
+- canonical schema version
+- analyzer name, analyzer version, and observed ffmpeg runtime version
+- the policy hash used for the current classification
+
+A source or analyzer change requires future media analysis. A policy-only hash
+change produces `classification_required`, so the stored measurements can be
+reclassified cheaply. Projection never probes the currently installed ffmpeg
+version; it records only the runtime identity already present in canonical JSON.
+
+The projection source identity is intentionally content-oriented so an
+mtime-only touch does not invalidate measured evidence. Run manifests continue
+to use the stricter file fingerprint for final encode-time source validation.
+
+## Retry foundation
+
+The state row carries `attempt_count`, `retry_not_before`, `last_attempt_at`,
+and `last_error` for the bounded worker introduced by the next workstream slice.
+There are no leases or worker ownership fields here. Projection rebuilds update
+derived columns while preserving existing retry metadata.
+
+## Migration and rebuild
+
+Alembic revision `20260719_0011` creates the table and projects every existing
+item inside the migration transaction. The frozen migration projector parses
+SQLite text only and cannot launch `ffmpeg` or `ffprobe`.
+
+`rebuild_library_item_evidence_states()` can rebuild the full projection or a
+targeted set of library items. It never commits, never touches canonical JSON,
+and never reads media. Dropping or truncating the projection therefore cannot
+destroy catalog membership or measured evidence.
+
+Rebuild preserves existing source and policy identities so it can mark source,
+analyzer, or policy invalidation without discarding prior state. When a
+projection row is absent, rebuild binds the canonical payload to the current
+catalog identity. The later worker will complete policy-only reclassification
+and then adopt the current policy hash without rereading media.
+
+Read APIs never call projection sync or rebuild helpers. Missing projection rows
+mean the projection needs an explicit rebuild; they do not mean the canonical
+media evidence is missing.

--- a/docs/architecture/media-fingerprint-evidence.md
+++ b/docs/architecture/media-fingerprint-evidence.md
@@ -11,6 +11,9 @@
   reconciling unchanged catalog rows, even when the summary is missing,
   malformed, old, or retryable. New or content-changed files still receive the
   existing full probe until the durable evidence worker owns refreshes.
+- `mediaforce/library/evidence_state.py` projects canonical fingerprint JSON
+  into independently queryable lifecycle state and keeps policy-only
+  reclassification separate from media analysis.
 - `mediaforce/library/planner.py` binds persisted fingerprint facts to the
   current source fingerprint and carries the versioned envelope on manifest
   items.

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -163,6 +163,11 @@ Guidance:
 - `scanner.py`
   - library inventory orchestration and catalog updates
   - unchanged inventory rows preserve evidence without launching deep analysis
+- `evidence_state.py`
+  - rebuildable per-item/per-kind projection of canonical cadence and
+    fingerprint JSON
+  - compact freshness reasons, source/analyzer/policy identities, retry timing,
+    and media-free status/count queries
 - `media_scopes.py`
   - canonical operator grouping for TV, movie, and generic media roots
   - exact-item versus descendant matching, SQL-safe boundaries, and API scope payloads

--- a/mediaforce/core/db_migration_scripts/env.py
+++ b/mediaforce/core/db_migration_scripts/env.py
@@ -5,6 +5,7 @@ from alembic import context
 from sqlalchemy import create_engine
 from sqlalchemy import pool
 
+from mediaforce.core.db_migrations import SQLITE_BUSY_TIMEOUT_MS
 from mediaforce.core.db_tables import metadata
 
 config = context.config
@@ -31,7 +32,11 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
-    connectable = create_engine(migration_url(), poolclass=pool.NullPool)
+    connectable = create_engine(
+        migration_url(),
+        connect_args={"timeout": SQLITE_BUSY_TIMEOUT_MS / 1000},
+        poolclass=pool.NullPool,
+    )
 
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)

--- a/mediaforce/core/db_migration_scripts/versions/20260719_0011_library_item_evidence_state.py
+++ b/mediaforce/core/db_migration_scripts/versions/20260719_0011_library_item_evidence_state.py
@@ -1,0 +1,303 @@
+"""Add rebuildable per-item evidence state.
+
+Revision ID: 20260719_0011
+Revises: 20260712_0010
+Create Date: 2026-07-19 14:30:00
+"""
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+import sqlalchemy as sa
+# noinspection PyPackageRequirements
+from alembic import op
+
+revision = "20260719_0011"
+down_revision = "20260712_0010"
+branch_labels = None
+depends_on = None
+
+_CADENCE_KIND = "cadence_analysis"
+_FINGERPRINT_KIND = "media_fingerprint"
+_CADENCE_POLICY_HASH = "sha256:6f3581cacb06b5a41606db639cdf3731ae987dfc1fe2af6bd8cdc838e249340a"
+_FINGERPRINT_POLICY_HASH = "sha256:622106f9a69c2ca6886c0bba2d0b9590267a5e282a0c98b4f84f2214e35a7450"
+_SPECS = {
+    _CADENCE_KIND: {
+        "column": "cadence_summary_json",
+        "schema_version": 1,
+        "analyzer_name": "mediaforce.ffmpeg_idet",
+        "analyzer_version": "1",
+        "policy_hash": _CADENCE_POLICY_HASH,
+    },
+    _FINGERPRINT_KIND: {
+        "column": "media_fingerprint_json",
+        "schema_version": 1,
+        "analyzer_name": "mediaforce.media_fingerprint",
+        "analyzer_version": "1",
+        "policy_hash": _FINGERPRINT_POLICY_HASH,
+    },
+}
+
+
+def upgrade() -> None:
+    if not _has_table("library_item_evidence_state"):
+        op.create_table(
+            "library_item_evidence_state",
+            sa.Column(
+                "library_item_id",
+                sa.Integer(),
+                sa.ForeignKey("library_items.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("evidence_kind", sa.Text(), nullable=False),
+            sa.Column("state", sa.Text(), nullable=False),
+            sa.Column("reason", sa.Text(), nullable=True),
+            sa.Column("summary_sha256", sa.Text(), nullable=True),
+            sa.Column("source_fingerprint", sa.Text(), nullable=True),
+            sa.Column("summary_schema_version", sa.Integer(), nullable=True),
+            sa.Column("analyzer_name", sa.Text(), nullable=True),
+            sa.Column("analyzer_version", sa.Text(), nullable=True),
+            sa.Column("analyzer_runtime_version", sa.Text(), nullable=True),
+            sa.Column("policy_hash", sa.Text(), nullable=False),
+            sa.Column("decision_status", sa.Text(), nullable=True),
+            sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("retry_not_before", sa.Text(), nullable=True),
+            sa.Column("last_attempt_at", sa.Text(), nullable=True),
+            sa.Column("last_error", sa.Text(), nullable=True),
+            sa.Column("updated_at", sa.Text(), nullable=False),
+            sa.PrimaryKeyConstraint("library_item_id", "evidence_kind"),
+        )
+    if not _has_index("library_item_evidence_state", "idx_library_item_evidence_state_kind_state"):
+        op.create_index(
+            "idx_library_item_evidence_state_kind_state",
+            "library_item_evidence_state",
+            ["evidence_kind", "state", "reason"],
+        )
+    if not _has_index("library_item_evidence_state", "idx_library_item_evidence_state_work_ready"):
+        op.create_index(
+            "idx_library_item_evidence_state_work_ready",
+            "library_item_evidence_state",
+            ["state", "retry_not_before", "evidence_kind"],
+        )
+    _backfill_existing_items()
+
+
+def downgrade() -> None:
+    if _has_table("library_item_evidence_state"):
+        op.drop_table("library_item_evidence_state")
+
+
+def _backfill_existing_items() -> None:
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, fingerprint, content_version_fingerprint, cadence_summary_json, "
+            "media_fingerprint_json FROM library_items ORDER BY id"
+        )
+    ).mappings().fetchall()
+    updated_at = datetime.now(UTC).isoformat(timespec="seconds")
+    pending: list[dict[str, Any]] = []
+    insert_statement = sa.text(
+        "INSERT OR IGNORE INTO library_item_evidence_state ("
+        "library_item_id, evidence_kind, state, reason, summary_sha256, source_fingerprint, "
+        "summary_schema_version, analyzer_name, analyzer_version, analyzer_runtime_version, "
+        "policy_hash, decision_status, attempt_count, updated_at"
+        ") VALUES ("
+        ":library_item_id, :evidence_kind, :state, :reason, :summary_sha256, :source_fingerprint, "
+        ":summary_schema_version, :analyzer_name, :analyzer_version, :analyzer_runtime_version, "
+        ":policy_hash, :decision_status, 0, :updated_at"
+        ")"
+    )
+    for row in rows:
+        source_fingerprint = (
+            _optional_text(row.get("content_version_fingerprint"))
+            or _optional_text(row.get("fingerprint"))
+        )
+        for evidence_kind, spec in _SPECS.items():
+            pending.append(
+                {
+                    "library_item_id": int(row["id"]),
+                    **_project_state(
+                        evidence_kind,
+                        row.get(str(spec["column"])),
+                        source_fingerprint=source_fingerprint,
+                        spec=spec,
+                        updated_at=updated_at,
+                    ),
+                }
+            )
+        if len(pending) >= 500:
+            bind.execute(insert_statement, pending)
+            pending.clear()
+    if pending:
+        bind.execute(insert_statement, pending)
+
+
+def _project_state(
+        evidence_kind: str,
+        summary_json: object,
+        *,
+        source_fingerprint: str | None,
+        spec: Mapping[str, object],
+        updated_at: str,
+) -> dict[str, Any]:
+    raw_summary = summary_json if isinstance(summary_json, str) else None
+    summary_sha256 = _summary_hash(raw_summary)
+    payload, state, reason = _canonical_state(raw_summary, evidence_kind, spec)
+    analysis = _object_dict(payload.get("analysis")) if payload is not None else {}
+    decision = _object_dict(payload.get("decision")) if payload is not None else {}
+    tool = _object_dict(analysis.get("tool"))
+    return {
+        "evidence_kind": evidence_kind,
+        "state": state,
+        "reason": reason,
+        "summary_sha256": summary_sha256,
+        "source_fingerprint": source_fingerprint,
+        "summary_schema_version": _optional_int(payload.get("schema_version")) if payload is not None else None,
+        "analyzer_name": _optional_text(tool.get("name")),
+        "analyzer_version": _optional_text(tool.get("version")),
+        "analyzer_runtime_version": _optional_text(tool.get("ffmpeg_version")),
+        "policy_hash": str(spec["policy_hash"]),
+        "decision_status": _optional_text(decision.get("status")),
+        "updated_at": updated_at,
+    }
+
+
+def _canonical_state(
+        raw_summary: str | None,
+        evidence_kind: str,
+        spec: Mapping[str, object],
+) -> tuple[dict[str, Any] | None, str, str | None]:
+    if raw_summary is None or not raw_summary.strip():
+        return None, "analysis_required", "missing"
+    try:
+        parsed = json.loads(raw_summary)
+    except json.JSONDecodeError:
+        return None, "analysis_required", "malformed"
+    if not isinstance(parsed, dict):
+        return None, "analysis_required", "malformed"
+    if not parsed:
+        return parsed, "analysis_required", "missing"
+    if parsed.get("retry_required") is True:
+        return parsed, "analysis_required", "retry_required"
+    if _int_value(parsed.get("schema_version")) != int(spec["schema_version"]):
+        return parsed, "analysis_required", "schema_changed"
+    analysis_value = parsed.get("analysis")
+    decision_value = parsed.get("decision")
+    if not isinstance(analysis_value, Mapping) or not isinstance(decision_value, Mapping):
+        return parsed, "analysis_required", "malformed"
+    analysis = _object_dict(analysis_value)
+    decision = _object_dict(decision_value)
+    tool_value = analysis.get("tool")
+    if not isinstance(tool_value, Mapping):
+        return parsed, "analysis_required", "malformed"
+    tool = _object_dict(tool_value)
+    analyzer_name = _optional_text(tool.get("name"))
+    analyzer_version = _optional_text(tool.get("version"))
+    decision_status = _optional_text(decision.get("status"))
+    if not analyzer_name or not analyzer_version or not decision_status:
+        return parsed, "analysis_required", "malformed"
+    if evidence_kind == _CADENCE_KIND:
+        classification = _optional_text(decision.get("classification"))
+        if decision_status not in {"resolved", "blocked"} or classification not in {
+            "progressive",
+            "tff",
+            "bff",
+            "telecine",
+            "mixed",
+            "unknown",
+        }:
+            return parsed, "analysis_required", "malformed"
+    elif decision_status not in {"measured", "unknown"}:
+        return parsed, "analysis_required", "malformed"
+    if analyzer_name != spec["analyzer_name"] or analyzer_version != spec["analyzer_version"]:
+        return parsed, "analysis_required", "tool_changed"
+    if not _measurements_are_usable(evidence_kind, parsed, analysis, decision):
+        return parsed, "analysis_required", "unknown"
+    if evidence_kind == _CADENCE_KIND:
+        unknown = str(decision.get("classification") or "") == "unknown"
+    else:
+        unknown = str(decision.get("status") or "") == "unknown"
+    if unknown:
+        return parsed, "analysis_required", "unknown"
+    return parsed, "current", None
+
+
+def _measurements_are_usable(
+        evidence_kind: str,
+        payload: Mapping[str, Any],
+        analysis: Mapping[str, Any],
+        decision: Mapping[str, Any],
+) -> bool:
+    sampled_frames = _int_value(analysis.get("sampled_frames"))
+    if evidence_kind == _FINGERPRINT_KIND:
+        return sampled_frames >= 90 and bool(_object_dict(analysis.get("aggregate")))
+    classification = str(decision.get("classification") or "")
+    if sampled_frames <= 0:
+        probe = _object_dict(payload.get("probe"))
+        return (
+            classification == "progressive"
+            and str(probe.get("field_order") or "").lower() == "progressive"
+            and not bool(probe.get("idet_required"))
+        )
+    measured_frames = sum(
+        _int_value(analysis.get(key))
+        for key in ("tff_frames", "bff_frames", "progressive_frames", "undetermined_frames")
+    )
+    return sampled_frames >= 120 and measured_frames == sampled_frames
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    return any(
+        str(index.get("name") or "") == index_name
+        for index in sa.inspect(op.get_bind()).get_indexes(table_name)
+    )
+
+
+def _object_dict(value: object) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    return {}
+
+
+def _summary_hash(raw_summary: str | None) -> str | None:
+    if raw_summary is None or not raw_summary.strip():
+        return None
+    return f"sha256:{hashlib.sha256(raw_summary.encode(), usedforsecurity=False).hexdigest()}"
+
+
+def _optional_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _optional_int(value: object) -> int | None:
+    if value in (None, ""):
+        return None
+    return _int_value(value)
+
+
+def _int_value(value: object) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0

--- a/mediaforce/core/db_tables.py
+++ b/mediaforce/core/db_tables.py
@@ -76,6 +76,45 @@ library_items = Table(
 Index("idx_library_items_rel_path", library_items.c.rel_path)
 Index("idx_library_items_status_score", library_items.c.status, library_items.c.priority_score.desc())
 
+library_item_evidence_state = Table(
+    "library_item_evidence_state",
+    metadata,
+    Column(
+        "library_item_id",
+        Integer,
+        ForeignKey("library_items.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column("evidence_kind", Text, primary_key=True),
+    Column("state", Text, nullable=False),
+    Column("reason", Text),
+    Column("summary_sha256", Text),
+    Column("source_fingerprint", Text),
+    Column("summary_schema_version", Integer),
+    Column("analyzer_name", Text),
+    Column("analyzer_version", Text),
+    Column("analyzer_runtime_version", Text),
+    Column("policy_hash", Text, nullable=False),
+    Column("decision_status", Text),
+    Column("attempt_count", Integer, nullable=False, server_default="0"),
+    Column("retry_not_before", Text),
+    Column("last_attempt_at", Text),
+    Column("last_error", Text),
+    Column("updated_at", Text, nullable=False),
+)
+Index(
+    "idx_library_item_evidence_state_kind_state",
+    library_item_evidence_state.c.evidence_kind,
+    library_item_evidence_state.c.state,
+    library_item_evidence_state.c.reason,
+)
+Index(
+    "idx_library_item_evidence_state_work_ready",
+    library_item_evidence_state.c.state,
+    library_item_evidence_state.c.retry_not_before,
+    library_item_evidence_state.c.evidence_kind,
+)
+
 plex_item_metadata = Table(
     "plex_item_metadata",
     metadata,

--- a/mediaforce/encoding/cadence.py
+++ b/mediaforce/encoding/cadence.py
@@ -13,6 +13,7 @@ from mediaforce.core.evidence import build_evidence_envelope, evidence_envelope_
 from mediaforce.core.type_defs import float_value, int_value, object_dict, object_list
 
 CADENCE_SCHEMA_VERSION = 1
+CADENCE_EVIDENCE_KIND = "cadence_analysis"
 CADENCE_TOOL_NAME = "mediaforce.ffmpeg_idet"
 CADENCE_TOOL_VERSION = "1"
 DEFAULT_IDET_MAX_FRAMES = 600
@@ -328,7 +329,7 @@ def cadence_manifest_payload(
         for item in (object_dict(value) for value in object_list(analysis.get("ranges")))
     ]
     envelope = build_evidence_envelope(
-        kind="cadence_analysis",
+        kind=CADENCE_EVIDENCE_KIND,
         sources=[{"source_id": source_id, "fingerprint": source_fingerprint}],
         policy_hash=stable_policy_hash(cadence_policy_snapshot()),
         tool_name=str(tool.get("name") or CADENCE_TOOL_NAME),

--- a/mediaforce/encoding/fingerprint.py
+++ b/mediaforce/encoding/fingerprint.py
@@ -16,6 +16,7 @@ from mediaforce.core.process_control import ManagedProcessController, ProcessCan
 from mediaforce.core.type_defs import float_value, int_value, object_dict, object_list
 
 MEDIA_FINGERPRINT_SCHEMA_VERSION = 1
+MEDIA_FINGERPRINT_EVIDENCE_KIND = "media_fingerprint"
 MEDIA_FINGERPRINT_TOOL_NAME = "mediaforce.media_fingerprint"
 MEDIA_FINGERPRINT_TOOL_VERSION = "1"
 DEFAULT_FINGERPRINT_MAX_FRAMES = 360
@@ -319,7 +320,7 @@ def media_fingerprint_manifest_payload(
         for item in (object_dict(value) for value in object_list(analysis.get("ranges")))
     ]
     envelope = build_evidence_envelope(
-        kind="media_fingerprint",
+        kind=MEDIA_FINGERPRINT_EVIDENCE_KIND,
         sources=[{"source_id": source_id, "fingerprint": source_fingerprint}],
         policy_hash=stable_policy_hash(media_fingerprint_policy_snapshot()),
         tool_name=str(tool.get("name") or MEDIA_FINGERPRINT_TOOL_NAME),

--- a/mediaforce/library/evidence_state.py
+++ b/mediaforce/library/evidence_state.py
@@ -1,0 +1,580 @@
+import hashlib
+import json
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from mediaforce.core.db import DBClient
+from mediaforce.core.db_tables import library_item_evidence_state, library_items
+from mediaforce.core.evidence import stable_policy_hash
+from mediaforce.core.type_defs import int_value, object_dict
+from mediaforce.core.utils import timestamp
+from mediaforce.encoding.cadence import CADENCE_EVIDENCE_KIND, CADENCE_SCHEMA_VERSION, CADENCE_TOOL_NAME, \
+    CADENCE_TOOL_VERSION, cadence_policy_snapshot
+from mediaforce.encoding.fingerprint import MEDIA_FINGERPRINT_EVIDENCE_KIND, MEDIA_FINGERPRINT_SCHEMA_VERSION, \
+    MEDIA_FINGERPRINT_TOOL_NAME, MEDIA_FINGERPRINT_TOOL_VERSION, media_fingerprint_policy_snapshot
+
+EvidenceKind = Literal["cadence_analysis", "media_fingerprint"]
+
+EVIDENCE_STATE_CURRENT = "current"
+EVIDENCE_STATE_ANALYSIS_REQUIRED = "analysis_required"
+EVIDENCE_STATE_CLASSIFICATION_REQUIRED = "classification_required"
+
+EVIDENCE_REASON_MISSING = "missing"
+EVIDENCE_REASON_MALFORMED = "malformed"
+EVIDENCE_REASON_RETRY_REQUIRED = "retry_required"
+EVIDENCE_REASON_SCHEMA_CHANGED = "schema_changed"
+EVIDENCE_REASON_TOOL_CHANGED = "tool_changed"
+EVIDENCE_REASON_UNKNOWN = "unknown"
+EVIDENCE_REASON_SOURCE_CHANGED = "source_changed"
+EVIDENCE_REASON_POLICY_CHANGED = "policy_changed"
+
+EVIDENCE_KINDS: tuple[EvidenceKind, ...] = (
+    CADENCE_EVIDENCE_KIND,
+    MEDIA_FINGERPRINT_EVIDENCE_KIND,
+)
+
+_PROJECTION_COLUMNS = (
+    "state",
+    "reason",
+    "summary_sha256",
+    "source_fingerprint",
+    "summary_schema_version",
+    "analyzer_name",
+    "analyzer_version",
+    "analyzer_runtime_version",
+    "policy_hash",
+    "decision_status",
+    "updated_at",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceStateProjection:
+    evidence_kind: EvidenceKind
+    state: str
+    reason: str | None
+    summary_sha256: str | None
+    source_fingerprint: str | None
+    summary_schema_version: int | None
+    analyzer_name: str | None
+    analyzer_version: str | None
+    analyzer_runtime_version: str | None
+    policy_hash: str
+    decision_status: str | None
+    updated_at: str
+
+    def to_values(self, library_item_id: int) -> dict[str, Any]:
+        return {
+            "library_item_id": library_item_id,
+            "evidence_kind": self.evidence_kind,
+            "state": self.state,
+            "reason": self.reason,
+            "summary_sha256": self.summary_sha256,
+            "source_fingerprint": self.source_fingerprint,
+            "summary_schema_version": self.summary_schema_version,
+            "analyzer_name": self.analyzer_name,
+            "analyzer_version": self.analyzer_version,
+            "analyzer_runtime_version": self.analyzer_runtime_version,
+            "policy_hash": self.policy_hash,
+            "decision_status": self.decision_status,
+            "updated_at": self.updated_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceStateRebuildStats:
+    item_count: int
+    row_count: int
+    current_count: int
+    analysis_required_count: int
+    classification_required_count: int
+    reason_counts: dict[str, int]
+
+
+@dataclass(frozen=True, slots=True)
+class _EvidenceSpec:
+    evidence_kind: EvidenceKind
+    column_name: str
+    schema_version: int
+    analyzer_name: str
+    analyzer_version: str
+    policy_snapshot: Callable[[], Mapping[str, Any]]
+
+
+_EVIDENCE_SPECS: dict[EvidenceKind, _EvidenceSpec] = {
+    CADENCE_EVIDENCE_KIND: _EvidenceSpec(
+        evidence_kind=CADENCE_EVIDENCE_KIND,
+        column_name="cadence_summary_json",
+        schema_version=CADENCE_SCHEMA_VERSION,
+        analyzer_name=CADENCE_TOOL_NAME,
+        analyzer_version=CADENCE_TOOL_VERSION,
+        policy_snapshot=cadence_policy_snapshot,
+    ),
+    MEDIA_FINGERPRINT_EVIDENCE_KIND: _EvidenceSpec(
+        evidence_kind=MEDIA_FINGERPRINT_EVIDENCE_KIND,
+        column_name="media_fingerprint_json",
+        schema_version=MEDIA_FINGERPRINT_SCHEMA_VERSION,
+        analyzer_name=MEDIA_FINGERPRINT_TOOL_NAME,
+        analyzer_version=MEDIA_FINGERPRINT_TOOL_VERSION,
+        policy_snapshot=media_fingerprint_policy_snapshot,
+    ),
+}
+
+
+def parse_evidence_summary(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def project_evidence_state(
+        evidence_kind: EvidenceKind,
+        summary_json: object,
+        *,
+        source_fingerprint: str | None,
+        previous_state: Mapping[str, Any] | None = None,
+        preserve_source_identity: bool = True,
+        preserve_policy_identity: bool = True,
+        current_policy_hash: str | None = None,
+        updated_at: str | None = None,
+) -> EvidenceStateProjection:
+    spec = _evidence_spec(evidence_kind)
+    projected_at = updated_at or timestamp()
+    policy_hash = current_policy_hash or stable_policy_hash(spec.policy_snapshot())
+    raw_summary = summary_json if isinstance(summary_json, str) else None
+    summary_hash = _summary_hash(raw_summary)
+    payload, base_state, base_reason = _canonical_state(raw_summary, spec)
+    analysis = object_dict(payload.get("analysis")) if payload is not None else {}
+    decision = object_dict(payload.get("decision")) if payload is not None else {}
+    tool = object_dict(analysis.get("tool"))
+    schema_version = _optional_int(payload.get("schema_version")) if payload is not None else None
+    analyzer_name = _optional_text(tool.get("name"))
+    analyzer_version = _optional_text(tool.get("version"))
+    analyzer_runtime_version = _optional_text(tool.get("ffmpeg_version"))
+    decision_status = _optional_text(decision.get("status"))
+    previous = object_dict(previous_state)
+    same_summary = bool(
+        previous
+        and summary_hash is not None
+        and str(previous.get("summary_sha256") or "") == summary_hash
+    )
+    bound_source_fingerprint = (
+        _optional_text(previous.get("source_fingerprint"))
+        if same_summary and preserve_source_identity
+        else _optional_text(source_fingerprint)
+    )
+    bound_policy_hash = (
+        str(previous.get("policy_hash") or policy_hash)
+        if same_summary and preserve_policy_identity
+        else policy_hash
+    )
+    state = base_state
+    reason = base_reason
+    if base_state == EVIDENCE_STATE_CURRENT and same_summary:
+        current_source_fingerprint = _optional_text(source_fingerprint)
+        if bound_source_fingerprint != current_source_fingerprint:
+            state = EVIDENCE_STATE_ANALYSIS_REQUIRED
+            reason = EVIDENCE_REASON_SOURCE_CHANGED
+        elif bound_policy_hash != policy_hash:
+            state = EVIDENCE_STATE_CLASSIFICATION_REQUIRED
+            reason = EVIDENCE_REASON_POLICY_CHANGED
+
+    return EvidenceStateProjection(
+        evidence_kind=evidence_kind,
+        state=state,
+        reason=reason,
+        summary_sha256=summary_hash,
+        source_fingerprint=bound_source_fingerprint,
+        summary_schema_version=schema_version,
+        analyzer_name=analyzer_name,
+        analyzer_version=analyzer_version,
+        analyzer_runtime_version=analyzer_runtime_version,
+        policy_hash=bound_policy_hash,
+        decision_status=decision_status,
+        updated_at=projected_at,
+    )
+
+
+def sync_library_item_evidence_states(
+        connection: DBClient,
+        item: Mapping[str, Any],
+        *,
+        preserve_source_identity: bool = True,
+        preserve_policy_identity: bool = True,
+        reset_attempt_state: bool = False,
+        updated_at: str | None = None,
+) -> list[EvidenceStateProjection]:
+    library_item_id = int(item["id"])
+    previous_by_kind = (
+        load_library_item_evidence_states(connection, library_item_id)
+        if preserve_source_identity or preserve_policy_identity
+        else {}
+    )
+    source_fingerprint = _item_source_fingerprint(item)
+    projections = [
+        project_evidence_state(
+            evidence_kind,
+            item.get(_evidence_spec(evidence_kind).column_name),
+            source_fingerprint=source_fingerprint,
+            previous_state=previous_by_kind.get(evidence_kind),
+            preserve_source_identity=preserve_source_identity,
+            preserve_policy_identity=preserve_policy_identity,
+            updated_at=updated_at,
+        )
+        for evidence_kind in EVIDENCE_KINDS
+    ]
+    _upsert_projections(
+        connection,
+        library_item_id,
+        projections,
+        reset_attempt_state=reset_attempt_state,
+    )
+    return projections
+
+
+def rebuild_library_item_evidence_states(
+        connection: DBClient,
+        *,
+        library_item_ids: Sequence[int] | None = None,
+        batch_size: int = 500,
+) -> EvidenceStateRebuildStats:
+    return _project_library_item_evidence_states(
+        connection,
+        library_item_ids=library_item_ids,
+        batch_size=batch_size,
+        preserve_identities=True,
+    )
+
+
+def _project_library_item_evidence_states(
+        connection: DBClient,
+        *,
+        library_item_ids: Sequence[int] | None,
+        batch_size: int,
+        preserve_identities: bool,
+) -> EvidenceStateRebuildStats:
+    query = select(
+        library_items.c.id,
+        library_items.c.fingerprint,
+        library_items.c.content_version_fingerprint,
+        library_items.c.cadence_summary_json,
+        library_items.c.media_fingerprint_json,
+    ).order_by(library_items.c.id)
+    normalized_ids = sorted({int(item_id) for item_id in library_item_ids or []})
+    if library_item_ids is not None:
+        if not normalized_ids:
+            return EvidenceStateRebuildStats(0, 0, 0, 0, 0, {})
+        query = query.where(library_items.c.id.in_(normalized_ids))
+
+    item_count = 0
+    row_count = 0
+    state_counts: Counter[str] = Counter()
+    reason_counts: Counter[str] = Counter()
+    item_batch: list[Mapping[str, Any]] = []
+    projected_at = timestamp()
+    current_policy_hashes = {
+        evidence_kind: stable_policy_hash(_evidence_spec(evidence_kind).policy_snapshot())
+        for evidence_kind in EVIDENCE_KINDS
+    }
+    normalized_batch_size = max(1, batch_size)
+    for item in connection.execute(query).mappings():
+        item_batch.append(item)
+        if len(item_batch) < normalized_batch_size:
+            continue
+        item_count_delta, row_count_delta = _project_item_batch(
+            connection,
+            item_batch,
+            preserve_identities=preserve_identities,
+            projected_at=projected_at,
+            current_policy_hashes=current_policy_hashes,
+            state_counts=state_counts,
+            reason_counts=reason_counts,
+        )
+        item_count += item_count_delta
+        row_count += row_count_delta
+        item_batch.clear()
+    if item_batch:
+        item_count_delta, row_count_delta = _project_item_batch(
+            connection,
+            item_batch,
+            preserve_identities=preserve_identities,
+            projected_at=projected_at,
+            current_policy_hashes=current_policy_hashes,
+            state_counts=state_counts,
+            reason_counts=reason_counts,
+        )
+        item_count += item_count_delta
+        row_count += row_count_delta
+
+    return EvidenceStateRebuildStats(
+        item_count=item_count,
+        row_count=row_count,
+        current_count=state_counts[EVIDENCE_STATE_CURRENT],
+        analysis_required_count=state_counts[EVIDENCE_STATE_ANALYSIS_REQUIRED],
+        classification_required_count=state_counts[EVIDENCE_STATE_CLASSIFICATION_REQUIRED],
+        reason_counts=dict(sorted(reason_counts.items())),
+    )
+
+
+def _project_item_batch(
+        connection: DBClient,
+        items: Sequence[Mapping[str, Any]],
+        *,
+        preserve_identities: bool,
+        projected_at: str,
+        current_policy_hashes: Mapping[EvidenceKind, str],
+        state_counts: Counter[str],
+        reason_counts: Counter[str],
+) -> tuple[int, int]:
+    previous_by_item: dict[int, dict[str, dict[str, Any]]] = {}
+    if preserve_identities:
+        item_ids = [int(item["id"]) for item in items]
+        previous_rows = connection.execute(
+            select(library_item_evidence_state)
+            .where(library_item_evidence_state.c.library_item_id.in_(item_ids))
+        ).mappings().fetchall()
+        for row in previous_rows:
+            library_item_id = int(row["library_item_id"])
+            previous_by_item.setdefault(library_item_id, {})[str(row["evidence_kind"])] = dict(row)
+
+    values: list[dict[str, Any]] = []
+    for item in items:
+        library_item_id = int(item["id"])
+        source_fingerprint = _item_source_fingerprint(item)
+        for evidence_kind in EVIDENCE_KINDS:
+            projection = project_evidence_state(
+                evidence_kind,
+                item.get(_evidence_spec(evidence_kind).column_name),
+                source_fingerprint=source_fingerprint,
+                previous_state=previous_by_item.get(library_item_id, {}).get(evidence_kind),
+                current_policy_hash=current_policy_hashes[evidence_kind],
+                updated_at=projected_at,
+            )
+            values.append(projection.to_values(library_item_id))
+            state_counts[projection.state] += 1
+            if projection.reason:
+                reason_counts[projection.reason] += 1
+    _upsert_projection_values(connection, values)
+    return len(items), len(values)
+
+
+def load_library_item_evidence_states(
+        connection: DBClient,
+        library_item_id: int,
+) -> dict[str, dict[str, Any]]:
+    rows = connection.execute(
+        select(library_item_evidence_state)
+        .where(library_item_evidence_state.c.library_item_id == library_item_id)
+        .order_by(library_item_evidence_state.c.evidence_kind)
+    ).mappings().fetchall()
+    return {str(row["evidence_kind"]): dict(row) for row in rows}
+
+
+def summarize_evidence_states(connection: DBClient) -> dict[str, Any]:
+    rows = connection.execute(
+        select(
+            library_item_evidence_state.c.evidence_kind,
+            library_item_evidence_state.c.state,
+            library_item_evidence_state.c.reason,
+            func.count().label("item_count"),
+        )
+        .group_by(
+            library_item_evidence_state.c.evidence_kind,
+            library_item_evidence_state.c.state,
+            library_item_evidence_state.c.reason,
+        )
+        .order_by(
+            library_item_evidence_state.c.evidence_kind,
+            library_item_evidence_state.c.state,
+            library_item_evidence_state.c.reason,
+        )
+    ).mappings().fetchall()
+    by_kind: dict[str, dict[str, Any]] = {}
+    total = 0
+    for row in rows:
+        evidence_kind = str(row["evidence_kind"])
+        state = str(row["state"])
+        reason = _optional_text(row["reason"])
+        item_count = int(row["item_count"] or 0)
+        total += item_count
+        kind_payload = by_kind.setdefault(evidence_kind, {"total": 0, "states": {}, "reasons": {}})
+        kind_payload["total"] += item_count
+        kind_payload["states"][state] = kind_payload["states"].get(state, 0) + item_count
+        if reason:
+            kind_payload["reasons"][reason] = kind_payload["reasons"].get(reason, 0) + item_count
+    return {"total": total, "by_kind": by_kind}
+
+
+def _canonical_state(
+        raw_summary: str | None,
+        spec: _EvidenceSpec,
+) -> tuple[dict[str, Any] | None, str, str | None]:
+    if raw_summary is None or not raw_summary.strip():
+        return None, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_MISSING
+    try:
+        parsed = json.loads(raw_summary)
+    except json.JSONDecodeError:
+        return None, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_MALFORMED
+    if not isinstance(parsed, dict):
+        return None, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_MALFORMED
+    if not parsed:
+        return parsed, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_MISSING
+    if parsed.get("retry_required") is True:
+        return parsed, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_RETRY_REQUIRED
+    if int_value(parsed.get("schema_version")) != spec.schema_version:
+        return parsed, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_SCHEMA_CHANGED
+
+    analysis_value = parsed.get("analysis")
+    decision_value = parsed.get("decision")
+    if not isinstance(analysis_value, Mapping) or not isinstance(decision_value, Mapping):
+        return parsed, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_MALFORMED
+    analysis = object_dict(analysis_value)
+    decision = object_dict(decision_value)
+    tool_value = analysis.get("tool")
+    if not isinstance(tool_value, Mapping):
+        return parsed, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_MALFORMED
+    tool = object_dict(tool_value)
+    analyzer_name = _optional_text(tool.get("name"))
+    analyzer_version = _optional_text(tool.get("version"))
+    decision_status = _optional_text(decision.get("status"))
+    if not analyzer_name or not analyzer_version or not decision_status:
+        return parsed, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_MALFORMED
+    if spec.evidence_kind == CADENCE_EVIDENCE_KIND:
+        classification = _optional_text(decision.get("classification"))
+        if decision_status not in {"resolved", "blocked"} or classification not in {
+            "progressive",
+            "tff",
+            "bff",
+            "telecine",
+            "mixed",
+            "unknown",
+        }:
+            return parsed, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_MALFORMED
+    elif decision_status not in {"measured", "unknown"}:
+        return parsed, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_MALFORMED
+    if analyzer_name != spec.analyzer_name or analyzer_version != spec.analyzer_version:
+        return parsed, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_TOOL_CHANGED
+    if not _measurements_are_usable(spec.evidence_kind, parsed, analysis, decision):
+        return parsed, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_UNKNOWN
+    if _decision_is_unknown(spec.evidence_kind, decision):
+        return parsed, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_UNKNOWN
+    return parsed, EVIDENCE_STATE_CURRENT, None
+
+
+def _decision_is_unknown(evidence_kind: EvidenceKind, decision: Mapping[str, Any]) -> bool:
+    if evidence_kind == CADENCE_EVIDENCE_KIND:
+        return str(decision.get("classification") or "") == "unknown"
+    return str(decision.get("status") or "") == "unknown"
+
+
+def _measurements_are_usable(
+        evidence_kind: EvidenceKind,
+        payload: Mapping[str, Any],
+        analysis: Mapping[str, Any],
+        decision: Mapping[str, Any],
+) -> bool:
+    sampled_frames = int_value(analysis.get("sampled_frames"))
+    if evidence_kind == MEDIA_FINGERPRINT_EVIDENCE_KIND:
+        return sampled_frames >= 90 and bool(object_dict(analysis.get("aggregate")))
+    classification = str(decision.get("classification") or "")
+    if sampled_frames <= 0:
+        probe = object_dict(payload.get("probe"))
+        return (
+            classification == "progressive"
+            and str(probe.get("field_order") or "").lower() == "progressive"
+            and not bool(probe.get("idet_required"))
+        )
+    measured_frames = sum(
+        int_value(analysis.get(key))
+        for key in ("tff_frames", "bff_frames", "progressive_frames", "undetermined_frames")
+    )
+    return sampled_frames >= 120 and measured_frames == sampled_frames
+
+
+def _upsert_projections(
+        connection: DBClient,
+        library_item_id: int,
+        projections: Sequence[EvidenceStateProjection],
+        *,
+        reset_attempt_state: bool,
+) -> None:
+    values = [projection.to_values(library_item_id) for projection in projections]
+    _upsert_projection_values(
+        connection,
+        values,
+        reset_attempt_state=reset_attempt_state,
+    )
+
+
+def _upsert_projection_values(
+        connection: DBClient,
+        values: Sequence[Mapping[str, Any]],
+        *,
+        reset_attempt_state: bool = False,
+) -> None:
+    if not values:
+        return
+    statement = sqlite_insert(library_item_evidence_state)
+    update_values = {
+        column_name: getattr(statement.excluded, column_name)
+        for column_name in _PROJECTION_COLUMNS
+    }
+    if reset_attempt_state:
+        update_values.update(
+            {
+                "attempt_count": 0,
+                "retry_not_before": None,
+                "last_attempt_at": None,
+                "last_error": None,
+            }
+        )
+    connection.execute(
+        statement.on_conflict_do_update(
+            index_elements=[
+                library_item_evidence_state.c.library_item_id,
+                library_item_evidence_state.c.evidence_kind,
+            ],
+            set_=update_values,
+        ),
+        [dict(value) for value in values],
+    )
+
+
+def _evidence_spec(evidence_kind: EvidenceKind) -> _EvidenceSpec:
+    try:
+        return _EVIDENCE_SPECS[evidence_kind]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported evidence kind: {evidence_kind}") from exc
+
+
+def _item_source_fingerprint(item: Mapping[str, Any]) -> str | None:
+    return (
+        _optional_text(item.get("content_version_fingerprint"))
+        or _optional_text(item.get("fingerprint"))
+    )
+
+
+def _summary_hash(raw_summary: str | None) -> str | None:
+    if raw_summary is None or not raw_summary.strip():
+        return None
+    return f"sha256:{hashlib.sha256(raw_summary.encode(), usedforsecurity=False).hexdigest()}"
+
+
+def _optional_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _optional_int(value: object) -> int | None:
+    if value in (None, ""):
+        return None
+    return int_value(value)

--- a/mediaforce/library/planner.py
+++ b/mediaforce/library/planner.py
@@ -8,6 +8,7 @@ from mediaforce.core.evidence import stable_source_id
 from mediaforce.core.type_defs import float_value, object_dict
 from mediaforce.encoding.cadence import cadence_manifest_payload
 from mediaforce.encoding.fingerprint import media_fingerprint_manifest_payload
+from mediaforce.library.evidence_state import parse_evidence_summary
 from mediaforce.tuning.size_goals import operator_intent_from_policy
 from mediaforce.tuning.stream_budget import resolve_stream_budget_ledger
 
@@ -152,10 +153,4 @@ def build_manifest_item(row: dict[str, Any], config: MediaforceConfig) -> dict[s
 
 
 def _evidence_summary(value: object) -> dict[str, Any] | None:
-    if not isinstance(value, str) or not value.strip():
-        return None
-    try:
-        payload = json.loads(value)
-    except json.JSONDecodeError:
-        return None
-    return payload if isinstance(payload, dict) else None
+    return parse_evidence_summary(value)

--- a/mediaforce/library/scanner.py
+++ b/mediaforce/library/scanner.py
@@ -20,6 +20,7 @@ from mediaforce.core.db_tables import scan_runs
 from mediaforce.core.models import ProbeSummary
 from mediaforce.encoding.cadence import unavailable_cadence_summary
 from mediaforce.encoding.fingerprint import unavailable_media_fingerprint_summary
+from mediaforce.library.evidence_state import sync_library_item_evidence_states
 from mediaforce.library.media_scopes import logical_library_rel_path, path_matches_scope
 from mediaforce.library.planner import recommend_item
 from mediaforce.library.probe import probe_media
@@ -155,6 +156,21 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
                         status=case((library_items.c.status == "missing", "discovered"), else_=library_items.c.status),
                     )
                 )
+                if not row.get("content_version_fingerprint") and content_fingerprint:
+                    sync_library_item_evidence_states(
+                        connection,
+                        {
+                            **dict(row),
+                            "fingerprint": file_fingerprint(
+                                file_path=file_path,
+                                stat_result=stat_result,
+                                duration_seconds=float_value(row.get("duration_seconds")),
+                            ),
+                            "content_version_fingerprint": content_fingerprint,
+                        },
+                        preserve_source_identity=False,
+                        updated_at=started_at,
+                    )
                 stats.unchanged += 1
                 pending_writes = _flush_scan_progress(connection, scan_id, stats, pending_writes + 1)
                 continue
@@ -217,11 +233,13 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
             }
 
             if row is None:
-                connection.execute(
+                insert_result = connection.execute(
                     insert(library_items).values(**values)
                 )
+                library_item_id = int(insert_result.inserted_primary_key[0])
                 stats.discovered += 1
             else:
+                library_item_id = int(row["id"])
                 previous_content_fingerprint = str(row.get("content_version_fingerprint") or "") or None
                 content_changed = _content_version_changed(
                     row,
@@ -241,6 +259,14 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
                     )
                 )
                 stats.reprobed += 1
+            sync_library_item_evidence_states(
+                connection,
+                {**values, "id": library_item_id},
+                preserve_source_identity=False,
+                preserve_policy_identity=False,
+                reset_attempt_state=True,
+                updated_at=started_at,
+            )
             pending_writes = _flush_scan_progress(connection, scan_id, stats, pending_writes + 1)
 
             if limit is not None and stats.total_seen >= limit:

--- a/scripts/benchmark_catalog_refresh.py
+++ b/scripts/benchmark_catalog_refresh.py
@@ -19,6 +19,7 @@ from mediaforce.core.config import DEFAULT_CONFIG_PATH, ConfigPaths, MediaforceC
 from mediaforce.core.db import DBClient, open_db, reset_engine_cache
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.utils import content_version_fingerprint
+from mediaforce.library.evidence_state import rebuild_library_item_evidence_states
 from mediaforce.library.scanner import scan_library
 
 
@@ -54,6 +55,9 @@ class _MeasuredConnection:
 
     def execute(self, *args: Any, **kwargs: Any) -> Any:
         return self._measure(self.connection.execute, *args, **kwargs)
+
+    def exec_driver_sql(self, *args: Any, **kwargs: Any) -> Any:
+        return self._measure(self.connection.exec_driver_sql, *args, **kwargs)
 
     def commit(self) -> None:
         self._measure(self.connection.commit)
@@ -279,6 +283,8 @@ def _seed_fixture_catalog(config: MediaforceConfig, media_root: Path, item_count
         if rows:
             connection.execute(library_items.insert(), rows)
             connection.commit()
+        rebuild_library_item_evidence_states(connection)
+        connection.commit()
     reset_engine_cache()
 
 

--- a/tests/test_db_runtime.py
+++ b/tests/test_db_runtime.py
@@ -1,9 +1,12 @@
+import json
 import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+# noinspection PyPackageRequirements
+from alembic import command
 from sqlalchemy import create_engine
 from sqlalchemy import inspect
 from sqlalchemy import select
@@ -14,9 +17,15 @@ from mediaforce.core.db import reset_engine_cache
 from mediaforce.core.db_tables import alembic_version
 from mediaforce.core.db_tables import encode_jobs
 from mediaforce.core.db_tables import encode_queue_state
+from mediaforce.core.db_tables import library_item_evidence_state
+from mediaforce.core.db_tables import library_items
+from mediaforce.core.db_migrations import _alembic_config, _alembic_script_location
+from mediaforce.core.evidence import stable_policy_hash
 from mediaforce.core.type_defs import object_dict
+from mediaforce.encoding.cadence import cadence_policy_snapshot
+from mediaforce.encoding.fingerprint import media_fingerprint_policy_snapshot
 
-CURRENT_DB_REVISION = "20260712_0010"
+CURRENT_DB_REVISION = "20260719_0011"
 
 
 class DatabaseRuntimeTests(unittest.TestCase):
@@ -27,11 +36,18 @@ class DatabaseRuntimeTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             db_path = Path(temp_dir) / "library.sqlite3"
 
-            with open_db(db_path) as connection:
+            with patch("subprocess.run", side_effect=AssertionError("unexpected subprocess")), patch(
+                "subprocess.Popen",
+                side_effect=AssertionError("unexpected subprocess"),
+            ), open_db(db_path) as connection:
                 version = connection.execute(select(alembic_version.c.version_num)).scalar_one()
                 inspector = inspect(connection)
                 table_names = inspector.get_table_names()
                 indexes = {str(index_row["name"]) for index_row in inspector.get_indexes("encode_jobs")}
+                evidence_indexes = {
+                    str(index_row["name"])
+                    for index_row in inspector.get_indexes("library_item_evidence_state")
+                }
                 library_columns = {str(column["name"]) for column in inspector.get_columns("library_items")}
 
             self.assertEqual(version, CURRENT_DB_REVISION)
@@ -45,6 +61,9 @@ class DatabaseRuntimeTests(unittest.TestCase):
             self.assertIn("plex_item_metadata", table_names)
             self.assertIn("series_metadata", table_names)
             self.assertIn("metadata_sync_state", table_names)
+            self.assertIn("library_item_evidence_state", table_names)
+            self.assertIn("idx_library_item_evidence_state_kind_state", evidence_indexes)
+            self.assertIn("idx_library_item_evidence_state_work_ready", evidence_indexes)
 
     def test_open_db_stamps_existing_legacy_database(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -271,6 +290,131 @@ class DatabaseRuntimeTests(unittest.TestCase):
             self.assertEqual(version, CURRENT_DB_REVISION)
             self.assertIn("metadata_sync_state", table_names)
 
+    def test_open_db_projects_existing_evidence_without_media_subprocesses(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "library.sqlite3"
+            cadence_json = json.dumps(
+                {
+                    "schema_version": 1,
+                    "probe": {
+                        "field_order": "progressive",
+                        "idet_required": False,
+                    },
+                    "analysis": {
+                        "sampled_frames": 0,
+                        "tool": {
+                            "name": "mediaforce.ffmpeg_idet",
+                            "version": "1",
+                            "ffmpeg_version": "ffmpeg fixture",
+                        }
+                    },
+                    "decision": {"status": "resolved", "classification": "progressive"},
+                },
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+            fingerprint_json = '{"retry_required":true}'
+            with open_db(db_path) as connection:
+                connection.execute(
+                    library_items.insert().values(
+                        **self._library_item_values(
+                            cadence_summary_json=cadence_json,
+                            media_fingerprint_json=fingerprint_json,
+                        )
+                    )
+                )
+            reset_engine_cache()
+
+            raw_connection = sqlite3.connect(db_path)
+            try:
+                raw_connection.execute("DROP TABLE library_item_evidence_state")
+                raw_connection.execute(
+                    "UPDATE alembic_version SET version_num = ?",
+                    ("20260712_0010",),
+                )
+                raw_connection.commit()
+            finally:
+                raw_connection.close()
+
+            with patch("subprocess.run", side_effect=AssertionError("unexpected subprocess")), patch(
+                "subprocess.Popen",
+                side_effect=AssertionError("unexpected subprocess"),
+            ), open_db(db_path) as connection:
+                version = connection.execute(select(alembic_version.c.version_num)).scalar_one()
+                state_rows = connection.execute(
+                    select(
+                        library_item_evidence_state.c.evidence_kind,
+                        library_item_evidence_state.c.state,
+                        library_item_evidence_state.c.reason,
+                        library_item_evidence_state.c.policy_hash,
+                    ).order_by(library_item_evidence_state.c.evidence_kind)
+                ).mappings().fetchall()
+                canonical = connection.execute(
+                    select(
+                        library_items.c.cadence_summary_json,
+                        library_items.c.media_fingerprint_json,
+                    )
+                ).mappings().one()
+
+            self.assertEqual(version, CURRENT_DB_REVISION)
+            self.assertEqual(
+                [(row["evidence_kind"], row["state"], row["reason"]) for row in state_rows],
+                [
+                    ("cadence_analysis", "current", None),
+                    ("media_fingerprint", "analysis_required", "retry_required"),
+                ],
+            )
+            self.assertEqual(canonical["cadence_summary_json"], cadence_json)
+            self.assertEqual(canonical["media_fingerprint_json"], fingerprint_json)
+            self.assertEqual(
+                {row["evidence_kind"]: row["policy_hash"] for row in state_rows},
+                {
+                    "cadence_analysis": stable_policy_hash(cadence_policy_snapshot()),
+                    "media_fingerprint": stable_policy_hash(media_fingerprint_policy_snapshot()),
+                },
+            )
+
+    def test_evidence_state_downgrade_preserves_canonical_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "library.sqlite3"
+            cadence_json = '{"schema_version":1}'
+            fingerprint_json = '{"schema_version":1}'
+            with open_db(db_path) as connection:
+                connection.execute(
+                    library_items.insert().values(
+                        **self._library_item_values(
+                            cadence_summary_json=cadence_json,
+                            media_fingerprint_json=fingerprint_json,
+                        )
+                    )
+                )
+            reset_engine_cache()
+
+            with _alembic_script_location() as script_location:
+                command.downgrade(
+                    _alembic_config(db_path, script_location),
+                    "20260712_0010",
+                )
+
+            raw_connection = sqlite3.connect(db_path)
+            try:
+                table_names = {
+                    str(row[0])
+                    for row in raw_connection.execute(
+                        "SELECT name FROM sqlite_master WHERE type = 'table'"
+                    ).fetchall()
+                }
+                canonical = raw_connection.execute(
+                    "SELECT cadence_summary_json, media_fingerprint_json FROM library_items"
+                ).fetchone()
+                version = raw_connection.execute("SELECT version_num FROM alembic_version").fetchone()
+            finally:
+                raw_connection.close()
+
+            self.assertNotIn("library_item_evidence_state", table_names)
+            self.assertEqual(canonical, (cadence_json, fingerprint_json))
+            self.assertEqual(version, ("20260712_0010",))
+
     def test_open_db_rolls_back_on_base_exception(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             db_path = Path(temp_dir) / "library.sqlite3"
@@ -327,6 +471,43 @@ class DatabaseRuntimeTests(unittest.TestCase):
         self.assertTrue(fake.commit_called)
         self.assertTrue(fake.close_called)
         self.assertTrue(fake.closed)
+
+    @staticmethod
+    def _library_item_values(
+            *,
+            cadence_summary_json: str | None,
+            media_fingerprint_json: str | None,
+    ) -> dict[str, object]:
+        now = "2026-07-19T12:00:00+00:00"
+        return {
+            "source_path": "/media/item.mkv",
+            "rel_path": "tv/show/item.mkv",
+            "media_root": "tv",
+            "parent_dir": "tv/show",
+            "file_name": "item.mkv",
+            "container": ".mkv",
+            "size_bytes": 1000,
+            "mtime_ns": 1,
+            "fingerprint": "file-1",
+            "duration_seconds": 60.0,
+            "video_codec": "h264",
+            "audio_track_count": 1,
+            "subtitle_track_count": 0,
+            "english_audio_count": 1,
+            "english_subtitle_count": 0,
+            "audio_summary_json": "[]",
+            "subtitle_summary_json": "[]",
+            "cadence_summary_json": cadence_summary_json,
+            "media_fingerprint_json": media_fingerprint_json,
+            "content_version_changed_at": now,
+            "content_version_fingerprint": "content-1",
+            "status": "discovered",
+            "priority_score": 0,
+            "last_scan_id": "fixture",
+            "discovered_at": now,
+            "last_seen_at": now,
+            "updated_at": now,
+        }
 
 
 if __name__ == "__main__":

--- a/tests/test_evidence_state.py
+++ b/tests/test_evidence_state.py
@@ -1,0 +1,320 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from sqlalchemy import delete, insert, select, update
+
+from mediaforce.core.db import open_db, reset_engine_cache
+from mediaforce.core.db_tables import library_item_evidence_state, library_items
+from mediaforce.encoding.cadence import CADENCE_EVIDENCE_KIND, analyze_cadence, unavailable_cadence_summary
+from mediaforce.encoding.fingerprint import MEDIA_FINGERPRINT_EVIDENCE_KIND, unavailable_media_fingerprint_summary
+from mediaforce.library.evidence_state import EVIDENCE_REASON_MALFORMED, EVIDENCE_REASON_MISSING, \
+    EVIDENCE_REASON_POLICY_CHANGED, EVIDENCE_REASON_RETRY_REQUIRED, EVIDENCE_REASON_SCHEMA_CHANGED, \
+    EVIDENCE_REASON_SOURCE_CHANGED, EVIDENCE_REASON_TOOL_CHANGED, EVIDENCE_REASON_UNKNOWN, \
+    EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_STATE_CLASSIFICATION_REQUIRED, EVIDENCE_STATE_CURRENT, \
+    load_library_item_evidence_states, project_evidence_state, rebuild_library_item_evidence_states, \
+    summarize_evidence_states
+
+
+class EvidenceStateProjectionTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        reset_engine_cache()
+
+    def test_projection_distinguishes_noncurrent_cadence_states(self) -> None:
+        valid = self._cadence_summary()
+        old_tool = json.loads(valid)
+        old_tool["analysis"]["tool"]["version"] = "0"
+        old_schema = json.loads(valid)
+        old_schema["schema_version"] = 0
+        invalid_shape = json.loads(valid)
+        invalid_shape["decision"] = {}
+        retry = unavailable_cadence_summary("fixture failure")
+        retry["retry_required"] = True
+        cases = (
+            (None, EVIDENCE_REASON_MISSING),
+            ("not-json", EVIDENCE_REASON_MALFORMED),
+            (json.dumps(invalid_shape), EVIDENCE_REASON_MALFORMED),
+            (json.dumps(old_schema), EVIDENCE_REASON_SCHEMA_CHANGED),
+            (json.dumps(old_tool), EVIDENCE_REASON_TOOL_CHANGED),
+            (json.dumps(retry), EVIDENCE_REASON_RETRY_REQUIRED),
+            (json.dumps(unavailable_cadence_summary("fixture unknown")), EVIDENCE_REASON_UNKNOWN),
+        )
+
+        for summary_json, reason in cases:
+            with self.subTest(reason=reason):
+                projection = project_evidence_state(
+                    CADENCE_EVIDENCE_KIND,
+                    summary_json,
+                    source_fingerprint="content-1",
+                )
+
+                self.assertEqual(projection.state, EVIDENCE_STATE_ANALYSIS_REQUIRED)
+                self.assertEqual(projection.reason, reason)
+
+        current = project_evidence_state(
+            CADENCE_EVIDENCE_KIND,
+            valid,
+            source_fingerprint="content-1",
+        )
+        self.assertEqual(current.state, EVIDENCE_STATE_CURRENT)
+        self.assertIsNone(current.reason)
+
+    def test_cadence_and_fingerprint_states_are_independent(self) -> None:
+        cadence = project_evidence_state(
+            CADENCE_EVIDENCE_KIND,
+            self._cadence_summary(),
+            source_fingerprint="content-1",
+        )
+        fingerprint = project_evidence_state(
+            MEDIA_FINGERPRINT_EVIDENCE_KIND,
+            json.dumps(unavailable_media_fingerprint_summary("fixture unknown")),
+            source_fingerprint="content-1",
+        )
+
+        self.assertEqual(cadence.state, EVIDENCE_STATE_CURRENT)
+        self.assertEqual(fingerprint.state, EVIDENCE_STATE_ANALYSIS_REQUIRED)
+        self.assertEqual(fingerprint.reason, EVIDENCE_REASON_UNKNOWN)
+
+    def test_source_and_policy_changes_require_different_work(self) -> None:
+        original = project_evidence_state(
+            CADENCE_EVIDENCE_KIND,
+            self._cadence_summary(),
+            source_fingerprint="content-1",
+            current_policy_hash="sha256:policy-1",
+            updated_at="2026-07-19T12:00:00+00:00",
+        )
+        previous = original.to_values(1)
+
+        source_changed = project_evidence_state(
+            CADENCE_EVIDENCE_KIND,
+            self._cadence_summary(),
+            source_fingerprint="content-2",
+            previous_state=previous,
+            current_policy_hash="sha256:policy-1",
+        )
+        policy_changed = project_evidence_state(
+            CADENCE_EVIDENCE_KIND,
+            self._cadence_summary(),
+            source_fingerprint="content-1",
+            previous_state=previous,
+            current_policy_hash="sha256:policy-2",
+        )
+
+        self.assertEqual(source_changed.state, EVIDENCE_STATE_ANALYSIS_REQUIRED)
+        self.assertEqual(source_changed.reason, EVIDENCE_REASON_SOURCE_CHANGED)
+        self.assertEqual(source_changed.source_fingerprint, "content-1")
+        self.assertEqual(policy_changed.state, EVIDENCE_STATE_CLASSIFICATION_REQUIRED)
+        self.assertEqual(policy_changed.reason, EVIDENCE_REASON_POLICY_CHANGED)
+        self.assertEqual(policy_changed.policy_hash, "sha256:policy-1")
+
+    def test_summary_hash_tracks_exact_canonical_text(self) -> None:
+        compact = self._cadence_summary()
+        spaced = f" {compact} "
+
+        first = project_evidence_state(
+            CADENCE_EVIDENCE_KIND,
+            compact,
+            source_fingerprint="content-1",
+        )
+        second = project_evidence_state(
+            CADENCE_EVIDENCE_KIND,
+            spaced,
+            source_fingerprint="content-1",
+        )
+
+        self.assertNotEqual(first.summary_sha256, second.summary_sha256)
+
+    def test_rebuild_preserves_identities_and_detects_source_and_policy_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "library.sqlite3"
+            with open_db(db_path) as connection:
+                library_item_id = int(
+                    connection.execute(
+                        insert(library_items).values(
+                            **self._item_values(
+                                1,
+                                cadence_summary_json=self._cadence_summary(),
+                                media_fingerprint_json=self._fingerprint_summary(),
+                            )
+                        )
+                    ).inserted_primary_key[0]
+                )
+                rebuild_library_item_evidence_states(connection)
+                connection.execute(
+                    update(library_item_evidence_state)
+                    .where(library_item_evidence_state.c.library_item_id == library_item_id)
+                    .values(policy_hash="sha256:old-policy")
+                )
+
+                refreshed = rebuild_library_item_evidence_states(connection)
+                policy_states = load_library_item_evidence_states(connection, library_item_id)
+                connection.execute(
+                    update(library_items)
+                    .where(library_items.c.id == library_item_id)
+                    .values(content_version_fingerprint="content-2")
+                )
+                source_refresh = rebuild_library_item_evidence_states(connection)
+                source_states = load_library_item_evidence_states(connection, library_item_id)
+
+        self.assertEqual(refreshed.classification_required_count, 2)
+        self.assertEqual(
+            [state["reason"] for state in policy_states.values()],
+            [EVIDENCE_REASON_POLICY_CHANGED, EVIDENCE_REASON_POLICY_CHANGED],
+        )
+        self.assertEqual(source_refresh.analysis_required_count, 2)
+        self.assertEqual(
+            [state["reason"] for state in source_states.values()],
+            [EVIDENCE_REASON_SOURCE_CHANGED, EVIDENCE_REASON_SOURCE_CHANGED],
+        )
+
+    def test_rebuild_is_media_free_preserves_retry_state_and_supports_counts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "library.sqlite3"
+            with open_db(db_path) as connection:
+                first_id = int(
+                    connection.execute(
+                        insert(library_items).values(
+                            **self._item_values(
+                                1,
+                                cadence_summary_json=self._cadence_summary(),
+                                media_fingerprint_json=self._fingerprint_summary(),
+                            )
+                        )
+                    ).inserted_primary_key[0]
+                )
+                second_id = int(
+                    connection.execute(
+                        insert(library_items).values(
+                            **self._item_values(
+                                2,
+                                cadence_summary_json="not-json",
+                                media_fingerprint_json=None,
+                            )
+                        )
+                    ).inserted_primary_key[0]
+                )
+                with patch("subprocess.run", side_effect=AssertionError("unexpected subprocess")), patch(
+                    "subprocess.Popen",
+                    side_effect=AssertionError("unexpected subprocess"),
+                ):
+                    first_stats = rebuild_library_item_evidence_states(connection)
+                connection.execute(
+                    update(library_item_evidence_state)
+                    .where(
+                        library_item_evidence_state.c.library_item_id == first_id,
+                        library_item_evidence_state.c.evidence_kind == CADENCE_EVIDENCE_KIND,
+                    )
+                    .values(
+                        attempt_count=3,
+                        retry_not_before="2026-07-20T00:00:00+00:00",
+                        last_attempt_at="2026-07-19T12:00:00+00:00",
+                        last_error="fixture",
+                    )
+                )
+                second_stats = rebuild_library_item_evidence_states(connection)
+                first_states = load_library_item_evidence_states(connection, first_id)
+                summary = summarize_evidence_states(connection)
+                canonical = connection.execute(
+                    select(
+                        library_items.c.cadence_summary_json,
+                        library_items.c.media_fingerprint_json,
+                    ).where(library_items.c.id == first_id)
+                ).mappings().one()
+
+                self.assertEqual(first_stats.item_count, 2)
+                self.assertEqual(first_stats.row_count, 4)
+                self.assertEqual(first_stats.current_count, 2)
+                self.assertEqual(first_stats.analysis_required_count, 2)
+                self.assertEqual(second_stats, first_stats)
+                self.assertEqual(first_states[CADENCE_EVIDENCE_KIND]["attempt_count"], 3)
+                self.assertEqual(summary["total"], 4)
+                self.assertEqual(canonical["cadence_summary_json"], self._cadence_summary())
+                self.assertEqual(canonical["media_fingerprint_json"], self._fingerprint_summary())
+
+                connection.execute(delete(library_items).where(library_items.c.id == second_id))
+                remaining = connection.execute(
+                    select(library_item_evidence_state.c.library_item_id)
+                    .where(library_item_evidence_state.c.library_item_id == second_id)
+                ).fetchall()
+                self.assertEqual(remaining, [])
+
+    @staticmethod
+    def _cadence_summary() -> str:
+        summary = analyze_cadence(
+            Path("unused.mkv"),
+            video_stream={
+                "field_order": "progressive",
+                "avg_frame_rate": "24/1",
+                "r_frame_rate": "24/1",
+                "time_base": "1/1000",
+            },
+            duration_seconds=60.0,
+        )
+        return json.dumps(summary, separators=(",", ":"), sort_keys=True)
+
+    @staticmethod
+    def _fingerprint_summary() -> str:
+        return json.dumps(
+            {
+                "schema_version": 1,
+                "analysis": {
+                    "sampled_frames": 120,
+                    "coverage": 1.0,
+                    "ranges": [],
+                    "aggregate": {"dark_frame_fraction": 0.05},
+                    "audio_probe": {"track_count": 0},
+                    "tool": {
+                        "name": "mediaforce.media_fingerprint",
+                        "version": "1",
+                        "ffmpeg_version": "ffmpeg fixture",
+                    },
+                },
+                "decision": {"status": "measured"},
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    @staticmethod
+    def _item_values(
+            index: int,
+            *,
+            cadence_summary_json: str | None,
+            media_fingerprint_json: str | None,
+    ) -> dict[str, object]:
+        now = "2026-07-19T12:00:00+00:00"
+        return {
+            "source_path": f"/media/item-{index}.mkv",
+            "rel_path": f"tv/show/item-{index}.mkv",
+            "media_root": "tv",
+            "parent_dir": "tv/show",
+            "file_name": f"item-{index}.mkv",
+            "container": ".mkv",
+            "size_bytes": 1000,
+            "mtime_ns": index,
+            "fingerprint": f"file-{index}",
+            "duration_seconds": 60.0,
+            "video_codec": "h264",
+            "audio_track_count": 1,
+            "subtitle_track_count": 0,
+            "english_audio_count": 1,
+            "english_subtitle_count": 0,
+            "audio_summary_json": "[]",
+            "subtitle_summary_json": "[]",
+            "cadence_summary_json": cadence_summary_json,
+            "media_fingerprint_json": media_fingerprint_json,
+            "content_version_changed_at": now,
+            "content_version_fingerprint": f"content-{index}",
+            "status": "discovered",
+            "priority_score": 0,
+            "last_scan_id": "fixture",
+            "discovered_at": now,
+            "last_seen_at": now,
+            "updated_at": now,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_planner_evidence.py
+++ b/tests/test_planner_evidence.py
@@ -1,6 +1,9 @@
+import tempfile
 import unittest
+from pathlib import Path
 
-from mediaforce.library.planner import _evidence_summary
+from mediaforce.core.config import ConfigPaths, MediaforceConfig
+from mediaforce.library.planner import _evidence_summary, build_manifest_item
 
 
 class PlannerEvidenceTests(unittest.TestCase):
@@ -9,6 +12,75 @@ class PlannerEvidenceTests(unittest.TestCase):
         self.assertIsNone(_evidence_summary("not-json"))
         self.assertIsNone(_evidence_summary("[]"))
         self.assertEqual(_evidence_summary('{"retry_required":true}'), {"retry_required": True})
+
+    def test_manifest_compatibility_remains_canonical_json_driven(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            config = MediaforceConfig(
+                raw={
+                    "media": {
+                        "staging_root": str(project_root / "staging"),
+                        "output_container": "mkv",
+                        "libraries": [
+                            {
+                                "key": "tv",
+                                "label": "TV",
+                                "path": str(project_root / "tv"),
+                                "type": "tv",
+                                "availability": "browse_only",
+                            }
+                        ],
+                    },
+                    "video": {},
+                    "audio": {},
+                    "subtitle": {},
+                    "planning": {},
+                    "validation": {},
+                    "overrides": [],
+                    "remote_hosts": [],
+                },
+                paths=ConfigPaths(
+                    project_root=project_root,
+                    config_path=project_root / "config.toml",
+                    db_path=project_root / "library.sqlite3",
+                    run_manifest_dir=project_root / "runs",
+                    web_state_dir=project_root / "web",
+                    review_dir=project_root / "review",
+                    runtime_settings_path=project_root / "runtime-settings.json",
+                ),
+            )
+            item = build_manifest_item(
+                {
+                    "id": 1,
+                    "source_path": str(project_root / "tv" / "Show" / "Episode.mkv"),
+                    "rel_path": "tv/Show/Episode.mkv",
+                    "media_root": "tv",
+                    "fingerprint": "file-1",
+                    "size_bytes": 1_000_000,
+                    "duration_seconds": 60.0,
+                    "video_codec": "h264",
+                    "video_bitrate": 1_000_000,
+                    "width": 1920,
+                    "height": 1080,
+                    "container": ".mkv",
+                    "status": "discovered",
+                    "audio_track_count": 1,
+                    "subtitle_track_count": 0,
+                    "english_audio_count": 1,
+                    "english_subtitle_count": 0,
+                    "audio_summary_json": "[]",
+                    "subtitle_summary_json": "[]",
+                    "attachment_summary_json": None,
+                    "cadence_summary_json": "not-json",
+                    "media_fingerprint_json": "not-json",
+                },
+                config,
+            )
+
+        self.assertIsNone(item["cadence_summary"])
+        self.assertEqual(item["cadence_decision"]["classification"], "unknown")
+        self.assertIsNone(item["media_fingerprint"])
+        self.assertEqual(item["media_fingerprint_decision"]["status"], "unknown")
 
 
 if __name__ == "__main__":

--- a/tests/test_scanner_runtime.py
+++ b/tests/test_scanner_runtime.py
@@ -10,8 +10,12 @@ from sqlalchemy import select, update
 
 from mediaforce.core.config import ConfigPaths, MediaforceConfig
 from mediaforce.core.db import open_db, reset_engine_cache
-from mediaforce.core.db_tables import library_items, scan_runs
+from mediaforce.core.db_tables import library_item_evidence_state, library_items, scan_runs
 from mediaforce.core.models import ProbeSummary
+from mediaforce.encoding.cadence import CADENCE_EVIDENCE_KIND
+from mediaforce.encoding.fingerprint import MEDIA_FINGERPRINT_EVIDENCE_KIND
+from mediaforce.library.evidence_state import EVIDENCE_REASON_POLICY_CHANGED, EVIDENCE_REASON_RETRY_REQUIRED, \
+    EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_STATE_CLASSIFICATION_REQUIRED, EVIDENCE_STATE_CURRENT
 from mediaforce.library.scanner import (
     _content_version_changed,
     _failed_probe_summary,
@@ -289,6 +293,65 @@ class ScannerRuntimeTests(unittest.TestCase):
         )
         self.assertEqual(refreshed_row["cadence_summary_json"], original_row["cadence_summary_json"])
         self.assertEqual(refreshed_row["media_fingerprint_json"], original_row["media_fingerprint_json"])
+
+    def test_first_unchanged_scan_upgrades_legacy_source_without_rebinding_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            movie = media_root / "Feature.mkv"
+            movie.write_bytes(b"movie")
+            config = self._config(project_root, {"movies": media_root})
+
+            try:
+                with open_db(config.paths.db_path) as connection:
+                    with patch(
+                        "mediaforce.library.scanner.probe_media",
+                        return_value=self._successful_probe_summary(),
+                    ):
+                        scan_library(connection, config)
+                    item = connection.execute(select(library_items)).mappings().one()
+                    connection.execute(
+                        update(library_items)
+                        .where(library_items.c.id == item["id"])
+                        .values(content_version_fingerprint=None)
+                    )
+                    connection.execute(
+                        update(library_item_evidence_state)
+                        .where(library_item_evidence_state.c.library_item_id == item["id"])
+                        .values(
+                            source_fingerprint=item["fingerprint"],
+                            policy_hash="sha256:old-policy",
+                        )
+                    )
+                    connection.commit()
+
+                    with patch(
+                        "mediaforce.library.scanner.probe_media",
+                        return_value=self._successful_probe_summary(),
+                    ) as probe_mock:
+                        stats = scan_library(connection, config)
+                    refreshed_item = connection.execute(select(library_items)).mappings().one()
+                    state_rows = connection.execute(
+                        select(library_item_evidence_state)
+                        .order_by(library_item_evidence_state.c.evidence_kind)
+                    ).mappings().fetchall()
+            finally:
+                reset_engine_cache()
+
+        probe_mock.assert_not_called()
+        self.assertEqual(stats.unchanged, 1)
+        self.assertIsNotNone(refreshed_item["content_version_fingerprint"])
+        self.assertEqual(
+            [row["source_fingerprint"] for row in state_rows],
+            [refreshed_item["content_version_fingerprint"]] * 2,
+        )
+        self.assertEqual(
+            [row["state"] for row in state_rows],
+            [EVIDENCE_STATE_CLASSIFICATION_REQUIRED] * 2,
+        )
+        self.assertEqual([row["reason"] for row in state_rows], [EVIDENCE_REASON_POLICY_CHANGED] * 2)
+        self.assertEqual([row["policy_hash"] for row in state_rows], ["sha256:old-policy"] * 2)
 
     def test_same_size_same_mtime_content_replacement_still_probes(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -710,6 +773,68 @@ class ScannerRuntimeTests(unittest.TestCase):
         self.assertEqual(scan_row["scope"], "limited")
         self.assertEqual(scan_row["file_count"], 0)
 
+    def test_scan_projects_and_refreshes_evidence_state_with_canonical_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_root = Path(temp_dir)
+            media_root = project_root / "movies"
+            media_root.mkdir()
+            movie = media_root / "Feature.mkv"
+            movie.write_bytes(b"movie")
+            config = self._config(project_root, {"movies": media_root})
+
+            try:
+                with open_db(config.paths.db_path) as connection:
+                    with patch(
+                        "mediaforce.library.scanner.probe_media",
+                        return_value=_failed_probe_summary(RuntimeError("fixture failure")),
+                    ):
+                        scan_library(connection, config)
+                    retry_rows = connection.execute(
+                        select(library_item_evidence_state)
+                        .order_by(library_item_evidence_state.c.evidence_kind)
+                    ).mappings().fetchall()
+                    connection.execute(
+                        update(library_item_evidence_state).values(
+                            attempt_count=2,
+                            retry_not_before="2026-07-20T00:00:00+00:00",
+                            last_error="fixture",
+                        )
+                    )
+                    connection.commit()
+
+                    movie.write_bytes(b"other")
+                    successful = self._successful_probe_summary()
+                    with patch(
+                        "mediaforce.library.scanner.probe_media",
+                        return_value=successful,
+                    ):
+                        stats = scan_library(connection, config)
+                    current_rows = connection.execute(
+                        select(library_item_evidence_state)
+                        .order_by(library_item_evidence_state.c.evidence_kind)
+                    ).mappings().fetchall()
+                    item = connection.execute(select(library_items)).mappings().one()
+            finally:
+                reset_engine_cache()
+
+        self.assertEqual(
+            [(row["evidence_kind"], row["state"], row["reason"]) for row in retry_rows],
+            [
+                (CADENCE_EVIDENCE_KIND, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_RETRY_REQUIRED),
+                (
+                    MEDIA_FINGERPRINT_EVIDENCE_KIND,
+                    EVIDENCE_STATE_ANALYSIS_REQUIRED,
+                    EVIDENCE_REASON_RETRY_REQUIRED,
+                ),
+            ],
+        )
+        self.assertEqual(stats.reprobed, 1)
+        self.assertEqual([row["state"] for row in current_rows], [EVIDENCE_STATE_CURRENT, EVIDENCE_STATE_CURRENT])
+        self.assertEqual([row["attempt_count"] for row in current_rows], [0, 0])
+        self.assertEqual([row["retry_not_before"] for row in current_rows], [None, None])
+        self.assertEqual(item["cadence_summary_json"], successful.cadence_summary_json)
+        self.assertEqual(item["media_fingerprint_json"], successful.media_fingerprint_json)
+
     def test_failed_probe_becomes_blocked_unknown_evidence(self) -> None:
         summary = _failed_probe_summary(RuntimeError("corrupt media"))
 
@@ -719,6 +844,62 @@ class ScannerRuntimeTests(unittest.TestCase):
         self.assertIn('"status":"unknown"', summary.media_fingerprint_json)
         self.assertIn("corrupt media", summary.media_fingerprint_json)
         self.assertIn('"retry_required":true', summary.media_fingerprint_json)
+
+    @staticmethod
+    def _successful_probe_summary() -> ProbeSummary:
+        cadence_summary_json = json.dumps(
+            {
+                "schema_version": 1,
+                "probe": {"field_order": "progressive", "idet_required": False},
+                "analysis": {
+                    "sampled_frames": 0,
+                    "tool": {
+                        "name": "mediaforce.ffmpeg_idet",
+                        "version": "1",
+                        "ffmpeg_version": "ffmpeg fixture",
+                    }
+                },
+                "decision": {"status": "resolved", "classification": "progressive"},
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        fingerprint_json = json.dumps(
+            {
+                "schema_version": 1,
+                "analysis": {
+                    "sampled_frames": 120,
+                    "coverage": 1.0,
+                    "aggregate": {"dark_frame_fraction": 0.05},
+                    "tool": {
+                        "name": "mediaforce.media_fingerprint",
+                        "version": "1",
+                        "ffmpeg_version": "ffmpeg fixture",
+                    }
+                },
+                "decision": {"status": "measured"},
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        return ProbeSummary(
+            duration_seconds=60.0,
+            video_codec="h264",
+            video_bitrate=1_000_000,
+            width=1920,
+            height=1080,
+            pix_fmt="yuv420p",
+            audio_track_count=1,
+            subtitle_track_count=0,
+            english_audio_count=1,
+            english_subtitle_count=0,
+            default_audio_language="eng",
+            default_subtitle_language=None,
+            audio_summary_json="[]",
+            subtitle_summary_json="[]",
+            cadence_summary_json=cadence_summary_json,
+            media_fingerprint_json=fingerprint_json,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an additive per-item/per-kind evidence-state projection for cadence and media fingerprints
- backfill and rebuild state from canonical JSON without invoking ffmpeg/ffprobe or rewriting evidence
- preserve source, analyzer, policy, retry, and compatibility semantics across scans, rebuilds, and rollback

## Validation
- `bash scripts/pre-commit-check.sh`
- `uv build`
- PyCharm whole-project inspection: clean
- independent architecture, migration, compatibility, and final implementation reviews

Closes #216