### PR TITLE
Expose catalog and evidence work as operator state

### DIFF
--- a/docs/architecture/evidence-worker.md
+++ b/docs/architecture/evidence-worker.md
@@ -32,15 +32,18 @@ aggregate counts. Queue data is operational and rebuildable; canonical
 evidence is not.
 
 Alembic revision `20260719_0012` adds this operational state without creating a
-batch or queueing existing evidence. Analyzer or policy changes remain visible
-as projection state until an operator explicitly starts work.
+batch or queueing existing evidence. Revision `20260719_0013` adds the durable
+`background_work_state` switch shared by catalog inventory and evidence
+analysis. Analyzer or policy changes remain visible as projection state until
+an operator explicitly prepares and starts work.
 
 ## Batch lifecycle
 
 `start_evidence_work()` requires a non-empty resolved scope. It selects only
 non-current evidence inside that exact item or descendant scope, caps the
-batch at 25 work units by default, snapshots each source fingerprint, and
-creates the batch paused.
+batch at 25 evidence updates by default, snapshots each source fingerprint,
+and creates the batch paused. One media file can contribute two updates because
+cadence and media fingerprint are independent evidence kinds.
 
 Queue states are:
 
@@ -89,6 +92,10 @@ media.
 - Expired leases are reclaimed on the next explicit worker pass. A live lease
   is never stolen merely because another scheduler starts.
 - Pause prevents new claims but does not interrupt the active safe unit.
+- The global background-work pause prevents new catalog scans, batch creation,
+  queue resumes, and evidence claims. A scan or evidence update already running
+  is allowed to finish safely. A queued scan rechecks the switch before it opens
+  a source.
 - Cancel marks pending units cancelled and asks the heartbeat/controller path
   to terminate the active subprocess group. The attempt is restored when that
   cancellation is observed.
@@ -96,6 +103,27 @@ media.
   and reuses stored measurements without `ffmpeg` or `ffprobe`.
 
 ## Operator flow
+
+The Activity workstation exposes the same bounded state machine:
+
+1. `Refresh catalog` performs inventory only. It updates changed file facts and
+   never starts cadence or fingerprint analysis.
+2. `Prepare analysis` chooses one explicit item, folder, or root scope, evidence
+   kinds, and a maximum number of updates. The new batch is paused.
+3. `Start analysis` launches one process-local bounded runner. It exits when the
+   prepared batch completes, reaches its update budget, or becomes blocked.
+4. `Pause after this item`, `Resume analysis`, and `Cancel batch` write durable
+   queue controls near the visible scope and progress.
+5. `Pause new background work` is separate from encode approval and processing
+   controls. It governs catalog inventory and evidence analysis only.
+
+The workstation polls while a catalog scan or evidence runner is active and
+returns to manual refresh when idle. Backlog totals are paired with filters and
+pagination so every counted evidence update remains reachable. Source-root
+warnings use the scanner's preserved-cache messages rather than discarding the
+last known catalog.
+
+The CLI remains available for advanced or scripted operation.
 
 Create a paused folder pilot:
 

--- a/docs/design/basic-user-vocabulary.md
+++ b/docs/design/basic-user-vocabulary.md
@@ -9,7 +9,7 @@ implementation nouns.
 
 - Name the user's next decision before naming the subsystem.
 - Prefer short labels that describe work state: `Ready to review`, `Waiting for
-  worker`, `Needs sample`, `Safe to delete`.
+worker`, `Needs sample`, `Safe to delete`.
 - Keep implementation terms available in advanced settings, logs, tooltips, or
   metadata rows when they help diagnosis.
 - Do not use different names for the same state across routes.
@@ -85,6 +85,21 @@ debugging a worker, or comparing logs against backend output.
   tried again.
 - Historical sample failures: `Past sample issues`. Old sample/proof failures
   are history unless they block current work.
+- Catalog facts match policy: `Current`. Mediaforce can browse remembered file
+  facts without opening media.
+- Catalog age recommends another inventory pass: `Refresh suggested`.
+- A source could not be reconciled safely: `Needs a check`. Explain that cached
+  catalog state was preserved.
+- Evidence scope selected but not started: `Prepared`. Preparing never opens
+  media or starts FFmpeg.
+- Evidence analyzer owns a work unit: `Analyzing`.
+- Evidence work stopped before the next unit: `Paused`.
+- A retry delay protects the source: `Retry scheduled`.
+- The source root is unavailable: `Source unavailable`.
+- A bounded evidence batch finished cleanly: `Complete`.
+- A bounded evidence batch has failures: `Needs attention`.
+- No catalog or evidence work is active: `Quiet`. Do not imply a worker is
+  polling in the background.
 
 ### Completed
 
@@ -122,7 +137,7 @@ debugging a worker, or comparing logs against backend output.
 - Ops may expose more technical detail, but first-level headings should still
   use `workers`, `sample queue`, `processing queue`, and `retry available`.
 - Completed should use destructive language directly: `Delete archived
-  originals`, `selected originals`, `cleanup folder`, and `safe to delete`.
+originals`, `selected originals`, `cleanup folder`, and `safe to delete`.
 - Settings should split basic labels from advanced fields. `Working folder`,
   `cleanup folder`, `remote workers`, and `work windows` should be visible
   before `transcode root`, `archive root`, `SSH host`, or `staging root`.

--- a/docs/development/browser-qa-matrix.md
+++ b/docs/development/browser-qa-matrix.md
@@ -36,6 +36,10 @@ The managed smoke seeds a compact but non-empty workflow dataset:
 - Queue density: two pending `tv/Example Show/Season 1` items and one lower
   priority movie folder. The representative episode is 88 minutes so the goal
   screen resolves the 300 MB / 45 minute default to approximately 587 MB.
+- Activity catalog/evidence state: the catalog is current, four evidence updates
+  are reachable in the backlog, and a two-update `tv/Example Show/Season 1`
+  batch is prepared but paused. Loading or filtering the page must not start
+  analysis.
 - Movies Library: `/movies` includes a root-level exact file, a conventional
   title directory with two independently reachable editions, an excluded
   featurette, an uncertain nested file, active processing, completed titles,
@@ -99,6 +103,26 @@ The managed smoke seeds a compact but non-empty workflow dataset:
 Seeded rows use `last_scan_id = web-smoke-fixtures` and are replaced on each
 managed smoke run. Runtime state remains under `state/web-smoke/` and
 `scratch/web-smoke/`.
+
+## Activity Work-State Matrix
+
+For changes to catalog or evidence controls, verify these visible states in a
+real browser at desktop and 390px widths:
+
+- idle: `Quiet`, no repeating network refresh, manual refresh available
+- prepared: explicit scope/count, `Start analysis`, and `Cancel batch`
+- running: current path/evidence kind, completed/remaining counts, and elapsed
+  progress with `Pause after this item`
+- paused: scope and progress preserved with `Resume analysis`
+- retry waiting and source unavailable: plain labels plus next retry/source copy
+- failed, cancelled, and complete: terminal copy without pretending work is
+  still running
+- global pause: catalog refresh, preparation, and resume disabled while encode
+  approval/processing controls remain separate
+- source warning: cached-state preservation is explicit and the remembered
+  library count remains visible
+- backlog: filters, range, total, previous/next, and row scope controls remain
+  reachable without horizontal page overflow
 
 ## Required Route Coverage
 

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -486,6 +486,149 @@ export interface DashboardScanWarning {
 	preserved_item_count: number;
 }
 
+export interface OperatorWorkActionResult {
+	ok: boolean;
+	message: string;
+}
+
+export interface OperatorWorkBackground {
+	work_area: string;
+	is_paused: boolean;
+	updated_at: string | null;
+	status: 'active' | 'paused';
+}
+
+export interface OperatorCatalogRoot {
+	key: string;
+	label: string;
+	item_count: number;
+}
+
+export interface OperatorCatalogState {
+	status: string;
+	freshness: 'current' | 'stale' | 'unknown';
+	item_count: number;
+	last_completed_at: string | null;
+	job: DashboardScanJob | null;
+	source_roots: OperatorCatalogRoot[];
+	warnings: DashboardScanWarning[];
+	can_refresh: boolean;
+}
+
+export interface OperatorEvidenceScope extends MediaScopePayload {
+	work_limit: number;
+}
+
+export interface OperatorEvidenceRunningItem {
+	library_item_id: number;
+	evidence_kind: string;
+	attempt_count: number;
+	last_attempt_at: string | null;
+	heartbeat_at: string | null;
+	process_pid: number | null;
+	rel_path: string;
+}
+
+export interface OperatorEvidenceQueue {
+	queue_name: string;
+	batch_id: string | null;
+	status: string;
+	scope: OperatorEvidenceScope | null;
+	evidence_kinds: string[];
+	is_paused: boolean;
+	cancel_requested: boolean;
+	item_count: number;
+	completed_count: number;
+	failed_count: number;
+	cancelled_count: number;
+	created_at: string | null;
+	started_at: string | null;
+	finished_at: string | null;
+	updated_at: string | null;
+	counts: Record<string, number>;
+	running: OperatorEvidenceRunningItem | null;
+	remaining_count: number;
+}
+
+export interface OperatorEvidenceProgress {
+	total_count: number;
+	remaining_count: number;
+	done_count: number;
+	percent: number | null;
+	counts: Record<string, number>;
+	running: OperatorEvidenceRunningItem | null;
+}
+
+export interface OperatorEvidenceKindSummary {
+	total: number;
+	states: Record<string, number>;
+	reasons: Record<string, number>;
+}
+
+export interface OperatorEvidenceInventory {
+	total: number;
+	backlog_total: number;
+	by_kind: Record<string, OperatorEvidenceKindSummary>;
+}
+
+export interface OperatorEvidenceBacklogRow {
+	library_item_id: number;
+	evidence_kind: string;
+	state: string;
+	reason: string | null;
+	work_status: string | null;
+	attempt_count: number;
+	retry_not_before: string | null;
+	last_attempt_at: string | null;
+	last_error: string | null;
+	updated_at: string;
+	rel_path: string;
+	media_root: string;
+	parent_dir: string;
+	file_name: string;
+}
+
+export interface OperatorEvidenceBacklog {
+	offset: number;
+	limit: number;
+	total: number;
+	range_start: number;
+	range_end: number;
+	has_previous: boolean;
+	has_next: boolean;
+	filters: {
+		evidence_kind: string | null;
+		state: string | null;
+		media_root: string | null;
+		work_status: string | null;
+	};
+	rows: OperatorEvidenceBacklogRow[];
+}
+
+export interface OperatorEvidenceState {
+	live_status: string;
+	terminal_status: string | null;
+	runner_active: boolean;
+	queue: OperatorEvidenceQueue;
+	progress: OperatorEvidenceProgress;
+	inventory: OperatorEvidenceInventory;
+	backlog: OperatorEvidenceBacklog;
+	can_prepare: boolean;
+	can_pause: boolean;
+	can_resume: boolean;
+	can_cancel: boolean;
+}
+
+export interface OperatorWorkPayload {
+	background: OperatorWorkBackground;
+	catalog: OperatorCatalogState;
+	evidence: OperatorEvidenceState;
+	refresh: {
+		mode: 'active' | 'manual';
+		interval_ms: number | null;
+	};
+}
+
 export interface ArchiveCleanupSummary {
 	archive_root: string;
 	file_count: number;

--- a/frontend/src/lib/components/workstation/OperatorWorkConsole.svelte
+++ b/frontend/src/lib/components/workstation/OperatorWorkConsole.svelte
@@ -1,0 +1,1063 @@
+<script lang="ts">
+	import { postJson } from '$lib/api/client';
+	import type {
+		OperatorEvidenceBacklogRow,
+		OperatorWorkActionResult,
+		OperatorWorkPayload
+	} from '$lib/api/types';
+	import StateBadge from './StateBadge.svelte';
+	import WorkstationPanel from './WorkstationPanel.svelte';
+	import {
+		catalogStateView,
+		evidenceKindLabel,
+		evidenceReasonCopy,
+		evidenceStateLabel,
+		evidenceStateTone,
+		evidenceStateView,
+		evidenceWorkStatusView,
+		formatCount,
+		formatTimestamp,
+		scopeLabel,
+		type OperatorWorkQuery
+	} from './operator-work';
+
+	let {
+		work,
+		onRefresh = async () => {}
+	}: {
+		work: OperatorWorkPayload | null;
+		onRefresh?: (query?: OperatorWorkQuery) => Promise<void>;
+	} = $props();
+
+	const catalogView = $derived(catalogStateView(work?.catalog));
+	const evidenceView = $derived(evidenceStateView(work?.evidence));
+	const backgroundPaused = $derived(work?.background.is_paused ?? false);
+	const backlog = $derived(work?.evidence.backlog ?? null);
+	const queue = $derived(work?.evidence.queue ?? null);
+	const progress = $derived(work?.evidence.progress ?? null);
+	const currentItem = $derived(progress?.running ?? null);
+	const overallLabel = $derived(
+		backgroundPaused
+			? 'Background work paused'
+			: work?.refresh.mode === 'active'
+				? 'Work active'
+				: 'Quiet'
+	);
+	const overallTone = $derived(
+		backgroundPaused ? 'wait' : work?.refresh.mode === 'active' ? 'active' : 'idle'
+	);
+
+	let actionPending = $state('');
+	let actionMessage = $state('');
+	let actionError = $state('');
+	let cancelArmed = $state(false);
+	let prepareOpen = $state(false);
+	let prepareScope = $state('');
+	let prepareLimit = $state('5');
+	let prepareCadence = $state(true);
+	let prepareFingerprint = $state(true);
+	let evidenceKindFilter = $state('');
+	let evidenceStateFilter = $state('');
+	let mediaRootFilter = $state('');
+	let workStatusFilter = $state('');
+
+	function currentQuery(offset = backlog?.offset ?? 0): OperatorWorkQuery {
+		return {
+			offset,
+			limit: backlog?.limit ?? 25,
+			evidenceKind: evidenceKindFilter || undefined,
+			state: evidenceStateFilter || undefined,
+			mediaRoot: mediaRootFilter || undefined,
+			workStatus: workStatusFilter || undefined
+		};
+	}
+
+	async function runAction(id: string, path: string, body: unknown = {}) {
+		actionPending = id;
+		actionMessage = '';
+		actionError = '';
+		cancelArmed = false;
+		try {
+			const result = await postJson<OperatorWorkActionResult>(path, body);
+			actionMessage = result.message;
+			await onRefresh(currentQuery());
+		} catch (error) {
+			actionError = error instanceof Error ? error.message : 'The action could not be completed.';
+		} finally {
+			actionPending = '';
+		}
+	}
+
+	async function prepareAnalysis() {
+		const prefix = prepareScope.trim().replace(/^\/+|\/+$/g, '');
+		const evidenceKinds = [
+			...(prepareCadence ? ['cadence_analysis'] : []),
+			...(prepareFingerprint ? ['media_fingerprint'] : [])
+		];
+		if (!prefix) {
+			actionError = 'Enter one library, folder, or file scope before preparing analysis.';
+			return;
+		}
+		if (!evidenceKinds.length) {
+			actionError = 'Choose at least one kind of evidence.';
+			return;
+		}
+		await runAction('prepare', '/api/evidence-work/prepare', {
+			prefix,
+			evidence_kinds: evidenceKinds,
+			limit: Number(prepareLimit)
+		});
+		if (!actionError) prepareOpen = false;
+	}
+
+	async function applyFilters() {
+		await onRefresh(currentQuery(0));
+	}
+
+	function useRowScope(row: OperatorEvidenceBacklogRow) {
+		if (!work?.evidence.can_prepare) return;
+		prepareScope = row.parent_dir || row.rel_path;
+		prepareOpen = true;
+		actionMessage = `Scope set to ${prepareScope}. Review the batch options before preparing it.`;
+		actionError = '';
+	}
+
+	function catalogProgressCopy(): string {
+		const stats = work?.catalog.job?.stats;
+		const seen = stats?.total_seen ?? stats?.items_seen ?? 0;
+		if (work?.catalog.status === 'running') {
+			return seen ? `${formatCount(seen)} files checked so far` : 'Starting the library walk';
+		}
+		return `Last safe refresh ${formatTimestamp(work?.catalog.last_completed_at)}`;
+	}
+
+	function analysisMetric(): string {
+		if (!work) return '—';
+		if (queue?.batch_id && progress?.total_count) {
+			return `${formatCount(progress.done_count)} of ${formatCount(progress.total_count)} updates complete`;
+		}
+		return `${formatCount(work.evidence.inventory.backlog_total)} need analysis`;
+	}
+</script>
+
+<WorkstationPanel eyebrow="Catalog & analysis" title="Remembered media state">
+	<div class="work-console">
+		<div class="work-console__lead">
+			<div class="work-console__lead-copy">
+				<StateBadge tone={overallTone} label={overallLabel} />
+				<div>
+					<strong>Heavy media reads happen only when you ask.</strong>
+					<p>
+						Mediaforce keeps catalog facts and analysis results, then updates only the scope you
+						prepare. Browsing this page never starts FFmpeg.
+					</p>
+				</div>
+			</div>
+			<button
+				type="button"
+				class="work-button work-button--quiet"
+				disabled={Boolean(actionPending)}
+				onclick={() =>
+					runAction(
+						'background',
+						backgroundPaused ? '/api/background-work/resume' : '/api/background-work/pause'
+					)}
+			>
+				{actionPending === 'background'
+					? 'Working…'
+					: backgroundPaused
+						? 'Resume background work'
+						: 'Pause new background work'}
+			</button>
+		</div>
+
+		<div class="work-lanes">
+			<section class="work-lane work-lane--catalog" aria-labelledby="catalog-work-title">
+				<header class="work-lane__header">
+					<div>
+						<span class="work-lane__eyebrow">Catalog inventory</span>
+						<h4 id="catalog-work-title">
+							{formatCount(work?.catalog.item_count ?? 0)} remembered files
+						</h4>
+					</div>
+					<StateBadge tone={catalogView.tone} label={catalogView.label} />
+				</header>
+				<p class="work-lane__detail">{catalogView.detail}</p>
+				<div class="work-lane__metric">
+					<strong>{catalogProgressCopy()}</strong>
+					<span>
+						{work?.catalog.source_roots
+							.map((root) => `${root.label} ${formatCount(root.item_count)}`)
+							.join(' · ') || 'No production libraries configured'}
+					</span>
+				</div>
+				{#if work?.catalog.warnings.length}
+					<div class="source-warnings" aria-label="Catalog source warnings">
+						{#each work.catalog.warnings as warning (warning.library_key + warning.code)}
+							<div class="source-warning">
+								<strong>{warning.label} stayed remembered</strong>
+								<span>{warning.message}</span>
+							</div>
+						{/each}
+					</div>
+				{/if}
+				<div class="work-lane__actions">
+					<button
+						type="button"
+						class="work-button"
+						disabled={!work?.catalog.can_refresh || Boolean(actionPending)}
+						title={backgroundPaused
+							? 'Resume background work before refreshing the catalog.'
+							: work?.catalog.status === 'running' || work?.catalog.status === 'queued'
+								? 'A catalog refresh is already active.'
+								: 'Read library folders and update changed file facts.'}
+						onclick={() => runAction('catalog', '/api/catalog/refresh')}
+					>
+						{actionPending === 'catalog' ? 'Starting…' : 'Refresh catalog'}
+					</button>
+					<span>No cadence or fingerprint analysis starts here.</span>
+				</div>
+			</section>
+
+			<section class="work-lane work-lane--evidence" aria-labelledby="evidence-work-title">
+				<header class="work-lane__header">
+					<div>
+						<span class="work-lane__eyebrow">Evidence analysis</span>
+						<h4 id="evidence-work-title">{analysisMetric()}</h4>
+					</div>
+					<StateBadge tone={evidenceView.tone} label={evidenceView.label} />
+				</header>
+				<p class="work-lane__detail">{evidenceView.detail}</p>
+				<div class="work-lane__metric">
+					<strong>{scopeLabel(work?.evidence)}</strong>
+					<span>
+						{currentItem
+							? `${evidenceKindLabel(currentItem.evidence_kind)} · ${currentItem.rel_path}`
+							: queue?.batch_id
+								? `${formatCount(progress?.remaining_count ?? 0)} remaining · updated ${formatTimestamp(queue.updated_at)}`
+								: 'Prepare a bounded folder or library scope when evidence needs an update.'}
+					</span>
+				</div>
+				{#if progress?.total_count}
+					<div class="progress-track" aria-label={`${progress.percent ?? 0}% complete`}>
+						<span style={`width: ${progress.percent ?? 0}%`}></span>
+					</div>
+				{/if}
+				<div class="work-lane__actions work-lane__actions--cluster">
+					{#if work?.evidence.can_pause}
+						<button
+							type="button"
+							class="work-button"
+							disabled={Boolean(actionPending)}
+							onclick={() => runAction('pause-evidence', '/api/evidence-work/pause')}
+						>
+							{actionPending === 'pause-evidence' ? 'Pausing…' : 'Pause after this item'}
+						</button>
+					{:else if work?.evidence.can_resume}
+						<button
+							type="button"
+							class="work-button work-button--primary"
+							disabled={Boolean(actionPending)}
+							onclick={() => runAction('resume-evidence', '/api/evidence-work/resume')}
+						>
+							{actionPending === 'resume-evidence'
+								? 'Starting…'
+								: evidenceView.label === 'Prepared'
+									? 'Start analysis'
+									: 'Resume analysis'}
+						</button>
+					{/if}
+					{#if work?.evidence.can_cancel}
+						<button
+							type="button"
+							class="work-button work-button--danger"
+							class:work-button--armed={cancelArmed}
+							disabled={Boolean(actionPending)}
+							onclick={() =>
+								cancelArmed
+									? runAction('cancel-evidence', '/api/evidence-work/cancel')
+									: (cancelArmed = true)}
+						>
+							{actionPending === 'cancel-evidence'
+								? 'Cancelling…'
+								: cancelArmed
+									? 'Confirm cancel batch'
+									: 'Cancel batch'}
+						</button>
+					{:else if work?.evidence.can_prepare}
+						<button
+							type="button"
+							class="work-button work-button--primary"
+							disabled={Boolean(actionPending) || backgroundPaused}
+							onclick={() => (prepareOpen = !prepareOpen)}
+						>
+							{prepareOpen ? 'Close preparation' : 'Prepare analysis'}
+						</button>
+					{/if}
+				</div>
+			</section>
+		</div>
+
+		{#if prepareOpen}
+			<form
+				class="prepare-form"
+				onsubmit={(event) => (event.preventDefault(), void prepareAnalysis())}
+			>
+				<div class="prepare-form__intro">
+					<span class="work-lane__eyebrow">Prepare, then run</span>
+					<strong>Create a small paused batch</strong>
+					<p>This step only chooses work. FFmpeg does not start until you press Start analysis.</p>
+				</div>
+				<label class="field field--scope">
+					<span>Library, folder, or file scope</span>
+					<input bind:value={prepareScope} placeholder="tv/Show/Season 1" autocomplete="off" />
+				</label>
+				<fieldset class="kind-picker">
+					<legend>Evidence to update</legend>
+					<label><input type="checkbox" bind:checked={prepareCadence} /> Motion pattern</label>
+					<label
+						><input type="checkbox" bind:checked={prepareFingerprint} /> Media fingerprint</label
+					>
+				</fieldset>
+				<label class="field">
+					<span>Maximum updates</span>
+					<select bind:value={prepareLimit}>
+						<option value="1">1 update</option>
+						<option value="5">5 updates</option>
+						<option value="10">10 updates</option>
+						<option value="25">25 updates</option>
+					</select>
+				</label>
+				<button
+					type="submit"
+					class="work-button work-button--primary"
+					disabled={Boolean(actionPending) || !work?.evidence.can_prepare}
+					title={work?.evidence.can_prepare
+						? 'Prepare this bounded evidence batch.'
+						: 'Finish or cancel the active batch before preparing another scope.'}
+				>
+					{actionPending === 'prepare' ? 'Preparing…' : 'Prepare paused batch'}
+				</button>
+			</form>
+		{/if}
+
+		{#if actionMessage || actionError}
+			<div class="action-note" class:action-note--error={Boolean(actionError)} aria-live="polite">
+				{actionError || actionMessage}
+			</div>
+		{/if}
+
+		<section class="backlog" aria-labelledby="evidence-backlog-title">
+			<header class="backlog__header">
+				<div>
+					<span class="work-lane__eyebrow">Reachable backlog</span>
+					<h4 id="evidence-backlog-title">Evidence that needs an update</h4>
+				</div>
+				<strong>
+					{backlog?.total
+						? `${formatCount(backlog.range_start)}–${formatCount(backlog.range_end)} of ${formatCount(backlog.total)}`
+						: 'No matching items'}
+				</strong>
+			</header>
+
+			<div class="backlog-filters">
+				<label>
+					<span>Evidence</span>
+					<select bind:value={evidenceKindFilter} onchange={() => void applyFilters()}>
+						<option value="">All evidence</option>
+						<option value="cadence_analysis">Motion pattern</option>
+						<option value="media_fingerprint">Media fingerprint</option>
+					</select>
+				</label>
+				<label>
+					<span>Reason</span>
+					<select bind:value={evidenceStateFilter} onchange={() => void applyFilters()}>
+						<option value="">All reasons</option>
+						<option value="analysis_required">Needs analysis</option>
+						<option value="classification_required">Needs update only</option>
+					</select>
+				</label>
+				<label>
+					<span>Library</span>
+					<select bind:value={mediaRootFilter} onchange={() => void applyFilters()}>
+						<option value="">All libraries</option>
+						{#each work?.catalog.source_roots ?? [] as root (root.key)}
+							<option value={root.key}>{root.label}</option>
+						{/each}
+					</select>
+				</label>
+				<label>
+					<span>Batch state</span>
+					<select bind:value={workStatusFilter} onchange={() => void applyFilters()}>
+						<option value="">All batch states</option>
+						<option value="not_prepared">Not prepared</option>
+						<option value="queued">Prepared</option>
+						<option value="running">Running</option>
+						<option value="retry_wait">Retry scheduled</option>
+						<option value="waiting_source">Source unavailable</option>
+						<option value="failed">Failed</option>
+						<option value="cancelled">Cancelled</option>
+					</select>
+				</label>
+			</div>
+
+			<div class="backlog-table-wrap">
+				<table class="backlog-table">
+					<thead>
+						<tr>
+							<th>Media</th>
+							<th>Evidence</th>
+							<th>Why</th>
+							<th>Batch</th>
+							<th>Attempts</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each backlog?.rows ?? [] as row (row.library_item_id + ':' + row.evidence_kind)}
+							{@const workState = evidenceWorkStatusView(row)}
+							<tr>
+								<td data-label="Media">
+									<strong>{row.file_name}</strong>
+									<span class="path-copy">{row.parent_dir}</span>
+									<button
+										type="button"
+										class="text-action"
+										disabled={!work?.evidence.can_prepare}
+										title={work?.evidence.can_prepare
+											? 'Use this folder as the next bounded analysis scope.'
+											: 'Finish or cancel the active batch before preparing another scope.'}
+										onclick={() => useRowScope(row)}
+									>
+										Use this folder
+									</button>
+								</td>
+								<td data-label="Evidence">
+									<strong>{evidenceKindLabel(row.evidence_kind)}</strong>
+									<StateBadge
+										compact
+										tone={evidenceStateTone(row.state)}
+										label={evidenceStateLabel(row.state)}
+									/>
+								</td>
+								<td data-label="Why">
+									<span>{evidenceReasonCopy(row.reason)}</span>
+								</td>
+								<td data-label="Batch">
+									<StateBadge compact tone={workState.tone} label={workState.label} />
+									<span>{row.last_error || workState.detail}</span>
+								</td>
+								<td data-label="Attempts">
+									<strong>{row.attempt_count}</strong>
+									<span>
+										{row.retry_not_before
+											? `Next ${formatTimestamp(row.retry_not_before)}`
+											: `Updated ${formatTimestamp(row.updated_at)}`}
+									</span>
+								</td>
+							</tr>
+						{:else}
+							<tr>
+								<td colspan="5" class="backlog-empty">
+									<strong>No evidence matches these filters.</strong>
+									<span>Change a filter or refresh the catalog to update remembered state.</span>
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+
+			<footer class="backlog__footer">
+				<span>Every number above is reachable here; pages never start analysis.</span>
+				<div>
+					<button
+						type="button"
+						class="work-button work-button--quiet"
+						disabled={!backlog?.has_previous || Boolean(actionPending)}
+						onclick={() =>
+							void onRefresh(
+								currentQuery(Math.max(0, (backlog?.offset ?? 0) - (backlog?.limit ?? 25)))
+							)}
+					>
+						Previous
+					</button>
+					<button
+						type="button"
+						class="work-button work-button--quiet"
+						disabled={!backlog?.has_next || Boolean(actionPending)}
+						onclick={() =>
+							void onRefresh(currentQuery((backlog?.offset ?? 0) + (backlog?.limit ?? 25)))}
+					>
+						Next
+					</button>
+				</div>
+			</footer>
+		</section>
+	</div>
+</WorkstationPanel>
+
+<style>
+	.work-console {
+		color: var(--mf-fg-primary);
+	}
+
+	.work-console__lead {
+		align-items: center;
+		background: var(--mf-bg-strip);
+		border-bottom: var(--mf-border-muted);
+		display: flex;
+		gap: var(--mf-space-6);
+		justify-content: space-between;
+		padding: var(--mf-space-5) var(--mf-space-6);
+	}
+
+	.work-console__lead-copy {
+		align-items: flex-start;
+		display: flex;
+		gap: var(--mf-space-5);
+		min-width: 0;
+	}
+
+	.work-console__lead-copy strong,
+	.prepare-form__intro strong {
+		display: block;
+		font-size: var(--mf-text-sm);
+		font-weight: var(--mf-weight-semibold);
+	}
+
+	.work-console__lead-copy p,
+	.prepare-form__intro p {
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-xs);
+		line-height: var(--mf-leading-normal);
+		margin: 2px 0 0;
+		max-width: 760px;
+	}
+
+	.work-lanes {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+
+	.work-lane {
+		display: flex;
+		flex-direction: column;
+		gap: var(--mf-space-5);
+		min-width: 0;
+		padding: var(--mf-space-6);
+	}
+
+	.work-lane + .work-lane {
+		border-left: var(--mf-border-muted);
+	}
+
+	.work-lane--catalog {
+		box-shadow: inset 3px 0 0 var(--mf-ready-line);
+	}
+
+	.work-lane--evidence {
+		box-shadow: inset 3px 0 0 var(--mf-active-line);
+	}
+
+	.work-lane__header {
+		align-items: flex-start;
+		display: flex;
+		gap: var(--mf-space-5);
+		justify-content: space-between;
+	}
+
+	.work-lane__eyebrow {
+		color: var(--mf-fg-tertiary);
+		display: block;
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0.08em;
+		margin-bottom: var(--mf-space-2);
+		text-transform: uppercase;
+	}
+
+	.work-lane h4,
+	.backlog h4 {
+		font-size: var(--mf-text-lg);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: -0.01em;
+		margin: 0;
+	}
+
+	.work-lane__detail {
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-sm);
+		line-height: var(--mf-leading-normal);
+		margin: 0;
+	}
+
+	.work-lane__metric {
+		background: var(--mf-bg-panel-2);
+		border: var(--mf-border-muted);
+		border-radius: var(--mf-radius-2);
+		display: flex;
+		flex-direction: column;
+		gap: var(--mf-space-2);
+		min-height: 58px;
+		padding: var(--mf-space-4) var(--mf-space-5);
+	}
+
+	.work-lane__metric strong {
+		font-family: var(--mf-font-mono);
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-medium);
+	}
+
+	.work-lane__metric span,
+	.work-lane__actions span,
+	.source-warning span,
+	.backlog-table td span,
+	.backlog__footer > span {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-xs);
+		line-height: var(--mf-leading-normal);
+	}
+
+	.source-warnings {
+		display: grid;
+		gap: var(--mf-space-3);
+	}
+
+	.source-warning {
+		background: var(--mf-wait-bg);
+		border-left: 3px solid var(--mf-wait-line);
+		display: flex;
+		flex-direction: column;
+		gap: var(--mf-space-1);
+		padding: var(--mf-space-4) var(--mf-space-5);
+	}
+
+	.source-warning strong {
+		color: var(--mf-wait-fg);
+		font-size: var(--mf-text-xs);
+	}
+
+	.work-lane__actions {
+		align-items: center;
+		display: flex;
+		gap: var(--mf-space-4);
+		margin-top: auto;
+	}
+
+	.work-lane__actions--cluster {
+		flex-wrap: wrap;
+	}
+
+	.progress-track {
+		background: var(--mf-bg-raised);
+		border-radius: 999px;
+		height: 6px;
+		overflow: hidden;
+	}
+
+	.progress-track span {
+		background: var(--mf-active-solid);
+		display: block;
+		height: 100%;
+		transition: width var(--mf-dur-slow) var(--mf-ease);
+	}
+
+	.work-button {
+		align-items: center;
+		background: var(--mf-bg-panel);
+		border: var(--mf-border-strong);
+		border-radius: var(--mf-radius-1);
+		color: var(--mf-fg-primary);
+		cursor: pointer;
+		display: inline-flex;
+		font-family: var(--mf-font-sans);
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-semibold);
+		justify-content: center;
+		min-height: var(--mf-control-md);
+		padding: 0 var(--mf-space-5);
+		transition:
+			background var(--mf-dur-fast) var(--mf-ease),
+			border-color var(--mf-dur-fast) var(--mf-ease);
+	}
+
+	.work-button:hover:not(:disabled) {
+		background: var(--mf-bg-raised);
+	}
+
+	.work-button:focus-visible,
+	.text-action:focus-visible,
+	input:focus-visible,
+	select:focus-visible {
+		outline: none;
+		box-shadow: var(--mf-ring-focus);
+	}
+
+	.work-button:disabled {
+		cursor: not-allowed;
+		opacity: 0.46;
+	}
+
+	.work-button--primary {
+		background: var(--mf-active-solid);
+		border-color: var(--mf-active-solid);
+		color: var(--mf-fg-on-accent);
+	}
+
+	.work-button--primary:hover:not(:disabled) {
+		background: var(--mf-active-solid-hi);
+	}
+
+	.work-button--quiet {
+		background: transparent;
+	}
+
+	.work-button--danger {
+		color: var(--mf-fail-fg);
+	}
+
+	.work-button--danger.work-button--armed {
+		background: var(--mf-fail-solid);
+		border-color: var(--mf-fail-solid);
+		color: var(--mf-fg-on-accent);
+	}
+
+	.prepare-form {
+		align-items: end;
+		background: var(--mf-active-bg);
+		border-bottom: var(--mf-border-muted);
+		border-top: 1px solid var(--mf-active-line);
+		display: grid;
+		gap: var(--mf-space-5);
+		grid-template-columns: minmax(220px, 1.2fr) minmax(240px, 1.4fr) minmax(190px, 1fr) 130px auto;
+		padding: var(--mf-space-6);
+	}
+
+	.prepare-form__intro {
+		align-self: center;
+	}
+
+	.field,
+	.kind-picker,
+	.backlog-filters label {
+		display: flex;
+		flex-direction: column;
+		gap: var(--mf-space-2);
+		min-width: 0;
+	}
+
+	.field > span,
+	.kind-picker legend,
+	.backlog-filters label > span {
+		color: var(--mf-fg-secondary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0.03em;
+	}
+
+	.kind-picker {
+		border: 0;
+		margin: 0;
+		padding: 0;
+	}
+
+	.kind-picker label {
+		align-items: center;
+		display: flex;
+		font-size: var(--mf-text-xs);
+		gap: var(--mf-space-3);
+	}
+
+	input,
+	select {
+		background: var(--mf-bg-input);
+		border: var(--mf-border-strong);
+		border-radius: var(--mf-radius-1);
+		color: var(--mf-fg-primary);
+		font-family: var(--mf-font-sans);
+		font-size: var(--mf-text-xs);
+		height: var(--mf-control-lg);
+		min-width: 0;
+		padding: 0 var(--mf-space-4);
+	}
+
+	.action-note {
+		background: var(--mf-ready-bg);
+		border-bottom: 1px solid var(--mf-ready-line);
+		color: var(--mf-ready-fg);
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-medium);
+		padding: var(--mf-space-4) var(--mf-space-6);
+	}
+
+	.action-note--error {
+		background: var(--mf-fail-bg);
+		border-color: var(--mf-fail-line);
+		color: var(--mf-fail-fg);
+	}
+
+	.backlog {
+		border-top: var(--mf-border-muted);
+	}
+
+	.backlog__header,
+	.backlog__footer {
+		align-items: center;
+		display: flex;
+		gap: var(--mf-space-5);
+		justify-content: space-between;
+		padding: var(--mf-space-5) var(--mf-space-6);
+	}
+
+	.backlog__header strong {
+		color: var(--mf-fg-secondary);
+		font-family: var(--mf-font-mono);
+		font-size: var(--mf-text-xs);
+	}
+
+	.backlog-filters {
+		background: var(--mf-bg-panel-2);
+		border-bottom: var(--mf-border-muted);
+		border-top: var(--mf-border-muted);
+		display: grid;
+		gap: var(--mf-space-4);
+		grid-template-columns: repeat(4, minmax(130px, 1fr));
+		padding: var(--mf-space-4) var(--mf-space-6);
+	}
+
+	.backlog-table-wrap {
+		overflow-x: auto;
+	}
+
+	.backlog-table {
+		border-collapse: collapse;
+		font-size: var(--mf-text-xs);
+		min-width: 720px;
+		table-layout: fixed;
+		width: 100%;
+	}
+
+	.backlog-table th:nth-child(1) {
+		width: 25%;
+	}
+
+	.backlog-table th:nth-child(2) {
+		width: 18%;
+	}
+
+	.backlog-table th:nth-child(3) {
+		width: 24%;
+	}
+
+	.backlog-table th:nth-child(4) {
+		width: 23%;
+	}
+
+	.backlog-table th:nth-child(5) {
+		width: 10%;
+	}
+
+	.backlog-table th {
+		background: var(--mf-bg-strip);
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0.05em;
+		padding: var(--mf-space-3) var(--mf-space-5);
+		text-align: left;
+		text-transform: uppercase;
+	}
+
+	.backlog-table td {
+		border-top: var(--mf-border-muted);
+		max-width: 300px;
+		padding: var(--mf-space-4) var(--mf-space-5);
+		vertical-align: top;
+	}
+
+	.backlog-table td > strong,
+	.backlog-table td > span {
+		display: block;
+	}
+
+	.backlog-table td > strong {
+		font-weight: var(--mf-weight-semibold);
+		margin-bottom: var(--mf-space-2);
+	}
+
+	.path-copy {
+		font-family: var(--mf-font-mono);
+		max-width: 280px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.text-action {
+		background: none;
+		border: 0;
+		color: var(--mf-active-fg);
+		cursor: pointer;
+		font-family: var(--mf-font-sans);
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-semibold);
+		margin-top: var(--mf-space-3);
+		padding: 0;
+	}
+
+	.text-action:disabled {
+		color: var(--mf-fg-quaternary);
+		cursor: not-allowed;
+	}
+
+	.backlog-empty {
+		padding: var(--mf-space-8) !important;
+		text-align: center;
+	}
+
+	.backlog-empty span {
+		margin-top: var(--mf-space-2);
+	}
+
+	.backlog__footer {
+		background: var(--mf-bg-strip);
+		border-top: var(--mf-border-muted);
+	}
+
+	.backlog__footer div {
+		display: flex;
+		gap: var(--mf-space-3);
+	}
+
+	@media (max-width: 1080px) {
+		.prepare-form {
+			grid-template-columns: 1fr 1.5fr 1fr;
+		}
+
+		.prepare-form__intro {
+			grid-column: 1 / -1;
+		}
+	}
+
+	@media (max-width: 760px) {
+		.work-console__lead {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.work-console__lead-copy {
+			flex-direction: column;
+		}
+
+		.work-lanes {
+			grid-template-columns: 1fr;
+		}
+
+		.work-lane + .work-lane {
+			border-left: 0;
+			border-top: var(--mf-border-muted);
+		}
+
+		.prepare-form,
+		.backlog-filters {
+			grid-template-columns: 1fr 1fr;
+		}
+
+		.prepare-form__intro,
+		.field--scope {
+			grid-column: 1 / -1;
+		}
+	}
+
+	@media (max-width: 520px) {
+		.work-console__lead,
+		.work-lane,
+		.prepare-form,
+		.backlog__header,
+		.backlog__footer,
+		.backlog-filters {
+			padding-left: var(--mf-space-5);
+			padding-right: var(--mf-space-5);
+		}
+
+		.work-lane__header,
+		.backlog__header,
+		.backlog__footer {
+			align-items: flex-start;
+			flex-direction: column;
+		}
+
+		.work-lane__actions {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.work-button {
+			width: 100%;
+		}
+
+		.prepare-form,
+		.backlog-filters {
+			grid-template-columns: 1fr;
+		}
+
+		.prepare-form__intro,
+		.field--scope {
+			grid-column: auto;
+		}
+
+		.backlog-table-wrap {
+			overflow: visible;
+		}
+
+		.backlog-table {
+			min-width: 0;
+		}
+
+		.backlog-table thead {
+			display: none;
+		}
+
+		.backlog-table,
+		.backlog-table tbody,
+		.backlog-table tr,
+		.backlog-table td {
+			display: block;
+			width: 100%;
+		}
+
+		.backlog-table tr {
+			border-top: var(--mf-border-muted);
+			padding: var(--mf-space-4) var(--mf-space-5);
+		}
+
+		.backlog-table td {
+			border: 0;
+			display: grid;
+			grid-template-columns: 92px minmax(0, 1fr);
+			max-width: none;
+			padding: var(--mf-space-3) 0;
+		}
+
+		.backlog-table td::before {
+			color: var(--mf-fg-tertiary);
+			content: attr(data-label);
+			font-size: var(--mf-text-2xs);
+			font-weight: var(--mf-weight-semibold);
+			letter-spacing: 0.05em;
+			text-transform: uppercase;
+		}
+
+		.backlog-empty {
+			display: block !important;
+		}
+
+		.path-copy {
+			white-space: normal;
+		}
+
+		.backlog__footer div {
+			width: 100%;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
-	import { onDestroy, onMount } from 'svelte';
+	import { onMount } from 'svelte';
 	import { resolve } from '$app/paths';
 	import { postJson } from '$lib/api/client';
-	import type { DashboardSummaryPayload, HostRuntime, HostsPayload } from '$lib/api/types';
+	import type {
+		DashboardSummaryPayload,
+		HostRuntime,
+		HostsPayload,
+		OperatorWorkPayload
+	} from '$lib/api/types';
 	import { folderRoutePath } from '$lib/folder-display';
+	import OperatorWorkConsole from './OperatorWorkConsole.svelte';
 	import OperatorShell from './OperatorShell.svelte';
 	import StateBadge from './StateBadge.svelte';
 	import WorkstationPanel from './WorkstationPanel.svelte';
@@ -26,19 +32,22 @@
 		type OpsActionId,
 		type OpsQueueRow
 	} from './ops-workstation';
-
-	const OPS_REFRESH_INTERVAL_MS = 15_000;
+	import { operatorRefreshInterval, type OperatorWorkQuery } from './operator-work';
 
 	let {
 		dashboard,
 		hosts,
+		operatorWork,
 		loadError,
-		onRefresh = async () => {}
+		onRefresh = async () => {},
+		onOperatorRefresh = async () => {}
 	}: {
 		dashboard: DashboardSummaryPayload | null;
 		hosts: HostsPayload | null;
+		operatorWork: OperatorWorkPayload | null;
 		loadError: string | null;
 		onRefresh?: () => Promise<void>;
+		onOperatorRefresh?: (query?: OperatorWorkQuery) => Promise<void>;
 	} = $props();
 
 	const queueRows = $derived(buildOpsQueueRows(dashboard));
@@ -57,6 +66,14 @@
 	const readyHosts = $derived(hosts?.hosts.filter((host) => host.available).length ?? 0);
 	const fleetHasReadyCapacity = $derived(readyHosts > 0);
 	const closedHosts = $derived(hosts?.hosts.filter((host) => host.schedule_open === false) ?? []);
+	const liveRefreshInterval = $derived(
+		operatorRefreshInterval(operatorWork) ??
+			(!encodeQueue?.state.is_paused &&
+			!encodeQueue?.state.stop_requested &&
+			(encodeWorkCount > 0 || (calibrationQueue?.active_count ?? 0) > 0)
+				? 5_000
+				: null)
+	);
 
 	let actionPending = $state<OpsActionId | null>(null);
 	let confirmationAction = $state<OpsActionId | null>(null);
@@ -66,7 +83,6 @@
 	let refreshError = $state('');
 	let lastRefreshAt = $state<Date | null>(null);
 	let hostPasswords = $state<Record<string, string>>({});
-	let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
 	const globalCommands = $derived([
 		{
@@ -219,12 +235,14 @@
 
 	function refreshCopy(): string {
 		if (refreshPending) return 'refreshing';
-		if (!lastRefreshAt) return 'auto-refresh every 15s';
-		return `refreshed ${lastRefreshAt.toLocaleTimeString([], {
+		if (!lastRefreshAt)
+			return liveRefreshInterval ? 'watching active work' : 'manual refresh while idle';
+		const refreshedAt = lastRefreshAt.toLocaleTimeString([], {
 			hour: '2-digit',
 			minute: '2-digit',
 			second: '2-digit'
-		})}`;
+		});
+		return `refreshed ${refreshedAt} · ${liveRefreshInterval ? 'watching active work' : 'quiet while idle'}`;
 	}
 
 	function rowActionDisabled(row: OpsQueueRow): boolean {
@@ -285,11 +303,13 @@
 
 	onMount(() => {
 		lastRefreshAt = new Date();
-		refreshTimer = setInterval(() => void refreshOps({ quiet: true }), OPS_REFRESH_INTERVAL_MS);
 	});
 
-	onDestroy(() => {
-		if (refreshTimer) clearInterval(refreshTimer);
+	$effect(() => {
+		const interval = liveRefreshInterval;
+		if (!interval) return;
+		const timer = setInterval(() => void refreshOps({ quiet: true }), interval);
+		return () => clearInterval(timer);
 	});
 </script>
 
@@ -325,6 +345,8 @@
 					>
 				</div>
 			</header>
+
+			<OperatorWorkConsole work={operatorWork} onRefresh={onOperatorRefresh} />
 
 			<WorkstationPanel eyebrow="Attention" title="Needs your attention">
 				<div class="blocker-list">

--- a/frontend/src/lib/components/workstation/operator-work.test.ts
+++ b/frontend/src/lib/components/workstation/operator-work.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import type { OperatorEvidenceBacklogRow, OperatorEvidenceState } from '$lib/api/types';
+import {
+	catalogStateView,
+	evidenceStateView,
+	evidenceWorkStatusView,
+	operatorRefreshInterval
+} from './operator-work';
+
+function evidenceFixture(status: string, runnerActive = false): OperatorEvidenceState {
+	return {
+		live_status: status,
+		terminal_status: null,
+		runner_active: runnerActive,
+		queue: {
+			queue_name: 'evidence',
+			batch_id: 'batch-1',
+			status,
+			scope: null,
+			evidence_kinds: ['cadence_analysis'],
+			is_paused: status === 'paused',
+			cancel_requested: false,
+			item_count: 4,
+			completed_count: 0,
+			failed_count: 0,
+			cancelled_count: 0,
+			created_at: '2026-07-19T12:00:00+00:00',
+			started_at: null,
+			finished_at: null,
+			updated_at: '2026-07-19T12:00:00+00:00',
+			counts: { queued: 4 },
+			running: null,
+			remaining_count: 4
+		},
+		progress: {
+			total_count: 4,
+			remaining_count: 4,
+			done_count: 0,
+			percent: 0,
+			counts: { queued: 4 },
+			running: null
+		},
+		inventory: { total: 10, backlog_total: 4, by_kind: {} },
+		backlog: {
+			offset: 0,
+			limit: 25,
+			total: 4,
+			range_start: 1,
+			range_end: 4,
+			has_previous: false,
+			has_next: false,
+			filters: { evidence_kind: null, state: null, media_root: null, work_status: null },
+			rows: []
+		},
+		can_prepare: false,
+		can_pause: false,
+		can_resume: true,
+		can_cancel: true
+	};
+}
+
+describe('operator work copy', () => {
+	it('distinguishes current, stale, and failed catalog states', () => {
+		expect(
+			catalogStateView({
+				status: 'idle',
+				freshness: 'current',
+				item_count: 20,
+				last_completed_at: null,
+				job: null,
+				source_roots: [],
+				warnings: [],
+				can_refresh: true
+			}).label
+		).toBe('Current');
+		expect(
+			catalogStateView({
+				status: 'idle',
+				freshness: 'stale',
+				item_count: 20,
+				last_completed_at: null,
+				job: null,
+				source_roots: [],
+				warnings: [],
+				can_refresh: true
+			}).label
+		).toBe('Refresh suggested');
+		expect(
+			catalogStateView({
+				status: 'failed',
+				freshness: 'unknown',
+				item_count: 20,
+				last_completed_at: null,
+				job: { error: 'Source offline' } as never,
+				source_roots: [],
+				warnings: [],
+				can_refresh: true
+			}).detail
+		).toBe('Source offline');
+	});
+
+	it('uses prepared, running, and terminal analysis language', () => {
+		expect(evidenceStateView(evidenceFixture('paused')).label).toBe('Prepared');
+		expect(evidenceStateView(evidenceFixture('queued', true)).label).toBe('Analyzing');
+		expect(evidenceStateView(evidenceFixture('completed_with_errors')).label).toBe(
+			'Needs attention'
+		);
+	});
+
+	it('labels retry and source waits without raw state names', () => {
+		const row = {
+			work_status: 'retry_wait',
+			last_error: 'temporary failure'
+		} as OperatorEvidenceBacklogRow;
+		expect(evidenceWorkStatusView(row).label).toBe('Retry scheduled');
+		expect(evidenceWorkStatusView({ ...row, work_status: 'waiting_source' }).label).toBe(
+			'Source unavailable'
+		);
+	});
+
+	it('polls only while the server reports active work', () => {
+		expect(
+			operatorRefreshInterval({ refresh: { mode: 'manual', interval_ms: null } } as never)
+		).toBeNull();
+		expect(
+			operatorRefreshInterval({ refresh: { mode: 'active', interval_ms: 2500 } } as never)
+		).toBe(2500);
+	});
+});

--- a/frontend/src/lib/components/workstation/operator-work.ts
+++ b/frontend/src/lib/components/workstation/operator-work.ts
@@ -1,0 +1,251 @@
+import type {
+	OperatorCatalogState,
+	OperatorEvidenceBacklogRow,
+	OperatorEvidenceState,
+	OperatorWorkPayload
+} from '$lib/api/types';
+
+export type OperatorStateTone = 'active' | 'ready' | 'wait' | 'fail' | 'idle';
+
+export interface OperatorStateView {
+	label: string;
+	tone: OperatorStateTone;
+	detail: string;
+}
+
+export interface OperatorWorkQuery {
+	offset?: number;
+	limit?: number;
+	evidenceKind?: string;
+	state?: string;
+	mediaRoot?: string;
+	workStatus?: string;
+}
+
+export function catalogStateView(
+	catalog: OperatorCatalogState | null | undefined
+): OperatorStateView {
+	if (!catalog) {
+		return { label: 'Unknown', tone: 'idle', detail: 'Catalog status has not loaded yet.' };
+	}
+	if (catalog.status === 'running') {
+		return {
+			label: 'Refreshing',
+			tone: 'active',
+			detail: 'Reading changed files and preserving remembered results while the refresh runs.'
+		};
+	}
+	if (catalog.status === 'queued') {
+		return {
+			label: 'Queued',
+			tone: 'wait',
+			detail: 'The catalog refresh is waiting to start.'
+		};
+	}
+	if (catalog.status === 'failed') {
+		return {
+			label: 'Refresh failed',
+			tone: 'fail',
+			detail: catalog.job?.error || 'The last catalog refresh did not finish.'
+		};
+	}
+	if (catalog.status === 'paused') {
+		return {
+			label: 'Paused',
+			tone: 'wait',
+			detail:
+				'Background work was paused before this refresh began. Remembered catalog facts were unchanged.'
+		};
+	}
+	if (catalog.freshness === 'current') {
+		return {
+			label: 'Current',
+			tone: 'ready',
+			detail: 'Remembered file facts match the current catalog policy.'
+		};
+	}
+	if (catalog.freshness === 'stale') {
+		return {
+			label: 'Refresh suggested',
+			tone: 'wait',
+			detail: 'The remembered catalog is old enough to check again.'
+		};
+	}
+	return {
+		label: 'Needs a check',
+		tone: 'idle',
+		detail: 'Mediaforce is keeping the last known catalog until a safe refresh completes.'
+	};
+}
+
+export function evidenceStateView(
+	evidence: OperatorEvidenceState | null | undefined
+): OperatorStateView {
+	if (!evidence) {
+		return { label: 'Unknown', tone: 'idle', detail: 'Analysis status has not loaded yet.' };
+	}
+	const queue = evidence.queue;
+	if (queue.status === 'cancel_requested') {
+		return {
+			label: 'Cancelling',
+			tone: 'wait',
+			detail: 'Stopping the active analyzer and cancelling every item that has not started.'
+		};
+	}
+	if (evidence.runner_active || queue.status === 'running') {
+		return {
+			label: 'Analyzing',
+			tone: 'active',
+			detail: 'Expensive media analysis is running for the prepared batch.'
+		};
+	}
+	if (queue.status === 'paused') {
+		const started = evidence.progress.done_count > 0 || Boolean(queue.started_at);
+		return {
+			label: started ? 'Paused' : 'Prepared',
+			tone: 'wait',
+			detail: started
+				? 'No new analyzer will start until you resume this batch.'
+				: 'The scope is prepared, but no media will be opened until you start analysis.'
+		};
+	}
+	if (queue.status === 'queued') {
+		return {
+			label: 'Ready to continue',
+			tone: 'wait',
+			detail: 'Prepared work is waiting for an explicit start.'
+		};
+	}
+	if (queue.status === 'completed_with_errors') {
+		return {
+			label: 'Needs attention',
+			tone: 'fail',
+			detail: 'The bounded batch finished, but one or more items could not be updated.'
+		};
+	}
+	if (queue.status === 'cancelled') {
+		return {
+			label: 'Cancelled',
+			tone: 'idle',
+			detail: 'The last prepared batch was cancelled.'
+		};
+	}
+	if (queue.status === 'completed' && queue.batch_id) {
+		return {
+			label: 'Complete',
+			tone: 'ready',
+			detail: 'The last prepared batch finished.'
+		};
+	}
+	return {
+		label: 'Quiet',
+		tone: 'idle',
+		detail: 'No expensive analysis is running. Mediaforce is using remembered evidence.'
+	};
+}
+
+export function evidenceKindLabel(kind: string): string {
+	if (kind === 'cadence_analysis') return 'Motion pattern';
+	if (kind === 'media_fingerprint') return 'Media fingerprint';
+	return humanize(kind);
+}
+
+export function evidenceStateLabel(state: string): string {
+	if (state === 'current') return 'Current';
+	if (state === 'analysis_required') return 'Needs analysis';
+	if (state === 'classification_required') return 'Needs update';
+	return humanize(state);
+}
+
+export function evidenceStateTone(state: string): OperatorStateTone {
+	if (state === 'current') return 'ready';
+	if (state === 'analysis_required') return 'wait';
+	if (state === 'classification_required') return 'active';
+	return 'idle';
+}
+
+export function evidenceReasonCopy(reason: string | null): string {
+	if (!reason) return 'Evidence is not current.';
+	if (reason === 'missing') return 'No saved measurement exists yet.';
+	if (reason === 'malformed') return 'The saved measurement could not be read.';
+	if (reason === 'retry_required') return 'A previous measurement asked for another pass.';
+	if (reason === 'schema_changed') return 'The measurement format changed.';
+	if (reason === 'tool_changed') return 'The analyzer changed.';
+	if (reason === 'source_changed') return 'The media file changed.';
+	if (reason === 'policy_changed')
+		return 'The interpretation policy changed; stored measurements can be reused.';
+	return 'Mediaforce cannot prove this evidence is current.';
+}
+
+export function evidenceWorkStatusView(row: OperatorEvidenceBacklogRow): OperatorStateView {
+	const status = row.work_status;
+	if (!status) {
+		return { label: 'Not prepared', tone: 'idle', detail: 'This item is not in the active batch.' };
+	}
+	if (status === 'queued') {
+		return { label: 'Prepared', tone: 'wait', detail: 'Waiting for an explicit start.' };
+	}
+	if (status === 'running') {
+		return { label: 'Running', tone: 'active', detail: 'The analyzer owns this item now.' };
+	}
+	if (status === 'retry_wait') {
+		return {
+			label: 'Retry scheduled',
+			tone: 'wait',
+			detail: 'A retry delay is protecting the source.'
+		};
+	}
+	if (status === 'waiting_source') {
+		return {
+			label: 'Source unavailable',
+			tone: 'wait',
+			detail: 'The library must return before retrying.'
+		};
+	}
+	if (status === 'failed') {
+		return {
+			label: 'Failed',
+			tone: 'fail',
+			detail: row.last_error || 'Analysis could not finish.'
+		};
+	}
+	if (status === 'cancelled') {
+		return { label: 'Cancelled', tone: 'idle', detail: 'This prepared item was cancelled.' };
+	}
+	if (status === 'completed') {
+		return { label: 'Complete', tone: 'ready', detail: 'Saved evidence is current.' };
+	}
+	return { label: humanize(status), tone: 'idle', detail: 'Stored work state.' };
+}
+
+export function operatorRefreshInterval(
+	work: OperatorWorkPayload | null | undefined
+): number | null {
+	if (!work || work.refresh.mode !== 'active') return null;
+	return work.refresh.interval_ms ?? 2_500;
+}
+
+export function scopeLabel(evidence: OperatorEvidenceState | null | undefined): string {
+	const scope = evidence?.queue.scope;
+	return scope?.scope_label || scope?.title || scope?.prefix || 'No scope prepared';
+}
+
+export function formatCount(value: number): string {
+	return new Intl.NumberFormat().format(value);
+}
+
+export function formatTimestamp(value: string | null | undefined): string {
+	if (!value) return 'Never';
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) return 'Unknown';
+	return new Intl.DateTimeFormat(undefined, {
+		month: 'short',
+		day: 'numeric',
+		hour: 'numeric',
+		minute: '2-digit'
+	}).format(parsed);
+}
+
+function humanize(value: string): string {
+	return value.replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+}

--- a/frontend/src/routes/ops/+page.svelte
+++ b/frontend/src/routes/ops/+page.svelte
@@ -1,26 +1,62 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { SvelteURLSearchParams } from 'svelte/reactivity';
 
 	import { fetchJson } from '$lib/api/client';
 	import { initialDashboard, initialHosts } from '$lib/api/placeholders';
-	import type { DashboardSummaryPayload, HostsPayload } from '$lib/api/types';
+	import type { DashboardSummaryPayload, HostsPayload, OperatorWorkPayload } from '$lib/api/types';
 	import OpsWorkstationView from '$lib/components/workstation/OpsWorkstationView.svelte';
+	import type { OperatorWorkQuery } from '$lib/components/workstation/operator-work';
 
 	let dashboard = $state<DashboardSummaryPayload | null>(initialDashboard);
 	let hosts = $state<HostsPayload | null>(initialHosts);
+	let operatorWork = $state<OperatorWorkPayload | null>(null);
 	let loadError = $state('');
 	let refreshGeneration = 0;
+	let operatorRefreshGeneration = 0;
+	let operatorQuery = $state<OperatorWorkQuery>({ limit: 25 });
+
+	function operatorWorkUrl(query: OperatorWorkQuery): string {
+		const params = new SvelteURLSearchParams();
+		if (query.offset) params.set('offset', String(query.offset));
+		if (query.limit) params.set('limit', String(query.limit));
+		if (query.evidenceKind) params.set('evidence_kind', query.evidenceKind);
+		if (query.state) params.set('state', query.state);
+		if (query.mediaRoot) params.set('media_root', query.mediaRoot);
+		if (query.workStatus) params.set('work_status', query.workStatus);
+		const queryString = params.toString();
+		return `/api/operator-work${queryString ? `?${queryString}` : ''}`;
+	}
+
+	async function refreshOperatorWork(nextQuery: OperatorWorkQuery = operatorQuery) {
+		operatorQuery = { ...nextQuery };
+		const generation = ++operatorRefreshGeneration;
+		try {
+			const payload = await fetchJson<OperatorWorkPayload>(operatorWorkUrl(operatorQuery));
+			if (generation !== operatorRefreshGeneration) return;
+			operatorWork = payload;
+			loadError = '';
+		} catch (error) {
+			if (generation !== operatorRefreshGeneration) return;
+			loadError = error instanceof Error ? error.message : 'Operator work state failed to load.';
+			throw error instanceof Error ? error : new Error(loadError);
+		}
+	}
 
 	async function refreshOpsData() {
 		const generation = ++refreshGeneration;
+		const operatorGeneration = ++operatorRefreshGeneration;
 		try {
-			const [dashboardPayload, hostsPayload] = await Promise.all([
+			const [dashboardPayload, hostsPayload, operatorPayload] = await Promise.all([
 				fetchJson<DashboardSummaryPayload>('/api/dashboard?preview_limit=0'),
-				fetchJson<HostsPayload>('/api/hosts?compact=1')
+				fetchJson<HostsPayload>('/api/hosts?compact=1'),
+				fetchJson<OperatorWorkPayload>(operatorWorkUrl(operatorQuery))
 			]);
-			if (generation !== refreshGeneration) return;
+			if (generation !== refreshGeneration || operatorGeneration !== operatorRefreshGeneration)
+				return;
 			dashboard = dashboardPayload;
 			hosts = hostsPayload;
+			operatorWork = operatorPayload;
 			loadError = '';
 		} catch (error) {
 			if (generation !== refreshGeneration) return;
@@ -33,6 +69,7 @@
 		void refreshOpsData().catch(() => undefined);
 		return () => {
 			refreshGeneration += 1;
+			operatorRefreshGeneration += 1;
 		};
 	});
 </script>
@@ -41,4 +78,11 @@
 	<title>Activity · Mediaforce</title>
 </svelte:head>
 
-<OpsWorkstationView {dashboard} {hosts} loadError={loadError || null} onRefresh={refreshOpsData} />
+<OpsWorkstationView
+	{dashboard}
+	{hosts}
+	{operatorWork}
+	loadError={loadError || null}
+	onRefresh={refreshOpsData}
+	onOperatorRefresh={refreshOperatorWork}
+/>

--- a/mediaforce/core/db_migration_scripts/versions/20260719_0013_background_work_state.py
+++ b/mediaforce/core/db_migration_scripts/versions/20260719_0013_background_work_state.py
@@ -1,0 +1,34 @@
+"""Add durable catalog and evidence background-work controls.
+
+Revision ID: 20260719_0013
+Revises: 20260719_0012
+Create Date: 2026-07-19 18:00:00
+"""
+
+import sqlalchemy as sa
+# noinspection PyPackageRequirements
+from alembic import op
+
+revision = "20260719_0013"
+down_revision = "20260719_0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if not _has_table("background_work_state"):
+        op.create_table(
+            "background_work_state",
+            sa.Column("work_area", sa.Text(), primary_key=True),
+            sa.Column("is_paused", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("updated_at", sa.Text(), nullable=False),
+        )
+
+
+def downgrade() -> None:
+    if _has_table("background_work_state"):
+        op.drop_table("background_work_state")
+
+
+def _has_table(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()

--- a/mediaforce/core/db_tables.py
+++ b/mediaforce/core/db_tables.py
@@ -151,6 +151,14 @@ evidence_queue_state = Table(
     Column("updated_at", Text, nullable=False),
 )
 
+background_work_state = Table(
+    "background_work_state",
+    metadata,
+    Column("work_area", Text, primary_key=True),
+    Column("is_paused", Integer, nullable=False, server_default="0"),
+    Column("updated_at", Text, nullable=False),
+)
+
 plex_item_metadata = Table(
     "plex_item_metadata",
     metadata,

--- a/mediaforce/library/background_work.py
+++ b/mediaforce/library/background_work.py
@@ -1,0 +1,243 @@
+from typing import Any
+
+from sqlalchemy import func, select, update
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from mediaforce.core.db import DBClient
+from mediaforce.core.db_tables import background_work_state, library_item_evidence_state, library_items
+from mediaforce.core.utils import timestamp
+from mediaforce.library.evidence_state import EVIDENCE_KINDS, EVIDENCE_STATE_ANALYSIS_REQUIRED, \
+    EVIDENCE_STATE_CLASSIFICATION_REQUIRED
+
+BACKGROUND_WORK_AREA = "catalog_evidence"
+EVIDENCE_BACKLOG_STATES = (
+    EVIDENCE_STATE_ANALYSIS_REQUIRED,
+    EVIDENCE_STATE_CLASSIFICATION_REQUIRED,
+)
+EVIDENCE_BACKLOG_WORK_STATUSES = (
+    "not_prepared",
+    "queued",
+    "running",
+    "retry_wait",
+    "waiting_source",
+    "failed",
+    "cancelled",
+    "completed",
+)
+DEFAULT_EVIDENCE_BACKLOG_LIMIT = 25
+MAX_EVIDENCE_BACKLOG_LIMIT = 100
+
+
+def ensure_background_work_state(
+        connection: DBClient,
+        *,
+        updated_at: str | None = None,
+) -> None:
+    now_iso = updated_at or timestamp()
+    statement = sqlite_insert(background_work_state).values(
+        work_area=BACKGROUND_WORK_AREA,
+        is_paused=0,
+        updated_at=now_iso,
+    )
+    connection.execute(
+        statement.on_conflict_do_nothing(index_elements=[background_work_state.c.work_area])
+    )
+
+
+def load_background_work_state(connection: DBClient) -> dict[str, Any]:
+    row = connection.execute(
+        select(background_work_state).where(
+            background_work_state.c.work_area == BACKGROUND_WORK_AREA
+        )
+    ).mappings().fetchone()
+    if row is None:
+        return {
+            "work_area": BACKGROUND_WORK_AREA,
+            "is_paused": False,
+            "updated_at": None,
+        }
+    return {
+        "work_area": str(row["work_area"]),
+        "is_paused": bool(row["is_paused"]),
+        "updated_at": row["updated_at"],
+    }
+
+
+def background_work_is_paused(connection: DBClient) -> bool:
+    return bool(load_background_work_state(connection)["is_paused"])
+
+
+def set_background_work_paused(
+        connection: DBClient,
+        *,
+        is_paused: bool,
+        updated_at: str | None = None,
+) -> dict[str, Any]:
+    now_iso = updated_at or timestamp()
+    connection.commit()
+    connection.exec_driver_sql("BEGIN IMMEDIATE")
+    try:
+        ensure_background_work_state(connection, updated_at=now_iso)
+        connection.execute(
+            update(background_work_state)
+            .where(background_work_state.c.work_area == BACKGROUND_WORK_AREA)
+            .values(is_paused=int(is_paused), updated_at=now_iso)
+        )
+    except BaseException:
+        connection.rollback()
+        raise
+    return load_background_work_state(connection)
+
+
+def summarize_evidence_inventory(connection: DBClient) -> dict[str, Any]:
+    rows = connection.execute(
+        select(
+            library_item_evidence_state.c.evidence_kind,
+            library_item_evidence_state.c.state,
+            library_item_evidence_state.c.reason,
+            func.count().label("item_count"),
+        )
+        .select_from(
+            library_item_evidence_state.join(
+                library_items,
+                library_items.c.id == library_item_evidence_state.c.library_item_id,
+            )
+        )
+        .where(library_items.c.status != "missing")
+        .group_by(
+            library_item_evidence_state.c.evidence_kind,
+            library_item_evidence_state.c.state,
+            library_item_evidence_state.c.reason,
+        )
+        .order_by(
+            library_item_evidence_state.c.evidence_kind,
+            library_item_evidence_state.c.state,
+            library_item_evidence_state.c.reason,
+        )
+    ).mappings().fetchall()
+    by_kind: dict[str, dict[str, Any]] = {
+        kind: {"total": 0, "states": {}, "reasons": {}}
+        for kind in EVIDENCE_KINDS
+    }
+    total = 0
+    backlog_total = 0
+    for row in rows:
+        evidence_kind = str(row["evidence_kind"])
+        state = str(row["state"])
+        reason = str(row["reason"] or "")
+        item_count = int(row["item_count"] or 0)
+        total += item_count
+        if state in EVIDENCE_BACKLOG_STATES:
+            backlog_total += item_count
+        kind_payload = by_kind.setdefault(evidence_kind, {"total": 0, "states": {}, "reasons": {}})
+        kind_payload["total"] += item_count
+        kind_payload["states"][state] = kind_payload["states"].get(state, 0) + item_count
+        if reason:
+            kind_payload["reasons"][reason] = kind_payload["reasons"].get(reason, 0) + item_count
+    return {
+        "total": total,
+        "backlog_total": backlog_total,
+        "by_kind": by_kind,
+    }
+
+
+def list_evidence_backlog(
+        connection: DBClient,
+        *,
+        offset: int = 0,
+        limit: int = DEFAULT_EVIDENCE_BACKLOG_LIMIT,
+        evidence_kind: str | None = None,
+        state: str | None = None,
+        media_root: str | None = None,
+        work_status: str | None = None,
+) -> dict[str, Any]:
+    normalized_offset = max(0, int(offset))
+    normalized_limit = min(max(1, int(limit)), MAX_EVIDENCE_BACKLOG_LIMIT)
+    normalized_kind = _optional_choice(evidence_kind, EVIDENCE_KINDS, "evidence kind")
+    normalized_state = _optional_choice(state, EVIDENCE_BACKLOG_STATES, "evidence state")
+    normalized_work_status = _optional_choice(
+        work_status,
+        EVIDENCE_BACKLOG_WORK_STATUSES,
+        "work status",
+    )
+    normalized_root = str(media_root or "").strip() or None
+
+    conditions = [
+        library_item_evidence_state.c.state.in_(EVIDENCE_BACKLOG_STATES),
+        library_items.c.status != "missing",
+    ]
+    if normalized_kind:
+        conditions.append(library_item_evidence_state.c.evidence_kind == normalized_kind)
+    if normalized_state:
+        conditions.append(library_item_evidence_state.c.state == normalized_state)
+    if normalized_root:
+        conditions.append(library_items.c.media_root == normalized_root)
+    if normalized_work_status == "not_prepared":
+        conditions.append(library_item_evidence_state.c.work_status.is_(None))
+    elif normalized_work_status:
+        conditions.append(library_item_evidence_state.c.work_status == normalized_work_status)
+
+    joined = library_item_evidence_state.join(
+        library_items,
+        library_items.c.id == library_item_evidence_state.c.library_item_id,
+    )
+    total = int(
+        connection.execute(
+            select(func.count()).select_from(joined).where(*conditions)
+        ).scalar_one()
+    )
+    page_offset = normalized_offset
+    if total and page_offset >= total:
+        page_offset = ((total - 1) // normalized_limit) * normalized_limit
+    rows = connection.execute(
+        select(
+            library_item_evidence_state.c.library_item_id,
+            library_item_evidence_state.c.evidence_kind,
+            library_item_evidence_state.c.state,
+            library_item_evidence_state.c.reason,
+            library_item_evidence_state.c.work_status,
+            library_item_evidence_state.c.attempt_count,
+            library_item_evidence_state.c.retry_not_before,
+            library_item_evidence_state.c.last_attempt_at,
+            library_item_evidence_state.c.last_error,
+            library_item_evidence_state.c.updated_at,
+            library_items.c.rel_path,
+            library_items.c.media_root,
+            library_items.c.parent_dir,
+            library_items.c.file_name,
+        )
+        .select_from(joined)
+        .where(*conditions)
+        .order_by(
+            library_items.c.media_root,
+            library_items.c.rel_path,
+            library_item_evidence_state.c.evidence_kind,
+        )
+        .offset(page_offset)
+        .limit(normalized_limit)
+    ).mappings().fetchall()
+    range_start = page_offset + 1 if total and rows else 0
+    range_end = min(page_offset + len(rows), total)
+    return {
+        "offset": page_offset,
+        "limit": normalized_limit,
+        "total": total,
+        "range_start": range_start,
+        "range_end": range_end,
+        "has_previous": page_offset > 0,
+        "has_next": range_end < total,
+        "filters": {
+            "evidence_kind": normalized_kind,
+            "state": normalized_state,
+            "media_root": normalized_root,
+            "work_status": normalized_work_status,
+        },
+        "rows": [dict(row) for row in rows],
+    }
+
+
+def _optional_choice(value: str | None, choices: tuple[str, ...], label: str) -> str | None:
+    normalized = str(value or "").strip() or None
+    if normalized is not None and normalized not in choices:
+        raise ValueError(f"Unsupported {label}: {normalized}")
+    return normalized

--- a/mediaforce/library/evidence_queue.py
+++ b/mediaforce/library/evidence_queue.py
@@ -12,6 +12,7 @@ from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import evidence_queue_state, library_item_evidence_state, library_items
 from mediaforce.core.type_defs import int_value, object_dict, object_list
 from mediaforce.core.utils import timestamp
+from mediaforce.library.background_work import background_work_is_paused
 from mediaforce.library.evidence_state import EVIDENCE_KINDS, EVIDENCE_STATE_ANALYSIS_REQUIRED, \
     EVIDENCE_STATE_CLASSIFICATION_REQUIRED, EvidenceKind
 from mediaforce.library.media_scopes import MediaScope, resolve_media_scope, scope_rel_path_filter
@@ -128,6 +129,10 @@ def start_evidence_work(
     connection.exec_driver_sql("BEGIN IMMEDIATE")
     try:
         ensure_evidence_queue_state(connection, updated_at=now_iso)
+        if background_work_is_paused(connection):
+            raise EvidenceQueueConflict(
+                "Background catalog and analysis work is paused. Resume background work before preparing evidence."
+            )
         current_state = load_evidence_queue_state(connection)
         if str(current_state.get("status") or "") in EVIDENCE_QUEUE_ACTIVE_STATUSES:
             raise EvidenceQueueConflict(
@@ -306,6 +311,7 @@ def claim_next_evidence_work(
         batch_id = str(queue_state.get("batch_id") or "")
         if (
                 not batch_id
+                or background_work_is_paused(connection)
                 or bool(queue_state.get("is_paused"))
                 or bool(queue_state.get("cancel_requested"))
                 or str(queue_state.get("status") or "") not in EVIDENCE_QUEUE_ACTIVE_STATUSES
@@ -655,6 +661,10 @@ def _set_queue_control(
         if bool(state.get("cancel_requested")):
             connection.rollback()
             return evidence_queue_summary(connection)
+        if not is_paused and background_work_is_paused(connection):
+            raise EvidenceQueueConflict(
+                "Background catalog and analysis work is paused. Resume background work before analysis."
+            )
         connection.execute(
             update(evidence_queue_state)
             .where(evidence_queue_state.c.queue_name == DEFAULT_EVIDENCE_QUEUE_NAME)

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -60,6 +60,11 @@ from mediaforce.execution import (
     validate_manifest_items,
 )
 from mediaforce.library.folder_profiles import inspect_prefix
+from mediaforce.library.background_work import background_work_is_paused, ensure_background_work_state, \
+    set_background_work_paused
+from mediaforce.library.evidence_queue import DEFAULT_EVIDENCE_BATCH_LIMIT, EvidenceQueueConflict, \
+    cancel_evidence_queue, ensure_evidence_queue_state, evidence_queue_summary, pause_evidence_queue, \
+    resume_evidence_queue, start_evidence_work
 from mediaforce.library.media_scopes import media_group_scope_for_rel_path, resolve_media_scope, resolve_media_scopes, \
     scope_rel_path_filter, series_context_for_prefix, tv_series_scope_for_rel_path
 from mediaforce.library.movie_library import load_movie_library_payload, load_movie_scope_payload
@@ -108,7 +113,8 @@ from mediaforce.tuning.quality_risk import build_quality_risk_contract, quality_
 from mediaforce.tuning.size_goals import guided_size_goal_options, operator_intent_from_policy
 from mediaforce.core.type_defs import JSONValue, float_value, mapping_dict, object_dict, object_list
 from mediaforce.web.routes import register_completed_routes, register_dashboard_routes, register_folder_routes, \
-    register_frontend_routes, register_host_routes, register_queue_routes, register_settings_routes
+    register_frontend_routes, register_host_routes, register_operator_work_routes, register_queue_routes, \
+    register_settings_routes
 from mediaforce.web.runtime import FolderCard, cached_folder_cards, cached_host_statuses, dashboard_folders_payload, \
     dashboard_library_payload, dashboard_summary_payload, default_sample_host_key, default_sample_host_key_from_statuses, \
     FolderAiTuneDeps, FolderStateDeps, FolderTuningRuntimeDeps, clear_pending_proposal, \
@@ -209,6 +215,7 @@ from mediaforce.web.runtime.job_runtime import JobRuntimeDeps, active_scan_from_
     save_scan_job_state as runtime_save_scan_job_state, scan_is_stale as runtime_scan_is_stale, \
     scan_job_belongs_to_current_process as runtime_scan_job_belongs_to_current_process, \
     scan_process_is_alive as runtime_scan_process_is_alive
+from mediaforce.web.runtime.operator_work import BoundedEvidenceRunner, build_operator_work_payload
 from mediaforce.web.settings_runtime import (
     ALWAYS_SCHEDULE_PROFILE,
     DEFAULT_HOST_SCHEDULE_PROFILE,
@@ -414,6 +421,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     config = load_config(config_path or DEFAULT_CONFIG_PATH)
     advisor_routing = advisor_routing_from_config(config)
     cleanup_lock = threading.Lock()
+    evidence_runner = BoundedEvidenceRunner(config.paths.config_path)
 
     @asynccontextmanager
     async def _app_lifespan(_app: FastAPI) -> AsyncIterator[None]:
@@ -434,6 +442,8 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             if repaired_host_rows:
                 LOGGER.warning("Repaired %s persisted encode job host payloads.", repaired_host_rows)
             ensure_queue_state(connection, updated_at=_now_iso())
+            ensure_background_work_state(connection, updated_at=_now_iso())
+            ensure_evidence_queue_state(connection, updated_at=_now_iso())
             _recover_calibration_jobs(connection, config)
             _recover_encode_queue(connection, config)
         _start_background_workers(config)
@@ -467,6 +477,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
     if frontend_app_dir.exists():
         app.mount("/_app", StaticFiles(directory=str(frontend_app_dir)), name="frontend_app")
     app.state.config = config
+    app.state.evidence_runner = evidence_runner
 
     @app.middleware("http")
     async def periodic_cleanup(
@@ -849,6 +860,146 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         start_host_action=_start_host_action,
         prepare_host_action=_prepare_host_action,
         reset_host_trust_action=_reset_host_trust_action,
+    )
+
+    def _operator_work_payload(
+            *,
+            backlog_offset: int = 0,
+            backlog_limit: int = 25,
+            evidence_kind: str | None = None,
+            evidence_state: str | None = None,
+            media_root: str | None = None,
+            work_status: str | None = None,
+    ) -> dict[str, Any]:
+        with open_db(config.paths.db_path) as connection:
+            return build_operator_work_payload(
+                connection,
+                config,
+                scan_job=_load_scan_status(connection, config, prefix=None),
+                catalog_is_stale=_scan_is_stale(connection, config, prefix=None),
+                latest_scan_completed_at=_latest_scan_completed_at(connection, prefix=None),
+                evidence_runner_active=evidence_runner.active,
+                backlog_offset=backlog_offset,
+                backlog_limit=backlog_limit,
+                evidence_kind=evidence_kind,
+                evidence_state=evidence_state,
+                media_root=media_root,
+                work_status=work_status,
+            )
+
+    def _pause_background_work_action() -> dict[str, Any]:
+        with open_db(config.paths.db_path) as connection:
+            set_background_work_paused(connection, is_paused=True)
+            pause_evidence_queue(connection)
+        return {
+            "ok": True,
+            "message": "Paused new catalog and analysis work. Any item already running can finish safely.",
+        }
+
+    def _resume_background_work_action() -> dict[str, Any]:
+        with open_db(config.paths.db_path) as connection:
+            set_background_work_paused(connection, is_paused=False)
+        return {
+            "ok": True,
+            "message": "Background work can start again. Prepared analysis remains paused until you resume it.",
+        }
+
+    def _refresh_catalog_action() -> dict[str, Any]:
+        with open_db(config.paths.db_path) as connection:
+            if background_work_is_paused(connection):
+                raise EvidenceQueueConflict(
+                    "Background catalog and analysis work is paused. Resume it before refreshing the catalog."
+                )
+            job = _maybe_schedule_scan(connection, config, prefix=None, force=True)
+        status = str((job or {}).get("status") or "queued")
+        return {
+            "ok": True,
+            "message": (
+                "Catalog refresh is already running."
+                if status == "running"
+                else "Catalog refresh queued. Existing remembered results remain available while it runs."
+            ),
+        }
+
+    def _prepare_evidence_action(
+            prefix: str,
+            evidence_kinds: list[str] | tuple[str, ...] | None,
+            limit: int,
+    ) -> dict[str, Any]:
+        if limit > DEFAULT_EVIDENCE_BATCH_LIMIT:
+            raise ValueError(f"The operator work limit is {DEFAULT_EVIDENCE_BATCH_LIMIT} items per batch.")
+        with open_db(config.paths.db_path) as connection:
+            summary = start_evidence_work(
+                connection,
+                config,
+                prefix,
+                evidence_kinds=evidence_kinds,
+                limit=limit,
+            )
+        item_count = int(summary.get("item_count") or 0)
+        return {
+            "ok": True,
+            "message": (
+                f"Prepared {item_count} evidence {'update' if item_count == 1 else 'updates'}. Review the scope, then start analysis."
+                if item_count
+                else "That scope is already current. No analysis was prepared."
+            ),
+        }
+
+    def _pause_evidence_action() -> dict[str, Any]:
+        with open_db(config.paths.db_path) as connection:
+            pause_evidence_queue(connection)
+        return {
+            "ok": True,
+            "message": "Paused analysis before the next item. An item already running can finish safely.",
+        }
+
+    def _resume_evidence_action() -> dict[str, Any]:
+        with open_db(config.paths.db_path) as connection:
+            if background_work_is_paused(connection):
+                raise EvidenceQueueConflict(
+                    "Background catalog and analysis work is paused. Resume it before starting analysis."
+                )
+            summary = evidence_queue_summary(connection)
+            if not summary.get("batch_id") or str(summary.get("status") or "") not in {
+                "paused",
+                "queued",
+                "running",
+            }:
+                raise EvidenceQueueConflict("Prepare a bounded analysis batch before starting work.")
+            summary = resume_evidence_queue(connection)
+            item_budget = min(
+                max(1, int(summary.get("remaining_count") or summary.get("item_count") or 1)),
+                DEFAULT_EVIDENCE_BATCH_LIMIT,
+            )
+        started = evidence_runner.start(max_work_items=item_budget)
+        return {
+            "ok": True,
+            "message": (
+                "Analysis started. It will stop when this prepared batch is complete or blocked."
+                if started
+                else "Analysis is already running."
+            ),
+        }
+
+    def _cancel_evidence_action() -> dict[str, Any]:
+        with open_db(config.paths.db_path) as connection:
+            cancel_evidence_queue(connection)
+        return {
+            "ok": True,
+            "message": "Cancelled remaining analysis. A running media process is being stopped safely.",
+        }
+
+    register_operator_work_routes(
+        app,
+        operator_work_payload=_operator_work_payload,
+        pause_background_work_action=_pause_background_work_action,
+        resume_background_work_action=_resume_background_work_action,
+        refresh_catalog_action=_refresh_catalog_action,
+        prepare_evidence_action=_prepare_evidence_action,
+        pause_evidence_action=_pause_evidence_action,
+        resume_evidence_action=_resume_evidence_action,
+        cancel_evidence_action=_cancel_evidence_action,
     )
 
     def _folder_content_payload(normalized_prefix: str) -> tuple[dict[str, Any], int]:

--- a/mediaforce/web/routes/__init__.py
+++ b/mediaforce/web/routes/__init__.py
@@ -3,6 +3,7 @@ from mediaforce.web.routes.dashboard import register_dashboard_routes
 from mediaforce.web.routes.frontend import register_frontend_routes
 from mediaforce.web.routes.folders import register_folder_routes
 from mediaforce.web.routes.hosts import register_host_routes
+from mediaforce.web.routes.operator_work import register_operator_work_routes
 from mediaforce.web.routes.queues import register_queue_routes
 from mediaforce.web.routes.settings import register_settings_routes
 
@@ -12,6 +13,7 @@ __all__ = [
     "register_frontend_routes",
     "register_folder_routes",
     "register_host_routes",
+    "register_operator_work_routes",
     "register_queue_routes",
     "register_settings_routes",
 ]

--- a/mediaforce/web/routes/operator_work.py
+++ b/mediaforce/web/routes/operator_work.py
@@ -1,0 +1,99 @@
+from collections.abc import Callable, Sequence
+from typing import Annotated, Any
+
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
+from starlette.concurrency import run_in_threadpool
+
+from mediaforce.library.evidence_queue import EvidenceQueueConflict
+
+Offset = Annotated[int, Query(ge=0)]
+Limit = Annotated[int, Query(ge=1, le=100)]
+
+
+def register_operator_work_routes(
+        app: FastAPI,
+        *,
+        operator_work_payload: Callable[..., dict[str, Any]],
+        pause_background_work_action: Callable[[], dict[str, Any]],
+        resume_background_work_action: Callable[[], dict[str, Any]],
+        refresh_catalog_action: Callable[[], dict[str, Any]],
+        prepare_evidence_action: Callable[[str, Sequence[str] | None, int], dict[str, Any]],
+        pause_evidence_action: Callable[[], dict[str, Any]],
+        resume_evidence_action: Callable[[], dict[str, Any]],
+        cancel_evidence_action: Callable[[], dict[str, Any]],
+) -> None:
+    @app.get("/api/operator-work")
+    def api_operator_work(
+            offset: Offset = 0,
+            limit: Limit = 25,
+            evidence_kind: str | None = None,
+            state: str | None = None,
+            media_root: str | None = None,
+            work_status: str | None = None,
+    ) -> JSONResponse:
+        try:
+            payload = operator_work_payload(
+                backlog_offset=offset,
+                backlog_limit=limit,
+                evidence_kind=evidence_kind,
+                evidence_state=state,
+                media_root=media_root,
+                work_status=work_status,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return JSONResponse(payload)
+
+    @app.post("/api/background-work/pause")
+    async def api_pause_background_work() -> JSONResponse:
+        return JSONResponse(await _run_action(pause_background_work_action))
+
+    @app.post("/api/background-work/resume")
+    async def api_resume_background_work() -> JSONResponse:
+        return JSONResponse(await _run_action(resume_background_work_action))
+
+    @app.post("/api/catalog/refresh")
+    async def api_refresh_catalog() -> JSONResponse:
+        return JSONResponse(await _run_action(refresh_catalog_action))
+
+    @app.post("/api/evidence-work/prepare")
+    async def api_prepare_evidence(request: Request) -> JSONResponse:
+        body = await request.json()
+        raw_kinds = body.get("evidence_kinds")
+        if raw_kinds is not None and not isinstance(raw_kinds, list):
+            raise HTTPException(status_code=400, detail="Evidence kinds must be a list.")
+        evidence_kinds = [str(kind) for kind in raw_kinds] if isinstance(raw_kinds, list) else None
+        try:
+            limit = int(body.get("limit", 25))
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail="Evidence work limit must be a number.") from exc
+        return JSONResponse(
+            await _run_action(
+                prepare_evidence_action,
+                str(body.get("prefix") or ""),
+                evidence_kinds,
+                limit,
+            )
+        )
+
+    @app.post("/api/evidence-work/pause")
+    async def api_pause_evidence() -> JSONResponse:
+        return JSONResponse(await _run_action(pause_evidence_action))
+
+    @app.post("/api/evidence-work/resume")
+    async def api_resume_evidence() -> JSONResponse:
+        return JSONResponse(await _run_action(resume_evidence_action))
+
+    @app.post("/api/evidence-work/cancel")
+    async def api_cancel_evidence() -> JSONResponse:
+        return JSONResponse(await _run_action(cancel_evidence_action))
+
+
+async def _run_action(action: Callable[..., dict[str, Any]], *args: Any) -> dict[str, Any]:
+    try:
+        return await run_in_threadpool(action, *args)
+    except EvidenceQueueConflict as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/mediaforce/web/runtime/job_runtime.py
+++ b/mediaforce/web/runtime/job_runtime.py
@@ -25,6 +25,7 @@ from mediaforce.core.db_tables import library_items
 from mediaforce.core.db_tables import scan_runs
 from mediaforce.core.process_control import ManagedProcessController
 from mediaforce.library.media_scopes import path_matches_scope, resolve_media_scope, scope_rel_path_filter
+from mediaforce.library.background_work import background_work_is_paused
 from mediaforce.library.metadata_sync import sync_external_metadata
 from mediaforce.library.scanner import scan_library
 from mediaforce.state_cleanup import purge_transient_artifacts
@@ -265,6 +266,8 @@ def maybe_schedule_scan(
         job = _expire_scan_job(config, prefix, job, deps)
     if job and job.get("status") in {"queued", "running"}:
         return job
+    if background_work_is_paused(connection):
+        return job
     if not force and not scan_is_stale(connection, config, prefix, deps):
         return job
     if not force and job and job.get("status") == "failed":
@@ -309,10 +312,10 @@ def load_scan_status(
     if active_scan is not None:
         return active_scan
     if prefix is not None:
-        full_job = _scan_job_snapshot(config, None, deps)
+        full_job = _current_scan_job_snapshot(connection, config, None, deps)
         if full_job and full_job.get("status") in {"queued", "running"}:
             return full_job
-    return _scan_job_snapshot(config, prefix, deps)
+    return _current_scan_job_snapshot(connection, config, prefix, deps)
 
 
 def run_scan_job(
@@ -323,10 +326,39 @@ def run_scan_job(
         deps: JobRuntimeDeps,
 ) -> None:
     config = load_config(config_path)
+    job: dict[str, Any] = {}
+    with open_db(config.paths.db_path) as connection:
+        connection.commit()
+        connection.exec_driver_sql("BEGIN IMMEDIATE")
+        try:
+            job = deps.load_scan_job_state(config, prefix) or {}
+            if background_work_is_paused(connection):
+                job.update(
+                    {
+                        "job_id": job_id,
+                        "status": "paused",
+                        "started_at": None,
+                        "finished_at": deps.now_iso(),
+                        "error": None,
+                        "stats": None,
+                    }
+                )
+                deps.save_scan_job_state(config, prefix, job)
+                return
+            job.update(
+                {
+                    "job_id": job_id,
+                    "status": "running",
+                    "started_at": deps.now_iso(),
+                    "finished_at": None,
+                    "error": None,
+                }
+            )
+            deps.save_scan_job_state(config, prefix, job)
+        except BaseException:
+            connection.rollback()
+            raise
     purge_transient_artifacts(config, force=True)
-    job = deps.load_scan_job_state(config, prefix) or {}
-    job.update({"status": "running", "started_at": deps.now_iso(), "finished_at": None, "error": None})
-    deps.save_scan_job_state(config, prefix, job)
 
     try:
         metadata_stats: dict[str, Any] | None = None
@@ -740,6 +772,28 @@ def _scan_job_snapshot(
             deps,
             finished_at=job.get("finished_at") or job.get("started_at") or job.get("created_at"),
         )
+    return job
+
+
+def _current_scan_job_snapshot(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str | None,
+        deps: JobRuntimeDeps,
+) -> dict[str, Any] | None:
+    job = _scan_job_snapshot(config, prefix, deps)
+    if not job or job.get("status") in {"queued", "running"}:
+        return job
+    latest_completed = latest_scan_completed_at(connection, prefix)
+    if latest_completed is None:
+        return job
+    job_timestamp = deps.parse_iso(
+        job.get("finished_at")
+        or job.get("started_at")
+        or job.get("created_at")
+    )
+    if job_timestamp is None or job_timestamp < latest_completed:
+        return None
     return job
 
 

--- a/mediaforce/web/runtime/operator_work.py
+++ b/mediaforce/web/runtime/operator_work.py
@@ -1,0 +1,230 @@
+import logging
+import threading
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import func, select
+
+from mediaforce.core.config import MediaforceConfig
+from mediaforce.core.db import DBClient
+from mediaforce.core.db_tables import library_items
+from mediaforce.core.type_defs import object_dict, object_list
+from mediaforce.library.background_work import list_evidence_backlog, load_background_work_state, \
+    summarize_evidence_inventory
+from mediaforce.library.evidence_queue import EVIDENCE_QUEUE_ACTIVE_STATUSES, evidence_queue_summary
+from mediaforce.library.evidence_worker import run_evidence_queue_until_blocked
+
+LOGGER = logging.getLogger(__name__)
+
+ACTIVE_SCAN_STATUSES = ("queued", "running")
+TERMINAL_EVIDENCE_QUEUE_STATUSES = ("completed", "completed_with_errors", "cancelled")
+
+
+class BoundedEvidenceRunner:
+    def __init__(self, config_path: Path) -> None:
+        self._config_path = config_path
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+
+    @property
+    def active(self) -> bool:
+        with self._lock:
+            return self._thread is not None and self._thread.is_alive()
+
+    def start(self, *, max_work_items: int) -> bool:
+        if max_work_items <= 0:
+            raise ValueError("Evidence work item budget must be greater than zero.")
+        with self._lock:
+            if self._thread is not None and self._thread.is_alive():
+                return False
+            thread = threading.Thread(
+                target=self._run,
+                kwargs={"max_work_items": max_work_items},
+                name="bounded-evidence-runner",
+                daemon=True,
+            )
+            self._thread = thread
+            thread.start()
+        return True
+
+    def _run(self, *, max_work_items: int) -> None:
+        current_thread = threading.current_thread()
+        try:
+            run_evidence_queue_until_blocked(
+                config_path=self._config_path,
+                max_work_items=max_work_items,
+            )
+        except Exception:
+            LOGGER.exception("Bounded evidence work failed")
+        finally:
+            with self._lock:
+                if self._thread is current_thread:
+                    self._thread = None
+
+
+def build_operator_work_payload(
+        connection: DBClient,
+        config: MediaforceConfig,
+        *,
+        scan_job: dict[str, Any] | None,
+        catalog_is_stale: bool,
+        latest_scan_completed_at: datetime | None,
+        evidence_runner_active: bool,
+        backlog_offset: int = 0,
+        backlog_limit: int = 25,
+        evidence_kind: str | None = None,
+        evidence_state: str | None = None,
+        media_root: str | None = None,
+        work_status: str | None = None,
+) -> dict[str, Any]:
+    background = load_background_work_state(connection)
+    queue = evidence_queue_summary(connection)
+    inventory = summarize_evidence_inventory(connection)
+    backlog = list_evidence_backlog(
+        connection,
+        offset=backlog_offset,
+        limit=backlog_limit,
+        evidence_kind=evidence_kind,
+        state=evidence_state,
+        media_root=media_root,
+        work_status=work_status,
+    )
+    root_rows = _catalog_root_rows(connection, config)
+    warnings = _scan_warnings(scan_job)
+    catalog_item_count = sum(int(row["item_count"]) for row in root_rows)
+    scan_status = str((scan_job or {}).get("status") or "idle")
+    queue_status = str(queue.get("status") or "idle")
+    running_evidence = object_dict(queue.get("running")) or None
+    background_paused = bool(background["is_paused"])
+    queue_active = queue_status in EVIDENCE_QUEUE_ACTIVE_STATUSES
+    terminal_status = queue_status if queue_status in TERMINAL_EVIDENCE_QUEUE_STATUSES else None
+    live_status = "idle" if terminal_status else queue_status
+    progress = _evidence_progress(queue)
+    refresh_active = (
+        scan_status in ACTIVE_SCAN_STATUSES
+        or evidence_runner_active
+        or running_evidence is not None
+    )
+
+    return {
+        "background": {
+            **background,
+            "status": "paused" if background_paused else "active",
+        },
+        "catalog": {
+            "status": scan_status,
+            "freshness": _catalog_freshness(
+                item_count=catalog_item_count,
+                catalog_is_stale=catalog_is_stale,
+                warning_count=len(warnings),
+            ),
+            "item_count": catalog_item_count,
+            "last_completed_at": (
+                latest_scan_completed_at.isoformat(timespec="seconds")
+                if latest_scan_completed_at is not None
+                else None
+            ),
+            "job": scan_job,
+            "source_roots": root_rows,
+            "warnings": warnings,
+            "can_refresh": not background_paused and scan_status not in ACTIVE_SCAN_STATUSES,
+        },
+        "evidence": {
+            "live_status": live_status,
+            "terminal_status": terminal_status,
+            "runner_active": evidence_runner_active,
+            "queue": queue,
+            "progress": progress,
+            "inventory": inventory,
+            "backlog": backlog,
+            "can_prepare": not background_paused and not queue_active,
+            "can_pause": (
+                not background_paused
+                and not bool(queue.get("is_paused"))
+                and (evidence_runner_active or running_evidence is not None or queue_status == "running")
+            ),
+            "can_resume": (
+                not background_paused
+                and queue_status in {"paused", "queued"}
+                and not bool(queue.get("cancel_requested"))
+                and running_evidence is None
+                and not evidence_runner_active
+            ),
+            "can_cancel": queue_active,
+        },
+        "refresh": {
+            "mode": "active" if refresh_active else "manual",
+            "interval_ms": 2_500 if refresh_active else None,
+        },
+    }
+
+
+def _catalog_root_rows(connection: DBClient, config: MediaforceConfig) -> list[dict[str, Any]]:
+    counts = {
+        str(row["media_root"]): int(row["item_count"] or 0)
+        for row in connection.execute(
+            select(
+                library_items.c.media_root,
+                func.count().label("item_count"),
+            )
+            .where(library_items.c.status != "missing")
+            .group_by(library_items.c.media_root)
+        ).mappings()
+    }
+    definitions = config.library_definition_map
+    return [
+        {
+            "key": root_key,
+            "label": str(
+                object_dict(definitions.get(root_key)).get("label")
+                or root_key.replace("_", " ").replace("-", " ").title()
+            ),
+            "item_count": counts.get(root_key, 0),
+        }
+        for root_key in config.scan_source_root_map
+    ]
+
+
+def _scan_warnings(scan_job: dict[str, Any] | None) -> list[dict[str, Any]]:
+    warnings: list[dict[str, Any]] = []
+    for raw_warning in object_list(object_dict((scan_job or {}).get("stats")).get("warnings")):
+        warning = object_dict(raw_warning)
+        message = str(warning.get("message") or "").strip()
+        if not message:
+            continue
+        warnings.append(
+            {
+                "code": str(warning.get("code") or "source_warning"),
+                "library_key": str(warning.get("library_key") or ""),
+                "label": str(warning.get("label") or "Library"),
+                "message": message,
+                "preserved_item_count": int(warning.get("preserved_item_count") or 0),
+            }
+        )
+    return warnings
+
+
+def _catalog_freshness(*, item_count: int, catalog_is_stale: bool, warning_count: int) -> str:
+    if item_count <= 0 or warning_count:
+        return "unknown"
+    return "stale" if catalog_is_stale else "current"
+
+
+def _evidence_progress(queue: dict[str, Any]) -> dict[str, Any]:
+    total_count = int(queue.get("item_count") or 0)
+    counts = {
+        str(status): int(count or 0)
+        for status, count in object_dict(queue.get("counts")).items()
+    }
+    done_count = sum(counts.get(status, 0) for status in ("completed", "failed", "cancelled"))
+    percent = round(done_count * 100 / total_count) if total_count else None
+    return {
+        "total_count": total_count,
+        "remaining_count": int(queue.get("remaining_count") or 0),
+        "done_count": done_count,
+        "percent": percent,
+        "counts": counts,
+        "running": object_dict(queue.get("running")) or None,
+    }

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -12,9 +12,11 @@ from typing import Any
 from mediaforce.core.config import load_config
 from mediaforce.core.db import open_db
 from mediaforce.core.db_tables import (
+    background_work_state,
     calibration_jobs,
     encode_jobs,
     encode_queue_state,
+    evidence_queue_state,
     item_events,
     library_items,
     scan_runs,
@@ -22,6 +24,8 @@ from mediaforce.core.db_tables import (
     staged_artifacts,
 )
 from mediaforce.core.evidence import stable_policy_hash, stable_source_id
+from mediaforce.library.evidence_queue import start_evidence_work
+from mediaforce.library.evidence_state import rebuild_library_item_evidence_states
 from mediaforce.library.planner import build_manifest_item
 from mediaforce.tuning.size_goals import operator_intent_from_policy
 from mediaforce.web.runtime.folder_tuning_advice import (
@@ -177,6 +181,10 @@ def _library_item(
                         "ffmpeg_version": "web-smoke",
                     },
                 },
+                "decision": {
+                    "status": "resolved",
+                    "classification": "progressive",
+                },
             },
             sort_keys=True,
         ),
@@ -229,6 +237,7 @@ def _library_item(
                         "ffmpeg_version": "web-smoke",
                     },
                 },
+                "decision": {"status": "measured"},
             },
             sort_keys=True,
         ),
@@ -678,6 +687,8 @@ def _write_review_states(config: Any, rows_by_prefix: dict[str, dict[str, Any]])
 
 
 def _clear_fixture_files(config: Any) -> None:
+    for path in config.paths.web_state_dir.glob("scan-*.job.json"):
+        path.unlink(missing_ok=True)
     for prefix in FIXTURE_PREFIXES:
         slug = _slug(prefix)
         for suffix in (".json", ".advice.json", ".proposal.json", ".job.json"):
@@ -709,6 +720,8 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 encode_queue_state.c.queue_name == "heavy"
             )
         )
+        connection.execute(evidence_queue_state.delete())
+        connection.execute(background_work_state.delete())
         connection.execute(
             calibration_jobs.delete().where(
                 calibration_jobs.c.job_id.like("web-smoke-%")
@@ -1219,12 +1232,20 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
             )
             for index in range(251)
         )
+        for row in rows:
+            if row["rel_path"] == "tv/Example Show/Season 1/Episode 01.mkv":
+                row["cadence_summary_json"] = None
+            elif row["rel_path"] == "tv/Example Show/Season 1/Episode 02.mkv":
+                row["media_fingerprint_json"] = None
+            elif row["rel_path"] == "movies/Editions Showcase/Feature - Director Cut.mkv":
+                row["media_fingerprint_json"] = None
         inserted_ids: list[int] = []
         for row in rows:
             result = connection.execute(library_items.insert().values(**row))
             inserted_ids.append(int(result.inserted_primary_key[0]))
         for row, item_id in zip(rows, inserted_ids, strict=True):
             row["id"] = item_id
+        rebuild_library_item_evidence_states(connection, library_item_ids=inserted_ids)
         scan_timestamp = _now()
         connection.execute(
             scan_runs.insert().values(
@@ -1569,6 +1590,12 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 active_job_id="web-smoke-encode-running",
                 updated_at=_now(),
             )
+        )
+        start_evidence_work(
+            connection,
+            config,
+            FOLDER_PREFIX,
+            limit=2,
         )
 
     _write_review_states(config, rows_by_prefix)

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -50,6 +50,7 @@ const endpointChecks = [
   ["Host status", "/api/hosts?compact=1"],
   ["Settings initial payload", "/api/settings?include_archive_cleanup=0"],
   ["Completed payload", "/api/completed"],
+  ["Operator catalog and evidence work", "/api/operator-work"],
 ];
 
 const routeChecks = [
@@ -57,7 +58,7 @@ const routeChecks = [
   ["Movies Library", "/movies", "MOVIE WORKSTATION"],
   ["Other Library", "/other", "Other Library"],
   ["Folders compatibility", "/folders", "Your library"],
-  ["Activity", "/ops", "What’s happening"],
+  ["Activity", "/ops", "Remembered media state"],
   ["Settings", "/settings", "Library and working space"],
   ["Finished", "/completed", "Finished seasons"],
 ];

--- a/tests/test_db_runtime.py
+++ b/tests/test_db_runtime.py
@@ -15,6 +15,7 @@ from mediaforce.core.db import _load_sql_asset
 from mediaforce.core.db import open_db
 from mediaforce.core.db import reset_engine_cache
 from mediaforce.core.db_tables import alembic_version
+from mediaforce.core.db_tables import background_work_state
 from mediaforce.core.db_tables import evidence_queue_state
 from mediaforce.core.db_tables import encode_jobs
 from mediaforce.core.db_tables import encode_queue_state
@@ -26,7 +27,7 @@ from mediaforce.core.type_defs import object_dict
 from mediaforce.encoding.cadence import cadence_policy_snapshot
 from mediaforce.encoding.fingerprint import media_fingerprint_policy_snapshot
 
-CURRENT_DB_REVISION = "20260719_0012"
+CURRENT_DB_REVISION = "20260719_0013"
 
 
 class DatabaseRuntimeTests(unittest.TestCase):
@@ -68,6 +69,7 @@ class DatabaseRuntimeTests(unittest.TestCase):
             self.assertIn("metadata_sync_state", table_names)
             self.assertIn("library_item_evidence_state", table_names)
             self.assertIn("evidence_queue_state", table_names)
+            self.assertIn("background_work_state", table_names)
             self.assertIn("idx_library_item_evidence_state_kind_state", evidence_indexes)
             self.assertIn("idx_library_item_evidence_state_work_ready", evidence_indexes)
             self.assertIn("idx_library_item_evidence_state_work_claim", evidence_indexes)
@@ -513,6 +515,7 @@ class DatabaseRuntimeTests(unittest.TestCase):
                 raw_connection.close()
 
             self.assertNotIn("evidence_queue_state", table_names)
+            self.assertNotIn("background_work_state", table_names)
             self.assertNotIn("work_status", evidence_columns)
             self.assertEqual(
                 downgraded_state,
@@ -534,6 +537,9 @@ class DatabaseRuntimeTests(unittest.TestCase):
                     )
                 ).one()
                 queue_rows = connection.execute(select(evidence_queue_state.c.queue_name)).fetchall()
+                background_rows = connection.execute(
+                    select(background_work_state.c.work_area)
+                ).fetchall()
                 version = connection.execute(select(alembic_version.c.version_num)).scalar_one()
 
             self.assertEqual(version, CURRENT_DB_REVISION)
@@ -542,6 +548,7 @@ class DatabaseRuntimeTests(unittest.TestCase):
                 (2, "2026-07-20T00:00:00+00:00", "fixture failure", None, None),
             )
             self.assertEqual(queue_rows, [])
+            self.assertEqual(background_rows, [])
 
     def test_open_db_rolls_back_on_base_exception(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_operator_work.py
+++ b/tests/test_operator_work.py
@@ -1,0 +1,326 @@
+import tempfile
+import threading
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from mediaforce.core.config import ConfigPaths, MediaforceConfig
+from mediaforce.core.db import open_db, reset_engine_cache
+from mediaforce.core.db_tables import library_items, scan_runs
+from mediaforce.library.background_work import set_background_work_paused
+from mediaforce.library.evidence_queue import EvidenceQueueConflict, claim_next_evidence_work, resume_evidence_queue, \
+    start_evidence_work
+from mediaforce.library.evidence_state import rebuild_library_item_evidence_states
+from mediaforce.web.runtime.job_runtime import JobRuntimeDeps, load_scan_status, maybe_schedule_scan, run_scan_job
+from mediaforce.web.runtime.operator_work import BoundedEvidenceRunner, build_operator_work_payload
+
+
+class OperatorWorkTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        project_root = Path(self.temp_dir.name)
+        media_root = project_root / "tv"
+        media_root.mkdir()
+        self.config = MediaforceConfig(
+            raw={
+                "media": {
+                    "libraries": [
+                        {
+                            "key": "tv",
+                            "label": "Television",
+                            "path": str(media_root),
+                            "type": "tv",
+                            "availability": "production",
+                        }
+                    ]
+                }
+            },
+            paths=ConfigPaths(
+                project_root=project_root,
+                config_path=project_root / "config.toml",
+                db_path=project_root / "state" / "library.sqlite3",
+                run_manifest_dir=project_root / "state" / "runs",
+                web_state_dir=project_root / "state" / "web",
+                review_dir=project_root / "state" / "review",
+                runtime_settings_path=project_root / "state" / "settings.json",
+            ),
+        )
+
+    def tearDown(self) -> None:
+        reset_engine_cache()
+        self.temp_dir.cleanup()
+
+    def test_payload_is_idle_without_runner_and_paginates_reachable_backlog(self) -> None:
+        self._insert_item()
+
+        with open_db(self.config.paths.db_path) as connection:
+            payload = build_operator_work_payload(
+                connection,
+                self.config,
+                scan_job=None,
+                catalog_is_stale=False,
+                latest_scan_completed_at=None,
+                evidence_runner_active=False,
+                backlog_limit=1,
+            )
+
+        self.assertEqual(payload["background"]["status"], "active")
+        self.assertEqual(payload["catalog"]["freshness"], "current")
+        self.assertEqual(payload["evidence"]["live_status"], "idle")
+        self.assertEqual(payload["refresh"], {"mode": "manual", "interval_ms": None})
+        self.assertEqual(payload["evidence"]["backlog"]["total"], 2)
+        self.assertEqual(len(payload["evidence"]["backlog"]["rows"]), 1)
+        self.assertTrue(payload["evidence"]["backlog"]["has_next"])
+        self.assertNotIn("source_path", payload["evidence"]["backlog"]["rows"][0])
+
+    def test_prepared_batch_stays_quiet_until_explicit_runner_start(self) -> None:
+        self._insert_item()
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(connection, self.config, "tv", limit=1)
+            payload = build_operator_work_payload(
+                connection,
+                self.config,
+                scan_job=None,
+                catalog_is_stale=False,
+                latest_scan_completed_at=None,
+                evidence_runner_active=False,
+            )
+
+        self.assertEqual(payload["evidence"]["live_status"], "paused")
+        self.assertTrue(payload["evidence"]["can_resume"])
+        self.assertEqual(payload["refresh"]["mode"], "manual")
+
+    def test_resumed_queue_without_runner_offers_continue_instead_of_pause(self) -> None:
+        self._insert_item()
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(connection, self.config, "tv", limit=1)
+            resume_evidence_queue(connection)
+            payload = build_operator_work_payload(
+                connection,
+                self.config,
+                scan_job=None,
+                catalog_is_stale=False,
+                latest_scan_completed_at=None,
+                evidence_runner_active=False,
+            )
+
+        self.assertTrue(payload["evidence"]["can_resume"])
+        self.assertFalse(payload["evidence"]["can_pause"])
+
+    def test_backlog_offset_clamps_to_last_reachable_page(self) -> None:
+        self._insert_item()
+        with open_db(self.config.paths.db_path) as connection:
+            payload = build_operator_work_payload(
+                connection,
+                self.config,
+                scan_job=None,
+                catalog_is_stale=False,
+                latest_scan_completed_at=None,
+                evidence_runner_active=False,
+                backlog_offset=100,
+                backlog_limit=1,
+            )
+
+        backlog = payload["evidence"]["backlog"]
+        self.assertEqual(backlog["offset"], 1)
+        self.assertEqual(backlog["range_start"], 2)
+        self.assertEqual(backlog["range_end"], 2)
+        self.assertFalse(backlog["has_next"])
+
+    def test_global_pause_blocks_new_batches_and_claims(self) -> None:
+        self._insert_item()
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(connection, self.config, "tv", limit=1)
+            set_background_work_paused(connection, is_paused=True)
+            claim = claim_next_evidence_work(connection, worker_id="worker", lease_seconds=30)
+            with self.assertRaisesRegex(EvidenceQueueConflict, "Background catalog"):
+                start_evidence_work(connection, self.config, "tv", limit=1)
+
+        self.assertIsNone(claim)
+
+    def test_scan_scheduler_does_not_launch_while_background_work_is_paused(self) -> None:
+        run_scan_job = Mock()
+        save_scan_job_state = Mock()
+        deps = JobRuntimeDeps(
+            parse_iso=lambda _value: None,
+            now_iso=lambda: "2026-07-19T12:00:00+00:00",
+            run_scan_job=run_scan_job,
+            scan_process_is_alive=lambda _pid: False,
+            current_catalog_signature=lambda _config: "current",
+            load_catalog_signature=lambda _config: "saved",
+            load_scan_job_state=lambda _config, _prefix: None,
+            save_scan_job_state=save_scan_job_state,
+            calibration_job_notice_after=timedelta(hours=1),
+            full_scan_stale_after=timedelta(hours=1),
+            prefix_scan_stale_after=timedelta(hours=1),
+            scan_retry_cooldown=timedelta(minutes=1),
+            scan_interrupted_error="interrupted",
+            save_catalog_signature=Mock(),
+            reset_folder_card_cache=Mock(),
+        )
+        with open_db(self.config.paths.db_path) as connection:
+            set_background_work_paused(connection, is_paused=True)
+            result = maybe_schedule_scan(
+                connection,
+                self.config,
+                None,
+                deps,
+                force=True,
+            )
+
+        self.assertIsNone(result)
+        save_scan_job_state.assert_not_called()
+        run_scan_job.assert_not_called()
+
+    def test_scan_status_ignores_terminal_job_older_than_latest_catalog_snapshot(self) -> None:
+        old_job = {
+            "job_id": "old-job",
+            "status": "completed",
+            "created_at": "2026-07-19T10:00:00+00:00",
+            "started_at": "2026-07-19T10:00:00+00:00",
+            "finished_at": "2026-07-19T10:05:00+00:00",
+            "stats": {"warnings": [{"code": "source_unavailable"}]},
+        }
+        deps = self._job_runtime_deps(load_scan_job_state=lambda _config, _prefix: old_job)
+        with open_db(self.config.paths.db_path) as connection:
+            connection.execute(
+                scan_runs.insert().values(
+                    scan_id="newer-scan",
+                    started_at="2026-07-19T12:00:00+00:00",
+                    completed_at="2026-07-19T12:05:00+00:00",
+                    owner_pid=None,
+                    last_progress_at="2026-07-19T12:05:00+00:00",
+                    roots_json='["tv"]',
+                    scope="full",
+                    prefixes_json=None,
+                    file_count=1,
+                    reprobed_count=0,
+                    unchanged_count=1,
+                )
+            )
+            status = load_scan_status(connection, self.config, None, deps)
+
+        self.assertIsNone(status)
+
+    def test_queued_scan_rechecks_global_pause_before_media_work_starts(self) -> None:
+        queued_job = {
+            "job_id": "queued-job",
+            "status": "queued",
+            "created_at": "2026-07-19T12:00:00+00:00",
+        }
+        save_scan_job_state = Mock()
+        deps = self._job_runtime_deps(
+            load_scan_job_state=lambda _config, _prefix: queued_job,
+            save_scan_job_state=save_scan_job_state,
+        )
+        with open_db(self.config.paths.db_path) as connection:
+            set_background_work_paused(connection, is_paused=True)
+
+        with patch("mediaforce.web.runtime.job_runtime.load_config", return_value=self.config), patch(
+            "mediaforce.web.runtime.job_runtime.purge_transient_artifacts"
+        ) as purge, patch("mediaforce.web.runtime.job_runtime.scan_library") as scan:
+            run_scan_job(
+                config_path=self.config.paths.config_path,
+                prefix=None,
+                job_id="queued-job",
+                deps=deps,
+            )
+
+        saved = save_scan_job_state.call_args.args[2]
+        self.assertEqual(saved["status"], "paused")
+        self.assertIsNone(saved["started_at"])
+        purge.assert_not_called()
+        scan.assert_not_called()
+
+    def test_bounded_runner_rejects_duplicate_process_local_start(self) -> None:
+        started = threading.Event()
+        release = threading.Event()
+
+        def run_until_blocked(**_kwargs: object) -> None:
+            started.set()
+            release.wait(timeout=1)
+
+        runner = BoundedEvidenceRunner(self.config.paths.config_path)
+        with patch(
+            "mediaforce.web.runtime.operator_work.run_evidence_queue_until_blocked",
+            side_effect=run_until_blocked,
+        ):
+            self.assertTrue(runner.start(max_work_items=5))
+            self.assertTrue(started.wait(timeout=1))
+            self.assertTrue(runner.active)
+            self.assertFalse(runner.start(max_work_items=5))
+            release.set()
+            for _ in range(100):
+                if not runner.active:
+                    break
+                threading.Event().wait(0.01)
+
+        self.assertFalse(runner.active)
+
+    def _insert_item(self) -> None:
+        now = "2026-07-19T12:00:00+00:00"
+        with open_db(self.config.paths.db_path) as connection:
+            result = connection.execute(
+                library_items.insert().values(
+                    source_path=str(self.config.paths.project_root / "tv" / "show" / "episode.mkv"),
+                    rel_path="tv/show/episode.mkv",
+                    media_root="tv",
+                    parent_dir="tv/show",
+                    file_name="episode.mkv",
+                    container="mkv",
+                    size_bytes=1_024,
+                    mtime_ns=1,
+                    fingerprint="fixture:fingerprint",
+                    duration_seconds=60.0,
+                    video_codec="h264",
+                    audio_track_count=1,
+                    subtitle_track_count=0,
+                    english_audio_count=1,
+                    english_subtitle_count=0,
+                    audio_summary_json="[]",
+                    subtitle_summary_json="[]",
+                    cadence_summary_json=None,
+                    media_fingerprint_json=None,
+                    content_version_changed_at=now,
+                    content_version_fingerprint="fixture:content",
+                    status="discovered",
+                    priority_score=0,
+                    last_scan_id="fixture",
+                    discovered_at=now,
+                    last_seen_at=now,
+                    updated_at=now,
+                )
+            )
+            rebuild_library_item_evidence_states(
+                connection,
+                library_item_ids=[int(result.inserted_primary_key[0])],
+            )
+
+    @staticmethod
+    def _job_runtime_deps(
+            *,
+            load_scan_job_state: object,
+            save_scan_job_state: object | None = None,
+    ) -> JobRuntimeDeps:
+        return JobRuntimeDeps(
+            parse_iso=lambda value: datetime.fromisoformat(str(value)) if value else None,
+            now_iso=lambda: "2026-07-19T12:00:00+00:00",
+            run_scan_job=Mock(),
+            scan_process_is_alive=lambda _pid: False,
+            current_catalog_signature=lambda _config: "current",
+            load_catalog_signature=lambda _config: "current",
+            load_scan_job_state=load_scan_job_state,
+            save_scan_job_state=save_scan_job_state or Mock(),
+            calibration_job_notice_after=timedelta(hours=1),
+            full_scan_stale_after=timedelta(hours=1),
+            prefix_scan_stale_after=timedelta(hours=1),
+            scan_retry_cooldown=timedelta(minutes=1),
+            scan_interrupted_error="interrupted",
+            save_catalog_signature=Mock(),
+            reset_folder_card_cache=Mock(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_operator_work_routes.py
+++ b/tests/test_operator_work_routes.py
@@ -1,0 +1,121 @@
+import asyncio
+import json
+import unittest
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from starlette.requests import Request
+from starlette.routing import Route
+
+from mediaforce.library.evidence_queue import EvidenceQueueConflict
+from mediaforce.web.routes.operator_work import register_operator_work_routes
+
+
+class OperatorWorkRouteTests(unittest.TestCase):
+    def test_get_forwards_pagination_and_not_prepared_filter(self) -> None:
+        captured: dict[str, Any] = {}
+        app = self._app(
+            operator_work_payload=lambda **kwargs: captured.update(kwargs) or {"ok": True}
+        )
+
+        endpoint = _route_endpoint(app, "/api/operator-work", "GET")
+
+        response = endpoint(
+            offset=25,
+            limit=10,
+            evidence_kind=None,
+            state=None,
+            media_root=None,
+            work_status="not_prepared",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(captured["backlog_offset"], 25)
+        self.assertEqual(captured["backlog_limit"], 10)
+        self.assertEqual(captured["work_status"], "not_prepared")
+
+    def test_prepare_validates_and_forwards_explicit_scope(self) -> None:
+        captured: list[tuple[str, list[str] | None, int]] = []
+        app = self._app(
+            prepare_evidence_action=lambda prefix, kinds, limit: (
+                captured.append((prefix, list(kinds) if kinds is not None else None, limit))
+                or {"ok": True, "message": "Prepared."}
+            )
+        )
+
+        endpoint = _route_endpoint(app, "/api/evidence-work/prepare", "POST")
+        response = asyncio.run(
+            endpoint(
+                _json_request(
+                    {
+                        "prefix": "tv/Show/Season 1",
+                        "evidence_kinds": ["cadence_analysis"],
+                        "limit": 5,
+                    }
+                )
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(captured, [("tv/Show/Season 1", ["cadence_analysis"], 5)])
+
+    def test_conflicts_return_operator_visible_409(self) -> None:
+        def conflict() -> dict[str, Any]:
+            raise EvidenceQueueConflict("Prepare a batch first.")
+
+        app = self._app(resume_evidence_action=conflict)
+
+        endpoint = _route_endpoint(app, "/api/evidence-work/resume", "POST")
+        with self.assertRaises(HTTPException) as context:
+            asyncio.run(endpoint())
+
+        self.assertEqual(context.exception.status_code, 409)
+        self.assertEqual(context.exception.detail, "Prepare a batch first.")
+
+    @staticmethod
+    def _app(**overrides: Any) -> FastAPI:
+        callbacks: dict[str, Any] = {
+            "operator_work_payload": lambda **_kwargs: {"ok": True},
+            "pause_background_work_action": lambda: {"ok": True, "message": "Paused."},
+            "resume_background_work_action": lambda: {"ok": True, "message": "Resumed."},
+            "refresh_catalog_action": lambda: {"ok": True, "message": "Queued."},
+            "prepare_evidence_action": lambda _prefix, _kinds, _limit: {
+                "ok": True,
+                "message": "Prepared.",
+            },
+            "pause_evidence_action": lambda: {"ok": True, "message": "Paused."},
+            "resume_evidence_action": lambda: {"ok": True, "message": "Started."},
+            "cancel_evidence_action": lambda: {"ok": True, "message": "Cancelled."},
+        }
+        callbacks.update(overrides)
+        app = FastAPI()
+        register_operator_work_routes(app, **callbacks)
+        return app
+
+
+def _json_request(payload: dict[str, Any]) -> Request:
+    body = json.dumps(payload).encode()
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/",
+            "headers": [(b"content-type", b"application/json")],
+        },
+        receive,
+    )
+
+
+def _route_endpoint(app: FastAPI, path: str, method: str) -> Any:
+    for route in app.routes:
+        if isinstance(route, Route) and route.path == path and method.upper() in route.methods:
+            return route.endpoint
+    raise AssertionError(f"Route not found: {method.upper()} {path}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add durable background-work pause state and bounded catalog/evidence operator APIs
- add a human-readable Activity console with explicit prepare/start/pause/resume/cancel controls and a reachable, filtered evidence backlog
- replace unconditional idle polling with state-aware refresh, preserve source-warning truth, and add migration, route, fixture, documentation, and UI coverage

## Why
Mediaforce could appear idle while repeatedly probing media or launching FFmpeg-family work. This change makes catalog inventory and evidence analysis explicit workstation operations: remembered state is reused, expensive work only runs when stale or deliberately requested, and idle means quiet.

## Validation
- `bash scripts/pre-commit-check.sh`
  - backend: 1009 passed, 4 deselected, 19 subtests
  - frontend: ESLint, 211 Vitest tests, Svelte check, and production build
  - browser smoke: default, 1024px workstation, 390px narrow, and empty-state coverage
- manual headed-browser review of `/ops`, including global pause and evidence controls
- idle observation: no repeat Activity requests and no `ffmpeg`/`ffprobe` processes after load
- JetBrains changed-files inspection: zero findings; Svelte semantics additionally covered by ESLint, Svelte check, tests, build, and browser smoke
- independent blocker-focused review: no concrete defects or release blockers

Closes #219