### PR TITLE
Run evidence updates through a bounded resumable worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,22 @@ be reconciled. A full scan also refreshes configured Plex and TMDB metadata;
 provider failures leave the last successful metadata in place and surface a
 warning instead of blocking the catalog scan.
 
+Scans update inventory with `ffprobe` metadata only. Cadence and media
+fingerprint analysis is remembered as canonical evidence and refreshed through
+an explicit paused batch; it is never launched by web startup or an idle scan.
+For a small folder pilot:
+
+```bash
+uv run mediaforce evidence start "tv/Futurama/Season 1" --limit 10
+uv run mediaforce evidence status
+uv run mediaforce evidence resume
+uv run mediaforce evidence run --max-items 1
+```
+
+Repeat the final command to resume durable progress. `evidence pause` prevents
+the next claim, while `evidence cancel` terminates the active managed process
+and cancels the remainder. See `docs/architecture/evidence-worker.md`.
+
 The `/folders` index can browse either season folders or whole TV series
 prefixes. Use the Scope control there when an operation should cover an entire
 series instead of one season.
@@ -395,6 +411,11 @@ port, and reload mode. A checked-in template lives at `.env.example`. Startup
 precedence is explicit CLI arguments, then shell environment variables, then
 `.env`, then built-in defaults. Prefer the `MEDIAFORCE_WEB_*` variable names
 for local defaults.
+
+The macOS launch item is a long-running operator service, not a development
+reloader. Give it an explicit `--no-reload` argument even when `.env` enables
+reload for an active development session; otherwise Uvicorn `StatReload`
+continuously walks the checkout and consumes CPU while the app appears idle.
 
 The frontend dev server now reads the same repo-local `.env` file. The clearest
 local setup is:

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@ Use this directory for guidance that should not live in `AGENTS.md`.
   complexity, versioned media fingerprint evidence, and review-moment selection
 - `docs/architecture/evidence-state.md`: additive per-item cadence/fingerprint
   lifecycle state, identities, retry foundation, and media-free rebuilds
+- `docs/architecture/evidence-worker.md`: explicit paused evidence batches,
+  single-concurrency claims, retries, cancellation, and source-safe commits
 - `docs/architecture/stream-budget-ledger.md`: production stream selection,
   non-video overhead, uncertainty, and deterministic size feasibility
 - `docs/architecture/quality-risk-contract.md`: versioned quality-risk facts,

--- a/docs/architecture/evidence-state.md
+++ b/docs/architecture/evidence-state.md
@@ -70,9 +70,12 @@ to use the stricter file fingerprint for final encode-time source validation.
 ## Retry foundation
 
 The state row carries `attempt_count`, `retry_not_before`, `last_attempt_at`,
-and `last_error` for the bounded worker introduced by the next workstream slice.
-There are no leases or worker ownership fields here. Projection rebuilds update
-derived columns while preserving existing retry metadata.
+and `last_error` for the bounded worker. Revision `20260719_0012` also adds
+operational batch, lease, heartbeat, worker, and managed-process fields on the
+same per-kind row. Projection rebuilds update derived columns while preserving
+existing retry and ownership metadata unless the caller explicitly resets a
+changed source. See `docs/architecture/evidence-worker.md` for claim and
+cancellation semantics.
 
 ## Migration and rebuild
 
@@ -88,8 +91,8 @@ destroy catalog membership or measured evidence.
 Rebuild preserves existing source and policy identities so it can mark source,
 analyzer, or policy invalidation without discarding prior state. When a
 projection row is absent, rebuild binds the canonical payload to the current
-catalog identity. The later worker will complete policy-only reclassification
-and then adopt the current policy hash without rereading media.
+catalog identity. The bounded worker completes policy-only reclassification
+and then adopts the current policy hash without rereading media.
 
 Read APIs never call projection sync or rebuild helpers. Missing projection rows
 mean the projection needs an explicit rebuild; they do not mean the canonical

--- a/docs/architecture/evidence-worker.md
+++ b/docs/architecture/evidence-worker.md
@@ -1,0 +1,117 @@
+# Bounded Evidence Worker
+
+## Purpose
+
+Catalog refresh and evidence analysis are separate operations.
+
+- A scan inventories files with one bounded `ffprobe` metadata read. It never
+  launches cadence or media-fingerprint `ffmpeg` analysis.
+- Canonical cadence and fingerprint JSON remains on `library_items` and is
+  reused until the source, analyzer, schema, or policy makes it non-current.
+- Expensive updates run only after an operator creates an explicit item,
+  folder, or root batch and then resumes it.
+
+There is no evidence worker attached to web-server startup and no permanent
+idle polling loop. A foreground worker pass claims bounded work and exits.
+
+## Durable state
+
+`library_item_evidence_state` owns one independent work unit for each
+`(library_item_id, evidence_kind)` pair. Cadence and fingerprint can therefore
+complete, retry, or fail independently. The row stores:
+
+- projected evidence freshness and source/policy/tool identity
+- bounded retry state
+- batch and work status
+- worker ownership, lease, heartbeat, and managed child-process PID
+- the source fingerprint captured when the batch was created
+
+`evidence_queue_state` is a singleton control record for the active explicit
+batch. It stores the scope, selected evidence kinds, pause/cancel state, and
+aggregate counts. Queue data is operational and rebuildable; canonical
+evidence is not.
+
+Alembic revision `20260719_0012` adds this operational state without creating a
+batch or queueing existing evidence. Analyzer or policy changes remain visible
+as projection state until an operator explicitly starts work.
+
+## Batch lifecycle
+
+`start_evidence_work()` requires a non-empty resolved scope. It selects only
+non-current evidence inside that exact item or descendant scope, caps the
+batch at 25 work units by default, snapshots each source fingerprint, and
+creates the batch paused.
+
+Queue states are:
+
+- `paused`: no new claim is allowed
+- `queued`: claimable work exists
+- `running`: exactly one work unit owns the media-analysis lane
+- `cancel_requested`: queued work is cancelled and the active managed process
+  is being terminated
+- `completed`, `completed_with_errors`, or `cancelled`: terminal batch state
+
+The default foreground run budget is one work unit. `--max-items` can raise
+that bound, and `--max-seconds` prevents another claim after the requested
+foreground time budget. Each analyzer command retains its own subprocess
+timeout and cancellation boundary.
+
+## Claim and commit protocol
+
+Claims use a short SQLite `BEGIN IMMEDIATE` transaction:
+
+1. Read the singleton pause/cancel state.
+2. Refuse a claim while another work unit is `running`.
+3. Atomically move one ready work unit to `running` with a worker ID and lease.
+4. Commit and close the transaction before opening media or launching a child
+   process.
+
+The analyzer runs with a heartbeat thread. A lost claim, failed heartbeat, or
+cancel request terminates the managed process group. Completion opens a new
+short transaction and writes canonical JSON only when all of these still
+match:
+
+- batch ID
+- worker ownership
+- evidence kind and item ID
+- catalog source fingerprint captured at claim time
+- fresh filesystem source fingerprint after analysis
+
+The canonical result, refreshed projection, and terminal work transition
+commit together. A stale result is discarded rather than rebound to newer
+media.
+
+## Retry and recovery
+
+- Unavailable roots move to `waiting_source` without consuming an attempt.
+- Tool, corrupt-media, timeout, and parse failures use exponential backoff and
+  stop after three attempts by default.
+- Expired leases are reclaimed on the next explicit worker pass. A live lease
+  is never stolen merely because another scheduler starts.
+- Pause prevents new claims but does not interrupt the active safe unit.
+- Cancel marks pending units cancelled and asks the heartbeat/controller path
+  to terminate the active subprocess group. The attempt is restored when that
+  cancellation is observed.
+- Policy-only `classification_required` work is claimed before media analysis
+  and reuses stored measurements without `ffmpeg` or `ffprobe`.
+
+## Operator flow
+
+Create a paused folder pilot:
+
+```bash
+uv run mediaforce evidence start "tv/Show/Season 1" --limit 10
+```
+
+Inspect, permit claims, and process one unit:
+
+```bash
+uv run mediaforce evidence status
+uv run mediaforce evidence resume
+uv run mediaforce evidence run --max-items 1
+```
+
+Repeat `evidence run` to resume durable progress. Use `pause` before the next
+claim or `cancel` to stop the active managed process and cancel the remaining
+batch. A root pilot uses the same commands with an explicit root such as `tv`;
+keep the limit small before considering a broader backfill.

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -159,15 +159,22 @@ Guidance:
 - `planner.py`
   - item recommendation and manifest-item shaping
 - `probe.py`
-  - ffprobe-based media inspection and audio, subtitle, attachment track summaries
+  - inventory-only ffprobe inspection and audio, subtitle, attachment track summaries
+  - explicitly invoked per-kind cadence and fingerprint analysis for the worker
 - `scanner.py`
   - library inventory orchestration and catalog updates
-  - unchanged inventory rows preserve evidence without launching deep analysis
+  - all inventory rows preserve canonical evidence without launching deep analysis
 - `evidence_state.py`
   - rebuildable per-item/per-kind projection of canonical cadence and
     fingerprint JSON
   - compact freshness reasons, source/analyzer/policy identities, retry timing,
     and media-free status/count queries
+- `evidence_queue.py`
+  - explicit scoped batch state, atomic single-concurrency claims, pause/cancel,
+    lease recovery, retry readiness, and aggregate status
+- `evidence_worker.py`
+  - foreground bounded execution, heartbeat-managed subprocess cancellation,
+    policy-only reclassification, retry backoff, and source-safe canonical commits
 - `media_scopes.py`
   - canonical operator grouping for TV, movie, and generic media roots
   - exact-item versus descendant matching, SQL-safe boundaries, and API scope payloads

--- a/mediaforce/cli.py
+++ b/mediaforce/cli.py
@@ -14,6 +14,11 @@ from mediaforce.execution import describe_item_plan, encode_manifest_items, prom
 from mediaforce.encoding.bakeoff import DEFAULT_BAKEOFF_ENGINES, build_bakeoff_plan, write_bakeoff_plan
 from mediaforce.library.folder_profiles import inspect_prefix
 from mediaforce.library.candidate_selection import scope_target_size_blocker
+from mediaforce.library.evidence_queue import DEFAULT_EVIDENCE_BATCH_LIMIT, EvidenceQueueConflict, \
+    cancel_evidence_queue, evidence_queue_summary, pause_evidence_queue, resume_evidence_queue, \
+    start_evidence_work
+from mediaforce.library.evidence_state import EVIDENCE_KINDS
+from mediaforce.library.evidence_worker import run_evidence_queue_until_blocked
 from mediaforce.library.planner import recommend_item
 from mediaforce.library.run_manifests import build_run_manifest as build_db_run_manifest, \
     select_candidates as select_run_manifest_candidates, \
@@ -39,6 +44,49 @@ def build_parser() -> argparse.ArgumentParser:
     scan_parser.add_argument("--prefix", action="append", default=[],
                              help="Restrict scan to rel-path prefixes such as tv/Futurama")
     scan_parser.add_argument("--limit", type=int, help="Only scan the first N matching files")
+
+    evidence_parser = subparsers.add_parser(
+        "evidence",
+        help="Manage explicit bounded cadence and fingerprint evidence work",
+    )
+    evidence_actions = evidence_parser.add_subparsers(dest="evidence_action", required=True)
+    evidence_start_parser = evidence_actions.add_parser(
+        "start",
+        help="Create a paused evidence batch for one item, folder, or root",
+    )
+    evidence_start_parser.add_argument("prefix", help="Explicit scope such as tv/Show/Season 1 or movies")
+    evidence_start_parser.add_argument(
+        "--kind",
+        action="append",
+        choices=EVIDENCE_KINDS,
+        default=[],
+        help="Evidence kind to include; defaults to cadence and fingerprint",
+    )
+    evidence_start_parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_EVIDENCE_BATCH_LIMIT,
+        help=f"Maximum per-kind work units to queue (default: {DEFAULT_EVIDENCE_BATCH_LIMIT})",
+    )
+    evidence_actions.add_parser("status", help="Show the current evidence batch")
+    evidence_actions.add_parser("pause", help="Prevent new evidence claims")
+    evidence_actions.add_parser("resume", help="Allow claims from the paused evidence batch")
+    evidence_actions.add_parser("cancel", help="Cancel queued work and stop the active managed process")
+    evidence_run_parser = evidence_actions.add_parser(
+        "run",
+        help="Run a bounded foreground worker pass and exit",
+    )
+    evidence_run_parser.add_argument(
+        "--max-items",
+        type=int,
+        default=1,
+        help="Maximum work units to process before exiting (default: 1)",
+    )
+    evidence_run_parser.add_argument(
+        "--max-seconds",
+        type=float,
+        help="Stop claiming new work after this foreground time budget",
+    )
 
     report_parser = subparsers.add_parser("report", help="Show prioritized candidates from SQLite state")
     report_parser.add_argument("--limit", type=int, default=20, help="Number of rows to show")
@@ -142,6 +190,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     config = load_config(args.config)
     purge_transient_artifacts(config)
     default_review_dir = config.paths.review_dir
+
+    if args.command == "evidence":
+        return _run_evidence_command(config, args)
 
     with open_db(config.paths.db_path) as connection:
         if args.command == "scan":
@@ -368,6 +419,42 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
 
     return 1
+
+
+def _run_evidence_command(config: MediaforceConfig, args: argparse.Namespace) -> int:
+    action = str(args.evidence_action)
+    try:
+        if action == "run":
+            summary = run_evidence_queue_until_blocked(
+                config_path=config.paths.config_path,
+                max_work_items=args.max_items,
+                max_seconds=args.max_seconds,
+            )
+        else:
+            with open_db(config.paths.db_path) as connection:
+                if action == "start":
+                    summary = start_evidence_work(
+                        connection,
+                        config,
+                        args.prefix,
+                        evidence_kinds=args.kind or None,
+                        limit=args.limit,
+                    )
+                elif action == "status":
+                    summary = evidence_queue_summary(connection)
+                elif action == "pause":
+                    summary = pause_evidence_queue(connection)
+                elif action == "resume":
+                    summary = resume_evidence_queue(connection)
+                elif action == "cancel":
+                    summary = cancel_evidence_queue(connection)
+                else:
+                    raise ValueError(f"Unsupported evidence action: {action}")
+    except (EvidenceQueueConflict, ValueError) as exc:
+        print(f"Evidence command blocked: {exc}")
+        return 2
+    print(json.dumps(summary, separators=(",", ":"), sort_keys=True))
+    return 2 if action == "run" and summary.get("status") == "completed_with_errors" else 0
 
 
 def _add_manifest_selection_args(parser: argparse.ArgumentParser, *, require_manifest: bool = True) -> None:

--- a/mediaforce/core/db_migration_scripts/versions/20260719_0012_evidence_work_queue.py
+++ b/mediaforce/core/db_migration_scripts/versions/20260719_0012_evidence_work_queue.py
@@ -1,0 +1,103 @@
+"""Add bounded evidence work queue state.
+
+Revision ID: 20260719_0012
+Revises: 20260719_0011
+Create Date: 2026-07-19 16:00:00
+"""
+
+import sqlalchemy as sa
+# noinspection PyPackageRequirements
+from alembic import op
+
+revision = "20260719_0012"
+down_revision = "20260719_0011"
+branch_labels = None
+depends_on = None
+
+_WORK_COLUMNS = (
+    ("work_batch_id", sa.Text()),
+    ("work_status", sa.Text()),
+    ("work_source_fingerprint", sa.Text()),
+    ("leased_at", sa.Text()),
+    ("lease_expires_at", sa.Text()),
+    ("heartbeat_at", sa.Text()),
+    ("worker_id", sa.Text()),
+    ("process_pid", sa.Integer()),
+)
+
+
+def upgrade() -> None:
+    if not _has_table("evidence_queue_state"):
+        op.create_table(
+            "evidence_queue_state",
+            sa.Column("queue_name", sa.Text(), primary_key=True),
+            sa.Column("batch_id", sa.Text(), nullable=True),
+            sa.Column("status", sa.Text(), nullable=False, server_default="idle"),
+            sa.Column("scope_json", sa.Text(), nullable=True),
+            sa.Column("evidence_kinds_json", sa.Text(), nullable=False, server_default="[]"),
+            sa.Column("is_paused", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("cancel_requested", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("item_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("completed_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("failed_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("cancelled_count", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("created_at", sa.Text(), nullable=True),
+            sa.Column("started_at", sa.Text(), nullable=True),
+            sa.Column("finished_at", sa.Text(), nullable=True),
+            sa.Column("updated_at", sa.Text(), nullable=False),
+        )
+    for column_name, column_type in _WORK_COLUMNS:
+        if not _has_column("library_item_evidence_state", column_name):
+            op.add_column(
+                "library_item_evidence_state",
+                sa.Column(column_name, column_type, nullable=True),
+            )
+    if not _has_index(
+            "library_item_evidence_state",
+            "idx_library_item_evidence_state_work_claim",
+    ):
+        op.create_index(
+            "idx_library_item_evidence_state_work_claim",
+            "library_item_evidence_state",
+            [
+                "work_batch_id",
+                "work_status",
+                "retry_not_before",
+                "evidence_kind",
+                "library_item_id",
+            ],
+        )
+
+
+def downgrade() -> None:
+    if _has_index(
+            "library_item_evidence_state",
+            "idx_library_item_evidence_state_work_claim",
+    ):
+        op.drop_index(
+            "idx_library_item_evidence_state_work_claim",
+            table_name="library_item_evidence_state",
+        )
+    for column_name, _column_type in reversed(_WORK_COLUMNS):
+        if _has_column("library_item_evidence_state", column_name):
+            op.drop_column("library_item_evidence_state", column_name)
+    if _has_table("evidence_queue_state"):
+        op.drop_table("evidence_queue_state")
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    return any(
+        str(column.get("name") or "") == column_name
+        for column in sa.inspect(op.get_bind()).get_columns(table_name)
+    )
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    return any(
+        str(index.get("name") or "") == index_name
+        for index in sa.inspect(op.get_bind()).get_indexes(table_name)
+    )

--- a/mediaforce/core/db_tables.py
+++ b/mediaforce/core/db_tables.py
@@ -100,6 +100,14 @@ library_item_evidence_state = Table(
     Column("retry_not_before", Text),
     Column("last_attempt_at", Text),
     Column("last_error", Text),
+    Column("work_batch_id", Text),
+    Column("work_status", Text),
+    Column("work_source_fingerprint", Text),
+    Column("leased_at", Text),
+    Column("lease_expires_at", Text),
+    Column("heartbeat_at", Text),
+    Column("worker_id", Text),
+    Column("process_pid", Integer),
     Column("updated_at", Text, nullable=False),
 )
 Index(
@@ -113,6 +121,34 @@ Index(
     library_item_evidence_state.c.state,
     library_item_evidence_state.c.retry_not_before,
     library_item_evidence_state.c.evidence_kind,
+)
+Index(
+    "idx_library_item_evidence_state_work_claim",
+    library_item_evidence_state.c.work_batch_id,
+    library_item_evidence_state.c.work_status,
+    library_item_evidence_state.c.retry_not_before,
+    library_item_evidence_state.c.evidence_kind,
+    library_item_evidence_state.c.library_item_id,
+)
+
+evidence_queue_state = Table(
+    "evidence_queue_state",
+    metadata,
+    Column("queue_name", Text, primary_key=True),
+    Column("batch_id", Text),
+    Column("status", Text, nullable=False, server_default="idle"),
+    Column("scope_json", Text),
+    Column("evidence_kinds_json", Text, nullable=False, server_default="[]"),
+    Column("is_paused", Integer, nullable=False, server_default="0"),
+    Column("cancel_requested", Integer, nullable=False, server_default="0"),
+    Column("item_count", Integer, nullable=False, server_default="0"),
+    Column("completed_count", Integer, nullable=False, server_default="0"),
+    Column("failed_count", Integer, nullable=False, server_default="0"),
+    Column("cancelled_count", Integer, nullable=False, server_default="0"),
+    Column("created_at", Text),
+    Column("started_at", Text),
+    Column("finished_at", Text),
+    Column("updated_at", Text, nullable=False),
 )
 
 plex_item_metadata = Table(

--- a/mediaforce/core/models.py
+++ b/mediaforce/core/models.py
@@ -18,5 +18,5 @@ class ProbeSummary:
     audio_summary_json: str
     subtitle_summary_json: str
     attachment_summary_json: str = "[]"
-    cadence_summary_json: str = "{}"
-    media_fingerprint_json: str = "{}"
+    cadence_summary_json: str | None = None
+    media_fingerprint_json: str | None = None

--- a/mediaforce/core/process_control.py
+++ b/mediaforce/core/process_control.py
@@ -35,6 +35,10 @@ class ManagedProcessController:
             self._cancel_requested = True
             self._terminate_locked()
 
+    def terminate(self) -> None:
+        with self._lock:
+            self._terminate_locked()
+
     def reset(self) -> None:
         with self._lock:
             self._cancel_requested = False
@@ -97,9 +101,18 @@ def run_command(
         capture_output: bool = True,
         text: bool = True,
         env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        check: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     if process_controller is None:
-        return subprocess.run(cmd, capture_output=capture_output, text=text, env=env)
+        return subprocess.run(
+            cmd,
+            capture_output=capture_output,
+            text=text,
+            env=env,
+            timeout=timeout,
+            check=check,
+        )
 
     process_controller.throw_if_cancelled()
     stdout_pipe = subprocess.PIPE if capture_output else None
@@ -114,9 +127,25 @@ def run_command(
     )
     process_controller.attach(process, terminate_process_group=True)
     try:
-        stdout, stderr = process.communicate()
+        try:
+            if timeout is None:
+                stdout, stderr = process.communicate()
+            else:
+                stdout, stderr = process.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process_controller.terminate()
+            process.communicate()
+            raise
     finally:
         process_controller.clear(process)
     if process_controller.cancelled:
         raise ProcessCancelledError("Operation was cancelled.")
-    return subprocess.CompletedProcess(cmd, process.returncode, stdout, stderr)
+    completed = subprocess.CompletedProcess(cmd, process.returncode, stdout, stderr)
+    if check and completed.returncode:
+        raise subprocess.CalledProcessError(
+            completed.returncode,
+            cmd,
+            output=stdout,
+            stderr=stderr,
+        )
+    return completed

--- a/mediaforce/encoding/cadence.py
+++ b/mediaforce/encoding/cadence.py
@@ -10,6 +10,7 @@ from typing import Any, Literal, Mapping
 
 from mediaforce.core.binaries import ffmpeg_binary
 from mediaforce.core.evidence import build_evidence_envelope, evidence_envelope_valid, stable_policy_hash
+from mediaforce.core.process_control import ManagedProcessController, run_command
 from mediaforce.core.type_defs import float_value, int_value, object_dict, object_list
 
 CADENCE_SCHEMA_VERSION = 1
@@ -83,6 +84,7 @@ def analyze_cadence(
         max_frames: int = DEFAULT_IDET_MAX_FRAMES,
         range_count: int = DEFAULT_IDET_RANGE_COUNT,
         timeout_seconds: float = 60.0,
+        process_controller: ManagedProcessController | None = None,
 ) -> dict[str, Any]:
     stream = object_dict(video_stream)
     probe = {
@@ -111,12 +113,15 @@ def analyze_cadence(
     aggregate = _empty_counts()
     ranges: list[dict[str, Any]] = []
     for start_seconds in starts:
+        if process_controller is not None:
+            process_controller.throw_if_cancelled()
         result = _run_idet_range(
             path,
             ffmpeg_name=ffmpeg_name,
             start_seconds=start_seconds,
             frame_limit=frames_per_range,
             timeout_seconds=timeout_seconds,
+            process_controller=process_controller,
         )
         counts = parse_idet_output(result["stderr"]) if result["status"] == "measured" else _empty_counts()
         _merge_counts(aggregate, counts)
@@ -353,6 +358,18 @@ def cadence_manifest_payload(
     return envelope, decision
 
 
+def reclassify_cadence_summary(summary: Mapping[str, Any]) -> dict[str, Any]:
+    payload = copy.deepcopy(object_dict(summary))
+    probe = object_dict(payload.get("probe"))
+    analysis = object_dict(payload.get("analysis"))
+    payload["decision"] = classify_cadence(
+        probe=probe,
+        analysis=analysis,
+        coverage=_analysis_coverage(analysis),
+    )
+    return payload
+
+
 def cadence_filter(
         decision: Mapping[str, Any] | None,
         evidence: Mapping[str, Any] | None,
@@ -457,6 +474,7 @@ def _run_idet_range(
         start_seconds: float,
         frame_limit: int,
         timeout_seconds: float,
+        process_controller: ManagedProcessController | None = None,
 ) -> dict[str, str]:
     command = [
         ffmpeg_name,
@@ -481,9 +499,9 @@ def _run_idet_range(
         "-",
     ]
     try:
-        result = subprocess.run(
+        result = run_command(
             command,
-            check=False,
+            process_controller=process_controller,
             capture_output=True,
             text=True,
             timeout=timeout_seconds,

--- a/mediaforce/encoding/fingerprint.py
+++ b/mediaforce/encoding/fingerprint.py
@@ -342,6 +342,12 @@ def media_fingerprint_manifest_payload(
     return envelope, decision
 
 
+def reclassify_media_fingerprint_summary(summary: Mapping[str, Any]) -> dict[str, Any]:
+    payload = copy.deepcopy(object_dict(summary))
+    payload["decision"] = classify_media_fingerprint(object_dict(payload.get("analysis")))
+    return payload
+
+
 def media_fingerprint_staleness(
         envelope: Mapping[str, Any],
         *,

--- a/mediaforce/library/evidence_queue.py
+++ b/mediaforce/library/evidence_queue.py
@@ -1,0 +1,931 @@
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal, Sequence
+
+from sqlalchemy import bindparam, case, func, or_, select, update
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from mediaforce.core.config import MediaforceConfig
+from mediaforce.core.db import DBClient
+from mediaforce.core.db_tables import evidence_queue_state, library_item_evidence_state, library_items
+from mediaforce.core.type_defs import int_value, object_dict, object_list
+from mediaforce.core.utils import timestamp
+from mediaforce.library.evidence_state import EVIDENCE_KINDS, EVIDENCE_STATE_ANALYSIS_REQUIRED, \
+    EVIDENCE_STATE_CLASSIFICATION_REQUIRED, EvidenceKind
+from mediaforce.library.media_scopes import MediaScope, resolve_media_scope, scope_rel_path_filter
+
+DEFAULT_EVIDENCE_QUEUE_NAME = "evidence"
+DEFAULT_EVIDENCE_BATCH_LIMIT = 25
+
+EVIDENCE_QUEUE_ACTIVE_STATUSES = ("queued", "running", "paused", "cancel_requested")
+EVIDENCE_WORK_CLAIMABLE_STATUSES = ("queued", "retry_wait", "waiting_source")
+EVIDENCE_WORK_ACTIVE_STATUSES = (*EVIDENCE_WORK_CLAIMABLE_STATUSES, "running")
+EVIDENCE_WORK_TERMINAL_STATUSES = ("completed", "failed", "cancelled")
+EvidenceHeartbeatStatus = Literal["active", "cancel_requested", "claim_lost"]
+
+
+class EvidenceQueueConflict(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceWorkClaim:
+    batch_id: str
+    library_item_id: int
+    evidence_kind: EvidenceKind
+    evidence_state: str
+    evidence_reason: str | None
+    source_path: str
+    rel_path: str
+    media_root: str
+    expected_source_fingerprint: str | None
+    uses_content_fingerprint: bool
+    duration_seconds: float | None
+    canonical_summary_json: str | None
+    attempt_count: int
+    worker_id: str
+
+
+def ensure_evidence_queue_state(
+        connection: DBClient,
+        *,
+        queue_name: str = DEFAULT_EVIDENCE_QUEUE_NAME,
+        updated_at: str | None = None,
+) -> None:
+    now_iso = updated_at or timestamp()
+    statement = sqlite_insert(evidence_queue_state).values(
+        queue_name=queue_name,
+        batch_id=None,
+        status="idle",
+        scope_json=None,
+        evidence_kinds_json="[]",
+        is_paused=0,
+        cancel_requested=0,
+        item_count=0,
+        completed_count=0,
+        failed_count=0,
+        cancelled_count=0,
+        created_at=None,
+        started_at=None,
+        finished_at=None,
+        updated_at=now_iso,
+    )
+    connection.execute(
+        statement.on_conflict_do_nothing(index_elements=[evidence_queue_state.c.queue_name])
+    )
+
+
+def load_evidence_queue_state(
+        connection: DBClient,
+        *,
+        queue_name: str = DEFAULT_EVIDENCE_QUEUE_NAME,
+) -> dict[str, Any]:
+    row = connection.execute(
+        select(evidence_queue_state).where(evidence_queue_state.c.queue_name == queue_name)
+    ).mappings().fetchone()
+    if row is None:
+        return {
+            "queue_name": queue_name,
+            "batch_id": None,
+            "status": "idle",
+            "scope": None,
+            "evidence_kinds": [],
+            "is_paused": False,
+            "cancel_requested": False,
+            "item_count": 0,
+            "completed_count": 0,
+            "failed_count": 0,
+            "cancelled_count": 0,
+            "created_at": None,
+            "started_at": None,
+            "finished_at": None,
+            "updated_at": None,
+        }
+    return _hydrate_queue_state(row)
+
+
+def start_evidence_work(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+        *,
+        evidence_kinds: Sequence[str] | None = None,
+        limit: int = DEFAULT_EVIDENCE_BATCH_LIMIT,
+        updated_at: str | None = None,
+) -> dict[str, Any]:
+    scope_prefix = str(prefix or "").strip().strip("/")
+    if not scope_prefix:
+        raise ValueError("Evidence work requires an explicit item, folder, or root scope.")
+    selected_kinds = _normalize_evidence_kinds(evidence_kinds)
+    normalized_limit = int(limit)
+    if normalized_limit <= 0:
+        raise ValueError("Evidence work limit must be greater than zero.")
+    now_iso = updated_at or timestamp()
+
+    connection.commit()
+    connection.exec_driver_sql("BEGIN IMMEDIATE")
+    try:
+        ensure_evidence_queue_state(connection, updated_at=now_iso)
+        current_state = load_evidence_queue_state(connection)
+        if str(current_state.get("status") or "") in EVIDENCE_QUEUE_ACTIVE_STATUSES:
+            raise EvidenceQueueConflict(
+                "Evidence work is already active; pause, cancel, or finish it before starting another scope."
+            )
+        scope = resolve_media_scope(
+            connection,
+            scope_prefix,
+            library_types=config.library_type_map,
+        )
+        if scope.root not in config.source_root_map:
+            raise EvidenceQueueConflict(
+                f"Library {scope.root!r} is not enabled for production evidence work."
+            )
+        candidates = _evidence_work_candidates(
+            connection,
+            scope,
+            selected_kinds,
+            limit=normalized_limit,
+        )
+        batch_id = uuid.uuid4().hex
+        _queue_candidate_rows(
+            connection,
+            batch_id=batch_id,
+            candidates=candidates,
+            updated_at=now_iso,
+        )
+        item_count = len(candidates)
+        queue_status = "paused" if item_count else "completed"
+        finished_at = None if item_count else now_iso
+        scope_payload = scope.to_payload()
+        scope_payload["work_limit"] = normalized_limit
+        _save_evidence_queue_state(
+            connection,
+            {
+                "queue_name": DEFAULT_EVIDENCE_QUEUE_NAME,
+                "batch_id": batch_id,
+                "status": queue_status,
+                "scope": scope_payload,
+                "evidence_kinds": list(selected_kinds),
+                "is_paused": bool(item_count),
+                "cancel_requested": False,
+                "item_count": item_count,
+                "completed_count": 0,
+                "failed_count": 0,
+                "cancelled_count": 0,
+                "created_at": now_iso,
+                "started_at": None,
+                "finished_at": finished_at,
+                "updated_at": now_iso,
+            },
+        )
+    except BaseException:
+        connection.rollback()
+        raise
+    return evidence_queue_summary(connection)
+
+
+def evidence_queue_summary(connection: DBClient) -> dict[str, Any]:
+    queue_state = load_evidence_queue_state(connection)
+    batch_id = str(queue_state.get("batch_id") or "")
+    counts: dict[str, int] = {}
+    running: dict[str, Any] | None = None
+    if batch_id:
+        counts = {
+            str(row["work_status"]): int(row["item_count"] or 0)
+            for row in connection.execute(
+                select(
+                    library_item_evidence_state.c.work_status,
+                    func.count().label("item_count"),
+                )
+                .where(library_item_evidence_state.c.work_batch_id == batch_id)
+                .group_by(library_item_evidence_state.c.work_status)
+            ).mappings()
+            if row["work_status"]
+        }
+        running_row = connection.execute(
+            select(
+                library_item_evidence_state.c.library_item_id,
+                library_item_evidence_state.c.evidence_kind,
+                library_item_evidence_state.c.attempt_count,
+                library_item_evidence_state.c.last_attempt_at,
+                library_item_evidence_state.c.heartbeat_at,
+                library_item_evidence_state.c.process_pid,
+                library_items.c.rel_path,
+            )
+            .select_from(
+                library_item_evidence_state.join(
+                    library_items,
+                    library_items.c.id == library_item_evidence_state.c.library_item_id,
+                )
+            )
+            .where(
+                library_item_evidence_state.c.work_batch_id == batch_id,
+                library_item_evidence_state.c.work_status == "running",
+            )
+            .limit(1)
+        ).mappings().fetchone()
+        if running_row is not None:
+            running = dict(running_row)
+    queue_state["counts"] = counts
+    queue_state["running"] = running
+    queue_state["remaining_count"] = sum(
+        counts.get(status, 0)
+        for status in EVIDENCE_WORK_ACTIVE_STATUSES
+    )
+    return queue_state
+
+
+def pause_evidence_queue(connection: DBClient, *, updated_at: str | None = None) -> dict[str, Any]:
+    return _set_queue_control(connection, is_paused=True, updated_at=updated_at)
+
+
+def resume_evidence_queue(connection: DBClient, *, updated_at: str | None = None) -> dict[str, Any]:
+    return _set_queue_control(connection, is_paused=False, updated_at=updated_at)
+
+
+def cancel_evidence_queue(connection: DBClient, *, updated_at: str | None = None) -> dict[str, Any]:
+    now_iso = updated_at or timestamp()
+    connection.commit()
+    connection.exec_driver_sql("BEGIN IMMEDIATE")
+    try:
+        state = load_evidence_queue_state(connection)
+        batch_id = str(state.get("batch_id") or "")
+        if not batch_id or str(state.get("status") or "") not in EVIDENCE_QUEUE_ACTIVE_STATUSES:
+            connection.rollback()
+            return evidence_queue_summary(connection)
+        connection.execute(
+            update(library_item_evidence_state)
+            .where(
+                library_item_evidence_state.c.work_batch_id == batch_id,
+                library_item_evidence_state.c.work_status.in_(EVIDENCE_WORK_CLAIMABLE_STATUSES),
+            )
+            .values(
+                work_status="cancelled",
+                retry_not_before=None,
+                leased_at=None,
+                lease_expires_at=None,
+                heartbeat_at=None,
+                worker_id=None,
+                process_pid=None,
+                updated_at=now_iso,
+            )
+        )
+        connection.execute(
+            update(evidence_queue_state)
+            .where(evidence_queue_state.c.queue_name == DEFAULT_EVIDENCE_QUEUE_NAME)
+            .values(
+                status="cancel_requested",
+                is_paused=0,
+                cancel_requested=1,
+                updated_at=now_iso,
+            )
+        )
+        _refresh_evidence_queue_state(connection, batch_id=batch_id, updated_at=now_iso)
+    except BaseException:
+        connection.rollback()
+        raise
+    return evidence_queue_summary(connection)
+
+
+def claim_next_evidence_work(
+        connection: DBClient,
+        *,
+        worker_id: str,
+        lease_seconds: int,
+        now: datetime | None = None,
+) -> EvidenceWorkClaim | None:
+    current = now or datetime.now(UTC)
+    now_iso = current.isoformat(timespec="seconds")
+    lease_expires_at = (current + timedelta(seconds=max(1, lease_seconds))).isoformat(timespec="seconds")
+    connection.commit()
+    connection.exec_driver_sql("BEGIN IMMEDIATE")
+    try:
+        queue_state = load_evidence_queue_state(connection)
+        batch_id = str(queue_state.get("batch_id") or "")
+        if (
+                not batch_id
+                or bool(queue_state.get("is_paused"))
+                or bool(queue_state.get("cancel_requested"))
+                or str(queue_state.get("status") or "") not in EVIDENCE_QUEUE_ACTIVE_STATUSES
+        ):
+            connection.rollback()
+            return None
+        running_count = int(
+            connection.execute(
+                select(func.count())
+                .select_from(library_item_evidence_state)
+                .where(
+                    library_item_evidence_state.c.work_batch_id == batch_id,
+                    library_item_evidence_state.c.work_status == "running",
+                )
+            ).scalar_one()
+        )
+        if running_count:
+            connection.rollback()
+            return None
+        candidate = connection.execute(
+            select(
+                library_item_evidence_state.c.library_item_id,
+                library_item_evidence_state.c.evidence_kind,
+            )
+            .where(
+                library_item_evidence_state.c.work_batch_id == batch_id,
+                library_item_evidence_state.c.work_status.in_(EVIDENCE_WORK_CLAIMABLE_STATUSES),
+                or_(
+                    library_item_evidence_state.c.retry_not_before.is_(None),
+                    library_item_evidence_state.c.retry_not_before <= now_iso,
+                ),
+            )
+            .order_by(
+                case(
+                    (library_item_evidence_state.c.state == EVIDENCE_STATE_CLASSIFICATION_REQUIRED, 0),
+                    else_=1,
+                ),
+                library_item_evidence_state.c.library_item_id,
+                library_item_evidence_state.c.evidence_kind,
+            )
+            .limit(1)
+        ).mappings().fetchone()
+        if candidate is None:
+            _refresh_evidence_queue_state(connection, batch_id=batch_id, updated_at=now_iso)
+            connection.commit()
+            return None
+        update_result = connection.execute(
+            update(library_item_evidence_state)
+            .where(
+                library_item_evidence_state.c.library_item_id == int(candidate["library_item_id"]),
+                library_item_evidence_state.c.evidence_kind == str(candidate["evidence_kind"]),
+                library_item_evidence_state.c.work_batch_id == batch_id,
+                library_item_evidence_state.c.work_status.in_(EVIDENCE_WORK_CLAIMABLE_STATUSES),
+            )
+            .values(
+                work_status="running",
+                leased_at=now_iso,
+                lease_expires_at=lease_expires_at,
+                heartbeat_at=now_iso,
+                worker_id=worker_id,
+                process_pid=None,
+                retry_not_before=None,
+                updated_at=now_iso,
+            )
+        )
+        if _rowcount(update_result.rowcount) != 1:
+            connection.rollback()
+            return None
+        connection.execute(
+            update(evidence_queue_state)
+            .where(evidence_queue_state.c.queue_name == DEFAULT_EVIDENCE_QUEUE_NAME)
+            .values(
+                status="running",
+                started_at=func.coalesce(evidence_queue_state.c.started_at, now_iso),
+                updated_at=now_iso,
+            )
+        )
+        claim = load_evidence_work_claim(
+            connection,
+            library_item_id=int(candidate["library_item_id"]),
+            evidence_kind=str(candidate["evidence_kind"]),
+        )
+    except BaseException:
+        connection.rollback()
+        raise
+    return claim
+
+
+def load_evidence_work_claim(
+        connection: DBClient,
+        *,
+        library_item_id: int,
+        evidence_kind: str,
+) -> EvidenceWorkClaim | None:
+    normalized_kind = _normalize_evidence_kinds([evidence_kind])[0]
+    row = connection.execute(
+        select(
+            library_item_evidence_state.c.work_batch_id,
+            library_item_evidence_state.c.library_item_id,
+            library_item_evidence_state.c.evidence_kind,
+            library_item_evidence_state.c.state,
+            library_item_evidence_state.c.reason,
+            library_item_evidence_state.c.work_source_fingerprint,
+            library_item_evidence_state.c.attempt_count,
+            library_item_evidence_state.c.worker_id,
+            library_items.c.source_path,
+            library_items.c.rel_path,
+            library_items.c.media_root,
+            library_items.c.content_version_fingerprint,
+            library_items.c.duration_seconds,
+            library_items.c.cadence_summary_json,
+            library_items.c.media_fingerprint_json,
+        )
+        .select_from(
+            library_item_evidence_state.join(
+                library_items,
+                library_items.c.id == library_item_evidence_state.c.library_item_id,
+            )
+        )
+        .where(
+            library_item_evidence_state.c.library_item_id == library_item_id,
+            library_item_evidence_state.c.evidence_kind == normalized_kind,
+            library_item_evidence_state.c.work_status == "running",
+        )
+    ).mappings().fetchone()
+    if row is None:
+        return None
+    if normalized_kind == EVIDENCE_KINDS[0]:
+        summary_json = row["cadence_summary_json"]
+    else:
+        summary_json = row["media_fingerprint_json"]
+    return EvidenceWorkClaim(
+        batch_id=str(row["work_batch_id"]),
+        library_item_id=int(row["library_item_id"]),
+        evidence_kind=normalized_kind,
+        evidence_state=str(row["state"]),
+        evidence_reason=str(row["reason"]) if row["reason"] is not None else None,
+        source_path=str(row["source_path"]),
+        rel_path=str(row["rel_path"]),
+        media_root=str(row["media_root"]),
+        expected_source_fingerprint=(
+            str(row["work_source_fingerprint"])
+            if row["work_source_fingerprint"] is not None
+            else None
+        ),
+        uses_content_fingerprint=row["content_version_fingerprint"] is not None,
+        duration_seconds=(
+            float(row["duration_seconds"])
+            if row["duration_seconds"] is not None
+            else None
+        ),
+        canonical_summary_json=str(summary_json) if summary_json is not None else None,
+        attempt_count=int(row["attempt_count"] or 0),
+        worker_id=str(row["worker_id"]),
+    )
+
+
+def mark_evidence_attempt_started(
+        connection: DBClient,
+        claim: EvidenceWorkClaim,
+        *,
+        process_pid: int | None = None,
+        updated_at: str | None = None,
+) -> EvidenceWorkClaim | None:
+    now_iso = updated_at or timestamp()
+    result = connection.execute(
+        update(library_item_evidence_state)
+        .where(*_claim_owner_filter(claim))
+        .values(
+            attempt_count=library_item_evidence_state.c.attempt_count + 1,
+            last_attempt_at=now_iso,
+            last_error=None,
+            process_pid=process_pid,
+            updated_at=now_iso,
+        )
+    )
+    if _rowcount(result.rowcount) != 1:
+        return None
+    active_claim = load_evidence_work_claim(
+        connection,
+        library_item_id=claim.library_item_id,
+        evidence_kind=claim.evidence_kind,
+    )
+    if active_claim is None or active_claim.worker_id != claim.worker_id:
+        return None
+    return active_claim
+
+
+def heartbeat_evidence_work(
+        connection: DBClient,
+        claim: EvidenceWorkClaim,
+        *,
+        lease_seconds: int,
+        process_pid: int | None,
+        now: datetime | None = None,
+) -> EvidenceHeartbeatStatus:
+    current = now or datetime.now(UTC)
+    now_iso = current.isoformat(timespec="seconds")
+    lease_expires_at = (current + timedelta(seconds=max(1, lease_seconds))).isoformat(timespec="seconds")
+    result = connection.execute(
+        update(library_item_evidence_state)
+        .where(*_claim_owner_filter(claim))
+        .values(
+            heartbeat_at=now_iso,
+            lease_expires_at=lease_expires_at,
+            process_pid=process_pid,
+            updated_at=now_iso,
+        )
+    )
+    if _rowcount(result.rowcount) != 1:
+        return "claim_lost"
+    cancel_requested = connection.execute(
+        select(evidence_queue_state.c.cancel_requested)
+        .where(
+            evidence_queue_state.c.queue_name == DEFAULT_EVIDENCE_QUEUE_NAME,
+            evidence_queue_state.c.batch_id == claim.batch_id,
+        )
+    ).scalar_one_or_none()
+    return "cancel_requested" if bool(cancel_requested) else "active"
+
+
+def transition_evidence_work(
+        connection: DBClient,
+        claim: EvidenceWorkClaim,
+        *,
+        work_status: str,
+        last_error: str | None = None,
+        retry_not_before: str | None = None,
+        restore_attempt: bool = False,
+        reset_attempt_state: bool = False,
+        updated_at: str | None = None,
+) -> bool:
+    if work_status not in (*EVIDENCE_WORK_ACTIVE_STATUSES, *EVIDENCE_WORK_TERMINAL_STATUSES):
+        raise ValueError(f"Unsupported evidence work status: {work_status}")
+    now_iso = updated_at or timestamp()
+    values: dict[str, Any] = {
+        "work_status": work_status,
+        "last_error": last_error,
+        "retry_not_before": retry_not_before,
+        "leased_at": None,
+        "lease_expires_at": None,
+        "heartbeat_at": None,
+        "worker_id": None,
+        "process_pid": None,
+        "updated_at": now_iso,
+    }
+    if restore_attempt:
+        values["attempt_count"] = func.max(library_item_evidence_state.c.attempt_count - 1, 0)
+    elif reset_attempt_state:
+        values.update(
+            {
+                "attempt_count": 0,
+                "retry_not_before": None,
+                "last_attempt_at": None,
+                "last_error": None,
+            }
+        )
+    result = connection.execute(
+        update(library_item_evidence_state)
+        .where(*_claim_owner_filter(claim))
+        .values(**values)
+    )
+    if _rowcount(result.rowcount) != 1:
+        return False
+    _refresh_evidence_queue_state(connection, batch_id=claim.batch_id, updated_at=now_iso)
+    return True
+
+
+def recover_evidence_queue(
+        connection: DBClient,
+        *,
+        reclaim_all_running: bool = False,
+        now: datetime | None = None,
+) -> int:
+    current = now or datetime.now(UTC)
+    now_iso = current.isoformat(timespec="seconds")
+    queue_state = load_evidence_queue_state(connection)
+    batch_id = str(queue_state.get("batch_id") or "")
+    if not batch_id:
+        return 0
+    conditions = [
+        library_item_evidence_state.c.work_batch_id == batch_id,
+        library_item_evidence_state.c.work_status == "running",
+    ]
+    if not reclaim_all_running:
+        conditions.append(
+            or_(
+                library_item_evidence_state.c.lease_expires_at.is_(None),
+                library_item_evidence_state.c.lease_expires_at <= now_iso,
+            )
+        )
+    target_status = "cancelled" if bool(queue_state.get("cancel_requested")) else "queued"
+    result = connection.execute(
+        update(library_item_evidence_state)
+        .where(*conditions)
+        .values(
+            work_status=target_status,
+            leased_at=None,
+            lease_expires_at=None,
+            heartbeat_at=None,
+            worker_id=None,
+            process_pid=None,
+            retry_not_before=None,
+            last_error=(
+                "Evidence work was cancelled during worker recovery."
+                if target_status == "cancelled"
+                else "Evidence work was interrupted and reclaimed after worker restart."
+            ),
+            updated_at=now_iso,
+        )
+    )
+    recovered_count = _rowcount(result.rowcount)
+    _refresh_evidence_queue_state(connection, batch_id=batch_id, updated_at=now_iso)
+    return recovered_count
+
+
+def current_library_item_source_fingerprint(
+        connection: DBClient,
+        library_item_id: int,
+) -> str | None:
+    row = connection.execute(
+        select(
+            library_items.c.content_version_fingerprint,
+            library_items.c.fingerprint,
+        ).where(library_items.c.id == library_item_id)
+    ).mappings().fetchone()
+    if row is None:
+        return None
+    return _item_source_fingerprint(row)
+
+
+def _set_queue_control(
+        connection: DBClient,
+        *,
+        is_paused: bool,
+        updated_at: str | None,
+) -> dict[str, Any]:
+    now_iso = updated_at or timestamp()
+    connection.commit()
+    connection.exec_driver_sql("BEGIN IMMEDIATE")
+    try:
+        state = load_evidence_queue_state(connection)
+        batch_id = str(state.get("batch_id") or "")
+        if not batch_id or str(state.get("status") or "") not in EVIDENCE_QUEUE_ACTIVE_STATUSES:
+            connection.rollback()
+            return evidence_queue_summary(connection)
+        if bool(state.get("cancel_requested")):
+            connection.rollback()
+            return evidence_queue_summary(connection)
+        connection.execute(
+            update(evidence_queue_state)
+            .where(evidence_queue_state.c.queue_name == DEFAULT_EVIDENCE_QUEUE_NAME)
+            .values(
+                is_paused=int(is_paused),
+                updated_at=now_iso,
+            )
+        )
+        _refresh_evidence_queue_state(connection, batch_id=batch_id, updated_at=now_iso)
+    except BaseException:
+        connection.rollback()
+        raise
+    return evidence_queue_summary(connection)
+
+
+def _evidence_work_candidates(
+        connection: DBClient,
+        scope: MediaScope,
+        evidence_kinds: Sequence[EvidenceKind],
+        *,
+        limit: int,
+) -> list[dict[str, Any]]:
+    query = (
+        select(
+            library_item_evidence_state.c.library_item_id,
+            library_item_evidence_state.c.evidence_kind,
+            library_items.c.content_version_fingerprint,
+            library_items.c.fingerprint,
+        )
+        .select_from(
+            library_item_evidence_state.join(
+                library_items,
+                library_items.c.id == library_item_evidence_state.c.library_item_id,
+            )
+        )
+        .where(
+            library_item_evidence_state.c.state.in_((
+                EVIDENCE_STATE_ANALYSIS_REQUIRED,
+                EVIDENCE_STATE_CLASSIFICATION_REQUIRED,
+            )),
+            library_item_evidence_state.c.evidence_kind.in_(tuple(evidence_kinds)),
+            library_items.c.status != "missing",
+            scope_rel_path_filter(library_items.c.rel_path, scope),
+        )
+        .order_by(
+            library_item_evidence_state.c.library_item_id,
+            library_item_evidence_state.c.evidence_kind,
+        )
+        .limit(limit)
+    )
+    rows = connection.execute(query).mappings().fetchall()
+    return [
+        {
+            "library_item_id": int(row["library_item_id"]),
+            "evidence_kind": str(row["evidence_kind"]),
+            "work_source_fingerprint": _item_source_fingerprint(row),
+        }
+        for row in rows
+    ]
+
+
+def _queue_candidate_rows(
+        connection: DBClient,
+        *,
+        batch_id: str,
+        candidates: Sequence[dict[str, Any]],
+        updated_at: str,
+) -> None:
+    if not candidates:
+        return
+    statement = (
+        update(library_item_evidence_state)
+        .where(
+            library_item_evidence_state.c.library_item_id == bindparam("candidate_item_id"),
+            library_item_evidence_state.c.evidence_kind == bindparam("candidate_evidence_kind"),
+        )
+        .values(
+            work_batch_id=batch_id,
+            work_status="queued",
+            work_source_fingerprint=bindparam("candidate_source_fingerprint"),
+            leased_at=None,
+            lease_expires_at=None,
+            heartbeat_at=None,
+            worker_id=None,
+            process_pid=None,
+            retry_not_before=None,
+            attempt_count=0,
+            last_attempt_at=None,
+            last_error=None,
+            updated_at=updated_at,
+        )
+    )
+    connection.execute(
+        statement,
+        [
+            {
+                "candidate_item_id": candidate["library_item_id"],
+                "candidate_evidence_kind": candidate["evidence_kind"],
+                "candidate_source_fingerprint": candidate["work_source_fingerprint"],
+            }
+            for candidate in candidates
+        ],
+    )
+
+
+def _save_evidence_queue_state(connection: DBClient, payload: dict[str, Any]) -> None:
+    values = {
+        "queue_name": str(payload.get("queue_name") or DEFAULT_EVIDENCE_QUEUE_NAME),
+        "batch_id": payload.get("batch_id"),
+        "status": str(payload.get("status") or "idle"),
+        "scope_json": (
+            json.dumps(payload.get("scope"), separators=(",", ":"), sort_keys=True)
+            if payload.get("scope") is not None
+            else None
+        ),
+        "evidence_kinds_json": json.dumps(payload.get("evidence_kinds") or [], separators=(",", ":")),
+        "is_paused": int(bool(payload.get("is_paused"))),
+        "cancel_requested": int(bool(payload.get("cancel_requested"))),
+        "item_count": int_value(payload.get("item_count")),
+        "completed_count": int_value(payload.get("completed_count")),
+        "failed_count": int_value(payload.get("failed_count")),
+        "cancelled_count": int_value(payload.get("cancelled_count")),
+        "created_at": payload.get("created_at"),
+        "started_at": payload.get("started_at"),
+        "finished_at": payload.get("finished_at"),
+        "updated_at": payload.get("updated_at") or timestamp(),
+    }
+    statement = sqlite_insert(evidence_queue_state).values(**values)
+    connection.execute(
+        statement.on_conflict_do_update(
+            index_elements=[evidence_queue_state.c.queue_name],
+            set_={
+                key: getattr(statement.excluded, key)
+                for key in values
+                if key != "queue_name"
+            },
+        )
+    )
+
+
+def _refresh_evidence_queue_state(
+        connection: DBClient,
+        *,
+        batch_id: str,
+        updated_at: str,
+) -> None:
+    queue_state = load_evidence_queue_state(connection)
+    if str(queue_state.get("batch_id") or "") != batch_id:
+        return
+    counts = {
+        str(row["work_status"]): int(row["item_count"] or 0)
+        for row in connection.execute(
+            select(
+                library_item_evidence_state.c.work_status,
+                func.count().label("item_count"),
+            )
+            .where(library_item_evidence_state.c.work_batch_id == batch_id)
+            .group_by(library_item_evidence_state.c.work_status)
+        ).mappings()
+        if row["work_status"]
+    }
+    running_count = counts.get("running", 0)
+    claimable_count = sum(counts.get(status, 0) for status in EVIDENCE_WORK_CLAIMABLE_STATUSES)
+    completed_count = counts.get("completed", 0)
+    failed_count = counts.get("failed", 0)
+    cancelled_count = counts.get("cancelled", 0)
+    cancel_requested = bool(queue_state.get("cancel_requested"))
+    is_paused = bool(queue_state.get("is_paused"))
+    if cancel_requested:
+        status = "cancel_requested" if running_count else "cancelled"
+        finished_at = None if running_count else updated_at
+    elif running_count:
+        status = "paused" if is_paused else "running"
+        finished_at = None
+    elif claimable_count:
+        status = "paused" if is_paused else "queued"
+        finished_at = None
+    elif failed_count:
+        status = "completed_with_errors"
+        finished_at = updated_at
+    elif cancelled_count:
+        status = "cancelled"
+        finished_at = updated_at
+    else:
+        status = "completed"
+        finished_at = updated_at
+    connection.execute(
+        update(evidence_queue_state)
+        .where(
+            evidence_queue_state.c.queue_name == DEFAULT_EVIDENCE_QUEUE_NAME,
+            evidence_queue_state.c.batch_id == batch_id,
+        )
+        .values(
+            status=status,
+            is_paused=int(status == "paused"),
+            completed_count=completed_count,
+            failed_count=failed_count,
+            cancelled_count=cancelled_count,
+            finished_at=finished_at,
+            updated_at=updated_at,
+        )
+    )
+
+
+def _hydrate_queue_state(row: Any) -> dict[str, Any]:
+    scope_payload = _loads_json_object(row["scope_json"])
+    evidence_kinds = [
+        str(kind)
+        for kind in object_list(_loads_json_value(row["evidence_kinds_json"]))
+        if str(kind) in EVIDENCE_KINDS
+    ]
+    return {
+        "queue_name": str(row["queue_name"]),
+        "batch_id": str(row["batch_id"]) if row["batch_id"] is not None else None,
+        "status": str(row["status"]),
+        "scope": scope_payload or None,
+        "evidence_kinds": evidence_kinds,
+        "is_paused": bool(row["is_paused"]),
+        "cancel_requested": bool(row["cancel_requested"]),
+        "item_count": int(row["item_count"] or 0),
+        "completed_count": int(row["completed_count"] or 0),
+        "failed_count": int(row["failed_count"] or 0),
+        "cancelled_count": int(row["cancelled_count"] or 0),
+        "created_at": row["created_at"],
+        "started_at": row["started_at"],
+        "finished_at": row["finished_at"],
+        "updated_at": row["updated_at"],
+    }
+
+
+def _normalize_evidence_kinds(evidence_kinds: Sequence[str] | None) -> tuple[EvidenceKind, ...]:
+    requested = list(evidence_kinds) if evidence_kinds is not None else list(EVIDENCE_KINDS)
+    normalized = tuple(kind for kind in EVIDENCE_KINDS if kind in requested)
+    unknown = sorted({str(kind) for kind in requested if kind not in EVIDENCE_KINDS})
+    if unknown:
+        raise ValueError(f"Unsupported evidence kinds: {', '.join(unknown)}")
+    if not normalized:
+        raise ValueError("At least one evidence kind is required.")
+    return normalized
+
+
+def _item_source_fingerprint(item: Any) -> str | None:
+    payload = object_dict(item)
+    value = payload.get("content_version_fingerprint") or payload.get("fingerprint")
+    text = str(value or "").strip()
+    return text or None
+
+
+def _claim_owner_filter(claim: EvidenceWorkClaim) -> tuple[Any, ...]:
+    return (
+        library_item_evidence_state.c.library_item_id == claim.library_item_id,
+        library_item_evidence_state.c.evidence_kind == claim.evidence_kind,
+        library_item_evidence_state.c.work_batch_id == claim.batch_id,
+        library_item_evidence_state.c.work_status == "running",
+        library_item_evidence_state.c.worker_id == claim.worker_id,
+    )
+
+
+def _rowcount(value: Any) -> int:
+    if callable(value):
+        return int(value())
+    return int(value) if isinstance(value, int) else 0
+
+
+def _loads_json_value(value: Any) -> Any:
+    try:
+        return json.loads(str(value or "null"))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def _loads_json_object(value: Any) -> dict[str, Any]:
+    payload = _loads_json_value(value)
+    return payload if isinstance(payload, dict) else {}

--- a/mediaforce/library/evidence_state.py
+++ b/mediaforce/library/evidence_state.py
@@ -241,6 +241,38 @@ def sync_library_item_evidence_states(
     return projections
 
 
+def sync_library_item_evidence_state(
+        connection: DBClient,
+        item: Mapping[str, Any],
+        evidence_kind: EvidenceKind,
+        *,
+        preserve_source_identity: bool = True,
+        preserve_policy_identity: bool = True,
+        reset_attempt_state: bool = False,
+        updated_at: str | None = None,
+) -> EvidenceStateProjection:
+    library_item_id = int(item["id"])
+    previous_state = None
+    if preserve_source_identity or preserve_policy_identity:
+        previous_state = load_library_item_evidence_states(connection, library_item_id).get(evidence_kind)
+    projection = project_evidence_state(
+        evidence_kind,
+        item.get(_evidence_spec(evidence_kind).column_name),
+        source_fingerprint=_item_source_fingerprint(item),
+        previous_state=previous_state,
+        preserve_source_identity=preserve_source_identity,
+        preserve_policy_identity=preserve_policy_identity,
+        updated_at=updated_at,
+    )
+    _upsert_projections(
+        connection,
+        library_item_id,
+        [projection],
+        reset_attempt_state=reset_attempt_state,
+    )
+    return projection
+
+
 def rebuild_library_item_evidence_states(
         connection: DBClient,
         *,

--- a/mediaforce/library/evidence_worker.py
+++ b/mediaforce/library/evidence_worker.py
@@ -1,0 +1,516 @@
+import json
+import logging
+import os
+import socket
+import subprocess
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any, Literal
+
+from sqlalchemy import select, update
+
+from mediaforce.core.config import MediaforceConfig, load_config
+from mediaforce.core.db import open_db
+from mediaforce.core.db_tables import library_items
+from mediaforce.core.process_control import ManagedProcessController, ProcessCancelledError
+from mediaforce.core.utils import content_version_fingerprint, file_fingerprint
+from mediaforce.encoding.cadence import CADENCE_EVIDENCE_KIND, reclassify_cadence_summary
+from mediaforce.encoding.fingerprint import MEDIA_FINGERPRINT_EVIDENCE_KIND, reclassify_media_fingerprint_summary
+from mediaforce.library.evidence_queue import EvidenceWorkClaim, claim_next_evidence_work, \
+    current_library_item_source_fingerprint, evidence_queue_summary, heartbeat_evidence_work, \
+    load_evidence_queue_state, load_evidence_work_claim, mark_evidence_attempt_started, recover_evidence_queue, \
+    transition_evidence_work
+from mediaforce.library.evidence_state import EVIDENCE_STATE_ANALYSIS_REQUIRED, \
+    EVIDENCE_STATE_CLASSIFICATION_REQUIRED, EVIDENCE_STATE_CURRENT, parse_evidence_summary, \
+    sync_library_item_evidence_state
+from mediaforce.library.probe import probe_evidence
+
+EVIDENCE_JOB_LEASE_SECONDS = 45
+EVIDENCE_JOB_HEARTBEAT_SECONDS = 5.0
+EVIDENCE_JOB_RETRY_BASE_DELAY_SECONDS = 60
+EVIDENCE_JOB_RETRY_MAX_DELAY_SECONDS = 15 * 60
+EVIDENCE_JOB_MAX_ATTEMPTS = 3
+EVIDENCE_SOURCE_RETRY_DELAY_SECONDS = 30
+SourceAvailability = Literal["available", "root_unavailable", "source_unavailable"]
+
+
+@dataclass(slots=True)
+class EvidenceWorkerDeps:
+    load_config: Callable[[Path], MediaforceConfig]
+    analyze_evidence: Callable[..., dict[str, object]]
+    logger: Any
+    lease_seconds: int = EVIDENCE_JOB_LEASE_SECONDS
+    heartbeat_seconds: float = EVIDENCE_JOB_HEARTBEAT_SECONDS
+    retry_base_delay_seconds: int = EVIDENCE_JOB_RETRY_BASE_DELAY_SECONDS
+    retry_max_delay_seconds: int = EVIDENCE_JOB_RETRY_MAX_DELAY_SECONDS
+    max_attempts: int = EVIDENCE_JOB_MAX_ATTEMPTS
+    source_retry_delay_seconds: int = EVIDENCE_SOURCE_RETRY_DELAY_SECONDS
+
+
+def default_evidence_worker_deps() -> EvidenceWorkerDeps:
+    return EvidenceWorkerDeps(
+        load_config=load_config,
+        analyze_evidence=probe_evidence,
+        logger=logging.getLogger(__name__),
+    )
+
+
+def process_evidence_queue_once(
+        *,
+        config_path: Path,
+        deps: EvidenceWorkerDeps | None = None,
+) -> bool:
+    runtime_deps = deps or default_evidence_worker_deps()
+    config = runtime_deps.load_config(config_path)
+    worker_id = _evidence_worker_id()
+    with open_db(config.paths.db_path) as connection:
+        recover_evidence_queue(connection, reclaim_all_running=False)
+        claim = claim_next_evidence_work(
+            connection,
+            worker_id=worker_id,
+            lease_seconds=runtime_deps.lease_seconds,
+        )
+    if claim is None:
+        return False
+    _run_evidence_claim(
+        config=config,
+        claim=claim,
+        deps=runtime_deps,
+    )
+    return True
+
+
+def run_evidence_queue_until_blocked(
+        *,
+        config_path: Path,
+        deps: EvidenceWorkerDeps | None = None,
+        max_work_items: int = 1,
+        max_seconds: float | None = None,
+) -> dict[str, Any]:
+    if max_work_items <= 0:
+        raise ValueError("Evidence worker item budget must be greater than zero.")
+    if max_seconds is not None and max_seconds <= 0:
+        raise ValueError("Evidence worker time budget must be greater than zero.")
+    runtime_deps = deps or default_evidence_worker_deps()
+    config = runtime_deps.load_config(config_path)
+    processed = 0
+    started_at = time.monotonic()
+    stop_reason = "blocked"
+    while processed < max_work_items:
+        if max_seconds is not None and time.monotonic() - started_at >= max_seconds:
+            stop_reason = "time_budget"
+            break
+        if not process_evidence_queue_once(config_path=config_path, deps=runtime_deps):
+            break
+        processed += 1
+        if processed >= max_work_items:
+            stop_reason = "item_budget"
+    with open_db(config.paths.db_path) as connection:
+        summary = evidence_queue_summary(connection)
+    summary["processed_count"] = processed
+    summary["stop_reason"] = stop_reason
+    return summary
+
+
+def _run_evidence_claim(
+        *,
+        config: MediaforceConfig,
+        claim: EvidenceWorkClaim,
+        deps: EvidenceWorkerDeps,
+) -> None:
+    with open_db(config.paths.db_path) as connection:
+        active_claim = _reload_owned_claim(connection, claim)
+    if active_claim is None:
+        return
+    claim = active_claim
+    if claim.evidence_state == EVIDENCE_STATE_CURRENT:
+        _finish_claim(
+            config,
+            claim,
+            work_status="completed",
+            reset_attempt_state=True,
+        )
+        return
+    if claim.evidence_state == EVIDENCE_STATE_CLASSIFICATION_REQUIRED:
+        _run_classification_claim(config, claim)
+        return
+
+    source_path = Path(claim.source_path)
+    source_availability, actual_fingerprint = _source_fingerprint(config, claim, source_path)
+    if source_availability == "root_unavailable":
+        _defer_unavailable_source(config, claim, deps, restore_attempt=False)
+        return
+    if source_availability == "source_unavailable":
+        _finish_claim(
+            config,
+            claim,
+            work_status="failed",
+            last_error="Source file is unavailable; run a scan before starting new evidence work.",
+        )
+        return
+    if actual_fingerprint != claim.expected_source_fingerprint:
+        _finish_claim(
+            config,
+            claim,
+            work_status="failed",
+            last_error="Source changed since the catalog snapshot; run a scan before retrying evidence work.",
+        )
+        return
+
+    with open_db(config.paths.db_path) as connection:
+        active_claim = mark_evidence_attempt_started(connection, claim)
+    if active_claim is None:
+        return
+    claim = active_claim
+
+    process_controller = ManagedProcessController()
+    heartbeat_stop = threading.Event()
+    heartbeat_thread = threading.Thread(
+        target=_evidence_heartbeat_loop,
+        kwargs={
+            "config": config,
+            "claim": claim,
+            "process_controller": process_controller,
+            "stop_event": heartbeat_stop,
+            "deps": deps,
+        },
+        daemon=True,
+        name=f"evidence-heartbeat-{claim.library_item_id}-{claim.evidence_kind}",
+    )
+    heartbeat_thread.start()
+    try:
+        process_controller.throw_if_cancelled()
+        summary = deps.analyze_evidence(
+            source_path,
+            claim.evidence_kind,
+            process_controller=process_controller,
+        )
+        process_controller.throw_if_cancelled()
+    except ProcessCancelledError:
+        _finish_claim(
+            config,
+            claim,
+            work_status="cancelled",
+            last_error="Evidence work was cancelled.",
+            restore_attempt=True,
+        )
+        return
+    except (OSError, RuntimeError, TypeError, ValueError, json.JSONDecodeError, subprocess.SubprocessError) as exc:
+        source_availability, _current_fingerprint = _source_fingerprint(config, claim, source_path)
+        if source_availability == "root_unavailable":
+            _defer_unavailable_source(config, claim, deps, restore_attempt=True)
+        elif source_availability == "source_unavailable":
+            _finish_claim(
+                config,
+                claim,
+                work_status="failed",
+                last_error="Source file became unavailable during evidence analysis; the result was discarded.",
+                restore_attempt=True,
+            )
+        else:
+            _retry_or_fail(config, claim, deps, exc)
+        return
+    finally:
+        heartbeat_stop.set()
+        heartbeat_thread.join(timeout=1.0)
+        process_controller.reset()
+
+    final_availability, final_fingerprint = _source_fingerprint(config, claim, source_path)
+    if final_availability == "root_unavailable":
+        _defer_unavailable_source(config, claim, deps, restore_attempt=True)
+        return
+    if final_availability == "source_unavailable":
+        _finish_claim(
+            config,
+            claim,
+            work_status="failed",
+            last_error="Source file became unavailable during evidence analysis; the result was discarded.",
+            restore_attempt=True,
+        )
+        return
+    if final_fingerprint != actual_fingerprint:
+        _finish_claim(
+            config,
+            claim,
+            work_status="failed",
+            last_error="Source changed during evidence analysis; the result was discarded.",
+            restore_attempt=True,
+        )
+        return
+    _commit_evidence_summary(
+        config,
+        claim,
+        summary,
+        actual_fingerprint=final_fingerprint,
+        classification_only=False,
+    )
+
+
+def _run_classification_claim(
+        config: MediaforceConfig,
+        claim: EvidenceWorkClaim,
+) -> None:
+    summary = parse_evidence_summary(claim.canonical_summary_json)
+    if summary is None:
+        _finish_claim(
+            config,
+            claim,
+            work_status="failed",
+            last_error="Stored evidence could not be reclassified because its canonical JSON is malformed.",
+        )
+        return
+    if claim.evidence_kind == CADENCE_EVIDENCE_KIND:
+        reclassified = reclassify_cadence_summary(summary)
+    elif claim.evidence_kind == MEDIA_FINGERPRINT_EVIDENCE_KIND:
+        reclassified = reclassify_media_fingerprint_summary(summary)
+    else:
+        raise ValueError(f"Unsupported evidence kind: {claim.evidence_kind}")
+    _commit_evidence_summary(
+        config,
+        claim,
+        reclassified,
+        actual_fingerprint=claim.expected_source_fingerprint,
+        classification_only=True,
+    )
+
+
+def _commit_evidence_summary(
+        config: MediaforceConfig,
+        claim: EvidenceWorkClaim,
+        summary: dict[str, object],
+        *,
+        actual_fingerprint: str | None,
+        classification_only: bool,
+) -> None:
+    summary_json = json.dumps(summary, separators=(",", ":"), sort_keys=True)
+    with open_db(config.paths.db_path) as connection:
+        active_claim = _reload_owned_claim(connection, claim)
+        if active_claim is None:
+            return
+        queue_state = load_evidence_queue_state(connection)
+        if (
+                str(queue_state.get("batch_id") or "") != claim.batch_id
+                or bool(queue_state.get("cancel_requested"))
+        ):
+            transition_evidence_work(
+                connection,
+                claim,
+                work_status="cancelled",
+                last_error="Evidence work was cancelled before its result committed.",
+                restore_attempt=not classification_only,
+            )
+            return
+        current_source_fingerprint = current_library_item_source_fingerprint(
+            connection,
+            claim.library_item_id,
+        )
+        if (
+                actual_fingerprint is None
+                or actual_fingerprint != claim.expected_source_fingerprint
+                or current_source_fingerprint != claim.expected_source_fingerprint
+        ):
+            transition_evidence_work(
+                connection,
+                claim,
+                work_status="failed",
+                last_error="Source changed before evidence commit; the result was discarded.",
+                restore_attempt=not classification_only,
+            )
+            return
+        column = (
+            library_items.c.cadence_summary_json
+            if claim.evidence_kind == CADENCE_EVIDENCE_KIND
+            else library_items.c.media_fingerprint_json
+        )
+        connection.execute(
+            update(library_items)
+            .where(library_items.c.id == claim.library_item_id)
+            .values({column.name: summary_json})
+        )
+        item = connection.execute(
+            select(library_items).where(library_items.c.id == claim.library_item_id)
+        ).mappings().one()
+        projection = sync_library_item_evidence_state(
+            connection,
+            item,
+            claim.evidence_kind,
+            preserve_source_identity=False,
+            preserve_policy_identity=False,
+        )
+        if projection.state == EVIDENCE_STATE_CURRENT:
+            transition_evidence_work(
+                connection,
+                claim,
+                work_status="completed",
+                reset_attempt_state=True,
+            )
+        elif classification_only and projection.state == EVIDENCE_STATE_ANALYSIS_REQUIRED:
+            transition_evidence_work(
+                connection,
+                claim,
+                work_status="queued",
+            )
+        else:
+            transition_evidence_work(
+                connection,
+                claim,
+                work_status="failed",
+                last_error=(
+                    f"Evidence analysis completed with non-current result: "
+                    f"{projection.reason or projection.state}."
+                ),
+            )
+
+
+def _evidence_heartbeat_loop(
+        *,
+        config: MediaforceConfig,
+        claim: EvidenceWorkClaim,
+        process_controller: ManagedProcessController,
+        stop_event: threading.Event,
+        deps: EvidenceWorkerDeps,
+) -> None:
+    while not stop_event.wait(deps.heartbeat_seconds):
+        try:
+            with open_db(config.paths.db_path) as connection:
+                heartbeat_status = heartbeat_evidence_work(
+                    connection,
+                    claim,
+                    lease_seconds=deps.lease_seconds,
+                    process_pid=process_controller.pid,
+                )
+        except Exception:
+            deps.logger.exception("Evidence heartbeat failed; cancelling active media analysis")
+            process_controller.cancel()
+            return
+        if heartbeat_status != "active":
+            if heartbeat_status == "claim_lost":
+                deps.logger.warning("Evidence claim ownership was lost; cancelling active media analysis")
+            process_controller.cancel()
+            return
+
+
+def _retry_or_fail(
+        config: MediaforceConfig,
+        claim: EvidenceWorkClaim,
+        deps: EvidenceWorkerDeps,
+        exc: Exception,
+) -> None:
+    error_message = _error_message(exc)
+    if claim.attempt_count >= deps.max_attempts:
+        _finish_claim(
+            config,
+            claim,
+            work_status="failed",
+            last_error=error_message,
+        )
+        return
+    retry_delay = _retry_delay_seconds(claim.attempt_count, deps)
+    retry_not_before = (
+        datetime.now(UTC) + timedelta(seconds=retry_delay)
+    ).isoformat(timespec="seconds")
+    _finish_claim(
+        config,
+        claim,
+        work_status="retry_wait",
+        last_error=error_message,
+        retry_not_before=retry_not_before,
+    )
+
+
+def _defer_unavailable_source(
+        config: MediaforceConfig,
+        claim: EvidenceWorkClaim,
+        deps: EvidenceWorkerDeps,
+        *,
+        restore_attempt: bool,
+) -> None:
+    retry_not_before = (
+        datetime.now(UTC) + timedelta(seconds=deps.source_retry_delay_seconds)
+    ).isoformat(timespec="seconds")
+    _finish_claim(
+        config,
+        claim,
+        work_status="waiting_source",
+        last_error="Source root is unavailable; evidence work will resume without consuming an attempt.",
+        retry_not_before=retry_not_before,
+        restore_attempt=restore_attempt,
+    )
+
+
+def _finish_claim(
+        config: MediaforceConfig,
+        claim: EvidenceWorkClaim,
+        *,
+        work_status: str,
+        last_error: str | None = None,
+        retry_not_before: str | None = None,
+        restore_attempt: bool = False,
+        reset_attempt_state: bool = False,
+) -> None:
+    with open_db(config.paths.db_path) as connection:
+        transition_evidence_work(
+            connection,
+            claim,
+            work_status=work_status,
+            last_error=last_error,
+            retry_not_before=retry_not_before,
+            restore_attempt=restore_attempt,
+            reset_attempt_state=reset_attempt_state,
+        )
+
+
+def _reload_owned_claim(connection: Any, claim: EvidenceWorkClaim) -> EvidenceWorkClaim | None:
+    active_claim = load_evidence_work_claim(
+        connection,
+        library_item_id=claim.library_item_id,
+        evidence_kind=claim.evidence_kind,
+    )
+    if active_claim is None or active_claim.worker_id != claim.worker_id:
+        return None
+    return active_claim
+
+
+def _source_fingerprint(
+        config: MediaforceConfig,
+        claim: EvidenceWorkClaim,
+        source_path: Path,
+) -> tuple[SourceAvailability, str | None]:
+    root_path = config.source_root_map.get(claim.media_root)
+    if root_path is None:
+        return "root_unavailable", None
+    try:
+        if not root_path.is_dir():
+            return "root_unavailable", None
+        if not source_path.is_file():
+            return "source_unavailable", None
+        stat_result = source_path.stat()
+        if claim.uses_content_fingerprint:
+            return "available", content_version_fingerprint(source_path, stat_result)
+        return "available", file_fingerprint(source_path, stat_result, claim.duration_seconds)
+    except OSError:
+        try:
+            if not root_path.is_dir():
+                return "root_unavailable", None
+        except OSError:
+            return "root_unavailable", None
+        return "source_unavailable", None
+
+
+def _retry_delay_seconds(attempt_count: int, deps: EvidenceWorkerDeps) -> int:
+    exponent = max(attempt_count - 1, 0)
+    delay = deps.retry_base_delay_seconds * (2 ** exponent)
+    return min(delay, deps.retry_max_delay_seconds)
+
+
+def _evidence_worker_id() -> str:
+    return f"{socket.gethostname()}:{os.getpid()}:{threading.current_thread().name}"
+
+
+def _error_message(exc: Exception) -> str:
+    text = str(exc).strip()
+    return text[:2000] if text else exc.__class__.__name__

--- a/mediaforce/library/probe.py
+++ b/mediaforce/library/probe.py
@@ -4,9 +4,11 @@ from pathlib import Path
 
 from mediaforce.core.binaries import ffprobe_binary
 from mediaforce.core.models import ProbeSummary
+from mediaforce.core.process_control import ManagedProcessController, run_command
 from mediaforce.core.type_defs import int_value, object_dict, object_list
-from mediaforce.encoding.cadence import analyze_cadence
-from mediaforce.encoding.fingerprint import analyze_media_fingerprint
+from mediaforce.encoding.cadence import CADENCE_EVIDENCE_KIND, analyze_cadence
+from mediaforce.encoding.fingerprint import MEDIA_FINGERPRINT_EVIDENCE_KIND, analyze_media_fingerprint
+from mediaforce.library.evidence_state import EvidenceKind
 
 TRACK_FIELDS = (
     "index",
@@ -59,26 +61,12 @@ def _attachment_entry(stream: dict[str, object]) -> dict[str, object]:
     return {key: entry[key] for key in ATTACHMENT_FIELDS}
 
 
-def probe_media(path: Path) -> ProbeSummary:
-    cmd = [
-        ffprobe_binary(),
-        "-v",
-        "error",
-        "-print_format",
-        "json",
-        "-show_format",
-        "-show_streams",
-        str(path),
-    ]
-    result = subprocess.run(
-        cmd,
-        check=True,
-        capture_output=True,
-        text=True,
-        timeout=PROBE_TIMEOUT_SECONDS,
-    )
-    payload = object_dict(json.loads(result.stdout))
-
+def probe_media(
+        path: Path,
+        *,
+        process_controller: ManagedProcessController | None = None,
+) -> ProbeSummary:
+    payload = _probe_payload(path, process_controller=process_controller)
     streams = [object_dict(stream) for stream in object_list(payload.get("streams"))]
     format_info = object_dict(payload.get("format"))
     video_stream = next((stream for stream in streams if stream.get("codec_type") == "video"), None)
@@ -101,18 +89,6 @@ def probe_media(path: Path) -> ProbeSummary:
         _normalize_language(subtitle_streams[0]) if subtitle_streams else None,
     )
 
-    cadence_summary = analyze_cadence(
-        path,
-        video_stream=video_stream,
-        duration_seconds=duration_seconds,
-    )
-    media_fingerprint = analyze_media_fingerprint(
-        path,
-        video_stream=video_stream,
-        audio_streams=audio_streams,
-        duration_seconds=duration_seconds,
-    )
-
     return ProbeSummary(
         duration_seconds=duration_seconds,
         video_codec=video_stream.get("codec_name") if video_stream else None,
@@ -129,9 +105,74 @@ def probe_media(path: Path) -> ProbeSummary:
         audio_summary_json=json.dumps(audio_summary, separators=(",", ":"), sort_keys=True),
         subtitle_summary_json=json.dumps(subtitle_summary, separators=(",", ":"), sort_keys=True),
         attachment_summary_json=json.dumps(attachment_summary, separators=(",", ":"), sort_keys=True),
-        cadence_summary_json=json.dumps(cadence_summary, separators=(",", ":"), sort_keys=True),
-        media_fingerprint_json=json.dumps(media_fingerprint, separators=(",", ":"), sort_keys=True),
+        cadence_summary_json=None,
+        media_fingerprint_json=None,
     )
+
+
+def probe_evidence(
+        path: Path,
+        evidence_kind: EvidenceKind,
+        *,
+        process_controller: ManagedProcessController | None = None,
+) -> dict[str, object]:
+    payload = _probe_payload(path, process_controller=process_controller)
+    streams = [object_dict(stream) for stream in object_list(payload.get("streams"))]
+    format_info = object_dict(payload.get("format"))
+    video_stream = next((stream for stream in streams if stream.get("codec_type") == "video"), None)
+    duration_seconds = _as_float(format_info.get("duration"))
+    if evidence_kind == CADENCE_EVIDENCE_KIND:
+        return analyze_cadence(
+            path,
+            video_stream=video_stream,
+            duration_seconds=duration_seconds,
+            process_controller=process_controller,
+        )
+    if evidence_kind == MEDIA_FINGERPRINT_EVIDENCE_KIND:
+        audio_streams = [stream for stream in streams if stream.get("codec_type") == "audio"]
+        return analyze_media_fingerprint(
+            path,
+            video_stream=video_stream,
+            audio_streams=audio_streams,
+            duration_seconds=duration_seconds,
+            process_controller=process_controller,
+        )
+    raise ValueError(f"Unsupported evidence kind: {evidence_kind}")
+
+
+def _probe_payload(
+        path: Path,
+        *,
+        process_controller: ManagedProcessController | None,
+) -> dict[str, object]:
+    cmd = [
+        ffprobe_binary(),
+        "-v",
+        "error",
+        "-print_format",
+        "json",
+        "-show_format",
+        "-show_streams",
+        str(path),
+    ]
+    if process_controller is None:
+        result = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=PROBE_TIMEOUT_SECONDS,
+        )
+    else:
+        result = run_command(
+            cmd,
+            process_controller=process_controller,
+            capture_output=True,
+            text=True,
+            timeout=PROBE_TIMEOUT_SECONDS,
+            check=True,
+        )
+    return object_dict(json.loads(result.stdout))
 
 
 def _stream_bit_rate(stream: dict[str, object]) -> int | None:

--- a/mediaforce/library/scanner.py
+++ b/mediaforce/library/scanner.py
@@ -18,8 +18,6 @@ from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.db_tables import scan_runs
 from mediaforce.core.models import ProbeSummary
-from mediaforce.encoding.cadence import unavailable_cadence_summary
-from mediaforce.encoding.fingerprint import unavailable_media_fingerprint_summary
 from mediaforce.library.evidence_state import sync_library_item_evidence_states
 from mediaforce.library.media_scopes import logical_library_rel_path, path_matches_scope
 from mediaforce.library.planner import recommend_item
@@ -219,8 +217,6 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
                 "audio_summary_json": probe.audio_summary_json,
                 "subtitle_summary_json": probe.subtitle_summary_json,
                 "attachment_summary_json": probe.attachment_summary_json,
-                "cadence_summary_json": probe.cadence_summary_json,
-                "media_fingerprint_json": probe.media_fingerprint_json,
                 "priority_score": recommendation.score,
                 "recommendation": recommendation.bucket,
                 "recommendation_reason": recommendation.reason,
@@ -259,11 +255,14 @@ def scan_library(connection: DBClient, config: MediaforceConfig, prefixes: list[
                     )
                 )
                 stats.reprobed += 1
+            item = connection.execute(
+                select(library_items).where(library_items.c.id == library_item_id)
+            ).mappings().one()
             sync_library_item_evidence_states(
                 connection,
-                {**values, "id": library_item_id},
-                preserve_source_identity=False,
-                preserve_policy_identity=False,
+                item,
+                preserve_source_identity=row is not None,
+                preserve_policy_identity=row is not None,
                 reset_attempt_state=True,
                 updated_at=started_at,
             )
@@ -392,12 +391,7 @@ def _flush_scan_progress(
     return 0
 
 
-def _failed_probe_summary(error: Exception) -> ProbeSummary:
-    message = str(error).strip() or error.__class__.__name__
-    cadence_summary = unavailable_cadence_summary(f"Media probing failed: {message}")
-    media_fingerprint = unavailable_media_fingerprint_summary(f"Media probing failed: {message}")
-    cadence_summary["retry_required"] = True
-    media_fingerprint["retry_required"] = True
+def _failed_probe_summary(_error: Exception) -> ProbeSummary:
     return ProbeSummary(
         duration_seconds=None,
         video_codec=None,
@@ -413,9 +407,9 @@ def _failed_probe_summary(error: Exception) -> ProbeSummary:
         default_subtitle_language=None,
         audio_summary_json="[]",
         subtitle_summary_json="[]",
-        attachment_summary_json="",
-        cadence_summary_json=json.dumps(cadence_summary, separators=(",", ":"), sort_keys=True),
-        media_fingerprint_json=json.dumps(media_fingerprint, separators=(",", ":"), sort_keys=True),
+        attachment_summary_json="[]",
+        cadence_summary_json=None,
+        media_fingerprint_json=None,
     )
 
 

--- a/tests/test_cadence.py
+++ b/tests/test_cadence.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 from mediaforce.core.evidence import build_evidence_envelope
 from mediaforce.encoding.cadence import (
+    CADENCE_EVIDENCE_KIND,
     CadenceResolutionError,
     analyze_cadence,
     cadence_filter,
@@ -16,7 +17,7 @@ from mediaforce.encoding.commands import build_ffmpeg_command
 from mediaforce.encoding.quality import QualitySearchResult
 from mediaforce.encoding.quality_search import search_quality
 from mediaforce.encoding.video_filters import build_video_filter
-from mediaforce.library.probe import probe_media
+from mediaforce.library.probe import probe_evidence, probe_media
 
 
 class CadenceTests(unittest.TestCase):
@@ -58,7 +59,7 @@ class CadenceTests(unittest.TestCase):
         self.assertEqual(summary["decision"]["classification"], "progressive")
         self.assertEqual(summary["decision"]["transform"], "none")
 
-    def test_probe_summary_persists_frame_rate_and_field_order_evidence(self) -> None:
+    def test_evidence_probe_persists_frame_rate_and_field_order_evidence(self) -> None:
         payload = {
             "format": {"duration": "2700.0"},
             "streams": [
@@ -80,14 +81,33 @@ class CadenceTests(unittest.TestCase):
             "mediaforce.library.probe.subprocess.run",
             return_value=Mock(stdout=json.dumps(payload)),
         ) as run_probe:
-            summary = probe_media(Path("/tmp/progressive.mkv"))
+            summary = probe_evidence(Path("/tmp/progressive.mkv"), CADENCE_EVIDENCE_KIND)
 
         ffprobe_calls = [call for call in run_probe.call_args_list if call.args[0][0] == "ffprobe"]
         self.assertEqual(len(ffprobe_calls), 1)
-        cadence = json.loads(summary.cadence_summary_json)
-        self.assertEqual(cadence["probe"]["field_order"], "progressive")
-        self.assertEqual(cadence["probe"]["average_frame_rate"], "24000/1001")
-        self.assertEqual(cadence["probe"]["time_base"], "1/90000")
+        self.assertEqual(summary["probe"]["field_order"], "progressive")
+        self.assertEqual(summary["probe"]["average_frame_rate"], "24000/1001")
+        self.assertEqual(summary["probe"]["time_base"], "1/90000")
+
+    def test_inventory_probe_never_runs_deep_evidence_analysis(self) -> None:
+        payload = {
+            "format": {"duration": "120.0"},
+            "streams": [{"index": 0, "codec_type": "video", "codec_name": "h264"}],
+        }
+        with patch(
+            "mediaforce.library.probe.subprocess.run",
+            return_value=Mock(stdout=json.dumps(payload)),
+        ), patch(
+            "mediaforce.library.probe.analyze_cadence",
+            side_effect=AssertionError("unexpected cadence analysis"),
+        ), patch(
+            "mediaforce.library.probe.analyze_media_fingerprint",
+            side_effect=AssertionError("unexpected fingerprint analysis"),
+        ):
+            summary = probe_media(Path("/tmp/inventory-only.mkv"))
+
+        self.assertIsNone(summary.cadence_summary_json)
+        self.assertIsNone(summary.media_fingerprint_json)
 
     def test_probe_summary_persists_stream_bytes_and_attachments(self) -> None:
         payload = {

--- a/tests/test_db_runtime.py
+++ b/tests/test_db_runtime.py
@@ -15,6 +15,7 @@ from mediaforce.core.db import _load_sql_asset
 from mediaforce.core.db import open_db
 from mediaforce.core.db import reset_engine_cache
 from mediaforce.core.db_tables import alembic_version
+from mediaforce.core.db_tables import evidence_queue_state
 from mediaforce.core.db_tables import encode_jobs
 from mediaforce.core.db_tables import encode_queue_state
 from mediaforce.core.db_tables import library_item_evidence_state
@@ -25,7 +26,7 @@ from mediaforce.core.type_defs import object_dict
 from mediaforce.encoding.cadence import cadence_policy_snapshot
 from mediaforce.encoding.fingerprint import media_fingerprint_policy_snapshot
 
-CURRENT_DB_REVISION = "20260719_0011"
+CURRENT_DB_REVISION = "20260719_0012"
 
 
 class DatabaseRuntimeTests(unittest.TestCase):
@@ -48,6 +49,10 @@ class DatabaseRuntimeTests(unittest.TestCase):
                     str(index_row["name"])
                     for index_row in inspector.get_indexes("library_item_evidence_state")
                 }
+                evidence_columns = {
+                    str(column["name"])
+                    for column in inspector.get_columns("library_item_evidence_state")
+                }
                 library_columns = {str(column["name"]) for column in inspector.get_columns("library_items")}
 
             self.assertEqual(version, CURRENT_DB_REVISION)
@@ -62,8 +67,13 @@ class DatabaseRuntimeTests(unittest.TestCase):
             self.assertIn("series_metadata", table_names)
             self.assertIn("metadata_sync_state", table_names)
             self.assertIn("library_item_evidence_state", table_names)
+            self.assertIn("evidence_queue_state", table_names)
             self.assertIn("idx_library_item_evidence_state_kind_state", evidence_indexes)
             self.assertIn("idx_library_item_evidence_state_work_ready", evidence_indexes)
+            self.assertIn("idx_library_item_evidence_state_work_claim", evidence_indexes)
+            self.assertIn("work_batch_id", evidence_columns)
+            self.assertIn("work_status", evidence_columns)
+            self.assertIn("lease_expires_at", evidence_columns)
 
     def test_open_db_stamps_existing_legacy_database(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -414,6 +424,124 @@ class DatabaseRuntimeTests(unittest.TestCase):
             self.assertNotIn("library_item_evidence_state", table_names)
             self.assertEqual(canonical, (cadence_json, fingerprint_json))
             self.assertEqual(version, ("20260712_0010",))
+
+    def test_evidence_queue_migration_round_trip_preserves_state_without_starting_work(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "library.sqlite3"
+            cadence_json = '{"schema_version":1,"decision":{"status":"measured"}}'
+            with open_db(db_path) as connection:
+                item_result = connection.execute(
+                    library_items.insert().values(
+                        **self._library_item_values(
+                            cadence_summary_json=cadence_json,
+                            media_fingerprint_json=None,
+                        )
+                    )
+                )
+                item_id = int(item_result.inserted_primary_key[0])
+                connection.execute(
+                    library_item_evidence_state.insert().values(
+                        library_item_id=item_id,
+                        evidence_kind="cadence_analysis",
+                        state="analysis_required",
+                        reason="retry_required",
+                        summary_sha256="sha256:fixture",
+                        source_fingerprint="content-1",
+                        summary_schema_version=1,
+                        analyzer_name="mediaforce.ffmpeg_idet",
+                        analyzer_version="1",
+                        analyzer_runtime_version="ffmpeg fixture",
+                        policy_hash="sha256:policy",
+                        decision_status="measured",
+                        attempt_count=2,
+                        retry_not_before="2026-07-20T00:00:00+00:00",
+                        last_attempt_at="2026-07-19T12:30:00+00:00",
+                        last_error="fixture failure",
+                        work_batch_id="batch-1",
+                        work_status="queued",
+                        work_source_fingerprint="content-1",
+                        updated_at="2026-07-19T12:30:00+00:00",
+                    )
+                )
+                connection.execute(
+                    evidence_queue_state.insert().values(
+                        queue_name="evidence",
+                        batch_id="batch-1",
+                        status="paused",
+                        scope_json='{"prefix":"tv/show"}',
+                        evidence_kinds_json='["cadence_analysis"]',
+                        is_paused=1,
+                        cancel_requested=0,
+                        item_count=1,
+                        completed_count=0,
+                        failed_count=0,
+                        cancelled_count=0,
+                        created_at="2026-07-19T12:30:00+00:00",
+                        updated_at="2026-07-19T12:30:00+00:00",
+                    )
+                )
+            reset_engine_cache()
+
+            with _alembic_script_location() as script_location:
+                command.downgrade(
+                    _alembic_config(db_path, script_location),
+                    "20260719_0011",
+                )
+
+            raw_connection = sqlite3.connect(db_path)
+            try:
+                table_names = {
+                    str(row[0])
+                    for row in raw_connection.execute(
+                        "SELECT name FROM sqlite_master WHERE type = 'table'"
+                    ).fetchall()
+                }
+                evidence_columns = {
+                    str(row[1])
+                    for row in raw_connection.execute(
+                        "PRAGMA table_info(library_item_evidence_state)"
+                    ).fetchall()
+                }
+                downgraded_state = raw_connection.execute(
+                    "SELECT attempt_count, retry_not_before, last_error "
+                    "FROM library_item_evidence_state"
+                ).fetchone()
+                canonical = raw_connection.execute(
+                    "SELECT cadence_summary_json FROM library_items"
+                ).fetchone()
+            finally:
+                raw_connection.close()
+
+            self.assertNotIn("evidence_queue_state", table_names)
+            self.assertNotIn("work_status", evidence_columns)
+            self.assertEqual(
+                downgraded_state,
+                (2, "2026-07-20T00:00:00+00:00", "fixture failure"),
+            )
+            self.assertEqual(canonical, (cadence_json,))
+
+            with patch("subprocess.run", side_effect=AssertionError("unexpected subprocess")), patch(
+                "subprocess.Popen",
+                side_effect=AssertionError("unexpected subprocess"),
+            ), open_db(db_path) as connection:
+                upgraded_state = connection.execute(
+                    select(
+                        library_item_evidence_state.c.attempt_count,
+                        library_item_evidence_state.c.retry_not_before,
+                        library_item_evidence_state.c.last_error,
+                        library_item_evidence_state.c.work_batch_id,
+                        library_item_evidence_state.c.work_status,
+                    )
+                ).one()
+                queue_rows = connection.execute(select(evidence_queue_state.c.queue_name)).fetchall()
+                version = connection.execute(select(alembic_version.c.version_num)).scalar_one()
+
+            self.assertEqual(version, CURRENT_DB_REVISION)
+            self.assertEqual(
+                tuple(upgraded_state),
+                (2, "2026-07-20T00:00:00+00:00", "fixture failure", None, None),
+            )
+            self.assertEqual(queue_rows, [])
 
     def test_open_db_rolls_back_on_base_exception(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_evidence_worker.py
+++ b/tests/test_evidence_worker.py
@@ -1,0 +1,711 @@
+import json
+import sqlite3
+import tempfile
+import threading
+import time
+import unittest
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from sqlalchemy import select, update
+
+from mediaforce.cli import main as cli_main
+from mediaforce.core.config import ConfigPaths, MediaforceConfig
+from mediaforce.core.db import open_db, reset_engine_cache
+from mediaforce.core.db_tables import library_item_evidence_state, library_items
+from mediaforce.core.process_control import ProcessCancelledError
+from mediaforce.core.utils import content_version_fingerprint, file_fingerprint
+from mediaforce.encoding.cadence import CADENCE_EVIDENCE_KIND, analyze_cadence
+from mediaforce.encoding.fingerprint import MEDIA_FINGERPRINT_EVIDENCE_KIND
+from mediaforce.library.evidence_queue import cancel_evidence_queue, claim_next_evidence_work, \
+    evidence_queue_summary, mark_evidence_attempt_started, pause_evidence_queue, recover_evidence_queue, \
+    resume_evidence_queue, start_evidence_work
+from mediaforce.library.evidence_state import EVIDENCE_STATE_CLASSIFICATION_REQUIRED, EVIDENCE_STATE_CURRENT, \
+    load_library_item_evidence_states, rebuild_library_item_evidence_states, sync_library_item_evidence_state
+from mediaforce.library.evidence_worker import EvidenceWorkerDeps, process_evidence_queue_once
+
+
+class EvidenceWorkerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.project_root = Path(self.temp_dir.name)
+        self.media_root = self.project_root / "tv"
+        self.media_root.mkdir()
+        self.config = MediaforceConfig(
+            raw={
+                "media": {
+                    "libraries": [
+                        {
+                            "key": "tv",
+                            "path": str(self.media_root),
+                            "type": "tv",
+                            "availability": "production",
+                        }
+                    ]
+                }
+            },
+            paths=ConfigPaths(
+                project_root=self.project_root,
+                config_path=self.project_root / "config.toml",
+                db_path=self.project_root / "state" / "library.sqlite3",
+                run_manifest_dir=self.project_root / "state" / "runs",
+                web_state_dir=self.project_root / "state" / "web",
+                review_dir=self.project_root / "state" / "review",
+                runtime_settings_path=self.project_root / "state" / "settings.json",
+            ),
+        )
+
+    def tearDown(self) -> None:
+        reset_engine_cache()
+        self.temp_dir.cleanup()
+
+    def test_explicit_scope_queues_only_noncurrent_independent_kinds(self) -> None:
+        item_id, _path = self._insert_item(
+            1,
+            cadence_summary_json=self._cadence_summary_json(),
+            media_fingerprint_json=None,
+        )
+
+        with open_db(self.config.paths.db_path) as connection:
+            summary = start_evidence_work(connection, self.config, "tv/show/item-1.mkv")
+            rows = connection.execute(
+                select(
+                    library_item_evidence_state.c.evidence_kind,
+                    library_item_evidence_state.c.work_status,
+                ).where(library_item_evidence_state.c.library_item_id == item_id)
+            ).mappings().fetchall()
+
+        self.assertEqual(summary["item_count"], 1)
+        self.assertEqual(summary["status"], "paused")
+        self.assertTrue(summary["is_paused"])
+        self.assertEqual(summary["scope"]["work_limit"], 25)
+        self.assertEqual(
+            [(row["evidence_kind"], row["work_status"]) for row in rows],
+            [(CADENCE_EVIDENCE_KIND, None), (MEDIA_FINGERPRINT_EVIDENCE_KIND, "queued")],
+        )
+
+    def test_claim_is_single_concurrency_and_pause_prevents_new_claim(self) -> None:
+        self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(connection, self.config, "tv")
+            pause_evidence_queue(connection)
+        with open_db(self.config.paths.db_path) as connection:
+            paused_claim = claim_next_evidence_work(connection, worker_id="worker-a", lease_seconds=30)
+            resume_evidence_queue(connection)
+        with open_db(self.config.paths.db_path) as connection:
+            first_claim = claim_next_evidence_work(connection, worker_id="worker-a", lease_seconds=30)
+        with open_db(self.config.paths.db_path) as connection:
+            second_claim = claim_next_evidence_work(connection, worker_id="worker-b", lease_seconds=30)
+
+        self.assertIsNone(paused_claim)
+        self.assertIsNotNone(first_claim)
+        self.assertIsNone(second_claim)
+
+    def test_batch_limit_caps_root_scope(self) -> None:
+        self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        self._insert_item(2, cadence_summary_json=None, media_fingerprint_json=None)
+
+        with open_db(self.config.paths.db_path) as connection:
+            summary = start_evidence_work(connection, self.config, "tv", limit=1)
+
+        self.assertEqual(summary["item_count"], 1)
+        self.assertEqual(summary["counts"], {"queued": 1})
+        self.assertEqual(summary["scope"]["work_limit"], 1)
+
+    def test_zero_candidate_batch_completes_without_claims(self) -> None:
+        self._insert_item(
+            1,
+            cadence_summary_json=self._cadence_summary_json(),
+            media_fingerprint_json=self._fingerprint_summary_json(),
+        )
+
+        with open_db(self.config.paths.db_path) as connection:
+            summary = start_evidence_work(connection, self.config, "tv/show/item-1.mkv")
+
+        self.assertEqual(summary["status"], "completed")
+        self.assertEqual(summary["item_count"], 0)
+        self.assertEqual(summary["remaining_count"], 0)
+
+    def test_restart_recovery_requeues_owned_work(self) -> None:
+        self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+        with open_db(self.config.paths.db_path) as connection:
+            claim = claim_next_evidence_work(connection, worker_id="worker-a", lease_seconds=30)
+        with open_db(self.config.paths.db_path) as connection:
+            recovered = recover_evidence_queue(connection, reclaim_all_running=True)
+            summary = evidence_queue_summary(connection)
+
+        self.assertIsNotNone(claim)
+        self.assertEqual(recovered, 1)
+        self.assertEqual(summary["counts"], {"queued": 1})
+
+    def test_expired_lease_recovers_without_forcing_live_claims(self) -> None:
+        self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        claimed_at = datetime(2026, 7, 19, 12, 0, tzinfo=UTC)
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+        with open_db(self.config.paths.db_path) as connection:
+            claim = claim_next_evidence_work(
+                connection,
+                worker_id="worker-a",
+                lease_seconds=10,
+                now=claimed_at,
+            )
+        with open_db(self.config.paths.db_path) as connection:
+            live_recovery = recover_evidence_queue(
+                connection,
+                now=claimed_at + timedelta(seconds=5),
+            )
+            expired_recovery = recover_evidence_queue(
+                connection,
+                now=claimed_at + timedelta(seconds=11),
+            )
+
+        self.assertIsNotNone(claim)
+        self.assertEqual(live_recovery, 0)
+        self.assertEqual(expired_recovery, 1)
+
+    def test_classification_only_work_is_claimed_before_media_analysis(self) -> None:
+        analysis_item_id, _path = self._insert_item(
+            1,
+            cadence_summary_json=None,
+            media_fingerprint_json=self._fingerprint_summary_json(),
+        )
+        classification_item_id, _path = self._insert_item(
+            2,
+            cadence_summary_json=self._cadence_summary_json(),
+            media_fingerprint_json=self._fingerprint_summary_json(),
+        )
+        with open_db(self.config.paths.db_path) as connection:
+            connection.execute(
+                update(library_item_evidence_state)
+                .where(
+                    library_item_evidence_state.c.library_item_id == classification_item_id,
+                    library_item_evidence_state.c.evidence_kind == CADENCE_EVIDENCE_KIND,
+                )
+                .values(policy_hash="sha256:old-policy")
+            )
+            rebuild_library_item_evidence_states(connection, library_item_ids=[classification_item_id])
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+        with open_db(self.config.paths.db_path) as connection:
+            claim = claim_next_evidence_work(connection, worker_id="worker-a", lease_seconds=30)
+
+        self.assertIsNotNone(claim)
+        self.assertNotEqual(analysis_item_id, classification_item_id)
+        self.assertEqual(claim.library_item_id, classification_item_id)
+        self.assertEqual(claim.evidence_state, EVIDENCE_STATE_CLASSIFICATION_REQUIRED)
+
+    def test_attempt_start_rejects_lost_claim_ownership(self) -> None:
+        item_id, _path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+        with open_db(self.config.paths.db_path) as connection:
+            claim = claim_next_evidence_work(connection, worker_id="worker-a", lease_seconds=30)
+        self.assertIsNotNone(claim)
+
+        with open_db(self.config.paths.db_path) as connection:
+            active_claim = mark_evidence_attempt_started(
+                connection,
+                replace(claim, worker_id="worker-b"),
+            )
+            state = load_library_item_evidence_states(connection, item_id)[CADENCE_EVIDENCE_KIND]
+
+        self.assertIsNone(active_claim)
+        self.assertEqual(state["attempt_count"], 0)
+
+    def test_policy_only_reclassification_uses_no_media_analyzer(self) -> None:
+        item_id, _path = self._insert_item(
+            1,
+            cadence_summary_json=self._cadence_summary_json(),
+            media_fingerprint_json=self._fingerprint_summary_json(),
+        )
+        with open_db(self.config.paths.db_path) as connection:
+            connection.execute(
+                update(library_item_evidence_state)
+                .where(
+                    library_item_evidence_state.c.library_item_id == item_id,
+                    library_item_evidence_state.c.evidence_kind == CADENCE_EVIDENCE_KIND,
+                )
+                .values(policy_hash="sha256:old-policy")
+            )
+            rebuild_library_item_evidence_states(connection, library_item_ids=[item_id])
+            states = load_library_item_evidence_states(connection, item_id)
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+        analyze_mock = Mock(side_effect=AssertionError("unexpected media analysis"))
+
+        processed = process_evidence_queue_once(
+            config_path=self.config.paths.config_path,
+            deps=self._deps(analyze_mock),
+        )
+
+        with open_db(self.config.paths.db_path) as connection:
+            refreshed = load_library_item_evidence_states(connection, item_id)
+            summary = evidence_queue_summary(connection)
+        self.assertEqual(states[CADENCE_EVIDENCE_KIND]["state"], EVIDENCE_STATE_CLASSIFICATION_REQUIRED)
+        self.assertTrue(processed)
+        analyze_mock.assert_not_called()
+        self.assertEqual(refreshed[CADENCE_EVIDENCE_KIND]["state"], EVIDENCE_STATE_CURRENT)
+        self.assertEqual(summary["status"], "completed")
+
+    def test_concurrently_resolved_evidence_skips_media_analysis(self) -> None:
+        item_id, _path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+            connection.execute(
+                update(library_items)
+                .where(library_items.c.id == item_id)
+                .values(cadence_summary_json=self._cadence_summary_json())
+            )
+            item = connection.execute(
+                select(library_items).where(library_items.c.id == item_id)
+            ).mappings().one()
+            sync_library_item_evidence_state(
+                connection,
+                item,
+                CADENCE_EVIDENCE_KIND,
+                preserve_source_identity=False,
+                preserve_policy_identity=False,
+            )
+        analyze_mock = Mock(side_effect=AssertionError("unexpected media analysis"))
+
+        processed = process_evidence_queue_once(
+            config_path=self.config.paths.config_path,
+            deps=self._deps(analyze_mock),
+        )
+
+        with open_db(self.config.paths.db_path) as connection:
+            state = load_library_item_evidence_states(connection, item_id)[CADENCE_EVIDENCE_KIND]
+        self.assertTrue(processed)
+        analyze_mock.assert_not_called()
+        self.assertEqual(state["work_status"], "completed")
+        self.assertEqual(state["attempt_count"], 0)
+
+    def test_analysis_runs_without_sqlite_write_transaction_and_commits_current_evidence(self) -> None:
+        item_id, _path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+
+        def analyze_without_lock(
+                _path: Path,
+                _kind: str,
+                *,
+                process_controller: object,
+        ) -> dict[str, object]:
+            writer = sqlite3.connect(self.config.paths.db_path, timeout=0.1)
+            try:
+                writer.execute("BEGIN IMMEDIATE")
+                writer.commit()
+            finally:
+                writer.close()
+            return json.loads(self._cadence_summary_json())
+
+        processed = process_evidence_queue_once(
+            config_path=self.config.paths.config_path,
+            deps=self._deps(analyze_without_lock),
+        )
+
+        with open_db(self.config.paths.db_path) as connection:
+            states = load_library_item_evidence_states(connection, item_id)
+            item = connection.execute(
+                select(library_items.c.cadence_summary_json).where(library_items.c.id == item_id)
+            ).scalar_one()
+            summary = evidence_queue_summary(connection)
+        self.assertTrue(processed)
+        self.assertEqual(states[CADENCE_EVIDENCE_KIND]["state"], EVIDENCE_STATE_CURRENT)
+        self.assertEqual(states[CADENCE_EVIDENCE_KIND]["attempt_count"], 0)
+        self.assertEqual(item, self._cadence_summary_json())
+        self.assertEqual(summary["status"], "completed")
+
+    def test_source_identity_change_discards_completed_analysis(self) -> None:
+        item_id, _path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+
+        def change_catalog_source_identity(
+                _path: Path,
+                _kind: str,
+                *,
+                process_controller: object,
+        ) -> dict[str, object]:
+            with open_db(self.config.paths.db_path) as connection:
+                connection.execute(
+                    update(library_items)
+                    .where(library_items.c.id == item_id)
+                    .values(content_version_fingerprint="changed-after-claim")
+                )
+            return json.loads(self._cadence_summary_json())
+
+        processed = process_evidence_queue_once(
+            config_path=self.config.paths.config_path,
+            deps=self._deps(change_catalog_source_identity),
+        )
+
+        with open_db(self.config.paths.db_path) as connection:
+            state = load_library_item_evidence_states(connection, item_id)[CADENCE_EVIDENCE_KIND]
+            canonical_json = connection.execute(
+                select(library_items.c.cadence_summary_json).where(library_items.c.id == item_id)
+            ).scalar_one()
+        self.assertTrue(processed)
+        self.assertIsNone(canonical_json)
+        self.assertEqual(state["work_status"], "failed")
+        self.assertIn("Source changed", state["last_error"])
+
+    def test_unavailable_source_does_not_consume_attempt(self) -> None:
+        item_id, source_path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        source_path.unlink()
+        source_path.parent.rmdir()
+        self.media_root.rmdir()
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+
+        processed = process_evidence_queue_once(
+            config_path=self.config.paths.config_path,
+            deps=self._deps(Mock(side_effect=AssertionError("unexpected media analysis"))),
+        )
+
+        with open_db(self.config.paths.db_path) as connection:
+            state = load_library_item_evidence_states(connection, item_id)[CADENCE_EVIDENCE_KIND]
+        self.assertTrue(processed)
+        self.assertEqual(state["work_status"], "waiting_source")
+        self.assertEqual(state["attempt_count"], 0)
+
+    def test_missing_file_in_available_root_fails_without_retry_loop(self) -> None:
+        item_id, source_path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        source_path.unlink()
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+        analyze_mock = Mock(side_effect=AssertionError("unexpected media analysis"))
+
+        processed = process_evidence_queue_once(
+            config_path=self.config.paths.config_path,
+            deps=self._deps(analyze_mock),
+        )
+
+        with open_db(self.config.paths.db_path) as connection:
+            state = load_library_item_evidence_states(connection, item_id)[CADENCE_EVIDENCE_KIND]
+        self.assertTrue(processed)
+        analyze_mock.assert_not_called()
+        self.assertEqual(state["work_status"], "failed")
+        self.assertEqual(state["attempt_count"], 0)
+
+    def test_failures_back_off_then_become_terminal(self) -> None:
+        item_id, _path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+        deps = self._deps(Mock(side_effect=RuntimeError("fixture failure")), max_attempts=2)
+
+        process_evidence_queue_once(config_path=self.config.paths.config_path, deps=deps)
+        with open_db(self.config.paths.db_path) as connection:
+            first = load_library_item_evidence_states(connection, item_id)[CADENCE_EVIDENCE_KIND]
+            connection.execute(
+                update(library_item_evidence_state)
+                .where(
+                    library_item_evidence_state.c.library_item_id == item_id,
+                    library_item_evidence_state.c.evidence_kind == CADENCE_EVIDENCE_KIND,
+                )
+                .values(retry_not_before="2000-01-01T00:00:00+00:00")
+            )
+        process_evidence_queue_once(config_path=self.config.paths.config_path, deps=deps)
+
+        with open_db(self.config.paths.db_path) as connection:
+            second = load_library_item_evidence_states(connection, item_id)[CADENCE_EVIDENCE_KIND]
+            summary = evidence_queue_summary(connection)
+        self.assertEqual(first["work_status"], "retry_wait")
+        self.assertEqual(first["attempt_count"], 1)
+        self.assertEqual(second["work_status"], "failed")
+        self.assertEqual(second["attempt_count"], 2)
+        self.assertEqual(summary["status"], "completed_with_errors")
+
+    def test_cancel_terminates_active_claim_and_restores_attempt(self) -> None:
+        item_id, _path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+        analyzer_started = threading.Event()
+
+        def cancellable_analyzer(
+                _path: Path,
+                _kind: str,
+                *,
+                process_controller: object,
+        ) -> dict[str, object]:
+            analyzer_started.set()
+            while True:
+                process_controller.throw_if_cancelled()
+                time.sleep(0.005)
+
+        worker = threading.Thread(
+            target=process_evidence_queue_once,
+            kwargs={
+                "config_path": self.config.paths.config_path,
+                "deps": self._deps(cancellable_analyzer, heartbeat_seconds=0.01),
+            },
+        )
+        worker.start()
+        self.assertTrue(analyzer_started.wait(timeout=2.0))
+        with open_db(self.config.paths.db_path) as connection:
+            cancel_evidence_queue(connection)
+        worker.join(timeout=2.0)
+
+        with open_db(self.config.paths.db_path) as connection:
+            state = load_library_item_evidence_states(connection, item_id)[CADENCE_EVIDENCE_KIND]
+            summary = evidence_queue_summary(connection)
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(state["work_status"], "cancelled")
+        self.assertEqual(state["attempt_count"], 0)
+        self.assertEqual(summary["status"], "cancelled")
+
+    def test_cancel_requested_batch_cannot_be_resumed(self) -> None:
+        self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            resume_evidence_queue(connection)
+        with open_db(self.config.paths.db_path) as connection:
+            claim = claim_next_evidence_work(connection, worker_id="worker-a", lease_seconds=30)
+        self.assertIsNotNone(claim)
+        with open_db(self.config.paths.db_path) as connection:
+            cancelling = cancel_evidence_queue(connection)
+            resumed = resume_evidence_queue(connection)
+
+        self.assertEqual(cancelling["status"], "cancel_requested")
+        self.assertEqual(resumed["status"], "cancel_requested")
+        self.assertTrue(resumed["cancel_requested"])
+
+    def test_cli_starts_paused_batch_and_runs_without_outer_db_transaction(self) -> None:
+        self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        with patch("mediaforce.cli.load_config", return_value=self.config), patch(
+            "mediaforce.cli.purge_transient_artifacts"
+        ), patch("builtins.print") as print_line:
+            exit_code = cli_main([
+                "--config",
+                str(self.config.paths.config_path),
+                "evidence",
+                "start",
+                "tv/show/item-1.mkv",
+                "--kind",
+                CADENCE_EVIDENCE_KIND,
+                "--limit",
+                "1",
+            ])
+        payload = json.loads(str(print_line.call_args.args[0]))
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(payload["status"], "paused")
+        self.assertEqual(payload["item_count"], 1)
+
+        worker_summary = {"status": "paused", "processed_count": 0, "stop_reason": "blocked"}
+        with patch("mediaforce.cli.load_config", return_value=self.config), patch(
+            "mediaforce.cli.purge_transient_artifacts"
+        ), patch(
+            "mediaforce.cli.run_evidence_queue_until_blocked",
+            return_value=worker_summary,
+        ) as run_worker, patch(
+            "mediaforce.cli.open_db",
+            side_effect=AssertionError("run command must not hold an outer database transaction"),
+        ), patch("builtins.print"):
+            exit_code = cli_main([
+                "--config",
+                str(self.config.paths.config_path),
+                "evidence",
+                "run",
+                "--max-items",
+                "1",
+            ])
+
+        self.assertEqual(exit_code, 0)
+        run_worker.assert_called_once_with(
+            config_path=self.config.paths.config_path,
+            max_work_items=1,
+            max_seconds=None,
+        )
+
+    def _insert_item(
+            self,
+            index: int,
+            *,
+            cadence_summary_json: str | None,
+            media_fingerprint_json: str | None,
+    ) -> tuple[int, Path]:
+        source_path = self.media_root / "show" / f"item-{index}.mkv"
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        source_path.write_bytes(f"fixture-{index}".encode())
+        stat_result = source_path.stat()
+        content_fingerprint = content_version_fingerprint(source_path, stat_result)
+        now = "2026-07-19T12:00:00+00:00"
+        with open_db(self.config.paths.db_path) as connection:
+            result = connection.execute(
+                library_items.insert().values(
+                    source_path=str(source_path),
+                    rel_path=f"tv/show/item-{index}.mkv",
+                    media_root="tv",
+                    parent_dir="tv/show",
+                    file_name=f"item-{index}.mkv",
+                    container=".mkv",
+                    size_bytes=stat_result.st_size,
+                    mtime_ns=stat_result.st_mtime_ns,
+                    fingerprint=file_fingerprint(source_path, stat_result, 60.0),
+                    duration_seconds=60.0,
+                    video_codec="h264",
+                    audio_track_count=1,
+                    subtitle_track_count=0,
+                    english_audio_count=1,
+                    english_subtitle_count=0,
+                    audio_summary_json="[]",
+                    subtitle_summary_json="[]",
+                    cadence_summary_json=cadence_summary_json,
+                    media_fingerprint_json=media_fingerprint_json,
+                    content_version_changed_at=now,
+                    content_version_fingerprint=content_fingerprint,
+                    status="discovered",
+                    priority_score=0,
+                    last_scan_id="fixture",
+                    discovered_at=now,
+                    last_seen_at=now,
+                    updated_at=now,
+                )
+            )
+            item_id = int(result.inserted_primary_key[0])
+            rebuild_library_item_evidence_states(connection, library_item_ids=[item_id])
+        return item_id, source_path
+
+    def _deps(
+            self,
+            analyzer: object,
+            *,
+            max_attempts: int = 3,
+            heartbeat_seconds: float = 0.05,
+    ) -> EvidenceWorkerDeps:
+        return EvidenceWorkerDeps(
+            load_config=lambda _path: self.config,
+            analyze_evidence=analyzer,
+            logger=Mock(),
+            lease_seconds=1,
+            heartbeat_seconds=heartbeat_seconds,
+            retry_base_delay_seconds=1,
+            retry_max_delay_seconds=2,
+            max_attempts=max_attempts,
+            source_retry_delay_seconds=1,
+        )
+
+    @staticmethod
+    def _cadence_summary_json() -> str:
+        return json.dumps(
+            analyze_cadence(
+                Path("unused.mkv"),
+                video_stream={
+                    "field_order": "progressive",
+                    "avg_frame_rate": "24/1",
+                    "r_frame_rate": "24/1",
+                    "time_base": "1/1000",
+                },
+                duration_seconds=60.0,
+            ),
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    @staticmethod
+    def _fingerprint_summary_json() -> str:
+        return json.dumps(
+            {
+                "schema_version": 1,
+                "analysis": {
+                    "sampled_frames": 120,
+                    "coverage": 1.0,
+                    "ranges": [],
+                    "aggregate": {"dark_frame_fraction": 0.05},
+                    "audio_probe": {"track_count": 0},
+                    "tool": {
+                        "name": "mediaforce.media_fingerprint",
+                        "version": "1",
+                        "ffmpeg_version": "ffmpeg fixture",
+                    },
+                },
+                "decision": {"status": "measured"},
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scanner_runtime.py
+++ b/tests/test_scanner_runtime.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, cast
 from unittest.mock import patch
@@ -14,8 +15,9 @@ from mediaforce.core.db_tables import library_item_evidence_state, library_items
 from mediaforce.core.models import ProbeSummary
 from mediaforce.encoding.cadence import CADENCE_EVIDENCE_KIND
 from mediaforce.encoding.fingerprint import MEDIA_FINGERPRINT_EVIDENCE_KIND
-from mediaforce.library.evidence_state import EVIDENCE_REASON_POLICY_CHANGED, EVIDENCE_REASON_RETRY_REQUIRED, \
-    EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_STATE_CLASSIFICATION_REQUIRED, EVIDENCE_STATE_CURRENT
+from mediaforce.library.evidence_state import EVIDENCE_REASON_POLICY_CHANGED, EVIDENCE_REASON_SOURCE_CHANGED, \
+    EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_STATE_CLASSIFICATION_REQUIRED, EVIDENCE_STATE_CURRENT, \
+    sync_library_item_evidence_states
 from mediaforce.library.scanner import (
     _content_version_changed,
     _failed_probe_summary,
@@ -204,11 +206,11 @@ class ScannerRuntimeTests(unittest.TestCase):
             movie = media_root / "Feature.mkv"
             movie.write_bytes(b"movie")
             config = self._config(project_root, {"movies": media_root})
-            retryable_summary = _failed_probe_summary(RuntimeError("fixture probe failure"))
-            stale_cadence = json.loads(retryable_summary.cadence_summary_json)
+            retryable_summary = self._retryable_probe_summary()
+            stale_cadence = json.loads(str(retryable_summary.cadence_summary_json))
             stale_cadence.pop("retry_required", None)
             stale_cadence["analysis"]["tool"]["version"] = "0"
-            stale_fingerprint = json.loads(retryable_summary.media_fingerprint_json)
+            stale_fingerprint = json.loads(str(retryable_summary.media_fingerprint_json))
             stale_fingerprint.pop("retry_required", None)
             stale_fingerprint["analysis"]["tool"]["version"] = "0"
 
@@ -311,6 +313,22 @@ class ScannerRuntimeTests(unittest.TestCase):
                     ):
                         scan_library(connection, config)
                     item = connection.execute(select(library_items)).mappings().one()
+                    successful = self._successful_probe_summary()
+                    connection.execute(
+                        update(library_items)
+                        .where(library_items.c.id == item["id"])
+                        .values(
+                            cadence_summary_json=successful.cadence_summary_json,
+                            media_fingerprint_json=successful.media_fingerprint_json,
+                        )
+                    )
+                    item = connection.execute(select(library_items)).mappings().one()
+                    sync_library_item_evidence_states(
+                        connection,
+                        item,
+                        preserve_source_identity=False,
+                        preserve_policy_identity=False,
+                    )
                     connection.execute(
                         update(library_items)
                         .where(library_items.c.id == item["id"])
@@ -773,7 +791,7 @@ class ScannerRuntimeTests(unittest.TestCase):
         self.assertEqual(scan_row["scope"], "limited")
         self.assertEqual(scan_row["file_count"], 0)
 
-    def test_scan_projects_and_refreshes_evidence_state_with_canonical_json(self) -> None:
+    def test_scan_preserves_canonical_evidence_and_marks_changed_source_pending(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             project_root = Path(temp_dir)
             media_root = project_root / "movies"
@@ -789,10 +807,23 @@ class ScannerRuntimeTests(unittest.TestCase):
                         return_value=_failed_probe_summary(RuntimeError("fixture failure")),
                     ):
                         scan_library(connection, config)
-                    retry_rows = connection.execute(
-                        select(library_item_evidence_state)
-                        .order_by(library_item_evidence_state.c.evidence_kind)
-                    ).mappings().fetchall()
+                    item = connection.execute(select(library_items)).mappings().one()
+                    successful = self._successful_probe_summary()
+                    connection.execute(
+                        update(library_items)
+                        .where(library_items.c.id == item["id"])
+                        .values(
+                            cadence_summary_json=successful.cadence_summary_json,
+                            media_fingerprint_json=successful.media_fingerprint_json,
+                        )
+                    )
+                    item = connection.execute(select(library_items)).mappings().one()
+                    sync_library_item_evidence_states(
+                        connection,
+                        item,
+                        preserve_source_identity=False,
+                        preserve_policy_identity=False,
+                    )
                     connection.execute(
                         update(library_item_evidence_state).values(
                             attempt_count=2,
@@ -803,13 +834,12 @@ class ScannerRuntimeTests(unittest.TestCase):
                     connection.commit()
 
                     movie.write_bytes(b"other")
-                    successful = self._successful_probe_summary()
                     with patch(
                         "mediaforce.library.scanner.probe_media",
                         return_value=successful,
                     ):
                         stats = scan_library(connection, config)
-                    current_rows = connection.execute(
+                    pending_rows = connection.execute(
                         select(library_item_evidence_state)
                         .order_by(library_item_evidence_state.c.evidence_kind)
                     ).mappings().fetchall()
@@ -817,33 +847,22 @@ class ScannerRuntimeTests(unittest.TestCase):
             finally:
                 reset_engine_cache()
 
-        self.assertEqual(
-            [(row["evidence_kind"], row["state"], row["reason"]) for row in retry_rows],
-            [
-                (CADENCE_EVIDENCE_KIND, EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_REASON_RETRY_REQUIRED),
-                (
-                    MEDIA_FINGERPRINT_EVIDENCE_KIND,
-                    EVIDENCE_STATE_ANALYSIS_REQUIRED,
-                    EVIDENCE_REASON_RETRY_REQUIRED,
-                ),
-            ],
-        )
         self.assertEqual(stats.reprobed, 1)
-        self.assertEqual([row["state"] for row in current_rows], [EVIDENCE_STATE_CURRENT, EVIDENCE_STATE_CURRENT])
-        self.assertEqual([row["attempt_count"] for row in current_rows], [0, 0])
-        self.assertEqual([row["retry_not_before"] for row in current_rows], [None, None])
+        self.assertEqual(
+            [row["state"] for row in pending_rows],
+            [EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_STATE_ANALYSIS_REQUIRED],
+        )
+        self.assertEqual([row["reason"] for row in pending_rows], [EVIDENCE_REASON_SOURCE_CHANGED] * 2)
+        self.assertEqual([row["attempt_count"] for row in pending_rows], [0, 0])
+        self.assertEqual([row["retry_not_before"] for row in pending_rows], [None, None])
         self.assertEqual(item["cadence_summary_json"], successful.cadence_summary_json)
         self.assertEqual(item["media_fingerprint_json"], successful.media_fingerprint_json)
 
-    def test_failed_probe_becomes_blocked_unknown_evidence(self) -> None:
+    def test_failed_inventory_probe_does_not_create_canonical_evidence(self) -> None:
         summary = _failed_probe_summary(RuntimeError("corrupt media"))
 
-        self.assertIn('"classification":"unknown"', summary.cadence_summary_json)
-        self.assertIn("corrupt media", summary.cadence_summary_json)
-        self.assertIn('"retry_required":true', summary.cadence_summary_json)
-        self.assertIn('"status":"unknown"', summary.media_fingerprint_json)
-        self.assertIn("corrupt media", summary.media_fingerprint_json)
-        self.assertIn('"retry_required":true', summary.media_fingerprint_json)
+        self.assertIsNone(summary.cadence_summary_json)
+        self.assertIsNone(summary.media_fingerprint_json)
 
     @staticmethod
     def _successful_probe_summary() -> ProbeSummary:
@@ -899,6 +918,19 @@ class ScannerRuntimeTests(unittest.TestCase):
             subtitle_summary_json="[]",
             cadence_summary_json=cadence_summary_json,
             media_fingerprint_json=fingerprint_json,
+        )
+
+    @classmethod
+    def _retryable_probe_summary(cls) -> ProbeSummary:
+        summary = cls._successful_probe_summary()
+        cadence = json.loads(str(summary.cadence_summary_json))
+        cadence["retry_required"] = True
+        fingerprint = json.loads(str(summary.media_fingerprint_json))
+        fingerprint["retry_required"] = True
+        return replace(
+            summary,
+            cadence_summary_json=json.dumps(cadence, separators=(",", ":"), sort_keys=True),
+            media_fingerprint_json=json.dumps(fingerprint, separators=(",", ":"), sort_keys=True),
         )
 
 


### PR DESCRIPTION
# Bounded Evidence Worker

## Summary

- make catalog scans inventory-only so they cannot launch cadence or
  fingerprint `ffmpeg` analysis
- add a paused, scoped, single-concurrency evidence queue with leases,
  heartbeat cancellation, bounded retries, restart recovery, and
  source-fingerprint commit guards
- expose explicit `mediaforce evidence`
  start/status/pause/resume/cancel/run commands and document the operator flow

## Why

Mediaforce was coupling catalog refresh with deep evidence work, so ordinary
scans could repeatedly spawn `ffmpeg`. The long-running launch item also
inherited development reload mode, causing Uvicorn to walk the checkout while
apparently idle. This change separates cheap remembered inventory/evidence
state from explicitly requested expensive work.

## Validation

- `bash scripts/pre-commit-check.sh` — 1001 backend tests plus CLI, frontend,
  build, and route smoke
- `uv build`
- PyCharm changed-files inspection — GREEN, 0 findings
- live launch-item check — `mediaforce-web --no-reload` at ~0.2% CPU with no
  `ffmpeg`/`ffprobe` children
- independent Claude and Antigravity reviews; actionable cancellation,
  missing-source, stale-state, and operator findings resolved
- folder rollout pilot — one cadence unit completed in about 6 seconds with
  zero remaining work
- root rollout pilot — one media-fingerprint unit completed in about 15
  seconds with zero remaining work

Closes #217
