### PR TITLE
Prioritize evidence acquisition by decision need

### DIFF
--- a/docs/architecture/evidence-worker.md
+++ b/docs/architecture/evidence-worker.md
@@ -34,16 +34,29 @@ evidence is not.
 Alembic revision `20260719_0012` adds this operational state without creating a
 batch or queueing existing evidence. Revision `20260719_0013` adds the durable
 `background_work_state` switch shared by catalog inventory and evidence
-analysis. Analyzer or policy changes remain visible as projection state until
-an operator explicitly prepares and starts work.
+analysis. Revision `20260719_0014` adds durable work priority and a plain-language
+reason so decision-blocking safety work can run before advisory backfill.
+Analyzer or policy changes remain visible as projection state until an operator
+explicitly prepares and starts work.
 
 ## Batch lifecycle
 
 `start_evidence_work()` requires a non-empty resolved scope. It selects only
 non-current evidence inside that exact item or descendant scope, caps the
 batch at 25 evidence updates by default, snapshots each source fingerprint,
-and creates the batch paused. One media file can contribute two updates because
-cadence and media fingerprint are independent evidence kinds.
+and creates the batch paused. Policy-only reclassification is selected first.
+Cadence analysis then follows the explicit operator scope. Fingerprint analysis
+starts with technical representatives, stays within a per-scope budget, and
+adds only a small uncertainty frontier when measured hard cases justify it.
+One media file can contribute two updates because cadence and media fingerprint
+are independent evidence kinds.
+
+Sample and production actions use a separate just-in-time path. Missing or stale
+cadence blocks only the selected media items, adds those exact rows to the active
+batch at decision priority, and returns the operator to Activity. A retained
+terminal failure is reported as a failure and requires an explicit item retry;
+repeating the blocked action does not reset its attempt budget. Fingerprint
+evidence remains advisory and never blocks sample or production queueing.
 
 Queue states are:
 
@@ -101,6 +114,9 @@ media.
   cancellation is observed.
 - Policy-only `classification_required` work is claimed before media analysis
   and reuses stored measurements without `ffmpeg` or `ffprobe`.
+- If fingerprint reclassification reveals that new media measurements are
+  required, the row completes its policy-only pass and returns to the bounded
+  representative planner instead of fanning out into immediate analysis.
 
 ## Operator flow
 
@@ -116,6 +132,11 @@ The Activity workstation exposes the same bounded state machine:
    queue controls near the visible scope and progress.
 5. `Pause new background work` is separate from encode approval and processing
    controls. It governs catalog inventory and evidence analysis only.
+
+The active item and backlog show both why evidence needs an update and why that
+work is scheduled now. Decision-blocking cadence rows are labelled as blocking a
+sample or production action; policy-only rows explicitly say that no media read
+is required.
 
 The workstation polls while a catalog scan or evidence runner is active and
 returns to manual refresh when idle. Backlog totals are paired with filters and
@@ -143,3 +164,9 @@ Repeat `evidence run` to resume durable progress. Use `pause` before the next
 claim or `cancel` to stop the active managed process and cancel the remaining
 batch. A root pilot uses the same commands with an explicit root such as `tv`;
 keep the limit small before considering a broader backfill.
+
+Compare representative dimensions from stored evidence without opening media:
+
+```bash
+uv run mediaforce evidence replay "tv/Show/Season 1"
+```

--- a/docs/architecture/media-fingerprint-evidence.md
+++ b/docs/architecture/media-fingerprint-evidence.md
@@ -6,11 +6,11 @@
   parser helpers, deterministic classification, source-scoped evidence shaping,
   and low-confidence advisory gates.
 - `mediaforce/library/probe.py` records the persisted fingerprint summary during
-  media probing alongside cadence evidence.
+  explicitly requested evidence analysis alongside cadence evidence.
 - `mediaforce/library/scanner.py` preserves fingerprint summaries while
   reconciling unchanged catalog rows, even when the summary is missing,
-  malformed, old, or retryable. New or content-changed files still receive the
-  existing full probe until the durable evidence worker owns refreshes.
+  malformed, old, or retryable. Catalog inventory performs bounded metadata
+  probing only and does not launch fingerprint `ffmpeg` analysis.
 - `mediaforce/library/evidence_state.py` projects canonical fingerprint JSON
   into independently queryable lifecycle state and keeps policy-only
   reclassification separate from media analysis.
@@ -62,6 +62,13 @@ or folder categories. Representative selection may cover measured fingerprint
 dimensions, but those dimensions come from the fingerprint decision only.
 Missing fingerprint dimensions do not outvote available measured evidence when
 choosing the primary representative.
+
+Automatic acquisition is representative-driven rather than completeness-driven.
+It measures technical representatives first, expands only around measured
+coverage uncertainty, and stops at a small per-scope budget. Missing evidence
+therefore does not stale the catalog, block production, or request analysis for
+unrelated folders. `audio_complexity` cost is accounted separately because its
+loudness measurement adds an audio sampling pass.
 
 ## Review moments
 

--- a/docs/architecture/representative-evidence.md
+++ b/docs/architecture/representative-evidence.md
@@ -54,6 +54,34 @@ measured fingerprint coverage dimensions to the earlier technical profile.
 Changing the threshold, clustering, tie breakers, or coverage semantics
 requires a representative-selection tool or policy version bump.
 
+## Bounded acquisition
+
+Fingerprint completeness is not a catalog invariant. Acquisition starts from
+the representative set produced by codec, resolution, measured cadence, audio
+layout, and runtime alone. Missing or stale fingerprint decisions are removed
+from the selection input, so hidden historical facts cannot influence the next
+candidate.
+
+After those technical representatives are current, Mediaforce may select a
+small follow-up frontier near representatives that expose a non-typical measured
+trait but have not yet established a meaningful cluster. The frontier is capped
+at three items per prepared batch and the total automatic scope budget is the
+smaller of the candidate count or `max(3, 2 × technical representatives)`.
+Acquisition stops when meaningful representative coverage is satisfied or the
+scope budget is exhausted; unselected items intentionally remain unmeasured.
+
+`mediaforce evidence replay <prefix>` reports technical-only, all-dimension, and
+leave-one-fingerprint-dimension-out selections. Each replay includes added and
+removed representatives, hard-case recall, sample-set growth, full acquisition
+cost, and remaining cost. This is a policy/cost report only and launches no
+media subprocess.
+
+`audio_complexity` remains available because local replay across 20 measured TV
+season scopes changed the representative set in 8 scopes and improved hard-case
+recall in 4. Its separate audio sampling cost is reported explicitly; scopes
+where it changes neither selection nor recall are marked `defer`. This keeps the
+dimension reviewable without granting it safety or cleanup authority.
+
 ## Evidence envelope v1
 
 Every envelope has a deterministic `evidence_id`, schema version, kind,

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError, fetchJson } from './client';
+
+describe('API client errors', () => {
+	it('preserves structured blocker actions from failed responses', async () => {
+		const fetcher = async () =>
+			new Response(
+				JSON.stringify({
+					message: 'Motion-pattern evidence is required.',
+					next_route: '/ops',
+					next_action_label: 'Open Activity'
+				}),
+				{ status: 409, headers: { 'Content-Type': 'application/json' } }
+			);
+
+		try {
+			await fetchJson('/api/example', fetcher as typeof fetch);
+			expect.unreachable('Expected fetchJson to reject');
+		} catch (error) {
+			expect(error).toBeInstanceOf(ApiError);
+			const apiError = error as ApiError;
+			expect(apiError.message).toBe('Motion-pattern evidence is required.');
+			expect(apiError.status).toBe(409);
+			expect(apiError.payload).toMatchObject({
+				next_route: '/ops',
+				next_action_label: 'Open Activity'
+			});
+		}
+	});
+});

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,5 +1,17 @@
 type FetchLike = typeof fetch;
 
+export class ApiError extends Error {
+	readonly status: number;
+	readonly payload: Record<string, unknown> | null;
+
+	constructor(message: string, status: number, payload: Record<string, unknown> | null) {
+		super(message);
+		this.name = 'ApiError';
+		this.status = status;
+		this.payload = payload;
+	}
+}
+
 export function apiDownloadHref(path: string): string {
 	if (typeof window === 'undefined') return path;
 	const normalizedPath = path.startsWith('/') ? path : `/${path}`;
@@ -11,22 +23,34 @@ export function apiDownloadHref(path: string): string {
 	return normalizedPath;
 }
 
-function extractErrorMessage(raw: string, status: number): string {
+function parseErrorPayload(raw: string): Record<string, unknown> | null {
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+			? (parsed as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function extractErrorMessage(
+	raw: string,
+	status: number,
+	payload: Record<string, unknown> | null
+): string {
 	const trimmed = raw.trim();
 	if (!trimmed) {
 		return `Request failed with status ${status}`;
 	}
 
-	try {
-		const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+	if (payload) {
 		for (const key of ['message', 'detail', 'error']) {
-			const value = parsed[key];
+			const value = payload[key];
 			if (typeof value === 'string' && value.trim()) {
 				return value.trim();
 			}
 		}
-	} catch {
-		// Fall back to the raw response body when the server did not return JSON.
 	}
 
 	return trimmed;
@@ -46,8 +70,13 @@ export async function fetchJson<T>(
 	});
 
 	if (!response.ok) {
-		const message = extractErrorMessage(await response.text(), response.status);
-		throw new Error(message);
+		const raw = await response.text();
+		const payload = parseErrorPayload(raw);
+		throw new ApiError(
+			extractErrorMessage(raw, response.status, payload),
+			response.status,
+			payload
+		);
 	}
 
 	return (await response.json()) as T;

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -522,6 +522,8 @@ export interface OperatorEvidenceScope extends MediaScopePayload {
 export interface OperatorEvidenceRunningItem {
 	library_item_id: number;
 	evidence_kind: string;
+	work_priority: number;
+	work_reason: string | null;
 	attempt_count: number;
 	last_attempt_at: string | null;
 	heartbeat_at: string | null;
@@ -576,7 +578,10 @@ export interface OperatorEvidenceBacklogRow {
 	evidence_kind: string;
 	state: string;
 	reason: string | null;
+	decision_status: string | null;
 	work_status: string | null;
+	work_priority: number;
+	work_reason: string | null;
 	attempt_count: number;
 	retry_not_before: string | null;
 	last_attempt_at: string | null;
@@ -1182,6 +1187,8 @@ export interface QualityRiskPayload {
 	preview_policy_hash?: string | null;
 	blocked?: boolean;
 	blocking_reasons?: string[];
+	cadence_gate?: string | null;
+	cadence_transform?: string | null;
 	request_comparison?: boolean;
 	comparison_reason?: string | null;
 	typed_risks?: QualityRiskItem[];

--- a/frontend/src/lib/components/season/SeasonExperience.svelte
+++ b/frontend/src/lib/components/season/SeasonExperience.svelte
@@ -2,7 +2,7 @@
 	import { resolve } from '$app/paths';
 	import { onMount, tick } from 'svelte';
 
-	import { apiDownloadHref, postJson } from '$lib/api/client';
+	import { ApiError, apiDownloadHref, postJson } from '$lib/api/client';
 	import type {
 		FolderPayload,
 		FolderStatusPayload,
@@ -96,6 +96,7 @@
 	let actionPhase = $state<ActionPhase>('idle');
 	let actionError = $state('');
 	let actionMessage = $state('');
+	let blockerAction = $state<{ route: '/ops'; label: string } | null>(null);
 	let actionStartedAt = $state(0);
 	let clock = $state(Date.now());
 	let showInstructions = $state(false);
@@ -372,6 +373,7 @@
 	) {
 		actionError = '';
 		actionMessage = '';
+		blockerAction = null;
 		actionStartedAt = Date.now();
 		actionPhase = 'planning';
 		let succeeded = false;
@@ -421,6 +423,7 @@
 		const draftHash = asText(calibration.draft_hash);
 		actionError = '';
 		actionMessage = '';
+		blockerAction = null;
 		actionStartedAt = Date.now();
 		actionPhase = 'approving';
 		let succeeded = false;
@@ -671,6 +674,7 @@
 	async function runAction(phase: ActionPhase, fallback: string, operation: () => Promise<void>) {
 		actionError = '';
 		actionMessage = '';
+		blockerAction = null;
 		actionStartedAt = Date.now();
 		actionPhase = phase;
 		let succeeded = false;
@@ -687,6 +691,11 @@
 	}
 
 	function humanActionError(error: unknown, fallback: string): string {
+		if (error instanceof ApiError) {
+			const route = String(error.payload?.next_route ?? '').trim();
+			const label = String(error.payload?.next_action_label ?? '').trim();
+			if (route === '/ops' && label) blockerAction = { route, label };
+		}
 		const message = error instanceof Error ? error.message.trim() : '';
 		if (!message) return fallback;
 		const lower = message.toLowerCase();
@@ -899,6 +908,11 @@
 				<div>
 					<strong>Something needs your attention</strong>
 					<p>{actionError || loadError}</p>
+					{#if blockerAction}
+						<a class="action-notice__link" href={resolve(blockerAction.route)}
+							>{blockerAction.label}</a
+						>
+					{/if}
 				</div>
 			</div>
 		{:else if actionMessage}
@@ -1346,6 +1360,15 @@
 						{#if riskSummary.focusMoments.length}
 							<p class="risk-summary__focus">Review focus: {riskSummary.focusMoments[0]}</p>
 						{/if}
+						{#if riskSummary.requiresCadenceResolution}
+							<div class="risk-summary__resolution">
+								<div>
+									<span>Next step</span>
+									<strong>Resolve the selected file’s motion pattern</strong>
+									<small>This is evidence work, not a size or quality-setting problem.</small>
+								</div>
+							</div>
+						{/if}
 					</div>
 				{/if}
 
@@ -1416,63 +1439,65 @@
 					>
 				</div>
 
-				<div class="review-feedback-panel">
-					<div class="review-feedback-panel__heading">
-						<div>
-							<span>Want a revision?</span>
-							<h2>Tell Mediaforce what should change.</h2>
+				{#if !riskSummary?.requiresCadenceResolution}
+					<div class="review-feedback-panel">
+						<div class="review-feedback-panel__heading">
+							<div>
+								<span>Want a revision?</span>
+								<h2>Tell Mediaforce what should change.</h2>
+							</div>
+							<p>The same size target stays in place unless you choose a different goal.</p>
 						</div>
-						<p>The same size target stays in place unless you choose a different goal.</p>
-					</div>
-					<div class="concern-options" role="group" aria-label="Review concerns">
-						{#each REVIEW_CONCERNS as concern (concern.tag)}
+						<div class="concern-options" role="group" aria-label="Review concerns">
+							{#each REVIEW_CONCERNS as concern (concern.tag)}
+								<button
+									type="button"
+									class:active={selectedConcerns.includes(concern.tag)}
+									onclick={() => toggleConcern(concern.tag)}
+									aria-pressed={selectedConcerns.includes(concern.tag)}
+								>
+									{concern.label}
+								</button>
+							{/each}
+						</div>
+						<div class="review-feedback-fields">
+							<label>
+								<span>What did you notice?</span>
+								<textarea
+									bind:value={reviewFeedback}
+									maxlength="600"
+									rows="3"
+									placeholder="For example: fast movement loses texture around faces in Moment 2."
+								></textarea>
+								<small>{reviewFeedback.length}/600</small>
+							</label>
+							<label>
+								<span>Other priorities for the next test <small>(optional)</small></span>
+								<textarea
+									bind:value={operatorInstructions}
+									maxlength="600"
+									rows="3"
+									placeholder="Preserve surround audio, intentional grain, subtitle behavior, or another priority."
+								></textarea>
+								<small>{operatorInstructions.length}/600</small>
+							</label>
+						</div>
+						<div class="review-feedback-panel__action">
+							<p>
+								Submitting a concern records the current evidence as rejected and starts a revised
+								representative test.
+							</p>
 							<button
+								class="secondary-button"
 								type="button"
-								class:active={selectedConcerns.includes(concern.tag)}
-								onclick={() => toggleConcern(concern.tag)}
-								aria-pressed={selectedConcerns.includes(concern.tag)}
+								onclick={submitReviewFeedback}
+								disabled={!hasReviewFeedback || noAvailableHosts}
 							>
-								{concern.label}
+								Make a revised test
 							</button>
-						{/each}
+						</div>
 					</div>
-					<div class="review-feedback-fields">
-						<label>
-							<span>What did you notice?</span>
-							<textarea
-								bind:value={reviewFeedback}
-								maxlength="600"
-								rows="3"
-								placeholder="For example: fast movement loses texture around faces in Moment 2."
-							></textarea>
-							<small>{reviewFeedback.length}/600</small>
-						</label>
-						<label>
-							<span>Other priorities for the next test <small>(optional)</small></span>
-							<textarea
-								bind:value={operatorInstructions}
-								maxlength="600"
-								rows="3"
-								placeholder="Preserve surround audio, intentional grain, subtitle behavior, or another priority."
-							></textarea>
-							<small>{operatorInstructions.length}/600</small>
-						</label>
-					</div>
-					<div class="review-feedback-panel__action">
-						<p>
-							Submitting a concern records the current evidence as rejected and starts a revised
-							representative test.
-						</p>
-						<button
-							class="secondary-button"
-							type="button"
-							onclick={submitReviewFeedback}
-							disabled={!hasReviewFeedback || noAvailableHosts}
-						>
-							Make a revised test
-						</button>
-					</div>
-				</div>
+				{/if}
 
 				<div
 					class="decision"
@@ -1483,6 +1508,11 @@
 						{#if targetConstraint}
 							<h2>{targetConstraint.title}</h2>
 							<p>{targetConstraint.detail}</p>
+						{:else if riskSummary?.requiresCadenceResolution}
+							<h2>Mediaforce needs a motion-pattern decision.</h2>
+							<p>
+								Resolve the selected file in Activity, then return here to finish your decision.
+							</p>
 						{:else if riskSummary?.blocked}
 							<h2>This test is not safe to approve yet.</h2>
 							<p>{riskSummary.detail}</p>
@@ -1512,6 +1542,11 @@
 								{targetConstraint.recoveryLabel}
 								<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 10h11M11 5l5 5-5 5" /></svg>
 							</button>
+						{:else if riskSummary?.requiresCadenceResolution}
+							<a class="primary-button primary-button--light" href={resolve('/ops')}>
+								Open Activity
+								<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 10h11M11 5l5 5-5 5" /></svg>
+							</a>
 						{:else if riskSummary?.blocked}
 							<button class="secondary-button" type="button" onclick={chooseDifferentSize}>
 								Choose a different goal
@@ -3794,6 +3829,15 @@
 		color: inherit;
 	}
 
+	.action-notice__link {
+		color: inherit;
+		display: inline-flex;
+		font-size: 12px;
+		font-weight: 700;
+		margin-top: 8px;
+		text-underline-offset: 3px;
+	}
+
 	.lifecycle-notice {
 		align-items: flex-start;
 		background: var(--mf-wait-bg);
@@ -4896,6 +4940,12 @@
 		color: var(--mf-fg-secondary) !important;
 		grid-column: 1 / -1;
 		margin: 0 !important;
+	}
+
+	.risk-summary__resolution {
+		border-top: 1px solid var(--mf-fail-line);
+		grid-column: 1 / -1;
+		padding-top: 12px;
 	}
 
 	.comparison-ledger {

--- a/frontend/src/lib/components/workstation/FolderStudioView.svelte
+++ b/frontend/src/lib/components/workstation/FolderStudioView.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
-	import { apiDownloadHref, postJson } from '$lib/api/client';
+	import { ApiError, apiDownloadHref, postJson } from '$lib/api/client';
 	import { folderRoutePath, folderRoutePrefix } from '$lib/folder-display';
 	import {
 		formatDateTimeCopy,
@@ -79,6 +79,7 @@
 	let benchError = $state('');
 	let profileMessage = $state('');
 	let profileError = $state('');
+	let blockerAction = $state<{ route: '/ops'; label: string } | null>(null);
 	let benchTextarea = $state<HTMLTextAreaElement | null>(null);
 	let localPendingProposal = $state<Record<string, unknown> | null | undefined>(undefined);
 	let localProposalPrefix = $state('');
@@ -107,7 +108,18 @@
 		}
 		benchMessage = '';
 		benchError = '';
+		blockerAction = null;
 	});
+
+	function actionErrorMessage(error: unknown, fallback: string): string {
+		blockerAction = null;
+		if (error instanceof ApiError) {
+			const route = String(error.payload?.next_route ?? '').trim();
+			const label = String(error.payload?.next_action_label ?? '').trim();
+			if (route === '/ops' && label) blockerAction = { route, label };
+		}
+		return error instanceof Error ? error.message : fallback;
+	}
 	const summary = $derived(studioFolder.summary);
 	const title = $derived(resolveFolderTitle(prefix));
 	const library = $derived(prefix.split('/')[0] || 'Library');
@@ -271,6 +283,7 @@
 		benchPending = true;
 		benchMessage = '';
 		benchError = '';
+		blockerAction = null;
 		try {
 			const response = await postJson<FolderBenchPreviewResponse>(
 				`${resolve('/')}api/folders/${encodedPrefix}/ai-tune/preview`,
@@ -283,7 +296,7 @@
 				response.message || 'Sample plan ready. Nothing is queued until you confirm it.';
 			benchNote = '';
 		} catch (error) {
-			benchError = error instanceof Error ? error.message : 'Review request failed.';
+			benchError = actionErrorMessage(error, 'Review request failed.');
 		} finally {
 			benchPending = false;
 		}
@@ -296,6 +309,7 @@
 		workflowPending = action;
 		benchMessage = '';
 		benchError = '';
+		blockerAction = null;
 		try {
 			const response = await postJson<FolderBenchConfirmResponse>(
 				`${resolve('/')}api/folders/${encodedPrefix}/ai-tune/confirm`,
@@ -306,7 +320,7 @@
 			benchMessage = response.message || 'Queued the sample run from the plan.';
 			await onMutate();
 		} catch (error) {
-			benchError = error instanceof Error ? error.message : 'Sample could not be queued.';
+			benchError = actionErrorMessage(error, 'Sample could not be queued.');
 		} finally {
 			workflowPending = null;
 		}
@@ -321,6 +335,8 @@
 		workflowPending = action;
 		profileMessage = '';
 		profileError = '';
+		blockerAction = null;
+		blockerAction = null;
 		try {
 			const response =
 				submissionMode === 'queue-approved'
@@ -340,8 +356,7 @@
 				response.message || 'Approved the sample plan and queued the folder process.';
 			await onMutate();
 		} catch (error) {
-			profileError =
-				error instanceof Error ? error.message : 'Folder profile could not be approved.';
+			profileError = actionErrorMessage(error, 'Folder profile could not be approved.');
 		} finally {
 			workflowPending = null;
 		}
@@ -354,6 +369,7 @@
 		workflowPending = action;
 		profileMessage = '';
 		profileError = '';
+		blockerAction = null;
 		try {
 			const response = await postJson<{ ok: boolean; message?: string }>(
 				`${resolve('/')}api/encode-queue/retry-prefix`,
@@ -398,6 +414,7 @@
 		workflowPending = action;
 		benchMessage = '';
 		benchError = '';
+		blockerAction = null;
 		try {
 			const response = await postJson<{ ok?: boolean; message?: string }>(
 				`${resolve('/')}api/calibration-queue/stop`,
@@ -852,6 +869,10 @@
 					{/if}
 					{#if profileError}
 						<p class="decision__status decision__status--fail">{profileError}</p>
+						{#if blockerAction}
+							<a class="blocker-action" href={resolve(blockerAction.route)}>{blockerAction.label}</a
+							>
+						{/if}
 					{:else if profileMessage}
 						<p class="decision__status decision__status--ready">{profileMessage}</p>
 					{/if}
@@ -1035,6 +1056,11 @@
 							</div>
 							{#if benchError}
 								<p class="bench__status bench__status--fail">{benchError}</p>
+								{#if blockerAction}
+									<a class="blocker-action" href={resolve(blockerAction.route)}
+										>{blockerAction.label}</a
+									>
+								{/if}
 							{:else if benchMessage}
 								<p class="bench__status bench__status--ready">{benchMessage}</p>
 							{:else if benchPending}
@@ -1885,6 +1911,14 @@
 	.decision__status--fail {
 		border-left-color: var(--mf-fail-fg);
 		color: var(--mf-fail-fg);
+	}
+
+	.blocker-action {
+		color: var(--mf-active-fg);
+		font-size: var(--mf-text-xs);
+		font-weight: var(--mf-weight-semibold);
+		text-decoration-thickness: 1px;
+		text-underline-offset: 0.2em;
 	}
 
 	.review-workspace {

--- a/frontend/src/lib/components/workstation/OperatorWorkConsole.svelte
+++ b/frontend/src/lib/components/workstation/OperatorWorkConsole.svelte
@@ -14,6 +14,7 @@
 		evidenceStateLabel,
 		evidenceStateTone,
 		evidenceStateView,
+		evidenceWorkReasonView,
 		evidenceWorkStatusView,
 		formatCount,
 		formatTimestamp,
@@ -36,6 +37,7 @@
 	const queue = $derived(work?.evidence.queue ?? null);
 	const progress = $derived(work?.evidence.progress ?? null);
 	const currentItem = $derived(progress?.running ?? null);
+	const currentWorkReason = $derived(evidenceWorkReasonView(currentItem?.work_reason ?? null));
 	const overallLabel = $derived(
 		backgroundPaused
 			? 'Background work paused'
@@ -238,6 +240,12 @@
 								: 'Prepare a bounded folder or library scope when evidence needs an update.'}
 					</span>
 				</div>
+				{#if currentWorkReason}
+					<div class="active-reason" aria-label="Why this analysis is running">
+						<strong>{currentWorkReason.label}</strong>
+						<span>{currentWorkReason.detail}</span>
+					</div>
+				{/if}
 				{#if progress?.total_count}
 					<div class="progress-track" aria-label={`${progress.percent ?? 0}% complete`}>
 						<span style={`width: ${progress.percent ?? 0}%`}></span>
@@ -415,6 +423,7 @@
 					<tbody>
 						{#each backlog?.rows ?? [] as row (row.library_item_id + ':' + row.evidence_kind)}
 							{@const workState = evidenceWorkStatusView(row)}
+							{@const workReason = evidenceWorkReasonView(row.work_reason)}
 							<tr>
 								<td data-label="Media">
 									<strong>{row.file_name}</strong>
@@ -435,12 +444,21 @@
 									<strong>{evidenceKindLabel(row.evidence_kind)}</strong>
 									<StateBadge
 										compact
-										tone={evidenceStateTone(row.state)}
-										label={evidenceStateLabel(row.state)}
+										tone={evidenceStateTone(row.state, row.decision_status)}
+										label={evidenceStateLabel(row.state, row.decision_status)}
 									/>
 								</td>
 								<td data-label="Why">
-									<span>{evidenceReasonCopy(row.reason)}</span>
+									<span class="reason-copy">
+										<strong>Needs update because</strong>
+										{evidenceReasonCopy(row.reason, row.state, row.decision_status)}
+									</span>
+									{#if workReason}
+										<span class="reason-copy reason-copy--priority">
+											<strong>{workReason.label}</strong>
+											{workReason.detail}
+										</span>
+									{/if}
 								</td>
 								<td data-label="Batch">
 									<StateBadge compact tone={workState.tone} label={workState.label} />
@@ -611,11 +629,47 @@
 	.work-lane__metric span,
 	.work-lane__actions span,
 	.source-warning span,
-	.backlog-table td span,
 	.backlog__footer > span {
 		color: var(--mf-fg-tertiary);
 		font-size: var(--mf-text-xs);
 		line-height: var(--mf-leading-normal);
+	}
+
+	.active-reason {
+		border-left: 3px solid var(--mf-wait-border);
+		display: grid;
+		gap: var(--mf-space-1);
+		padding: var(--mf-space-2) var(--mf-space-4);
+	}
+
+	.active-reason strong,
+	.reason-copy strong {
+		color: var(--mf-fg-primary);
+		font-size: var(--mf-text-2xs);
+		font-weight: var(--mf-weight-semibold);
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+	}
+
+	.active-reason span,
+	.reason-copy {
+		color: var(--mf-fg-tertiary);
+		font-size: var(--mf-text-xs);
+		line-height: var(--mf-leading-normal);
+	}
+
+	.reason-copy {
+		display: grid;
+		gap: var(--mf-space-1);
+	}
+
+	.reason-copy + .reason-copy {
+		margin-top: var(--mf-space-3);
+	}
+
+	.reason-copy--priority {
+		border-left: 2px solid var(--mf-wait-border);
+		padding-left: var(--mf-space-3);
 	}
 
 	.source-warnings {
@@ -883,6 +937,7 @@
 	.backlog-table td > strong {
 		font-weight: var(--mf-weight-semibold);
 		margin-bottom: var(--mf-space-2);
+		overflow-wrap: anywhere;
 	}
 
 	.path-copy {

--- a/frontend/src/lib/components/workstation/operator-work.test.ts
+++ b/frontend/src/lib/components/workstation/operator-work.test.ts
@@ -3,6 +3,7 @@ import type { OperatorEvidenceBacklogRow, OperatorEvidenceState } from '$lib/api
 import {
 	catalogStateView,
 	evidenceStateView,
+	evidenceWorkReasonView,
 	evidenceWorkStatusView,
 	operatorRefreshInterval
 } from './operator-work';
@@ -116,6 +117,25 @@ describe('operator work copy', () => {
 		expect(evidenceWorkStatusView({ ...row, work_status: 'waiting_source' }).label).toBe(
 			'Source unavailable'
 		);
+	});
+
+	it('explains decision-priority work in operator language', () => {
+		expect(evidenceWorkReasonView('sample_safety')).toEqual({
+			label: 'Blocks sample',
+			detail: 'Required before the selected sample can run.'
+		});
+		expect(evidenceWorkReasonView('encode_safety')?.label).toBe('Blocks production');
+		expect(evidenceWorkReasonView('policy_reclassification')?.label).toBe('No media read');
+		expect(evidenceWorkReasonView('representative_technical_coverage')?.detail).toContain(
+			'codec, resolution, cadence, audio layout, and runtime'
+		);
+		expect(evidenceWorkReasonView('representative_uncertainty')?.label).toBe('Bounded follow-up');
+		expect(evidenceWorkReasonView('operator_scope')?.label).toBe('Operator request');
+		expect(evidenceWorkReasonView('future_reason')).toEqual({
+			label: 'Priority work',
+			detail: 'Prepared for a decision that needs current evidence.'
+		});
+		expect(evidenceWorkReasonView(null)).toBeNull();
 	});
 
 	it('polls only while the server reports active work', () => {

--- a/frontend/src/lib/components/workstation/operator-work.ts
+++ b/frontend/src/lib/components/workstation/operator-work.ts
@@ -150,21 +150,37 @@ export function evidenceKindLabel(kind: string): string {
 	return humanize(kind);
 }
 
-export function evidenceStateLabel(state: string): string {
+export function evidenceStateLabel(state: string, decisionStatus: string | null = null): string {
+	if (state === 'current' && decisionStatus && !['resolved', 'measured'].includes(decisionStatus)) {
+		return 'Needs decision';
+	}
 	if (state === 'current') return 'Current';
 	if (state === 'analysis_required') return 'Needs analysis';
 	if (state === 'classification_required') return 'Needs update';
 	return humanize(state);
 }
 
-export function evidenceStateTone(state: string): OperatorStateTone {
+export function evidenceStateTone(
+	state: string,
+	decisionStatus: string | null = null
+): OperatorStateTone {
+	if (state === 'current' && decisionStatus && !['resolved', 'measured'].includes(decisionStatus)) {
+		return 'wait';
+	}
 	if (state === 'current') return 'ready';
 	if (state === 'analysis_required') return 'wait';
 	if (state === 'classification_required') return 'active';
 	return 'idle';
 }
 
-export function evidenceReasonCopy(reason: string | null): string {
+export function evidenceReasonCopy(
+	reason: string | null,
+	state: string | null = null,
+	decisionStatus: string | null = null
+): string {
+	if (state === 'current' && decisionStatus && !['resolved', 'measured'].includes(decisionStatus)) {
+		return 'The measured motion pattern needs an operator decision before conversion.';
+	}
 	if (!reason) return 'Evidence is not current.';
 	if (reason === 'missing') return 'No saved measurement exists yet.';
 	if (reason === 'malformed') return 'The saved measurement could not be read.';
@@ -175,6 +191,46 @@ export function evidenceReasonCopy(reason: string | null): string {
 	if (reason === 'policy_changed')
 		return 'The interpretation policy changed; stored measurements can be reused.';
 	return 'Mediaforce cannot prove this evidence is current.';
+}
+
+export interface EvidenceWorkReasonView {
+	label: string;
+	detail: string;
+}
+
+export function evidenceWorkReasonView(reason: string | null): EvidenceWorkReasonView | null {
+	if (!reason) return null;
+	if (reason === 'sample_safety') {
+		return { label: 'Blocks sample', detail: 'Required before the selected sample can run.' };
+	}
+	if (reason === 'encode_safety') {
+		return {
+			label: 'Blocks production',
+			detail: 'Required before the selected production work can start.'
+		};
+	}
+	if (reason === 'policy_reclassification') {
+		return {
+			label: 'No media read',
+			detail: 'Reinterprets stored measurements without opening the media.'
+		};
+	}
+	if (reason === 'representative_technical_coverage') {
+		return {
+			label: 'Representative check',
+			detail: 'Chosen from codec, resolution, cadence, audio layout, and runtime.'
+		};
+	}
+	if (reason === 'representative_uncertainty') {
+		return {
+			label: 'Bounded follow-up',
+			detail: 'Checks one nearby file because measured representative coverage is uncertain.'
+		};
+	}
+	if (reason === 'operator_scope') {
+		return { label: 'Operator request', detail: 'Prepared from the scope you selected.' };
+	}
+	return { label: 'Priority work', detail: 'Prepared for a decision that needs current evidence.' };
 }
 
 export function evidenceWorkStatusView(row: OperatorEvidenceBacklogRow): OperatorStateView {

--- a/frontend/src/lib/season/experience.test.ts
+++ b/frontend/src/lib/season/experience.test.ts
@@ -411,6 +411,7 @@ describe('season experience translation', () => {
 		expect(summary).toEqual({
 			verdict: 'Request comparison',
 			blocked: false,
+			requiresCadenceResolution: false,
 			tone: 'ready',
 			title: 'Grain / noise treatment',
 			detail: 'Low-confidence grain findings require comparison.',
@@ -431,6 +432,62 @@ describe('season experience translation', () => {
 				detail: 'Listen for clarity, channel layout, balance, and anything distracting.'
 			}
 		});
+	});
+
+	it('identifies a blocked cadence decision that needs Activity resolution', () => {
+		const summary = compareRiskSummary(
+			folder({
+				quality_risk: {
+					verdict: 'blocked',
+					blocked: true,
+					cadence_gate: 'unknown',
+					cadence_transform: null,
+					blocking_reasons: ['Measured cadence needs explicit review.'],
+					typed_risks: [
+						{
+							tag: 'cadence_interlace_artifacts',
+							label: 'Cadence / interlace artifacts',
+							level: 'medium',
+							rationale: 'Measured cadence needs explicit review.'
+						}
+					]
+				}
+			})
+		);
+
+		expect(summary?.requiresCadenceResolution).toBe(true);
+	});
+
+	it('keeps unrelated quality blockers in the normal revision workflow', () => {
+		const summary = compareRiskSummary(
+			folder({
+				quality_risk: {
+					verdict: 'blocked',
+					blocked: true,
+					cadence_gate: 'progressive',
+					cadence_transform: 'none',
+					blocking_reasons: ['The target-size search is infeasible.']
+				}
+			})
+		);
+
+		expect(summary?.requiresCadenceResolution).toBe(false);
+	});
+
+	it('routes stored cadence blockers without structured gate fields to Activity', () => {
+		const summary = compareRiskSummary(
+			folder({
+				quality_risk: {
+					verdict: 'blocked',
+					blocked: true,
+					blocking_reasons: [
+						'Cadence evidence is missing or inconclusive; refresh cadence analysis before encoding.'
+					]
+				}
+			})
+		);
+
+		expect(summary?.requiresCadenceResolution).toBe(true);
 	});
 
 	it('falls through a pending proposal without video settings', () => {

--- a/frontend/src/lib/season/experience.ts
+++ b/frontend/src/lib/season/experience.ts
@@ -88,6 +88,7 @@ export interface ReviewPair {
 export interface CompareRiskSummary {
 	verdict: string;
 	blocked: boolean;
+	requiresCadenceResolution: boolean;
 	tone: HumanSeasonTone;
 	title: string;
 	detail: string;
@@ -287,6 +288,17 @@ export function compareRiskSummary(folder: FolderPayload): CompareRiskSummary | 
 		typedRisks[0] ??
 		null;
 	const authority = riskAuthority(risk);
+	const cadenceGate = text(risk.cadence_gate).toLowerCase();
+	const cadenceTransform = text(risk.cadence_transform).toLowerCase();
+	const legacyCadenceBlocker = (risk.blocking_reasons ?? []).some((reason) =>
+		/\b(cadence|motion[ -]pattern)\b/i.test(reason)
+	);
+	const requiresCadenceResolution =
+		Boolean(risk.blocked) &&
+		(legacyCadenceBlocker ||
+			cadenceGate === 'mixed' ||
+			cadenceGate === 'unknown' ||
+			(['tff', 'bff', 'telecine'].includes(cadenceGate) && !cadenceTransform));
 	const picture = compareRiskFact(
 		typedRisks,
 		(tag) => tag !== 'audio_quality_layout',
@@ -306,6 +318,7 @@ export function compareRiskSummary(folder: FolderPayload): CompareRiskSummary | 
 	return {
 		verdict: riskVerdictCopy(risk.verdict),
 		blocked: Boolean(risk.blocked),
+		requiresCadenceResolution,
 		tone: riskTone(risk),
 		title: topRisk ? topRisk.label : riskVerdictCopy(risk.verdict),
 		detail:

--- a/mediaforce/cli.py
+++ b/mediaforce/cli.py
@@ -1,4 +1,5 @@
 import argparse
+from dataclasses import asdict
 import json
 import os
 from pathlib import Path
@@ -14,6 +15,8 @@ from mediaforce.execution import describe_item_plan, encode_manifest_items, prom
 from mediaforce.encoding.bakeoff import DEFAULT_BAKEOFF_ENGINES, build_bakeoff_plan, write_bakeoff_plan
 from mediaforce.library.folder_profiles import inspect_prefix
 from mediaforce.library.candidate_selection import scope_target_size_blocker
+from mediaforce.library.evidence_acquisition import load_fingerprint_acquisition_items, \
+    replay_representative_dimensions
 from mediaforce.library.evidence_queue import DEFAULT_EVIDENCE_BATCH_LIMIT, EvidenceQueueConflict, \
     cancel_evidence_queue, evidence_queue_summary, pause_evidence_queue, resume_evidence_queue, \
     start_evidence_work
@@ -72,6 +75,14 @@ def build_parser() -> argparse.ArgumentParser:
     evidence_actions.add_parser("pause", help="Prevent new evidence claims")
     evidence_actions.add_parser("resume", help="Allow claims from the paused evidence batch")
     evidence_actions.add_parser("cancel", help="Cancel queued work and stop the active managed process")
+    evidence_replay_parser = evidence_actions.add_parser(
+        "replay",
+        help="Compare representative dimensions from stored evidence without reading media",
+    )
+    evidence_replay_parser.add_argument(
+        "prefix",
+        help="Explicit scope such as tv/Show/Season 1 or movies/Title (Year)",
+    )
     evidence_run_parser = evidence_actions.add_parser(
         "run",
         help="Run a bounded foreground worker pass and exit",
@@ -448,6 +459,26 @@ def _run_evidence_command(config: MediaforceConfig, args: argparse.Namespace) ->
                     summary = resume_evidence_queue(connection)
                 elif action == "cancel":
                     summary = cancel_evidence_queue(connection)
+                elif action == "replay":
+                    scope, items, measured_source_ids = load_fingerprint_acquisition_items(
+                        connection,
+                        config,
+                        args.prefix,
+                    )
+                    if not items:
+                        raise ValueError(f"No representative candidates were found for {args.prefix!r}.")
+                    report = replay_representative_dimensions(
+                        items,
+                        prefix=scope.prefix,
+                        policy=config.resolve_policy(scope.prefix),
+                        measured_source_ids=measured_source_ids,
+                    )
+                    summary = {
+                        "scope": scope.to_payload(),
+                        "candidate_count": len(items),
+                        "measured_fingerprint_count": len(measured_source_ids),
+                        "report": asdict(report),
+                    }
                 else:
                     raise ValueError(f"Unsupported evidence action: {action}")
     except (EvidenceQueueConflict, ValueError) as exc:

--- a/mediaforce/core/db_migration_scripts/versions/20260719_0014_evidence_work_priority.py
+++ b/mediaforce/core/db_migration_scripts/versions/20260719_0014_evidence_work_priority.py
@@ -1,0 +1,88 @@
+"""Add evidence-work priority and operator reason.
+
+Revision ID: 20260719_0014
+Revises: 20260719_0013
+Create Date: 2026-07-19 19:30:00
+"""
+
+import sqlalchemy as sa
+# noinspection PyPackageRequirements
+from alembic import op
+
+revision = "20260719_0014"
+down_revision = "20260719_0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if not _has_column("library_item_evidence_state", "work_priority"):
+        op.add_column(
+            "library_item_evidence_state",
+            sa.Column("work_priority", sa.Integer(), nullable=False, server_default="100"),
+        )
+    if not _has_column("library_item_evidence_state", "work_reason"):
+        op.add_column(
+            "library_item_evidence_state",
+            sa.Column("work_reason", sa.Text(), nullable=True),
+        )
+    if _has_index(
+            "library_item_evidence_state",
+            "idx_library_item_evidence_state_work_claim",
+    ):
+        op.drop_index(
+            "idx_library_item_evidence_state_work_claim",
+            table_name="library_item_evidence_state",
+        )
+    op.create_index(
+        "idx_library_item_evidence_state_work_claim",
+        "library_item_evidence_state",
+        [
+            "work_batch_id",
+            "work_status",
+            "retry_not_before",
+            "work_priority",
+            "evidence_kind",
+            "library_item_id",
+        ],
+    )
+
+
+def downgrade() -> None:
+    if _has_index(
+            "library_item_evidence_state",
+            "idx_library_item_evidence_state_work_claim",
+    ):
+        op.drop_index(
+            "idx_library_item_evidence_state_work_claim",
+            table_name="library_item_evidence_state",
+        )
+    op.create_index(
+        "idx_library_item_evidence_state_work_claim",
+        "library_item_evidence_state",
+        [
+            "work_batch_id",
+            "work_status",
+            "retry_not_before",
+            "evidence_kind",
+            "library_item_id",
+        ],
+    )
+    if _has_column("library_item_evidence_state", "work_reason"):
+        op.drop_column("library_item_evidence_state", "work_reason")
+    if _has_column("library_item_evidence_state", "work_priority"):
+        op.drop_column("library_item_evidence_state", "work_priority")
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    return any(
+        str(column.get("name") or "") == column_name
+        for column in sa.inspect(op.get_bind()).get_columns(table_name)
+    )
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    return any(
+        str(index.get("name") or "") == index_name
+        for index in sa.inspect(op.get_bind()).get_indexes(table_name)
+    )

--- a/mediaforce/core/db_tables.py
+++ b/mediaforce/core/db_tables.py
@@ -102,6 +102,8 @@ library_item_evidence_state = Table(
     Column("last_error", Text),
     Column("work_batch_id", Text),
     Column("work_status", Text),
+    Column("work_priority", Integer, nullable=False, server_default="100"),
+    Column("work_reason", Text),
     Column("work_source_fingerprint", Text),
     Column("leased_at", Text),
     Column("lease_expires_at", Text),
@@ -127,6 +129,7 @@ Index(
     library_item_evidence_state.c.work_batch_id,
     library_item_evidence_state.c.work_status,
     library_item_evidence_state.c.retry_not_before,
+    library_item_evidence_state.c.work_priority,
     library_item_evidence_state.c.evidence_kind,
     library_item_evidence_state.c.library_item_id,
 )

--- a/mediaforce/library/background_work.py
+++ b/mediaforce/library/background_work.py
@@ -1,18 +1,20 @@
 from typing import Any
 
-from sqlalchemy import func, select, update
+from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import background_work_state, library_item_evidence_state, library_items
 from mediaforce.core.utils import timestamp
+from mediaforce.encoding.cadence import CADENCE_EVIDENCE_KIND
 from mediaforce.library.evidence_state import EVIDENCE_KINDS, EVIDENCE_STATE_ANALYSIS_REQUIRED, \
-    EVIDENCE_STATE_CLASSIFICATION_REQUIRED
+    EVIDENCE_STATE_CLASSIFICATION_REQUIRED, EVIDENCE_STATE_CURRENT
 
 BACKGROUND_WORK_AREA = "catalog_evidence"
 EVIDENCE_BACKLOG_STATES = (
     EVIDENCE_STATE_ANALYSIS_REQUIRED,
     EVIDENCE_STATE_CLASSIFICATION_REQUIRED,
+    EVIDENCE_STATE_CURRENT,
 )
 EVIDENCE_BACKLOG_WORK_STATUSES = (
     "not_prepared",
@@ -95,6 +97,7 @@ def summarize_evidence_inventory(connection: DBClient) -> dict[str, Any]:
             library_item_evidence_state.c.evidence_kind,
             library_item_evidence_state.c.state,
             library_item_evidence_state.c.reason,
+            library_item_evidence_state.c.decision_status,
             func.count().label("item_count"),
         )
         .select_from(
@@ -108,6 +111,7 @@ def summarize_evidence_inventory(connection: DBClient) -> dict[str, Any]:
             library_item_evidence_state.c.evidence_kind,
             library_item_evidence_state.c.state,
             library_item_evidence_state.c.reason,
+            library_item_evidence_state.c.decision_status,
         )
         .order_by(
             library_item_evidence_state.c.evidence_kind,
@@ -127,7 +131,11 @@ def summarize_evidence_inventory(connection: DBClient) -> dict[str, Any]:
         reason = str(row["reason"] or "")
         item_count = int(row["item_count"] or 0)
         total += item_count
-        if state in EVIDENCE_BACKLOG_STATES:
+        if _evidence_needs_attention(
+                evidence_kind=evidence_kind,
+                state=state,
+                decision_status=str(row["decision_status"] or ""),
+        ):
             backlog_total += item_count
         kind_payload = by_kind.setdefault(evidence_kind, {"total": 0, "states": {}, "reasons": {}})
         kind_payload["total"] += item_count
@@ -163,7 +171,7 @@ def list_evidence_backlog(
     normalized_root = str(media_root or "").strip() or None
 
     conditions = [
-        library_item_evidence_state.c.state.in_(EVIDENCE_BACKLOG_STATES),
+        _evidence_backlog_condition(),
         library_items.c.status != "missing",
     ]
     if normalized_kind:
@@ -195,7 +203,10 @@ def list_evidence_backlog(
             library_item_evidence_state.c.evidence_kind,
             library_item_evidence_state.c.state,
             library_item_evidence_state.c.reason,
+            library_item_evidence_state.c.decision_status,
             library_item_evidence_state.c.work_status,
+            library_item_evidence_state.c.work_priority,
+            library_item_evidence_state.c.work_reason,
             library_item_evidence_state.c.attempt_count,
             library_item_evidence_state.c.retry_not_before,
             library_item_evidence_state.c.last_attempt_at,
@@ -209,6 +220,7 @@ def list_evidence_backlog(
         .select_from(joined)
         .where(*conditions)
         .order_by(
+            library_item_evidence_state.c.work_priority,
             library_items.c.media_root,
             library_items.c.rel_path,
             library_item_evidence_state.c.evidence_kind,
@@ -241,3 +253,33 @@ def _optional_choice(value: str | None, choices: tuple[str, ...], label: str) ->
     if normalized is not None and normalized not in choices:
         raise ValueError(f"Unsupported {label}: {normalized}")
     return normalized
+
+
+def _evidence_backlog_condition() -> Any:
+    return or_(
+        library_item_evidence_state.c.state.in_((
+            EVIDENCE_STATE_ANALYSIS_REQUIRED,
+            EVIDENCE_STATE_CLASSIFICATION_REQUIRED,
+        )),
+        and_(
+            library_item_evidence_state.c.evidence_kind == CADENCE_EVIDENCE_KIND,
+            library_item_evidence_state.c.state == EVIDENCE_STATE_CURRENT,
+            library_item_evidence_state.c.decision_status != "resolved",
+        ),
+    )
+
+
+def _evidence_needs_attention(
+        *,
+        evidence_kind: str,
+        state: str,
+        decision_status: str,
+) -> bool:
+    return (
+        state in {EVIDENCE_STATE_ANALYSIS_REQUIRED, EVIDENCE_STATE_CLASSIFICATION_REQUIRED}
+        or (
+            evidence_kind == CADENCE_EVIDENCE_KIND
+            and state == EVIDENCE_STATE_CURRENT
+            and decision_status != "resolved"
+        )
+    )

--- a/mediaforce/library/evidence_acquisition.py
+++ b/mediaforce/library/evidence_acquisition.py
@@ -1,0 +1,561 @@
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Collection, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from mediaforce.core.evidence import stable_source_id
+from mediaforce.encoding.fingerprint import (
+    DEFAULT_FINGERPRINT_MAX_FRAMES,
+    DEFAULT_FINGERPRINT_RANGE_COUNT,
+    DEFAULT_FINGERPRINT_SAMPLE_FPS,
+)
+from mediaforce.library.representatives import FINGERPRINT_DIMENSIONS, RepresentativeSelection, select_representatives
+
+
+DEFAULT_UNCERTAINTY_FRONTIER_LIMIT = 3
+
+FingerprintAcquisitionPhase = Literal["technical_representatives", "uncertainty_frontier", "complete"]
+AudioComplexityRecommendation = Literal["retain", "defer", "not_applicable", "evaluate_with_replay"]
+
+
+@dataclass(frozen=True, slots=True)
+class SharedVisualPassCost:
+    candidate_count: int
+    estimated_range_count: int
+    estimated_frame_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class AudioComplexityCost:
+    candidate_count: int
+    estimated_range_count: int
+    estimated_sample_seconds: float
+    recommendation: AudioComplexityRecommendation
+
+
+@dataclass(frozen=True, slots=True)
+class FingerprintAnalysisCost:
+    shared_visual_pass: SharedVisualPassCost
+    audio_complexity: AudioComplexityCost
+
+
+@dataclass(frozen=True, slots=True)
+class FingerprintAcquisitionCoverage:
+    total_item_count: int
+    measured_item_count: int
+    unmeasured_item_count: int
+    technical_representative_count: int
+    measured_technical_representative_count: int
+    all_dimension_representative_count: int
+    measured_all_dimension_representative_count: int
+    global_fingerprint_coverage: float
+    technical_representative_coverage: float
+    all_dimension_representative_coverage: float
+
+
+@dataclass(frozen=True, slots=True)
+class FingerprintAcquisitionPlan:
+    phase: FingerprintAcquisitionPhase
+    candidate_ids: tuple[str, ...]
+    technical_representative_ids: tuple[str, ...]
+    all_dimension_representative_ids: tuple[str, ...]
+    coverage: FingerprintAcquisitionCoverage
+    stop_reason: str
+    intentionally_unqueued_count: int
+    estimated_analysis_cost: FingerprintAnalysisCost
+
+
+@dataclass(frozen=True, slots=True)
+class RepresentativeChanges:
+    baseline_ids: tuple[str, ...]
+    added_ids: tuple[str, ...]
+    removed_ids: tuple[str, ...]
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.added_ids or self.removed_ids)
+
+
+@dataclass(frozen=True, slots=True)
+class HardCaseRecall:
+    total_hard_case_count: int
+    recalled_hard_case_count: int
+    fraction: float
+    recalled_cases: tuple[tuple[str, str], ...]
+    missed_cases: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class SampleSetGrowth:
+    baseline_count: int
+    selected_count: int
+    change_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class RepresentativeDimensionReplay:
+    name: str
+    omitted_fingerprint_dimension: str | None
+    fingerprint_dimensions: tuple[str, ...]
+    representative_ids: tuple[str, ...]
+    representative_changes: RepresentativeChanges
+    hard_case_recall: HardCaseRecall
+    sample_set_growth: SampleSetGrowth
+    estimated_analysis_cost: FingerprintAnalysisCost
+
+
+@dataclass(frozen=True, slots=True)
+class RepresentativeDimensionReplayReport:
+    technical_only: RepresentativeDimensionReplay
+    all_dimensions: RepresentativeDimensionReplay
+    leave_one_dimension_out: tuple[RepresentativeDimensionReplay, ...]
+    shared_visual_pass_cost: SharedVisualPassCost
+    audio_complexity_cost: AudioComplexityCost
+
+
+def plan_fingerprint_acquisition(
+        items: Sequence[Mapping[str, Any]],
+        *,
+        prefix: str = "",
+        policy: Mapping[str, Any] | None = None,
+        max_uncertainty_frontier: int = DEFAULT_UNCERTAINTY_FRONTIER_LIMIT,
+        measured_source_ids: Collection[str] | None = None,
+) -> FingerprintAcquisitionPlan:
+    if max_uncertainty_frontier <= 0:
+        raise ValueError("max_uncertainty_frontier must be greater than zero")
+
+    item_by_source_id = _items_by_source_id(items)
+    current_source_ids = _current_source_ids(items, measured_source_ids)
+    technical_selection = select_representatives(
+        items,
+        prefix=prefix,
+        policy=policy,
+        fingerprint_dimensions=(),
+    )
+    all_dimension_selection = select_representatives(
+        items,
+        prefix=prefix,
+        policy=policy,
+        fingerprint_dimensions=FINGERPRINT_DIMENSIONS,
+    )
+    technical_representative_ids = _selected_source_ids(technical_selection)
+    all_dimension_representative_ids = _selected_source_ids(all_dimension_selection)
+    technical_candidates = tuple(
+        source_id
+        for source_id in technical_representative_ids
+        if source_id not in current_source_ids
+    )
+    uncertainty_frontier = tuple(
+        source_id
+        for source_id in all_dimension_representative_ids
+        if source_id not in current_source_ids and source_id not in technical_representative_ids
+    )
+
+    if technical_candidates:
+        phase: FingerprintAcquisitionPhase = "technical_representatives"
+        candidate_ids = technical_candidates
+        stop_reason = "technical_representatives_pending"
+    elif uncertainty_frontier:
+        phase = "uncertainty_frontier"
+        candidate_ids = uncertainty_frontier[:max_uncertainty_frontier]
+        stop_reason = (
+            "uncertainty_frontier_capped"
+            if len(uncertainty_frontier) > len(candidate_ids)
+            else "uncertainty_frontier_pending"
+        )
+    else:
+        phase = "complete"
+        candidate_ids = ()
+        stop_reason = "representative_coverage_satisfied"
+
+    coverage = _acquisition_coverage(
+        item_by_source_id,
+        current_source_ids,
+        technical_representative_ids,
+        all_dimension_representative_ids,
+    )
+    unmeasured_source_ids = set(item_by_source_id) - current_source_ids
+    intentionally_unqueued_count = len(unmeasured_source_ids - set(candidate_ids))
+    return FingerprintAcquisitionPlan(
+        phase=phase,
+        candidate_ids=candidate_ids,
+        technical_representative_ids=technical_representative_ids,
+        all_dimension_representative_ids=all_dimension_representative_ids,
+        coverage=coverage,
+        stop_reason=stop_reason,
+        intentionally_unqueued_count=intentionally_unqueued_count,
+        estimated_analysis_cost=_estimate_analysis_cost(
+            candidate_ids,
+            item_by_source_id,
+            audio_recommendation="evaluate_with_replay",
+        ),
+    )
+
+
+def replay_representative_dimensions(
+        items: Sequence[Mapping[str, Any]],
+        *,
+        prefix: str = "",
+        policy: Mapping[str, Any] | None = None,
+        measured_source_ids: Collection[str] | None = None,
+) -> RepresentativeDimensionReplayReport:
+    item_by_source_id = _items_by_source_id(items)
+    current_source_ids = _current_source_ids(items, measured_source_ids)
+    technical_selection = select_representatives(
+        items,
+        prefix=prefix,
+        policy=policy,
+        fingerprint_dimensions=(),
+    )
+    all_dimension_selection = select_representatives(
+        items,
+        prefix=prefix,
+        policy=policy,
+        fingerprint_dimensions=FINGERPRINT_DIMENSIONS,
+    )
+    technical_representative_ids = _selected_source_ids(technical_selection)
+    all_dimension_representative_ids = _selected_source_ids(all_dimension_selection)
+    hard_cases = _hard_case_clusters(all_dimension_selection)
+    technical_only = _replay_entry(
+        name="technical_only",
+        omitted_fingerprint_dimension=None,
+        fingerprint_dimensions=(),
+        selection=technical_selection,
+        baseline_ids=technical_representative_ids,
+        hard_cases=hard_cases,
+        current_source_ids=current_source_ids,
+        item_by_source_id=item_by_source_id,
+    )
+    all_dimensions = _replay_entry(
+        name="all_dimensions",
+        omitted_fingerprint_dimension=None,
+        fingerprint_dimensions=FINGERPRINT_DIMENSIONS,
+        selection=all_dimension_selection,
+        baseline_ids=technical_representative_ids,
+        hard_cases=hard_cases,
+        current_source_ids=current_source_ids,
+        item_by_source_id=item_by_source_id,
+    )
+    leave_one_dimension_out_entries: list[RepresentativeDimensionReplay] = []
+    for omitted_dimension in FINGERPRINT_DIMENSIONS:
+        replay_dimensions = tuple(
+            dimension
+            for dimension in FINGERPRINT_DIMENSIONS
+            if dimension != omitted_dimension
+        )
+        leave_one_dimension_out_entries.append(
+            _replay_entry(
+                name="leave_one_dimension_out",
+                omitted_fingerprint_dimension=omitted_dimension,
+                fingerprint_dimensions=replay_dimensions,
+                selection=select_representatives(
+                    items,
+                    prefix=prefix,
+                    policy=policy,
+                    fingerprint_dimensions=replay_dimensions,
+                ),
+                baseline_ids=all_dimension_representative_ids,
+                hard_cases=hard_cases,
+                current_source_ids=current_source_ids,
+                item_by_source_id=item_by_source_id,
+            )
+        )
+    leave_one_dimension_out = tuple(leave_one_dimension_out_entries)
+    audio_omission = next(
+        replay
+        for replay in leave_one_dimension_out
+        if replay.omitted_fingerprint_dimension == "audio_complexity"
+    )
+    audio_recommendation = _audio_complexity_recommendation(all_dimensions, audio_omission)
+    return RepresentativeDimensionReplayReport(
+        technical_only=technical_only,
+        all_dimensions=all_dimensions,
+        leave_one_dimension_out=leave_one_dimension_out,
+        shared_visual_pass_cost=all_dimensions.estimated_analysis_cost.shared_visual_pass,
+        audio_complexity_cost=_audio_cost(
+            _unmeasured_selected_items(
+                all_dimension_representative_ids,
+                current_source_ids,
+                item_by_source_id,
+            ),
+            recommendation=audio_recommendation,
+        ),
+    )
+
+
+def _items_by_source_id(items: Sequence[Mapping[str, Any]]) -> dict[str, Mapping[str, Any]]:
+    item_by_source_id = {stable_source_id(item): item for item in items}
+    if len(item_by_source_id) != len(items):
+        raise ValueError("Fingerprint acquisition candidates must have unique source IDs")
+    return item_by_source_id
+
+
+def _current_source_ids(
+        items: Sequence[Mapping[str, Any]],
+        measured_source_ids: Collection[str] | None,
+) -> frozenset[str]:
+    if measured_source_ids is not None:
+        return frozenset(str(source_id).strip() for source_id in measured_source_ids if str(source_id).strip())
+    return frozenset(
+        stable_source_id(item)
+        for item in items
+        if _fingerprint_is_measured(item)
+    )
+
+
+def _fingerprint_is_measured(item: Mapping[str, Any]) -> bool:
+    decision = item.get("media_fingerprint_decision")
+    return (
+        isinstance(decision, Mapping)
+        and str(decision.get("status") or "").strip().lower() == "measured"
+    )
+
+
+def _selected_source_ids(selection: RepresentativeSelection) -> tuple[str, ...]:
+    return tuple(str(item["source_id"]) for item in selection.payload["selected_items"])
+
+
+def _acquisition_coverage(
+        item_by_source_id: Mapping[str, Mapping[str, Any]],
+        current_source_ids: Collection[str],
+        technical_representative_ids: Sequence[str],
+        all_dimension_representative_ids: Sequence[str],
+) -> FingerprintAcquisitionCoverage:
+    relevant_current_ids = set(item_by_source_id) & set(current_source_ids)
+    technical_current_count = sum(
+        source_id in relevant_current_ids
+        for source_id in technical_representative_ids
+    )
+    all_dimension_current_count = sum(
+        source_id in relevant_current_ids
+        for source_id in all_dimension_representative_ids
+    )
+    total_item_count = len(item_by_source_id)
+    return FingerprintAcquisitionCoverage(
+        total_item_count=total_item_count,
+        measured_item_count=len(relevant_current_ids),
+        unmeasured_item_count=total_item_count - len(relevant_current_ids),
+        technical_representative_count=len(technical_representative_ids),
+        measured_technical_representative_count=technical_current_count,
+        all_dimension_representative_count=len(all_dimension_representative_ids),
+        measured_all_dimension_representative_count=all_dimension_current_count,
+        global_fingerprint_coverage=_fraction(len(relevant_current_ids), total_item_count),
+        technical_representative_coverage=_fraction(
+            technical_current_count,
+            len(technical_representative_ids),
+        ),
+        all_dimension_representative_coverage=_fraction(
+            all_dimension_current_count,
+            len(all_dimension_representative_ids),
+        ),
+    )
+
+
+def _replay_entry(
+        *,
+        name: str,
+        omitted_fingerprint_dimension: str | None,
+        fingerprint_dimensions: tuple[str, ...],
+        selection: RepresentativeSelection,
+        baseline_ids: tuple[str, ...],
+        hard_cases: tuple[tuple[str, str], ...],
+        current_source_ids: Collection[str],
+        item_by_source_id: Mapping[str, Mapping[str, Any]],
+) -> RepresentativeDimensionReplay:
+    representative_ids = _selected_source_ids(selection)
+    return RepresentativeDimensionReplay(
+        name=name,
+        omitted_fingerprint_dimension=omitted_fingerprint_dimension,
+        fingerprint_dimensions=fingerprint_dimensions,
+        representative_ids=representative_ids,
+        representative_changes=_representative_changes(baseline_ids, representative_ids),
+        hard_case_recall=_hard_case_recall(hard_cases, selection),
+        sample_set_growth=SampleSetGrowth(
+            baseline_count=len(baseline_ids),
+            selected_count=len(representative_ids),
+            change_count=len(representative_ids) - len(baseline_ids),
+        ),
+        estimated_analysis_cost=_estimate_analysis_cost(
+            representative_ids,
+            item_by_source_id,
+            current_source_ids=current_source_ids,
+            audio_recommendation="evaluate_with_replay",
+        ),
+    )
+
+
+def _representative_changes(
+        baseline_ids: Sequence[str],
+        representative_ids: Sequence[str],
+) -> RepresentativeChanges:
+    baseline_id_set = set(baseline_ids)
+    representative_id_set = set(representative_ids)
+    return RepresentativeChanges(
+        baseline_ids=tuple(baseline_ids),
+        added_ids=tuple(source_id for source_id in representative_ids if source_id not in baseline_id_set),
+        removed_ids=tuple(source_id for source_id in baseline_ids if source_id not in representative_id_set),
+    )
+
+
+def _hard_case_clusters(selection: RepresentativeSelection) -> tuple[tuple[str, str], ...]:
+    coverage_dimensions = selection.payload["coverage"]["dimensions"]
+    hard_cases: set[tuple[str, str]] = set()
+    for dimension in FINGERPRINT_DIMENSIONS:
+        dimension_coverage = coverage_dimensions.get(dimension)
+        if not isinstance(dimension_coverage, Mapping):
+            continue
+        values = {
+            str(value)
+            for value in dimension_coverage.get("covered_values", [])
+        }
+        values.update(
+            str(value.get("value"))
+            for value in dimension_coverage.get("uncovered_values", [])
+            if isinstance(value, Mapping)
+        )
+        hard_cases.update(
+            (dimension, value)
+            for value in values
+            if value not in {"typical", "unknown"}
+        )
+    return tuple(sorted(hard_cases))
+
+
+def _hard_case_recall(
+        hard_cases: tuple[tuple[str, str], ...],
+        selection: RepresentativeSelection,
+) -> HardCaseRecall:
+    selected_profiles = [
+        profile
+        for item in selection.payload["selected_items"]
+        if isinstance(profile := item.get("technical_profile"), Mapping)
+    ]
+    recalled_cases = tuple(
+        hard_case
+        for hard_case in hard_cases
+        if any(profile.get(hard_case[0]) == hard_case[1] for profile in selected_profiles)
+    )
+    recalled_case_set = set(recalled_cases)
+    return HardCaseRecall(
+        total_hard_case_count=len(hard_cases),
+        recalled_hard_case_count=len(recalled_cases),
+        fraction=_fraction(len(recalled_cases), len(hard_cases)),
+        recalled_cases=recalled_cases,
+        missed_cases=tuple(hard_case for hard_case in hard_cases if hard_case not in recalled_case_set),
+    )
+
+
+def _estimate_analysis_cost(
+        candidate_ids: Sequence[str],
+        item_by_source_id: Mapping[str, Mapping[str, Any]],
+        *,
+        current_source_ids: Collection[str] = (),
+        audio_recommendation: AudioComplexityRecommendation,
+) -> FingerprintAnalysisCost:
+    candidate_items = _unmeasured_selected_items(candidate_ids, current_source_ids, item_by_source_id)
+    return FingerprintAnalysisCost(
+        shared_visual_pass=_visual_cost(candidate_items),
+        audio_complexity=_audio_cost(candidate_items, recommendation=audio_recommendation),
+    )
+
+
+def _unmeasured_selected_items(
+        candidate_ids: Sequence[str],
+        current_source_ids: Collection[str],
+        item_by_source_id: Mapping[str, Mapping[str, Any]],
+) -> tuple[Mapping[str, Any], ...]:
+    current_id_set = set(current_source_ids)
+    return tuple(
+        item_by_source_id[source_id]
+        for source_id in candidate_ids
+        if source_id not in current_id_set
+    )
+
+
+def _visual_cost(candidate_items: Sequence[Mapping[str, Any]]) -> SharedVisualPassCost:
+    range_counts = [_fingerprint_range_count(item) for item in candidate_items]
+    return SharedVisualPassCost(
+        candidate_count=len(candidate_items),
+        estimated_range_count=sum(range_counts),
+        estimated_frame_count=len(candidate_items) * DEFAULT_FINGERPRINT_MAX_FRAMES,
+    )
+
+
+def _audio_cost(
+        candidate_items: Sequence[Mapping[str, Any]],
+        *,
+        recommendation: AudioComplexityRecommendation,
+) -> AudioComplexityCost:
+    audio_items = tuple(item for item in candidate_items if _has_audio(item))
+    range_counts = [_fingerprint_range_count(item) for item in audio_items]
+    estimated_sample_seconds = sum(
+        _audio_sample_seconds(range_count)
+        for range_count in range_counts
+    )
+    return AudioComplexityCost(
+        candidate_count=len(audio_items),
+        estimated_range_count=sum(range_counts),
+        estimated_sample_seconds=round(estimated_sample_seconds, 3),
+        recommendation=recommendation if audio_items else "not_applicable",
+    )
+
+
+def _fingerprint_range_count(item: Mapping[str, Any]) -> int:
+    duration_seconds = _positive_duration(item.get("duration_seconds"))
+    if duration_seconds is None or duration_seconds < 30:
+        return 1
+    return DEFAULT_FINGERPRINT_RANGE_COUNT
+
+
+def _audio_sample_seconds(range_count: int) -> float:
+    frames_per_range = max(1, DEFAULT_FINGERPRINT_MAX_FRAMES // max(1, range_count))
+    return float(
+        range_count
+        * min(max(frames_per_range / max(DEFAULT_FINGERPRINT_SAMPLE_FPS, 0.1), 4.0), 12.0)
+    )
+
+
+def _has_audio(item: Mapping[str, Any]) -> bool:
+    audio_summary = item.get("audio_summary")
+    if isinstance(audio_summary, str):
+        try:
+            audio_summary = json.loads(audio_summary)
+        except json.JSONDecodeError:
+            return False
+    return isinstance(audio_summary, list) and any(isinstance(track, Mapping) for track in audio_summary)
+
+
+def _positive_duration(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, int | float | str):
+        return None
+    try:
+        duration_seconds = float(value)
+    except ValueError:
+        return None
+    if not math.isfinite(duration_seconds) or duration_seconds <= 0:
+        return None
+    return duration_seconds
+
+
+def _fraction(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 1.0
+    return round(numerator / denominator, 4)
+
+
+def _audio_complexity_recommendation(
+        all_dimensions: RepresentativeDimensionReplay,
+        audio_omission: RepresentativeDimensionReplay,
+) -> AudioComplexityRecommendation:
+    if all_dimensions.estimated_analysis_cost.audio_complexity.candidate_count == 0:
+        return "not_applicable"
+    if (
+            audio_omission.representative_changes.changed
+            or audio_omission.hard_case_recall.recalled_hard_case_count
+            < all_dimensions.hard_case_recall.recalled_hard_case_count
+    ):
+        return "retain"
+    return "defer"

--- a/mediaforce/library/evidence_acquisition.py
+++ b/mediaforce/library/evidence_acquisition.py
@@ -2,20 +2,33 @@ from __future__ import annotations
 
 import json
 import math
+from collections import Counter
 from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from sqlalchemy import select
+
+from mediaforce.core.config import MediaforceConfig
+from mediaforce.core.db import DBClient
+from mediaforce.core.db_tables import library_item_evidence_state
 from mediaforce.core.evidence import stable_source_id
+from mediaforce.core.type_defs import int_value, object_dict, object_list
 from mediaforce.encoding.fingerprint import (
     DEFAULT_FINGERPRINT_MAX_FRAMES,
     DEFAULT_FINGERPRINT_RANGE_COUNT,
     DEFAULT_FINGERPRINT_SAMPLE_FPS,
 )
-from mediaforce.library.representatives import FINGERPRINT_DIMENSIONS, RepresentativeSelection, select_representatives
+from mediaforce.library.evidence_state import EVIDENCE_KINDS, parse_evidence_summary
+from mediaforce.library.media_scopes import MediaScope
+from mediaforce.library.representatives import FINGERPRINT_DIMENSIONS, MEANINGFUL_CLUSTER_FRACTION, \
+    TECHNICAL_PROFILE_DIMENSIONS, RepresentativeSelection, load_representative_candidate_rows, \
+    representative_profiles, select_representatives
 
 
 DEFAULT_UNCERTAINTY_FRONTIER_LIMIT = 3
+MIN_FINGERPRINT_ANALYSIS_BUDGET = 3
+FINGERPRINT_ANALYSIS_BUDGET_MULTIPLIER = 2
 
 FingerprintAcquisitionPhase = Literal["technical_representatives", "uncertainty_frontier", "complete"]
 AudioComplexityRecommendation = Literal["retain", "defer", "not_applicable", "evaluate_with_replay"]
@@ -62,6 +75,8 @@ class FingerprintAcquisitionPlan:
     candidate_ids: tuple[str, ...]
     technical_representative_ids: tuple[str, ...]
     all_dimension_representative_ids: tuple[str, ...]
+    analysis_budget: int
+    remaining_analysis_budget: int
     coverage: FingerprintAcquisitionCoverage
     stop_reason: str
     intentionally_unqueued_count: int
@@ -73,10 +88,7 @@ class RepresentativeChanges:
     baseline_ids: tuple[str, ...]
     added_ids: tuple[str, ...]
     removed_ids: tuple[str, ...]
-
-    @property
-    def changed(self) -> bool:
-        return bool(self.added_ids or self.removed_ids)
+    changed: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,6 +117,7 @@ class RepresentativeDimensionReplay:
     hard_case_recall: HardCaseRecall
     sample_set_growth: SampleSetGrowth
     estimated_analysis_cost: FingerprintAnalysisCost
+    remaining_analysis_cost: FingerprintAnalysisCost
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,6 +127,50 @@ class RepresentativeDimensionReplayReport:
     leave_one_dimension_out: tuple[RepresentativeDimensionReplay, ...]
     shared_visual_pass_cost: SharedVisualPassCost
     audio_complexity_cost: AudioComplexityCost
+
+
+def load_fingerprint_acquisition_items(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+) -> tuple[MediaScope, list[dict[str, Any]], frozenset[str]]:
+    scope, rows = load_representative_candidate_rows(connection, config, prefix)
+    if not rows:
+        return scope, [], frozenset()
+    item_ids = {int(row["id"]) for row in rows}
+    current_rows = connection.execute(
+        select(
+            library_item_evidence_state.c.library_item_id,
+            library_item_evidence_state.c.evidence_kind,
+        )
+        .where(
+            library_item_evidence_state.c.library_item_id.in_(item_ids),
+            library_item_evidence_state.c.evidence_kind.in_(EVIDENCE_KINDS),
+            library_item_evidence_state.c.state == "current",
+        )
+    ).mappings().fetchall()
+    current_item_ids_by_kind = {
+        evidence_kind: {
+            int(row["library_item_id"])
+            for row in current_rows
+            if str(row["evidence_kind"]) == evidence_kind
+        }
+        for evidence_kind in EVIDENCE_KINDS
+    }
+    items = [
+        _acquisition_item(
+            row,
+            cadence_current=int(row["id"]) in current_item_ids_by_kind[EVIDENCE_KINDS[0]],
+            fingerprint_current=int(row["id"]) in current_item_ids_by_kind[EVIDENCE_KINDS[1]],
+        )
+        for row in rows
+    ]
+    measured_source_ids = frozenset(
+        stable_source_id(item)
+        for item in items
+        if int(item["library_item_id"]) in current_item_ids_by_kind[EVIDENCE_KINDS[1]]
+    )
+    return scope, items, measured_source_ids
 
 
 def plan_fingerprint_acquisition(
@@ -129,14 +186,15 @@ def plan_fingerprint_acquisition(
 
     item_by_source_id = _items_by_source_id(items)
     current_source_ids = _current_source_ids(items, measured_source_ids)
+    selection_items = _selection_items(item_by_source_id, current_source_ids)
     technical_selection = select_representatives(
-        items,
+        selection_items,
         prefix=prefix,
         policy=policy,
         fingerprint_dimensions=(),
     )
     all_dimension_selection = select_representatives(
-        items,
+        selection_items,
         prefix=prefix,
         policy=policy,
         fingerprint_dimensions=FINGERPRINT_DIMENSIONS,
@@ -148,24 +206,38 @@ def plan_fingerprint_acquisition(
         for source_id in technical_representative_ids
         if source_id not in current_source_ids
     )
-    uncertainty_frontier = tuple(
-        source_id
-        for source_id in all_dimension_representative_ids
-        if source_id not in current_source_ids and source_id not in technical_representative_ids
+    analysis_budget = min(
+        len(item_by_source_id),
+        max(
+            MIN_FINGERPRINT_ANALYSIS_BUDGET,
+            len(technical_representative_ids) * FINGERPRINT_ANALYSIS_BUDGET_MULTIPLIER,
+        ),
+    )
+    measured_item_count = len(set(item_by_source_id) & set(current_source_ids))
+    remaining_analysis_budget = max(0, analysis_budget - measured_item_count)
+    uncertainty_frontier = _uncertainty_frontier(
+        selection_items,
+        current_source_ids=current_source_ids,
+        technical_representative_ids=technical_representative_ids,
+        all_dimension_representative_ids=all_dimension_representative_ids,
     )
 
     if technical_candidates:
         phase: FingerprintAcquisitionPhase = "technical_representatives"
         candidate_ids = technical_candidates
         stop_reason = "technical_representatives_pending"
-    elif uncertainty_frontier:
+    elif uncertainty_frontier and remaining_analysis_budget:
         phase = "uncertainty_frontier"
-        candidate_ids = uncertainty_frontier[:max_uncertainty_frontier]
+        candidate_ids = uncertainty_frontier[:min(max_uncertainty_frontier, remaining_analysis_budget)]
         stop_reason = (
             "uncertainty_frontier_capped"
             if len(uncertainty_frontier) > len(candidate_ids)
             else "uncertainty_frontier_pending"
         )
+    elif uncertainty_frontier:
+        phase = "complete"
+        candidate_ids = ()
+        stop_reason = "bounded_analysis_budget_reached"
     else:
         phase = "complete"
         candidate_ids = ()
@@ -184,6 +256,8 @@ def plan_fingerprint_acquisition(
         candidate_ids=candidate_ids,
         technical_representative_ids=technical_representative_ids,
         all_dimension_representative_ids=all_dimension_representative_ids,
+        analysis_budget=analysis_budget,
+        remaining_analysis_budget=max(0, remaining_analysis_budget - len(candidate_ids)),
         coverage=coverage,
         stop_reason=stop_reason,
         intentionally_unqueued_count=intentionally_unqueued_count,
@@ -276,9 +350,8 @@ def replay_representative_dimensions(
         leave_one_dimension_out=leave_one_dimension_out,
         shared_visual_pass_cost=all_dimensions.estimated_analysis_cost.shared_visual_pass,
         audio_complexity_cost=_audio_cost(
-            _unmeasured_selected_items(
+            _selected_items(
                 all_dimension_representative_ids,
-                current_source_ids,
                 item_by_source_id,
             ),
             recommendation=audio_recommendation,
@@ -286,11 +359,149 @@ def replay_representative_dimensions(
     )
 
 
+def _acquisition_item(
+        row: Mapping[str, Any],
+        *,
+        cadence_current: bool,
+        fingerprint_current: bool,
+) -> dict[str, Any]:
+    cadence_summary = parse_evidence_summary(row.get("cadence_summary_json")) if cadence_current else None
+    fingerprint_summary = (
+        parse_evidence_summary(row.get("media_fingerprint_json"))
+        if fingerprint_current
+        else None
+    )
+    cadence_decision = object_dict(cadence_summary.get("decision")) if cadence_summary else {}
+    fingerprint_decision = object_dict(fingerprint_summary.get("decision")) if fingerprint_summary else {}
+    source_fingerprint = str(
+        row.get("content_version_fingerprint")
+        or row.get("fingerprint")
+        or ""
+    ).strip() or None
+    item = {
+        "library_item_id": int(row["id"]),
+        "rel_path": str(row["rel_path"]),
+        "source_fingerprint": source_fingerprint,
+        "source_size_bytes": int_value(row.get("size_bytes")),
+        "video_codec": row.get("video_codec"),
+        "width": row.get("width"),
+        "height": row.get("height"),
+        "cadence_class": str(cadence_decision.get("classification") or "unknown"),
+        "duration_seconds": row.get("duration_seconds"),
+        "audio_summary": _json_list(row.get("audio_summary_json")),
+    }
+    if fingerprint_decision:
+        item["media_fingerprint_decision"] = fingerprint_decision
+    return item
+
+
+def _json_list(value: object) -> list[Any]:
+    if isinstance(value, str):
+        try:
+            return object_list(json.loads(value))
+        except json.JSONDecodeError:
+            return []
+    return object_list(value)
+
+
 def _items_by_source_id(items: Sequence[Mapping[str, Any]]) -> dict[str, Mapping[str, Any]]:
     item_by_source_id = {stable_source_id(item): item for item in items}
     if len(item_by_source_id) != len(items):
         raise ValueError("Fingerprint acquisition candidates must have unique source IDs")
     return item_by_source_id
+
+
+def _selection_items(
+        item_by_source_id: Mapping[str, Mapping[str, Any]],
+        current_source_ids: Collection[str],
+) -> tuple[dict[str, Any], ...]:
+    current_id_set = set(current_source_ids)
+    selection_items: list[dict[str, Any]] = []
+    for source_id, item in item_by_source_id.items():
+        payload = dict(item)
+        if source_id not in current_id_set:
+            payload.pop("media_fingerprint_decision", None)
+        selection_items.append(payload)
+    return tuple(selection_items)
+
+
+def _uncertainty_frontier(
+        items: Sequence[Mapping[str, Any]],
+        *,
+        current_source_ids: Collection[str],
+        technical_representative_ids: Sequence[str],
+        all_dimension_representative_ids: Sequence[str],
+) -> tuple[str, ...]:
+    current_id_set = set(current_source_ids)
+    if not current_id_set:
+        return ()
+    fingerprint_profiles = representative_profiles(
+        items,
+        fingerprint_dimensions=FINGERPRINT_DIMENSIONS,
+    )
+    hard_value_counts: Counter[tuple[str, str]] = Counter(
+        (dimension, value)
+        for source_id in current_id_set
+        for dimension, value in fingerprint_profiles.get(source_id, {}).items()
+        if dimension in FINGERPRINT_DIMENSIONS and _fingerprint_value_is_hard(value)
+    )
+    meaningful_count = max(1, math.ceil(len(items) * MEANINGFUL_CLUSTER_FRACTION))
+    uncertain_values = {
+        fingerprint_value
+        for fingerprint_value, count in hard_value_counts.items()
+        if count < meaningful_count
+    }
+    if not uncertain_values:
+        return ()
+    seed_ids = tuple(dict.fromkeys((
+        *technical_representative_ids,
+        *all_dimension_representative_ids,
+    )))
+    uncertain_seed_ids = tuple(
+        source_id
+        for source_id in seed_ids
+        if source_id in current_id_set
+        and any(
+            (dimension, value) in uncertain_values
+            for dimension, value in fingerprint_profiles.get(source_id, {}).items()
+        )
+    )
+    if not uncertain_seed_ids:
+        return ()
+    technical_profiles = representative_profiles(items, fingerprint_dimensions=())
+    item_by_source_id = _items_by_source_id(items)
+    all_dimension_id_set = set(all_dimension_representative_ids)
+    unmeasured_ids = set(item_by_source_id) - current_id_set
+    return tuple(sorted(
+        unmeasured_ids,
+        key=lambda source_id: (
+            source_id not in all_dimension_id_set,
+            min(
+                _technical_profile_distance(
+                    technical_profiles[source_id],
+                    technical_profiles[seed_id],
+                )
+                for seed_id in uncertain_seed_ids
+            ),
+            str(item_by_source_id[source_id].get("rel_path") or "").casefold(),
+            source_id,
+        ),
+    ))
+
+
+def _fingerprint_value_is_hard(value: object) -> bool:
+    normalized = str(value or "").strip().lower()
+    return normalized not in {"", "unknown", "typical"}
+
+
+def _technical_profile_distance(
+        first: Mapping[str, str],
+        second: Mapping[str, str],
+) -> int:
+    return sum(
+        first.get(dimension) != second.get(dimension)
+        for dimension in TECHNICAL_PROFILE_DIMENSIONS
+    )
 
 
 def _current_source_ids(
@@ -381,6 +592,11 @@ def _replay_entry(
         estimated_analysis_cost=_estimate_analysis_cost(
             representative_ids,
             item_by_source_id,
+            audio_recommendation="evaluate_with_replay",
+        ),
+        remaining_analysis_cost=_estimate_analysis_cost(
+            representative_ids,
+            item_by_source_id,
             current_source_ids=current_source_ids,
             audio_recommendation="evaluate_with_replay",
         ),
@@ -397,6 +613,7 @@ def _representative_changes(
         baseline_ids=tuple(baseline_ids),
         added_ids=tuple(source_id for source_id in representative_ids if source_id not in baseline_id_set),
         removed_ids=tuple(source_id for source_id in baseline_ids if source_id not in representative_id_set),
+        changed=baseline_id_set != representative_id_set,
     )
 
 
@@ -473,6 +690,13 @@ def _unmeasured_selected_items(
         for source_id in candidate_ids
         if source_id not in current_id_set
     )
+
+
+def _selected_items(
+        candidate_ids: Sequence[str],
+        item_by_source_id: Mapping[str, Mapping[str, Any]],
+) -> tuple[Mapping[str, Any], ...]:
+    return tuple(item_by_source_id[source_id] for source_id in candidate_ids)
 
 
 def _visual_cost(candidate_items: Sequence[Mapping[str, Any]]) -> SharedVisualPassCost:

--- a/mediaforce/library/evidence_queue.py
+++ b/mediaforce/library/evidence_queue.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal, Sequence
 
@@ -10,15 +10,23 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import evidence_queue_state, library_item_evidence_state, library_items
+from mediaforce.core.evidence import stable_source_id
 from mediaforce.core.type_defs import int_value, object_dict, object_list
 from mediaforce.core.utils import timestamp
 from mediaforce.library.background_work import background_work_is_paused
+from mediaforce.library.evidence_acquisition import DEFAULT_UNCERTAINTY_FRONTIER_LIMIT, \
+    FingerprintAcquisitionPlan, load_fingerprint_acquisition_items, plan_fingerprint_acquisition
 from mediaforce.library.evidence_state import EVIDENCE_KINDS, EVIDENCE_STATE_ANALYSIS_REQUIRED, \
     EVIDENCE_STATE_CLASSIFICATION_REQUIRED, EvidenceKind
 from mediaforce.library.media_scopes import MediaScope, resolve_media_scope, scope_rel_path_filter
 
 DEFAULT_EVIDENCE_QUEUE_NAME = "evidence"
 DEFAULT_EVIDENCE_BATCH_LIMIT = 25
+
+EVIDENCE_WORK_PRIORITY_DECISION = 0
+EVIDENCE_WORK_PRIORITY_RECLASSIFICATION = 10
+EVIDENCE_WORK_PRIORITY_OPERATOR = 50
+EVIDENCE_WORK_PRIORITY_REPRESENTATIVE = 70
 
 EVIDENCE_QUEUE_ACTIVE_STATUSES = ("queued", "running", "paused", "cancel_requested")
 EVIDENCE_WORK_CLAIMABLE_STATUSES = ("queued", "retry_wait", "waiting_source")
@@ -38,6 +46,8 @@ class EvidenceWorkClaim:
     evidence_kind: EvidenceKind
     evidence_state: str
     evidence_reason: str | None
+    work_priority: int
+    work_reason: str | None
     source_path: str
     rel_path: str
     media_root: str
@@ -147,8 +157,9 @@ def start_evidence_work(
             raise EvidenceQueueConflict(
                 f"Library {scope.root!r} is not enabled for production evidence work."
             )
-        candidates = _evidence_work_candidates(
+        candidates, fingerprint_plan = _evidence_work_candidates(
             connection,
+            config,
             scope,
             selected_kinds,
             limit=normalized_limit,
@@ -165,6 +176,8 @@ def start_evidence_work(
         finished_at = None if item_count else now_iso
         scope_payload = scope.to_payload()
         scope_payload["work_limit"] = normalized_limit
+        if fingerprint_plan is not None:
+            scope_payload["fingerprint_acquisition"] = _fingerprint_plan_summary(fingerprint_plan)
         _save_evidence_queue_state(
             connection,
             {
@@ -191,6 +204,279 @@ def start_evidence_work(
     return evidence_queue_summary(connection)
 
 
+def queue_decision_evidence_work(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+        *,
+        library_item_ids: Sequence[int],
+        evidence_kind: str,
+        work_reason: str,
+        updated_at: str | None = None,
+        manage_transaction: bool = True,
+) -> dict[str, Any]:
+    scope_prefix = str(prefix or "").strip().strip("/")
+    if not scope_prefix:
+        raise ValueError("Decision evidence work requires an explicit item or folder scope.")
+    normalized_ids = sorted({int(item_id) for item_id in library_item_ids})
+    if not normalized_ids:
+        return {
+            "evidence_kind": _normalize_evidence_kinds([evidence_kind])[0],
+            "required_count": 0,
+            "prepared_count": 0,
+            "work": evidence_queue_summary(connection),
+        }
+    selected_kind = _normalize_evidence_kinds([evidence_kind])[0]
+    normalized_reason = str(work_reason or "decision_required").strip() or "decision_required"
+    now_iso = updated_at or timestamp()
+
+    if manage_transaction:
+        connection.commit()
+        connection.exec_driver_sql("BEGIN IMMEDIATE")
+    try:
+        ensure_evidence_queue_state(connection, updated_at=now_iso)
+        if background_work_is_paused(connection):
+            raise EvidenceQueueConflict(
+                "Background catalog and analysis work is paused. Resume background work before requesting safety evidence."
+            )
+        scope = resolve_media_scope(
+            connection,
+            scope_prefix,
+            library_types=config.library_type_map,
+        )
+        if scope.root not in config.source_root_map:
+            raise EvidenceQueueConflict(
+                f"Library {scope.root!r} is not enabled for production evidence work."
+            )
+        rows = connection.execute(
+            select(
+                library_item_evidence_state.c.library_item_id,
+                library_item_evidence_state.c.evidence_kind,
+                library_item_evidence_state.c.state,
+                library_item_evidence_state.c.work_batch_id,
+                library_item_evidence_state.c.work_status,
+                library_item_evidence_state.c.work_priority,
+                library_item_evidence_state.c.work_source_fingerprint,
+                library_item_evidence_state.c.retry_not_before,
+                library_item_evidence_state.c.attempt_count,
+                library_item_evidence_state.c.last_attempt_at,
+                library_item_evidence_state.c.last_error,
+                library_items.c.content_version_fingerprint,
+                library_items.c.fingerprint,
+            )
+            .select_from(
+                library_item_evidence_state.join(
+                    library_items,
+                    library_items.c.id == library_item_evidence_state.c.library_item_id,
+                )
+            )
+            .where(
+                library_item_evidence_state.c.library_item_id.in_(normalized_ids),
+                library_item_evidence_state.c.evidence_kind == selected_kind,
+                library_item_evidence_state.c.state.in_((
+                    EVIDENCE_STATE_ANALYSIS_REQUIRED,
+                    EVIDENCE_STATE_CLASSIFICATION_REQUIRED,
+                )),
+                library_items.c.status != "missing",
+                scope_rel_path_filter(library_items.c.rel_path, scope),
+            )
+            .order_by(library_item_evidence_state.c.library_item_id)
+        ).mappings().fetchall()
+        if not rows:
+            if manage_transaction:
+                connection.commit()
+            return {
+                "evidence_kind": selected_kind,
+                "required_count": 0,
+                "prepared_count": 0,
+                "work": evidence_queue_summary(connection),
+            }
+
+        queue_state = load_evidence_queue_state(connection)
+        queue_status = str(queue_state.get("status") or "idle")
+        if bool(queue_state.get("cancel_requested")) or queue_status == "cancel_requested":
+            raise EvidenceQueueConflict(
+                "Evidence work is stopping. Wait for cancellation to finish before requesting safety evidence."
+            )
+        active_batch = queue_status in EVIDENCE_QUEUE_ACTIVE_STATUSES and bool(queue_state.get("batch_id"))
+        batch_id = str(queue_state.get("batch_id") or "") if active_batch else uuid.uuid4().hex
+        if any(
+                str(row.get("work_status") or "") == "running"
+                and str(row.get("work_batch_id") or "") != batch_id
+                for row in rows
+        ):
+            raise EvidenceQueueConflict(
+                "The required evidence item is already owned by another active batch."
+            )
+        prepared_count = 0
+        terminal_failure_count = 0
+        for row in rows:
+            row_batch_id = str(row.get("work_batch_id") or "")
+            row_status = str(row.get("work_status") or "")
+            current_priority = int_value(row.get("work_priority")) or EVIDENCE_WORK_PRIORITY_OPERATOR
+            if row_batch_id == batch_id and row_status in EVIDENCE_WORK_ACTIVE_STATUSES:
+                connection.execute(
+                    update(library_item_evidence_state)
+                    .where(
+                        library_item_evidence_state.c.library_item_id == int(row["library_item_id"]),
+                        library_item_evidence_state.c.evidence_kind == selected_kind,
+                    )
+                    .values(
+                        work_priority=min(current_priority, EVIDENCE_WORK_PRIORITY_DECISION),
+                        work_reason=normalized_reason,
+                        updated_at=now_iso,
+                    )
+                )
+                prepared_count += 1
+                continue
+            current_source_fingerprint = _item_source_fingerprint(row)
+            preserve_retry_state = bool(
+                str(row.get("state") or "") == EVIDENCE_STATE_ANALYSIS_REQUIRED
+                and current_source_fingerprint
+                and str(row.get("work_source_fingerprint") or "") == current_source_fingerprint
+                and row_status in {"retry_wait", "waiting_source", "failed"}
+            )
+            if preserve_retry_state and row_status == "failed":
+                connection.execute(
+                    update(library_item_evidence_state)
+                    .where(
+                        library_item_evidence_state.c.library_item_id == int(row["library_item_id"]),
+                        library_item_evidence_state.c.evidence_kind == selected_kind,
+                    )
+                    .values(
+                        work_priority=EVIDENCE_WORK_PRIORITY_DECISION,
+                        work_reason=normalized_reason,
+                        updated_at=now_iso,
+                    )
+                )
+                terminal_failure_count += 1
+                continue
+            next_status = row_status if preserve_retry_state else "queued"
+            connection.execute(
+                update(library_item_evidence_state)
+                .where(
+                    library_item_evidence_state.c.library_item_id == int(row["library_item_id"]),
+                    library_item_evidence_state.c.evidence_kind == selected_kind,
+                )
+                .values(
+                    work_batch_id=batch_id,
+                    work_status=next_status,
+                    work_priority=EVIDENCE_WORK_PRIORITY_DECISION,
+                    work_reason=normalized_reason,
+                    work_source_fingerprint=current_source_fingerprint,
+                    leased_at=None,
+                    lease_expires_at=None,
+                    heartbeat_at=None,
+                    worker_id=None,
+                    process_pid=None,
+                    retry_not_before=row.get("retry_not_before") if preserve_retry_state else None,
+                    attempt_count=int_value(row.get("attempt_count")) if preserve_retry_state else 0,
+                    last_attempt_at=row.get("last_attempt_at") if preserve_retry_state else None,
+                    last_error=row.get("last_error") if preserve_retry_state else None,
+                    updated_at=now_iso,
+                )
+            )
+            prepared_count += 1
+
+        if not active_batch and prepared_count == 0:
+            if manage_transaction:
+                connection.commit()
+            return {
+                "evidence_kind": selected_kind,
+                "required_count": len(rows),
+                "prepared_count": 0,
+                "terminal_failure_count": terminal_failure_count,
+                "work": evidence_queue_summary(connection),
+            }
+
+        if active_batch:
+            evidence_kinds = list(dict.fromkeys([
+                *object_list(queue_state.get("evidence_kinds")),
+                selected_kind,
+            ]))
+            item_count = int(
+                connection.execute(
+                    select(func.count())
+                    .select_from(library_item_evidence_state)
+                    .where(library_item_evidence_state.c.work_batch_id == batch_id)
+                ).scalar_one()
+            )
+            priority_rows = connection.execute(
+                select(
+                    library_item_evidence_state.c.work_reason,
+                    func.count().label("item_count"),
+                )
+                .where(
+                    library_item_evidence_state.c.work_batch_id == batch_id,
+                    library_item_evidence_state.c.work_priority == EVIDENCE_WORK_PRIORITY_DECISION,
+                )
+                .group_by(library_item_evidence_state.c.work_reason)
+            ).mappings().fetchall()
+            scope_payload = object_dict(queue_state.get("scope"))
+            scope_payload["priority_request_count"] = sum(
+                int(row["item_count"] or 0)
+                for row in priority_rows
+            )
+            scope_payload["priority_reasons"] = sorted(
+                str(row["work_reason"])
+                for row in priority_rows
+                if row["work_reason"]
+            )
+            connection.execute(
+                update(evidence_queue_state)
+                .where(evidence_queue_state.c.queue_name == DEFAULT_EVIDENCE_QUEUE_NAME)
+                .values(
+                    scope_json=json.dumps(scope_payload, separators=(",", ":"), sort_keys=True),
+                    evidence_kinds_json=json.dumps(evidence_kinds, separators=(",", ":")),
+                    item_count=item_count,
+                    finished_at=None,
+                    updated_at=now_iso,
+                )
+            )
+            _refresh_evidence_queue_state(connection, batch_id=batch_id, updated_at=now_iso)
+        else:
+            scope_payload = scope.to_payload()
+            scope_payload.update({
+                "work_limit": prepared_count,
+                "trigger": "decision",
+                "work_reason": normalized_reason,
+            })
+            _save_evidence_queue_state(
+                connection,
+                {
+                    "queue_name": DEFAULT_EVIDENCE_QUEUE_NAME,
+                    "batch_id": batch_id,
+                    "status": "paused",
+                    "scope": scope_payload,
+                    "evidence_kinds": [selected_kind],
+                    "is_paused": True,
+                    "cancel_requested": False,
+                    "item_count": prepared_count,
+                    "completed_count": 0,
+                    "failed_count": 0,
+                    "cancelled_count": 0,
+                    "created_at": now_iso,
+                    "started_at": None,
+                    "finished_at": None,
+                    "updated_at": now_iso,
+                },
+            )
+            _refresh_evidence_queue_state(connection, batch_id=batch_id, updated_at=now_iso)
+        if manage_transaction:
+            connection.commit()
+    except BaseException:
+        if manage_transaction:
+            connection.rollback()
+        raise
+    return {
+        "evidence_kind": selected_kind,
+        "required_count": len(rows),
+        "prepared_count": prepared_count,
+        "terminal_failure_count": terminal_failure_count,
+        "work": evidence_queue_summary(connection),
+    }
+
+
 def evidence_queue_summary(connection: DBClient) -> dict[str, Any]:
     queue_state = load_evidence_queue_state(connection)
     batch_id = str(queue_state.get("batch_id") or "")
@@ -213,6 +499,8 @@ def evidence_queue_summary(connection: DBClient) -> dict[str, Any]:
             select(
                 library_item_evidence_state.c.library_item_id,
                 library_item_evidence_state.c.evidence_kind,
+                library_item_evidence_state.c.work_priority,
+                library_item_evidence_state.c.work_reason,
                 library_item_evidence_state.c.attempt_count,
                 library_item_evidence_state.c.last_attempt_at,
                 library_item_evidence_state.c.heartbeat_at,
@@ -345,6 +633,7 @@ def claim_next_evidence_work(
                 ),
             )
             .order_by(
+                library_item_evidence_state.c.work_priority,
                 case(
                     (library_item_evidence_state.c.state == EVIDENCE_STATE_CLASSIFICATION_REQUIRED, 0),
                     else_=1,
@@ -414,6 +703,8 @@ def load_evidence_work_claim(
             library_item_evidence_state.c.evidence_kind,
             library_item_evidence_state.c.state,
             library_item_evidence_state.c.reason,
+            library_item_evidence_state.c.work_priority,
+            library_item_evidence_state.c.work_reason,
             library_item_evidence_state.c.work_source_fingerprint,
             library_item_evidence_state.c.attempt_count,
             library_item_evidence_state.c.worker_id,
@@ -449,6 +740,8 @@ def load_evidence_work_claim(
         evidence_kind=normalized_kind,
         evidence_state=str(row["state"]),
         evidence_reason=str(row["reason"]) if row["reason"] is not None else None,
+        work_priority=int(row["work_priority"] or EVIDENCE_WORK_PRIORITY_OPERATOR),
+        work_reason=str(row["work_reason"]) if row["work_reason"] is not None else None,
         source_path=str(row["source_path"]),
         rel_path=str(row["rel_path"]),
         media_root=str(row["media_root"]),
@@ -682,15 +975,17 @@ def _set_queue_control(
 
 def _evidence_work_candidates(
         connection: DBClient,
+        config: MediaforceConfig,
         scope: MediaScope,
         evidence_kinds: Sequence[EvidenceKind],
         *,
         limit: int,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], FingerprintAcquisitionPlan | None]:
     query = (
         select(
             library_item_evidence_state.c.library_item_id,
             library_item_evidence_state.c.evidence_kind,
+            library_item_evidence_state.c.state,
             library_items.c.content_version_fingerprint,
             library_items.c.fingerprint,
         )
@@ -713,17 +1008,125 @@ def _evidence_work_candidates(
             library_item_evidence_state.c.library_item_id,
             library_item_evidence_state.c.evidence_kind,
         )
-        .limit(limit)
     )
     rows = connection.execute(query).mappings().fetchall()
-    return [
-        {
-            "library_item_id": int(row["library_item_id"]),
-            "evidence_kind": str(row["evidence_kind"]),
-            "work_source_fingerprint": _item_source_fingerprint(row),
-        }
+    classification_rows = [
+        row
         for row in rows
+        if str(row["state"]) == EVIDENCE_STATE_CLASSIFICATION_REQUIRED
     ]
+    cadence_rows = [
+        row
+        for row in rows
+        if (
+            str(row["state"]) == EVIDENCE_STATE_ANALYSIS_REQUIRED
+            and str(row["evidence_kind"]) == EVIDENCE_KINDS[0]
+        )
+    ]
+    fingerprint_plan: FingerprintAcquisitionPlan | None = None
+    fingerprint_rows: list[Any] = []
+    fingerprint_analysis_required = any(
+        str(row["state"]) == EVIDENCE_STATE_ANALYSIS_REQUIRED
+        and str(row["evidence_kind"]) == EVIDENCE_KINDS[1]
+        for row in rows
+    )
+    if EVIDENCE_KINDS[1] in evidence_kinds and fingerprint_analysis_required:
+        _candidate_scope, representative_items, measured_source_ids = load_fingerprint_acquisition_items(
+            connection,
+            config,
+            scope.prefix,
+        )
+        if representative_items:
+            item_id_by_source_id = {
+                stable_source_id(item): int(item["library_item_id"])
+                for item in representative_items
+            }
+            fingerprint_plan = plan_fingerprint_acquisition(
+                representative_items,
+                prefix=scope.prefix,
+                policy=(
+                    config.resolve_policy(scope.prefix)
+                    if all(
+                        isinstance(config.raw.get(section), dict)
+                        for section in ("video", "audio", "subtitle", "planning")
+                    )
+                    else None
+                ),
+                max_uncertainty_frontier=min(DEFAULT_UNCERTAINTY_FRONTIER_LIMIT, max(1, limit)),
+                measured_source_ids=measured_source_ids,
+            )
+            planned_item_ids = {
+                item_id_by_source_id[source_id]
+                for source_id in fingerprint_plan.candidate_ids
+                if source_id in item_id_by_source_id
+            }
+            fingerprint_rows_by_item = {
+                int(row["library_item_id"]): row
+                for row in rows
+                if (
+                    str(row["state"]) == EVIDENCE_STATE_ANALYSIS_REQUIRED
+                    and str(row["evidence_kind"]) == EVIDENCE_KINDS[1]
+                    and int(row["library_item_id"]) in planned_item_ids
+                )
+            }
+            fingerprint_rows = [
+                fingerprint_rows_by_item[item_id_by_source_id[source_id]]
+                for source_id in fingerprint_plan.candidate_ids
+                if item_id_by_source_id.get(source_id) in fingerprint_rows_by_item
+            ]
+    candidates: list[dict[str, Any]] = []
+    for row in classification_rows:
+        candidates.append(_work_candidate(
+            row,
+            work_priority=EVIDENCE_WORK_PRIORITY_RECLASSIFICATION,
+            work_reason="policy_reclassification",
+        ))
+    for row in cadence_rows:
+        candidates.append(_work_candidate(
+            row,
+            work_priority=EVIDENCE_WORK_PRIORITY_OPERATOR,
+            work_reason="operator_scope",
+        ))
+    fingerprint_reason = (
+        "representative_uncertainty"
+        if fingerprint_plan is not None and fingerprint_plan.phase == "uncertainty_frontier"
+        else "representative_technical_coverage"
+    )
+    for row in fingerprint_rows:
+        candidates.append(_work_candidate(
+            row,
+            work_priority=EVIDENCE_WORK_PRIORITY_REPRESENTATIVE,
+            work_reason=fingerprint_reason,
+        ))
+    return candidates[:limit], fingerprint_plan
+
+
+def _work_candidate(
+        row: Any,
+        *,
+        work_priority: int,
+        work_reason: str,
+) -> dict[str, Any]:
+    return {
+        "library_item_id": int(row["library_item_id"]),
+        "evidence_kind": str(row["evidence_kind"]),
+        "work_priority": work_priority,
+        "work_reason": work_reason,
+        "work_source_fingerprint": _item_source_fingerprint(row),
+    }
+
+
+def _fingerprint_plan_summary(plan: FingerprintAcquisitionPlan) -> dict[str, Any]:
+    return {
+        "phase": plan.phase,
+        "candidate_count": len(plan.candidate_ids),
+        "analysis_budget": plan.analysis_budget,
+        "remaining_analysis_budget": plan.remaining_analysis_budget,
+        "stop_reason": plan.stop_reason,
+        "intentionally_unqueued_count": plan.intentionally_unqueued_count,
+        "coverage": asdict(plan.coverage),
+        "estimated_analysis_cost": asdict(plan.estimated_analysis_cost),
+    }
 
 
 def _queue_candidate_rows(
@@ -744,6 +1147,8 @@ def _queue_candidate_rows(
         .values(
             work_batch_id=batch_id,
             work_status="queued",
+            work_priority=bindparam("candidate_priority"),
+            work_reason=bindparam("candidate_reason"),
             work_source_fingerprint=bindparam("candidate_source_fingerprint"),
             leased_at=None,
             lease_expires_at=None,
@@ -763,6 +1168,8 @@ def _queue_candidate_rows(
             {
                 "candidate_item_id": candidate["library_item_id"],
                 "candidate_evidence_kind": candidate["evidence_kind"],
+                "candidate_priority": int(candidate.get("work_priority", EVIDENCE_WORK_PRIORITY_OPERATOR)),
+                "candidate_reason": str(candidate.get("work_reason") or "operator_scope"),
                 "candidate_source_fingerprint": candidate["work_source_fingerprint"],
             }
             for candidate in candidates

--- a/mediaforce/library/evidence_worker.py
+++ b/mediaforce/library/evidence_worker.py
@@ -349,11 +349,22 @@ def _commit_evidence_summary(
                 reset_attempt_state=True,
             )
         elif classification_only and projection.state == EVIDENCE_STATE_ANALYSIS_REQUIRED:
-            transition_evidence_work(
-                connection,
-                claim,
-                work_status="queued",
-            )
+            if (
+                    claim.evidence_kind == MEDIA_FINGERPRINT_EVIDENCE_KIND
+                    and claim.work_priority != 0
+            ):
+                transition_evidence_work(
+                    connection,
+                    claim,
+                    work_status="completed",
+                    reset_attempt_state=True,
+                )
+            else:
+                transition_evidence_work(
+                    connection,
+                    claim,
+                    work_status="queued",
+                )
         else:
             transition_evidence_work(
                 connection,

--- a/mediaforce/library/representatives.py
+++ b/mediaforce/library/representatives.py
@@ -14,7 +14,7 @@ from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items
 from mediaforce.core.evidence import build_evidence_envelope, stable_policy_hash, stable_source_id
 from mediaforce.core.type_defs import mapping_dict, object_dict, object_list
-from mediaforce.library.media_scopes import resolve_media_scope, scope_rel_path_filter
+from mediaforce.library.media_scopes import MediaScope, resolve_media_scope, scope_rel_path_filter
 from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
 from mediaforce.library.planner import build_manifest_item
 
@@ -121,6 +121,38 @@ def load_representative_selection(
         config: MediaforceConfig,
         prefix: str,
 ) -> RepresentativeSelection | None:
+    scope, items = load_representative_candidates(connection, config, prefix)
+    if not items:
+        return None
+    return select_representatives(
+        items,
+        prefix=scope.prefix,
+        policy=config.resolve_policy(scope.prefix),
+    )
+
+
+def load_representative_candidates(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+) -> tuple[MediaScope, list[dict[str, Any]]]:
+    scope, candidate_rows = load_representative_candidate_rows(connection, config, prefix)
+    items: list[dict[str, Any]] = []
+    for row in candidate_rows:
+        row_payload = mapping_dict(row)
+        item = build_manifest_item(row_payload, config)
+        for field in _OPTIONAL_TECHNICAL_FIELDS:
+            if row_payload.get(field) not in (None, ""):
+                item[field] = row_payload[field]
+        items.append(item)
+    return scope, items
+
+
+def load_representative_candidate_rows(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+) -> tuple[MediaScope, list[Mapping[str, Any]]]:
     scope = resolve_media_scope(connection, prefix, library_types=config.library_type_map)
     rows = connection.execute(
         select(library_items)
@@ -128,7 +160,7 @@ def load_representative_selection(
         .order_by(library_items.c.rel_path.asc())
     ).mappings().fetchall()
     if not rows:
-        return None
+        return scope, []
 
     library = config.library_definition_map.get(scope.root, {})
     if str(library.get("type") or "") == "movie":
@@ -143,23 +175,10 @@ def load_representative_selection(
             and movie_item_included(membership, policy, explicit_exact=explicit_exact)[0]
         ]
         if not rows:
-            return None
+            return scope, []
 
     preferred_rows = [row for row in rows if str(row.get("status") or "") in _PREFERRED_SAMPLE_STATUSES]
-    candidate_rows = preferred_rows or list(rows)
-    items: list[dict[str, Any]] = []
-    for row in candidate_rows:
-        row_payload = mapping_dict(row)
-        item = build_manifest_item(row_payload, config)
-        for field in _OPTIONAL_TECHNICAL_FIELDS:
-            if row_payload.get(field) not in (None, ""):
-                item[field] = row_payload[field]
-        items.append(item)
-    return select_representatives(
-        items,
-        prefix=scope.prefix,
-        policy=config.resolve_policy(scope.prefix),
-    )
+    return scope, preferred_rows or list(rows)
 
 
 def select_representatives(
@@ -176,12 +195,7 @@ def select_representatives(
     active_fingerprint_dimensions = _normalize_fingerprint_dimensions(fingerprint_dimensions)
     coverage_dimensions = (*TECHNICAL_PROFILE_DIMENSIONS, *active_fingerprint_dimensions)
     item_payloads = [copy.deepcopy(dict(item)) for item in items]
-    median_runtime = _median_positive(item.get("duration_seconds") for item in item_payloads)
-    median_size = _median_positive(item.get("source_size_bytes", item.get("size_bytes")) for item in item_payloads)
-    candidates = sorted(
-        (_candidate(item, median_runtime) for item in item_payloads),
-        key=lambda candidate: candidate.sort_key,
-    )
+    candidates, median_runtime, median_size = _representative_candidates(item_payloads)
     outlier_reasons = _outlier_reasons(candidates)
     profile_counts = _profile_counts(candidates, coverage_dimensions)
     dominant_profile = {
@@ -344,6 +358,40 @@ def select_representatives(
         selected_items=tuple(candidate.item for candidate in selected),
         payload=payload,
     )
+
+
+def representative_profiles(
+        items: Sequence[Mapping[str, Any]],
+        *,
+        fingerprint_dimensions: Iterable[str] | None = None,
+) -> dict[str, dict[str, str]]:
+    active_fingerprint_dimensions = _normalize_fingerprint_dimensions(fingerprint_dimensions)
+    profile_dimensions = (*TECHNICAL_PROFILE_DIMENSIONS, *active_fingerprint_dimensions)
+    candidates, _median_runtime, _median_size = _representative_candidates(
+        [copy.deepcopy(dict(item)) for item in items]
+    )
+    return {
+        candidate.source_id: {
+            dimension: candidate.profile[dimension]
+            for dimension in profile_dimensions
+        }
+        for candidate in candidates
+    }
+
+
+def _representative_candidates(
+        item_payloads: Sequence[dict[str, Any]],
+) -> tuple[list[_Candidate], float | None, float | None]:
+    median_runtime = _median_positive(item.get("duration_seconds") for item in item_payloads)
+    median_size = _median_positive(
+        item.get("source_size_bytes", item.get("size_bytes"))
+        for item in item_payloads
+    )
+    candidates = sorted(
+        (_candidate(item, median_runtime) for item in item_payloads),
+        key=lambda candidate: candidate.sort_key,
+    )
+    return candidates, median_runtime, median_size
 
 
 def _candidate(item: dict[str, Any], median_runtime: float | None) -> _Candidate:

--- a/mediaforce/library/representatives.py
+++ b/mediaforce/library/representatives.py
@@ -24,8 +24,8 @@ REPRESENTATIVE_SELECTION_POLICY_VERSION = 2
 MEANINGFUL_CLUSTER_FRACTION = 0.20
 
 _PREFERRED_SAMPLE_STATUSES = frozenset({"discovered", "planned", "validated", "encoded"})
-_PROFILE_DIMENSIONS = ("video_codec", "resolution", "cadence", "audio_layout", "runtime")
-_FINGERPRINT_DIMENSIONS = (
+TECHNICAL_PROFILE_DIMENSIONS = ("video_codec", "resolution", "cadence", "audio_layout", "runtime")
+FINGERPRINT_DIMENSIONS = (
     "luma",
     "gradient",
     "motion",
@@ -35,7 +35,6 @@ _FINGERPRINT_DIMENSIONS = (
     "animation",
     "audio_complexity",
 )
-_COVERAGE_DIMENSIONS = (*_PROFILE_DIMENSIONS, *_FINGERPRINT_DIMENSIONS)
 _UNKNOWN_PROFILE_VALUE = "unknown"
 _PUBLIC_ITEM_FIELDS = (
     "library_item_id",
@@ -169,10 +168,13 @@ def select_representatives(
         prefix: str = "",
         policy: Mapping[str, Any] | None = None,
         tool_version: str = REPRESENTATIVE_SELECTION_TOOL_VERSION,
+        fingerprint_dimensions: Iterable[str] | None = None,
 ) -> RepresentativeSelection:
     if not items:
         raise ValueError("At least one representative candidate is required")
 
+    active_fingerprint_dimensions = _normalize_fingerprint_dimensions(fingerprint_dimensions)
+    coverage_dimensions = (*TECHNICAL_PROFILE_DIMENSIONS, *active_fingerprint_dimensions)
     item_payloads = [copy.deepcopy(dict(item)) for item in items]
     median_runtime = _median_positive(item.get("duration_seconds") for item in item_payloads)
     median_size = _median_positive(item.get("source_size_bytes", item.get("size_bytes")) for item in item_payloads)
@@ -181,12 +183,16 @@ def select_representatives(
         key=lambda candidate: candidate.sort_key,
     )
     outlier_reasons = _outlier_reasons(candidates)
-    profile_counts = _profile_counts(candidates)
+    profile_counts = _profile_counts(candidates, coverage_dimensions)
     dominant_profile = {
         dimension: _dominant_value(profile_counts[dimension])
-        for dimension in _COVERAGE_DIMENSIONS
+        for dimension in coverage_dimensions
     }
-    required_targets, target_counts = _required_coverage_targets(candidates, outlier_reasons)
+    required_targets, target_counts = _required_coverage_targets(
+        candidates,
+        outlier_reasons,
+        profile_dimensions=coverage_dimensions,
+    )
 
     primary = min(
         candidates,
@@ -196,18 +202,19 @@ def select_representatives(
             median_runtime=median_runtime,
             median_size=median_size,
             outlier_reasons=outlier_reasons,
+            profile_dimensions=coverage_dimensions,
         ),
     )
     selected = [primary]
     newly_covered: dict[str, set[tuple[str, str]]] = {
-        primary.source_id: required_targets & _profile_targets(primary),
+        primary.source_id: required_targets & _profile_targets(primary, coverage_dimensions),
     }
-    uncovered_targets = required_targets - _profile_targets(primary)
+    uncovered_targets = required_targets - _profile_targets(primary, coverage_dimensions)
     while uncovered_targets:
         covering_candidates = [
             candidate
             for candidate in candidates
-            if candidate not in selected and uncovered_targets & _profile_targets(candidate)
+            if candidate not in selected and uncovered_targets & _profile_targets(candidate, coverage_dimensions)
         ]
         if not covering_candidates:
             break
@@ -221,14 +228,19 @@ def select_representatives(
                 median_runtime=median_runtime,
                 median_size=median_size,
                 outlier_reasons=outlier_reasons,
+                profile_dimensions=coverage_dimensions,
             ),
         )
-        covered = uncovered_targets & _profile_targets(next_candidate)
+        covered = uncovered_targets & _profile_targets(next_candidate, coverage_dimensions)
         selected.append(next_candidate)
         newly_covered[next_candidate.source_id] = covered
         uncovered_targets -= covered
 
-    assignments = _representation_assignments(candidates, selected)
+    assignments = _representation_assignments(
+        candidates,
+        selected,
+        profile_dimensions=coverage_dimensions,
+    )
     coverage = _coverage_payload(
         candidates,
         selected,
@@ -237,6 +249,7 @@ def select_representatives(
         required_targets,
         uncovered_targets,
         outlier_reasons,
+        profile_dimensions=coverage_dimensions,
     )
     confidence = _confidence_payload(coverage)
     rationale = [
@@ -249,6 +262,7 @@ def select_representatives(
             assignment=assignments[candidate.source_id],
             dominant_profile=dominant_profile,
             outlier_reasons=outlier_reasons,
+            profile_dimensions=coverage_dimensions,
         )
         for index, candidate in enumerate(selected)
     ]
@@ -269,8 +283,8 @@ def select_representatives(
     selection_policy = {
         "version": REPRESENTATIVE_SELECTION_POLICY_VERSION,
         "meaningful_cluster_fraction": MEANINGFUL_CLUSTER_FRACTION,
-        "profile_dimensions": list(_PROFILE_DIMENSIONS),
-        "fingerprint_dimensions": list(_FINGERPRINT_DIMENSIONS),
+        "profile_dimensions": list(TECHNICAL_PROFILE_DIMENSIONS),
+        "fingerprint_dimensions": list(active_fingerprint_dimensions),
         "numeric_outliers_required_for_coverage": False,
     }
     policy_snapshot = {
@@ -360,10 +374,11 @@ def _selection_sort_key(
         median_runtime: float | None,
         median_size: float | None,
         outlier_reasons: Mapping[str, list[str]],
+        profile_dimensions: Sequence[str],
 ) -> tuple[Any, ...]:
     mismatch_count = sum(
         candidate.profile[dimension] != dominant_profile[dimension]
-        for dimension in _COVERAGE_DIMENSIONS
+        for dimension in profile_dimensions
     )
     return (
         len(outlier_reasons.get(candidate.source_id, [])),
@@ -383,8 +398,9 @@ def _coverage_sort_key(
         median_runtime: float | None,
         median_size: float | None,
         outlier_reasons: Mapping[str, list[str]],
+        profile_dimensions: Sequence[str],
 ) -> tuple[Any, ...]:
-    covered = uncovered_targets & _profile_targets(candidate)
+    covered = uncovered_targets & _profile_targets(candidate, profile_dimensions)
     covered_items = sum(target_counts[target] for target in covered)
     return (
         -covered_items,
@@ -395,6 +411,7 @@ def _coverage_sort_key(
             median_runtime=median_runtime,
             median_size=median_size,
             outlier_reasons=outlier_reasons,
+            profile_dimensions=profile_dimensions,
         ),
     )
 
@@ -402,6 +419,8 @@ def _coverage_sort_key(
 def _representation_assignments(
         candidates: Sequence[_Candidate],
         selected: Sequence[_Candidate],
+        *,
+        profile_dimensions: Sequence[str],
 ) -> dict[str, dict[str, Any]]:
     assignments = {
         candidate.source_id: {
@@ -413,7 +432,11 @@ def _representation_assignments(
     for candidate in candidates:
         representative = min(
             selected,
-            key=lambda selected_candidate: _representation_distance(candidate, selected_candidate),
+            key=lambda selected_candidate: _representation_distance(
+                candidate,
+                selected_candidate,
+                profile_dimensions=profile_dimensions,
+            ),
         )
         assignment = assignments[representative.source_id]
         assignment["represented_item_count"] += 1
@@ -427,10 +450,15 @@ def _representation_assignments(
     return assignments
 
 
-def _representation_distance(candidate: _Candidate, representative: _Candidate) -> tuple[Any, ...]:
+def _representation_distance(
+        candidate: _Candidate,
+        representative: _Candidate,
+        *,
+        profile_dimensions: Sequence[str],
+) -> tuple[Any, ...]:
     profile_mismatches = sum(
         candidate.profile[dimension] != representative.profile[dimension]
-        for dimension in _COVERAGE_DIMENSIONS
+        for dimension in profile_dimensions
     )
     return (
         profile_mismatches,
@@ -448,21 +476,23 @@ def _coverage_payload(
         required_targets: set[tuple[str, str]],
         uncovered_targets: set[tuple[str, str]],
         outlier_reasons: Mapping[str, list[str]],
+        *,
+        profile_dimensions: Sequence[str],
 ) -> dict[str, Any]:
     selected_profiles = {
-        tuple(candidate.profile[dimension] for dimension in _COVERAGE_DIMENSIONS)
+        tuple(candidate.profile[dimension] for dimension in profile_dimensions)
         for candidate in selected
     }
     exact_candidates = [
         candidate
         for candidate in candidates
-        if tuple(candidate.profile[dimension] for dimension in _COVERAGE_DIMENSIONS) in selected_profiles
+        if tuple(candidate.profile[dimension] for dimension in profile_dimensions) in selected_profiles
     ]
     total_runtime = sum(candidate.duration_seconds or 0.0 for candidate in candidates)
     exact_runtime = sum(candidate.duration_seconds or 0.0 for candidate in exact_candidates)
     meaningful_covered = len(required_targets - uncovered_targets)
     dimensions: dict[str, Any] = {}
-    for dimension in _COVERAGE_DIMENSIONS:
+    for dimension in profile_dimensions:
         covered_values = {candidate.profile[dimension] for candidate in selected}
         covered_item_count = sum(
             count
@@ -489,9 +519,9 @@ def _coverage_payload(
     known_facts = sum(
         candidate.profile[dimension] != _UNKNOWN_PROFILE_VALUE
         for candidate in candidates
-        for dimension in _COVERAGE_DIMENSIONS
+        for dimension in profile_dimensions
     )
-    total_facts = len(candidates) * len(_COVERAGE_DIMENSIONS)
+    total_facts = len(candidates) * len(profile_dimensions)
     return {
         "candidate_item_count": len(candidates),
         "candidate_runtime_seconds": round(total_runtime, 3),
@@ -551,6 +581,7 @@ def _selection_rationale(
         assignment: Mapping[str, Any],
         dominant_profile: Mapping[str, str],
         outlier_reasons: Mapping[str, list[str]],
+        profile_dimensions: Sequence[str],
 ) -> dict[str, Any]:
     covered_clusters = [
         {
@@ -563,7 +594,7 @@ def _selection_rationale(
     ]
     dominant_matches = [
         dimension
-        for dimension in _COVERAGE_DIMENSIONS
+        for dimension in profile_dimensions
         if candidate.profile[dimension] == dominant_profile[dimension]
     ]
     if role == "primary":
@@ -599,11 +630,13 @@ def _selected_item_payload(candidate: _Candidate, rationale: Mapping[str, Any]) 
 def _required_coverage_targets(
         candidates: Sequence[_Candidate],
         outlier_reasons: Mapping[str, list[str]],
+        *,
+        profile_dimensions: Sequence[str],
 ) -> tuple[set[tuple[str, str]], dict[tuple[str, str], int]]:
     threshold = max(1, math.ceil(len(candidates) * MEANINGFUL_CLUSTER_FRACTION))
     targets: set[tuple[str, str]] = set()
     target_counts: dict[tuple[str, str], int] = {}
-    for dimension in _COVERAGE_DIMENSIONS:
+    for dimension in profile_dimensions:
         eligible_candidates = [
             candidate
             for candidate in candidates
@@ -622,18 +655,21 @@ def _required_coverage_targets(
     return targets, target_counts
 
 
-def _profile_targets(candidate: _Candidate) -> set[tuple[str, str]]:
+def _profile_targets(candidate: _Candidate, profile_dimensions: Sequence[str]) -> set[tuple[str, str]]:
     return {
         (dimension, candidate.profile[dimension])
-        for dimension in _COVERAGE_DIMENSIONS
+        for dimension in profile_dimensions
         if candidate.profile[dimension] != _UNKNOWN_PROFILE_VALUE
     }
 
 
-def _profile_counts(candidates: Sequence[_Candidate]) -> dict[str, Counter[str]]:
+def _profile_counts(
+        candidates: Sequence[_Candidate],
+        profile_dimensions: Sequence[str],
+) -> dict[str, Counter[str]]:
     return {
         dimension: Counter(candidate.profile[dimension] for candidate in candidates)
-        for dimension in _COVERAGE_DIMENSIONS
+        for dimension in profile_dimensions
     }
 
 
@@ -764,7 +800,7 @@ def _audio_layout_class(item: Mapping[str, Any]) -> str:
 def _fingerprint_profile(item: Mapping[str, Any]) -> dict[str, str]:
     decision = object_dict(item.get("media_fingerprint_decision"))
     if not decision or str(decision.get("status") or "") != "measured":
-        return {dimension: _UNKNOWN_PROFILE_VALUE for dimension in _FINGERPRINT_DIMENSIONS}
+        return {dimension: _UNKNOWN_PROFILE_VALUE for dimension in FINGERPRINT_DIMENSIONS}
     traits = {str(value) for value in object_list(decision.get("traits"))}
     finding_ids = {
         str(finding.get("id"))
@@ -781,6 +817,17 @@ def _fingerprint_profile(item: Mapping[str, Any]) -> dict[str, str]:
         "animation": "animation_cues" if "animation_cues" in values else "typical",
         "audio_complexity": "complex" if "audio_complexity" in values else "typical",
     }
+
+
+def _normalize_fingerprint_dimensions(dimensions: Iterable[str] | None) -> tuple[str, ...]:
+    if dimensions is None:
+        return FINGERPRINT_DIMENSIONS
+    requested_dimensions = {str(dimension).strip() for dimension in dimensions}
+    unsupported_dimensions = sorted(requested_dimensions - set(FINGERPRINT_DIMENSIONS))
+    if unsupported_dimensions:
+        labels = ", ".join(unsupported_dimensions)
+        raise ValueError(f"Unsupported fingerprint dimensions: {labels}")
+    return tuple(dimension for dimension in FINGERPRINT_DIMENSIONS if dimension in requested_dimensions)
 
 
 def _noise_profile(values: set[str]) -> str:

--- a/mediaforce/library/run_manifests.py
+++ b/mediaforce/library/run_manifests.py
@@ -236,7 +236,7 @@ def write_manifest(
     return manifest_path
 
 
-def create_folder_manifest(
+def build_folder_manifest(
         connection: DBClient,
         config: MediaforceConfig,
         *,
@@ -245,7 +245,7 @@ def create_folder_manifest(
         scan_first: bool = False,
         manual_override_prefix: str | None = None,
         older_season_override: OlderSeasonOverrideSelection | None = None,
-) -> tuple[dict[str, Any], Path]:
+) -> dict[str, Any]:
     if manual_override_prefix and older_season_override is not None:
         raise ValueError("Exact-season and older-season lifecycle overrides cannot be combined")
     if scan_first:
@@ -272,5 +272,30 @@ def create_folder_manifest(
     manifest["selection"]["media_scope"] = scope.to_payload()
     if older_season_override is not None:
         manifest["selection"]["lifecycle_override"] = older_season_override.to_payload()
+    return manifest
+
+
+def create_folder_manifest(
+        connection: DBClient,
+        config: MediaforceConfig,
+        *,
+        prefix: str,
+        limit: int | None = None,
+        scan_first: bool = False,
+        manual_override_prefix: str | None = None,
+        older_season_override: OlderSeasonOverrideSelection | None = None,
+        prepare_only: bool = False,
+) -> tuple[dict[str, Any], Path | None]:
+    manifest = build_folder_manifest(
+        connection,
+        config,
+        prefix=prefix,
+        limit=limit,
+        scan_first=scan_first,
+        manual_override_prefix=manual_override_prefix,
+        older_season_override=older_season_override,
+    )
+    if prepare_only:
+        return manifest, None
     manifest_path = write_manifest(connection, config, manifest)
     return manifest, manifest_path

--- a/mediaforce/tuning/quality_risk.py
+++ b/mediaforce/tuning/quality_risk.py
@@ -636,6 +636,8 @@ def quality_risk_public_view(contract: Mapping[str, Any] | None) -> dict[str, An
         "preview_policy_hash": str(policy.get("preview_policy_hash") or "") or None,
         "blocked": bool(gates.get("blocked")),
         "blocking_reasons": [str(reason) for reason in object_list(gates.get("blocking_reasons")) if str(reason).strip()],
+        "cadence_gate": str(gates.get("cadence_gate") or "") or None,
+        "cadence_transform": str(gates.get("cadence_transform") or "") or None,
         "request_comparison": bool(gates.get("request_comparison")),
         "comparison_reason": str(gates.get("comparison_reason") or "") or None,
         "typed_risks": typed_risks,

--- a/mediaforce/web/runtime/decision_evidence.py
+++ b/mediaforce/web/runtime/decision_evidence.py
@@ -1,0 +1,141 @@
+from collections.abc import Sequence
+from typing import Any
+
+from sqlalchemy import select
+
+from mediaforce.core.config import MediaforceConfig
+from mediaforce.core.db import DBClient
+from mediaforce.core.db_tables import library_item_evidence_state, library_items
+from mediaforce.encoding.cadence import CADENCE_EVIDENCE_KIND
+from mediaforce.library.evidence_queue import EvidenceQueueConflict, queue_decision_evidence_work
+from mediaforce.library.evidence_state import EVIDENCE_STATE_CURRENT, sync_library_item_evidence_state
+
+
+def cadence_evidence_blocker(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+        *,
+        library_item_ids: Sequence[int],
+        decision_label: str,
+        work_reason: str,
+) -> dict[str, Any] | None:
+    normalized_ids = sorted({int(item_id) for item_id in library_item_ids if int(item_id) > 0})
+    if not normalized_ids:
+        return None
+    items = connection.execute(
+        select(library_items).where(library_items.c.id.in_(normalized_ids))
+    ).mappings().fetchall()
+    for item in items:
+        sync_library_item_evidence_state(
+            connection,
+            item,
+            CADENCE_EVIDENCE_KIND,
+        )
+    unresolved_count = len(
+        connection.execute(
+            select(library_item_evidence_state.c.library_item_id)
+            .where(
+                library_item_evidence_state.c.library_item_id.in_(normalized_ids),
+                library_item_evidence_state.c.evidence_kind == CADENCE_EVIDENCE_KIND,
+                library_item_evidence_state.c.state == EVIDENCE_STATE_CURRENT,
+                library_item_evidence_state.c.decision_status != "resolved",
+            )
+        ).fetchall()
+    )
+    if unresolved_count:
+        file_label = "file has" if unresolved_count == 1 else "files have"
+        return {
+            "ok": False,
+            "code": "cadence_unresolved",
+            "message": (
+                f"{unresolved_count} selected {file_label} a measured motion pattern that Mediaforce cannot "
+                f"convert safely on its own. Review that item in Activity before {decision_label}."
+            ),
+            "affected_item_count": unresolved_count,
+            "next_route": "/ops",
+            "next_action_label": "Open Activity",
+        }
+    scope_prefix = str(prefix or "").strip().strip("/")
+    queue_groups: list[tuple[str, list[int]]]
+    if scope_prefix:
+        queue_groups = [(scope_prefix, normalized_ids)]
+    else:
+        item_ids_by_root: dict[str, list[int]] = {}
+        for item in items:
+            media_root = str(item.get("media_root") or "").strip()
+            if media_root:
+                item_ids_by_root.setdefault(media_root, []).append(int(item["id"]))
+        queue_groups = sorted(item_ids_by_root.items())
+    preparations: list[dict[str, Any]] = []
+    try:
+        for group_prefix, group_item_ids in queue_groups:
+            preparations.append(queue_decision_evidence_work(
+                connection,
+                config,
+                group_prefix,
+                library_item_ids=group_item_ids,
+                evidence_kind=CADENCE_EVIDENCE_KIND,
+                work_reason=work_reason,
+                manage_transaction=False,
+            ))
+    except EvidenceQueueConflict as exc:
+        return {
+            "ok": False,
+            "code": "cadence_analysis_unavailable",
+            "message": (
+                f"Cadence safety evidence is required before {decision_label}, but {str(exc).rstrip('.').lower()}."
+            ),
+            "affected_item_count": len(normalized_ids),
+            "next_route": "/ops",
+            "next_action_label": "Open Activity",
+        }
+    required_count = sum(int(preparation.get("required_count") or 0) for preparation in preparations)
+    if required_count == 0:
+        return None
+    terminal_failure_count = sum(
+        int(preparation.get("terminal_failure_count") or 0)
+        for preparation in preparations
+    )
+    work = next(
+        (
+            preparation.get("work")
+            for preparation in reversed(preparations)
+            if isinstance(preparation.get("work"), dict)
+        ),
+        {},
+    )
+    if terminal_failure_count:
+        file_label = "file" if terminal_failure_count == 1 else "files"
+        return {
+            "ok": False,
+            "code": "cadence_analysis_failed",
+            "message": (
+                f"Motion-pattern analysis previously failed for {terminal_failure_count} selected {file_label}. "
+                f"Open Activity and use Prepare item to retry explicitly before {decision_label}."
+            ),
+            "affected_item_count": terminal_failure_count,
+            "evidence_work": work,
+            "next_route": "/ops",
+            "next_action_label": "Open Activity",
+        }
+    work_status = str(work.get("status") or "")
+    if bool(work.get("is_paused")):
+        work_instruction = "The work is prepared in Activity. Select Start analysis, then try again."
+    elif work_status == "running":
+        work_instruction = "The analysis is already running in Activity. Try again after it finishes."
+    else:
+        work_instruction = "The work is queued in Activity. Try again after it finishes."
+    file_label = "file" if required_count == 1 else "files"
+    return {
+        "ok": False,
+        "code": "cadence_analysis_required",
+        "message": (
+            f"Motion-pattern safety evidence is needed for {required_count} selected {file_label}. "
+            f"{work_instruction}"
+        ),
+        "affected_item_count": required_count,
+        "evidence_work": work,
+        "next_route": "/ops",
+        "next_action_label": "Open Activity",
+    }

--- a/mediaforce/web/runtime/folder_actions.py
+++ b/mediaforce/web/runtime/folder_actions.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 import math
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
 import uuid
 from pathlib import Path
@@ -22,12 +22,13 @@ from mediaforce.library.media_scopes import MediaScope, path_matches_scope, reso
     scope_descendant_filter, scope_rel_path_filter
 from mediaforce.library.movie_workflow import classify_movie_path, movie_item_included
 from mediaforce.library.workflow_state import build_folder_workflow_state
-from mediaforce.library.run_manifests import create_folder_manifest
+from mediaforce.library.run_manifests import create_folder_manifest, write_manifest
 from mediaforce.library.candidate_selection import encode_candidate_decisions, older_season_override_selection, \
     project_candidates, scope_lifecycle_payload_from_decisions, scope_target_size_blocker, workflow_eligibility
 from mediaforce.tuning.quality_risk import build_quality_risk_contract
 from mediaforce.tuning.quality_risk import append_quality_risk_record
 from mediaforce.tuning.size_goals import operator_intent_from_policy
+from mediaforce.web.runtime.decision_evidence import cadence_evidence_blocker
 from mediaforce.web.runtime.folder_tuning_helpers import (
     proposal_alignment_issue,
     size_budget_sample_analysis,
@@ -221,8 +222,8 @@ def queue_folder_encode_action(
     if production_blocker is not None:
         return production_blocker
     with open_db(config.paths.db_path) as connection:
+        connection.exec_driver_sql("BEGIN IMMEDIATE")
         if validate_scope_action is not None:
-            connection.exec_driver_sql("BEGIN IMMEDIATE")
             scope_blocker = validate_scope_action(connection, normalized_prefix)
             if scope_blocker is not None:
                 return scope_blocker
@@ -330,6 +331,31 @@ def queue_folder_encode_action(
                 )
                 if requeue_blocker is not None:
                     raise HTTPException(status_code=409, detail=requeue_blocker)
+                recovery_plan = _folder_recovery_plan(connection, active_encode_job)
+                if recovery_plan is not None:
+                    _recoverable_children, recoverable_indexes = recovery_plan
+                    recoverable_item_ids = _manifest_library_item_ids(
+                        active_encode_job,
+                        recoverable_indexes,
+                    )
+                    if len(recoverable_item_ids) != len(recoverable_indexes):
+                        return {
+                            "ok": False,
+                            "message": (
+                                "The active folder manifest does not identify every failed media item. "
+                                "Cancel this recovery and prepare the folder again."
+                            ),
+                        }
+                    cadence_blocker = cadence_evidence_blocker(
+                        connection,
+                        preflight_config,
+                        normalized_prefix,
+                        library_item_ids=recoverable_item_ids,
+                        decision_label="retrying production",
+                        work_reason="encode_safety",
+                    )
+                    if cadence_blocker is not None:
+                        return cadence_blocker
                 recovered = _recover_active_folder_encode_job(
                     connection,
                     active_encode_job,
@@ -337,6 +363,7 @@ def queue_folder_encode_action(
                     now_iso=now_iso,
                     prepare_terminal_encode_job_for_requeue_fn=prepare_terminal_encode_job_for_requeue_fn,
                     save_encode_job=save_encode_job,
+                    recovery_plan=recovery_plan,
                 )
                 if recovered is not None:
                     return recovered
@@ -346,11 +373,14 @@ def queue_folder_encode_action(
                 "message": f"A folder encode is already {active_status} for {active_prefix}.",
             }
         latest_encode_job = load_latest_terminal_encode_job_for_prefix(connection, normalized_prefix)
-        if latest_encode_job is not None and str(latest_encode_job.get("status") or "") in {
+        terminal_job_needs_requeue = bool(
+            latest_encode_job is not None and str(latest_encode_job.get("status") or "") in {
             "needs_attention",
             "failed",
             "stopped",
-        }:
+            }
+        )
+        if terminal_job_needs_requeue and latest_encode_job is not None:
             requeue_blocker = _movie_requeue_policy_blocker(
                 connection,
                 config,
@@ -359,8 +389,6 @@ def queue_folder_encode_action(
             )
             if requeue_blocker is not None:
                 raise HTTPException(status_code=409, detail=requeue_blocker)
-            prepare_terminal_encode_job_for_requeue_fn(connection, latest_encode_job)
-            _reset_stale_prefix_encoding_items_for_requeue(connection, config, normalized_prefix, now_iso=now_iso)
         preflight_decisions = encode_candidate_decisions(
             connection,
             preflight_config,
@@ -386,9 +414,6 @@ def queue_folder_encode_action(
                 status_code=400,
                 detail=f"No encode candidates were found for this movie scope. Next action: {action_label}.",
             )
-        saved_profile_path = config.paths.runtime_settings_path
-        upsert_override(saved_profile_path, normalized_prefix, calibration_policy)
-        refreshed_config = load_config(config.paths.config_path)
         manifest_kwargs: dict[str, Any] = {"prefix": normalized_prefix}
         older_season_selection = None
         if override_policy_holds:
@@ -397,7 +422,7 @@ def queue_folder_encode_action(
             older_season_selection = older_season_override_selection(
                 project_candidates(
                     connection,
-                    refreshed_config,
+                    preflight_config,
                     prefixes=[normalized_prefix],
                 ),
                 normalized_prefix,
@@ -408,7 +433,30 @@ def queue_folder_encode_action(
                     detail="No safe older-season candidates remain for this show.",
                 )
             manifest_kwargs["older_season_override"] = older_season_selection
-        manifest, manifest_path = create_folder_manifest(connection, refreshed_config, **manifest_kwargs)
+        preview_transaction = None
+        if terminal_job_needs_requeue:
+            stale_rows = _stale_prefix_encoding_rows_for_requeue(
+                connection,
+                config,
+                normalized_prefix,
+            )
+            if stale_rows:
+                preview_transaction = connection.begin_nested()
+                connection.execute(
+                    update(library_items)
+                    .where(library_items.c.id.in_([int(row["id"]) for row in stale_rows]))
+                    .values(status="planned")
+                )
+        try:
+            manifest, manifest_path = create_folder_manifest(
+                connection,
+                preflight_config,
+                prepare_only=True,
+                **manifest_kwargs,
+            )
+        finally:
+            if preview_transaction is not None:
+                preview_transaction.rollback()
         if not manifest["items"]:
             if older_season_selection is not None:
                 raise HTTPException(
@@ -420,7 +468,7 @@ def queue_folder_encode_action(
                 )
             lifecycle_decisions = encode_candidate_decisions(
                 connection,
-                refreshed_config,
+                preflight_config,
                 prefixes=[normalized_prefix],
             )
             if scope.domain == "movie":
@@ -445,7 +493,7 @@ def queue_folder_encode_action(
                 connection,
                 normalized_prefix,
                 candidate_eligibility=workflow_eligibility(lifecycle_decisions),
-                library_types=refreshed_config.library_type_map,
+                library_types=preflight_config.library_type_map,
             ).to_payload()
             next_action = object_dict(workflow_state.get("next_action"))
             action_label = str(next_action.get("label") or "No action")
@@ -453,6 +501,27 @@ def queue_folder_encode_action(
                 status_code=400,
                 detail=f"No encode candidates were found for this folder. Next action: {action_label}.",
             )
+        cadence_blocker = cadence_evidence_blocker(
+            connection,
+            preflight_config,
+            normalized_prefix,
+            library_item_ids=[
+                int(item.get("library_item_id") or 0)
+                for item in manifest["items"]
+            ],
+            decision_label="queueing production",
+            work_reason="encode_safety",
+        )
+        if cadence_blocker is not None:
+            return cadence_blocker
+        if terminal_job_needs_requeue and latest_encode_job is not None:
+            prepare_terminal_encode_job_for_requeue_fn(connection, latest_encode_job)
+            _reset_stale_prefix_encoding_items_for_requeue(connection, config, normalized_prefix, now_iso=now_iso)
+        saved_profile_path = config.paths.runtime_settings_path
+        upsert_override(saved_profile_path, normalized_prefix, calibration_policy)
+        refreshed_config = load_config(config.paths.config_path)
+        if manifest_path is None:
+            manifest_path = write_manifest(connection, refreshed_config, manifest)
         clear_terminal_encode_jobs_for_prefix_fn(connection, normalized_prefix)
         created_at = now_iso()
         parent_job_id = uuid.uuid4().hex[:12]
@@ -572,6 +641,32 @@ def approve_measured_encode_recovery_action(
             "message": target_size_blocker.message,
             "target_size_blocker": target_size_blocker.to_payload(),
         }
+    recovery_indexes = [
+        index
+        for index in object_list(failure_analysis.get("manifest_indexes"))
+        if isinstance(index, int)
+    ]
+    recovery_item_ids = _manifest_library_item_ids(latest_encode_job, recovery_indexes)
+    if recovery_indexes and len(recovery_item_ids) != len(set(recovery_indexes)):
+        return {
+            "ok": False,
+            "message": (
+                "The failed encode manifest does not identify every media item. "
+                "Prepare the folder again before approving recovery."
+            ),
+        }
+    with open_db(config.paths.db_path) as connection:
+        connection.exec_driver_sql("BEGIN IMMEDIATE")
+        cadence_blocker = cadence_evidence_blocker(
+            connection,
+            preflight_config,
+            normalized_prefix,
+            library_item_ids=recovery_item_ids,
+            decision_label="approving measured recovery",
+            work_reason="encode_safety",
+        )
+        if cadence_blocker is not None:
+            return cadence_blocker
 
     calibration_payload["policy"] = recovery["policy"]
     calibration_payload["accepted_at"] = now_iso()
@@ -903,20 +998,14 @@ def _recover_active_folder_encode_job(
         now_iso: NowIsoFn,
         prepare_terminal_encode_job_for_requeue_fn: PrepareTerminalEncodeJobForRequeueFn,
         save_encode_job: SaveEncodeJobFn,
+        recovery_plan: tuple[list[JobPayload], list[int]] | None = None,
 ) -> ActionPayload | None:
     if str(active_encode_job.get("job_kind") or "single") != "folder":
         return None
-    recoverable_children: list[JobPayload] = []
-    recoverable_indexes: list[int] = []
-    for child in _folder_recoverable_children(connection, str(active_encode_job.get("job_id") or "")):
-        child_indexes = [index for index in object_list(child.get("manifest_indexes")) if isinstance(index, int)]
-        if not child_indexes:
-            continue
-        recoverable_children.append(child)
-        recoverable_indexes.extend(child_indexes)
-    recoverable_indexes = sorted(set(recoverable_indexes))
-    if not recoverable_children or not recoverable_indexes:
+    resolved_plan = recovery_plan or _folder_recovery_plan(connection, active_encode_job)
+    if resolved_plan is None:
         return None
+    recoverable_children, recoverable_indexes = resolved_plan
 
     created_at = now_iso()
     for child in recoverable_children:
@@ -969,6 +1058,45 @@ def _recover_active_folder_encode_job(
         "job": active_encode_job,
         "recovered_item_count": len(recoverable_indexes),
     }
+
+
+def _folder_recovery_plan(
+        connection: DBClient,
+        active_encode_job: JobPayload,
+) -> tuple[list[JobPayload], list[int]] | None:
+    if str(active_encode_job.get("job_kind") or "single") != "folder":
+        return None
+    recoverable_children: list[JobPayload] = []
+    recoverable_indexes: list[int] = []
+    for child in _folder_recoverable_children(connection, str(active_encode_job.get("job_id") or "")):
+        child_indexes = [index for index in object_list(child.get("manifest_indexes")) if isinstance(index, int)]
+        if not child_indexes:
+            continue
+        recoverable_children.append(child)
+        recoverable_indexes.extend(child_indexes)
+    unique_indexes = sorted(set(recoverable_indexes))
+    if not recoverable_children or not unique_indexes:
+        return None
+    return recoverable_children, unique_indexes
+
+
+def _manifest_library_item_ids(job: JobPayload, manifest_indexes: list[int]) -> list[int]:
+    manifest_path = Path(str(job.get("manifest_path") or "").strip())
+    if not str(manifest_path):
+        return []
+    try:
+        manifest = object_dict(json.loads(manifest_path.read_text()))
+    except (OSError, json.JSONDecodeError):
+        return []
+    items = [object_dict(item) for item in object_list(manifest.get("items"))]
+    item_ids: list[int] = []
+    for manifest_index in manifest_indexes:
+        if manifest_index < 0 or manifest_index >= len(items):
+            continue
+        library_item_id = int(items[manifest_index].get("library_item_id") or 0)
+        if library_item_id > 0:
+            item_ids.append(library_item_id)
+    return sorted(set(item_ids))
 
 
 def _folder_recoverable_children(connection: DBClient, parent_job_id: str) -> list[JobPayload]:
@@ -1052,36 +1180,12 @@ def _reset_stale_prefix_encoding_items_for_requeue(
         *,
         now_iso: NowIsoFn,
 ) -> None:
-    normalized_prefix = str(prefix).strip().strip("/")
-    if not normalized_prefix:
-        return
-    scope = resolve_media_scope(
-        connection,
-        normalized_prefix,
-        library_types=config.library_type_map,
-    )
-    protected_prefixes = _active_descendant_encode_prefixes(connection, scope)
-    rows = connection.execute(
-        select(library_items.c.id, library_items.c.rel_path)
-        .where(scope_rel_path_filter(library_items.c.rel_path, scope))
-        .where(library_items.c.status == "encoding")
-    ).mappings().fetchall()
+    rows = _stale_prefix_encoding_rows_for_requeue(connection, config, prefix)
     if not rows:
         return
     updated_at = now_iso()
     for row in rows:
         rel_path = str(row["rel_path"] or "").strip()
-        if _rel_path_is_within_any_prefix(rel_path, protected_prefixes):
-            continue
-        if scope.domain == "movie":
-            membership = classify_movie_path(rel_path, root=scope.root)
-            library = config.library_definition_map.get(scope.root, {})
-            if membership is None or not movie_item_included(
-                    membership,
-                    object_dict(library.get("policy")),
-                    explicit_exact=scope.match == "exact_item",
-            )[0]:
-                continue
         if rel_path:
             output_suffix = str(object_dict(config.media).get("output_container") or "").strip()
             if output_suffix:
@@ -1102,6 +1206,43 @@ def _reset_stale_prefix_encoding_items_for_requeue(
             .where(library_items.c.status == "encoding")
             .values(status="planned", updated_at=updated_at)
         )
+
+
+def _stale_prefix_encoding_rows_for_requeue(
+        connection: DBClient,
+        config: MediaforceConfig,
+        prefix: str,
+) -> list[Mapping[str, Any]]:
+    normalized_prefix = str(prefix).strip().strip("/")
+    if not normalized_prefix:
+        return []
+    scope = resolve_media_scope(
+        connection,
+        normalized_prefix,
+        library_types=config.library_type_map,
+    )
+    protected_prefixes = _active_descendant_encode_prefixes(connection, scope)
+    rows = connection.execute(
+        select(library_items.c.id, library_items.c.rel_path)
+        .where(scope_rel_path_filter(library_items.c.rel_path, scope))
+        .where(library_items.c.status == "encoding")
+    ).mappings().fetchall()
+    eligible_rows: list[Mapping[str, Any]] = []
+    for row in rows:
+        rel_path = str(row["rel_path"] or "").strip()
+        if _rel_path_is_within_any_prefix(rel_path, protected_prefixes):
+            continue
+        if scope.domain == "movie":
+            membership = classify_movie_path(rel_path, root=scope.root)
+            library = config.library_definition_map.get(scope.root, {})
+            if membership is None or not movie_item_included(
+                    membership,
+                    object_dict(library.get("policy")),
+                    explicit_exact=scope.match == "exact_item",
+            )[0]:
+                continue
+        eligible_rows.append(row)
+    return eligible_rows
 
 
 def _active_descendant_encode_prefixes(connection: DBClient, scope: MediaScope) -> set[str]:

--- a/mediaforce/web/runtime/folder_ai_tuning.py
+++ b/mediaforce/web/runtime/folder_ai_tuning.py
@@ -22,6 +22,7 @@ from mediaforce.tuning.quality_risk import (
 from mediaforce.tuning.size_goals import operator_intent_from_policy
 from mediaforce.tuning.stream_budget import StreamBudgetProjectionBlocker, stream_budget_projection_blocker
 from mediaforce.web.runtime.folder_tuning_advice import operator_preserves_source_resolution, operator_request_from_intent
+from mediaforce.web.runtime.decision_evidence import cadence_evidence_blocker
 from mediaforce.web.runtime.folder_tuning_helpers import (
     allows_measured_size_quality_tradeoff,
     measured_size_budget_policy_fragment,
@@ -582,6 +583,7 @@ def folder_ai_tune_preview_action(
     host = deps.resolve_sample_host(config, host_key)
 
     with open_db(config.paths.db_path) as connection:
+        connection.exec_driver_sql("BEGIN IMMEDIATE")
         existing_job = deps.load_job_state(connection, config, normalized_prefix)
         if existing_job and existing_job.get("status") in {"queued", "running", "pending_review"}:
             return {"ok": False, "message": "A calibration job is already active for this folder."}
@@ -593,6 +595,16 @@ def folder_ai_tune_preview_action(
         sample_item = deps.sample_item(connection, config, normalized_prefix)
         if sample_item is None:
             raise HTTPException(status_code=404, detail=f"No sample item found for {normalized_prefix}")
+        cadence_blocker = cadence_evidence_blocker(
+            connection,
+            config,
+            normalized_prefix,
+            library_item_ids=[int(sample_item.get("library_item_id") or 0)],
+            decision_label="queueing this sample",
+            work_reason="sample_safety",
+        )
+        if cadence_blocker is not None:
+            return cadence_blocker
         calibration = deps.load_calibration_state(config, normalized_prefix)
         current_policy = object_dict(calibration.get("policy")) if calibration else object_dict(sample_item.get("resolved_policy"))
     if object_dict(operator_intent):
@@ -696,12 +708,23 @@ def folder_ai_tune_confirm_action(
     advice_payload = object_dict(pending_proposal.get("advice_payload"))
 
     with open_db(config.paths.db_path) as connection:
+        connection.exec_driver_sql("BEGIN IMMEDIATE")
         existing_job = deps.load_job_state(connection, config, normalized_prefix)
         if existing_job and existing_job.get("status") in {"queued", "running", "pending_review"}:
             return {"ok": False, "message": "A calibration job is already active for this folder."}
         sample_item = deps.sample_item(connection, config, normalized_prefix)
         if sample_item is None:
             raise HTTPException(status_code=404, detail=f"No sample item found for {normalized_prefix}")
+        cadence_blocker = cadence_evidence_blocker(
+            connection,
+            config,
+            normalized_prefix,
+            library_item_ids=[int(sample_item.get("library_item_id") or 0)],
+            decision_label="queueing this sample",
+            work_reason="sample_safety",
+        )
+        if cadence_blocker is not None:
+            return cadence_blocker
         calibration = deps.load_calibration_state(config, normalized_prefix)
         if action == "baseline" and calibration is not None:
             return {
@@ -822,6 +845,7 @@ def _retry_latest_sample_job(
         normalized_prefix: str,
 ) -> dict[str, Any]:
     with open_db(config.paths.db_path) as connection:
+        connection.exec_driver_sql("BEGIN IMMEDIATE")
         existing_job = deps.load_retryable_sample_job_state(connection, config, normalized_prefix)
         if existing_job is None:
             return {"ok": False, "message": "Ask the bench for a draft first."}
@@ -846,11 +870,21 @@ def _retry_latest_sample_job(
         host = deps.resolve_sample_host(config, host_key)
 
         stored_sample_item = object_dict(existing_job.get("sample_item"))
-        if not stored_sample_item:
-            sample_item = deps.sample_item(connection, config, normalized_prefix)
-            if sample_item is None:
-                raise HTTPException(status_code=404, detail=f"No sample item found for {normalized_prefix}")
-            stored_sample_item = object_dict(sample_item)
+        current_sample_item = deps.sample_item(connection, config, normalized_prefix)
+        if current_sample_item is not None:
+            stored_sample_item = object_dict(current_sample_item)
+        elif not stored_sample_item or not int(stored_sample_item.get("library_item_id") or 0):
+            raise HTTPException(status_code=404, detail=f"No current sample item found for {normalized_prefix}")
+        cadence_blocker = cadence_evidence_blocker(
+            connection,
+            config,
+            normalized_prefix,
+            library_item_ids=[int(stored_sample_item.get("library_item_id") or 0)],
+            decision_label="queueing this sample",
+            work_reason="sample_safety",
+        )
+        if cadence_blocker is not None:
+            return cadence_blocker
         prepared_sample_item, target_size_blocker = _prepare_sample_item(
             config,
             stored_sample_item,

--- a/tests/test_db_runtime.py
+++ b/tests/test_db_runtime.py
@@ -27,7 +27,7 @@ from mediaforce.core.type_defs import object_dict
 from mediaforce.encoding.cadence import cadence_policy_snapshot
 from mediaforce.encoding.fingerprint import media_fingerprint_policy_snapshot
 
-CURRENT_DB_REVISION = "20260719_0013"
+CURRENT_DB_REVISION = "20260719_0014"
 
 
 class DatabaseRuntimeTests(unittest.TestCase):
@@ -50,8 +50,12 @@ class DatabaseRuntimeTests(unittest.TestCase):
                     str(index_row["name"])
                     for index_row in inspector.get_indexes("library_item_evidence_state")
                 }
-                evidence_columns = {
-                    str(column["name"])
+                evidence_index_columns = {
+                    str(index_row["name"]): tuple(index_row.get("column_names") or ())
+                    for index_row in inspector.get_indexes("library_item_evidence_state")
+                }
+                evidence_column_details = {
+                    str(column["name"]): column
                     for column in inspector.get_columns("library_item_evidence_state")
                 }
                 library_columns = {str(column["name"]) for column in inspector.get_columns("library_items")}
@@ -73,9 +77,26 @@ class DatabaseRuntimeTests(unittest.TestCase):
             self.assertIn("idx_library_item_evidence_state_kind_state", evidence_indexes)
             self.assertIn("idx_library_item_evidence_state_work_ready", evidence_indexes)
             self.assertIn("idx_library_item_evidence_state_work_claim", evidence_indexes)
-            self.assertIn("work_batch_id", evidence_columns)
-            self.assertIn("work_status", evidence_columns)
-            self.assertIn("lease_expires_at", evidence_columns)
+            self.assertIn("work_batch_id", evidence_column_details)
+            self.assertIn("work_status", evidence_column_details)
+            self.assertIn("work_priority", evidence_column_details)
+            self.assertIn("work_reason", evidence_column_details)
+            self.assertIn("lease_expires_at", evidence_column_details)
+            self.assertEqual(
+                str(evidence_column_details["work_priority"].get("default") or "").strip("()'\""),
+                "100",
+            )
+            self.assertEqual(
+                evidence_index_columns["idx_library_item_evidence_state_work_claim"],
+                (
+                    "work_batch_id",
+                    "work_status",
+                    "retry_not_before",
+                    "work_priority",
+                    "evidence_kind",
+                    "library_item_id",
+                ),
+            )
 
     def test_open_db_stamps_existing_legacy_database(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -42,6 +42,7 @@ from mediaforce.encoding import manifest as manifest
 from mediaforce.encoding import quality_search
 from mediaforce.encoding import staging as staging_runtime
 from mediaforce.encoding import video_filters
+from mediaforce.encoding.cadence import analyze_cadence
 from mediaforce.encoding.encode_queue import clear_terminal_encode_jobs_for_prefix, list_child_encode_jobs, \
     load_active_encode_job_for_prefix, load_encode_job, load_latest_encode_job, \
     load_latest_terminal_encode_job_for_prefix, load_queue_state, repair_persisted_encode_job_hosts, \
@@ -16244,7 +16245,9 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 _config: MediaforceConfig,
                 *,
                 prefix: str,
+                prepare_only: bool = False,
         ) -> tuple[folder_actions_runtime.ManifestPayload, Path]:
+            self.assertTrue(prepare_only)
             self.assertEqual(prefix, "tv/show")
             pending_ids = {
                 int(row["id"])
@@ -16352,7 +16355,9 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 _config: MediaforceConfig,
                 *,
                 prefix: str,
+                prepare_only: bool = False,
         ) -> tuple[folder_actions_runtime.ManifestPayload, Path]:
+            self.assertTrue(prepare_only)
             self.assertEqual(prefix, "tv/show")
             pending_ids = {
                 int(row["id"])
@@ -17794,6 +17799,20 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 video_codec="h264",
                 audio_summary_json="[]",
                 subtitle_summary_json="[]",
+                cadence_summary_json=json.dumps(
+                    analyze_cadence(
+                        Path("unused.mkv"),
+                        video_stream={
+                            "field_order": "progressive",
+                            "avg_frame_rate": "24/1",
+                            "r_frame_rate": "24/1",
+                            "time_base": "1/1000",
+                        },
+                        duration_seconds=60.0,
+                    ),
+                    separators=(",", ":"),
+                    sort_keys=True,
+                ),
                 media_fingerprint_json="{}",
                 last_scan_id="scan-1",
                 discovered_at=now,

--- a/tests/test_evidence_acquisition.py
+++ b/tests/test_evidence_acquisition.py
@@ -1,0 +1,180 @@
+import unittest
+from typing import Any
+
+from mediaforce.core.evidence import stable_source_id
+from mediaforce.encoding.fingerprint import DEFAULT_FINGERPRINT_MAX_FRAMES
+from mediaforce.library.evidence_acquisition import (
+    DEFAULT_UNCERTAINTY_FRONTIER_LIMIT,
+    plan_fingerprint_acquisition,
+    replay_representative_dimensions,
+)
+from mediaforce.library.representatives import select_representatives
+
+
+class EvidenceAcquisitionTests(unittest.TestCase):
+    def test_plan_starts_with_unmeasured_technical_representatives_deterministically(self) -> None:
+        items = [
+            self._item(1, measured=False),
+            self._item(
+                2,
+                measured=False,
+                video_codec="hevc",
+                width=1280,
+                height=720,
+                cadence_class="interlaced_tff",
+                channels=2,
+            ),
+            self._item(3, measured=False),
+        ]
+        technical_selection = select_representatives(
+            items,
+            prefix="tv/Example/Season 1",
+            fingerprint_dimensions=(),
+        )
+
+        plan = plan_fingerprint_acquisition(items, prefix="tv/Example/Season 1")
+        reversed_plan = plan_fingerprint_acquisition(list(reversed(items)), prefix="tv/Example/Season 1")
+
+        self.assertEqual(plan, reversed_plan)
+        self.assertEqual(plan.phase, "technical_representatives")
+        self.assertEqual(
+            plan.candidate_ids,
+            tuple(item["source_id"] for item in technical_selection.payload["selected_items"]),
+        )
+        self.assertEqual(plan.stop_reason, "technical_representatives_pending")
+        self.assertEqual(plan.coverage.technical_representative_coverage, 0.0)
+        self.assertEqual(plan.intentionally_unqueued_count, len(items) - len(plan.candidate_ids))
+        self.assertEqual(
+            plan.estimated_analysis_cost.shared_visual_pass.estimated_frame_count,
+            len(plan.candidate_ids) * DEFAULT_FINGERPRINT_MAX_FRAMES,
+        )
+
+    def test_plan_caps_the_uncertainty_frontier_and_stops_at_representative_coverage(self) -> None:
+        items = [
+            self._item(1, media_traits=["typical"]),
+            self._item(2, media_traits=["dark_luma", "dark_gradient_banding_risk"]),
+            self._item(3, media_traits=["high_motion"]),
+            self._item(4, media_traits=["typical"]),
+        ]
+        technical_selection = select_representatives(
+            items,
+            prefix="tv/Example/Season 1",
+            fingerprint_dimensions=(),
+        )
+        all_dimension_selection = select_representatives(items, prefix="tv/Example/Season 1")
+        technical_ids = tuple(item["source_id"] for item in technical_selection.payload["selected_items"])
+        all_dimension_ids = tuple(item["source_id"] for item in all_dimension_selection.payload["selected_items"])
+        frontier_ids = tuple(source_id for source_id in all_dimension_ids if source_id not in technical_ids)
+
+        plan = plan_fingerprint_acquisition(
+            items,
+            prefix="tv/Example/Season 1",
+            measured_source_ids=technical_ids,
+            max_uncertainty_frontier=1,
+        )
+
+        self.assertGreater(len(frontier_ids), 1)
+        self.assertEqual(plan.phase, "uncertainty_frontier")
+        self.assertEqual(plan.candidate_ids, frontier_ids[:1])
+        self.assertEqual(plan.stop_reason, "uncertainty_frontier_capped")
+        self.assertEqual(
+            plan.intentionally_unqueued_count,
+            len(items) - len(technical_ids) - len(plan.candidate_ids),
+        )
+
+        complete_plan = plan_fingerprint_acquisition(
+            items,
+            prefix="tv/Example/Season 1",
+            measured_source_ids=all_dimension_ids,
+        )
+        unselected_ids = {stable_source_id(item) for item in items} - set(all_dimension_ids)
+
+        self.assertEqual(complete_plan.phase, "complete")
+        self.assertEqual(complete_plan.candidate_ids, ())
+        self.assertEqual(complete_plan.stop_reason, "representative_coverage_satisfied")
+        self.assertEqual(complete_plan.intentionally_unqueued_count, len(unselected_ids))
+        self.assertLess(complete_plan.coverage.global_fingerprint_coverage, 1.0)
+        self.assertEqual(complete_plan.coverage.all_dimension_representative_coverage, 1.0)
+
+    def test_replay_reports_dimension_benefit_and_separate_audio_cost(self) -> None:
+        items = [
+            self._item(1, media_traits=["typical"]),
+            self._item(2, media_traits=["dark_luma", "dark_gradient_banding_risk"]),
+            self._item(3, media_traits=["audio_complexity"]),
+        ]
+
+        report = replay_representative_dimensions(
+            items,
+            prefix="tv/Example/Season 1",
+            measured_source_ids=(),
+        )
+        audio_omission = next(
+            replay
+            for replay in report.leave_one_dimension_out
+            if replay.omitted_fingerprint_dimension == "audio_complexity"
+        )
+
+        self.assertGreater(
+            report.all_dimensions.sample_set_growth.selected_count,
+            report.technical_only.sample_set_growth.selected_count,
+        )
+        self.assertTrue(report.all_dimensions.representative_changes.changed)
+        self.assertLess(
+            audio_omission.hard_case_recall.recalled_hard_case_count,
+            report.all_dimensions.hard_case_recall.recalled_hard_case_count,
+        )
+        self.assertEqual(
+            report.shared_visual_pass_cost,
+            report.all_dimensions.estimated_analysis_cost.shared_visual_pass,
+        )
+        self.assertEqual(
+            report.shared_visual_pass_cost.estimated_frame_count,
+            report.shared_visual_pass_cost.candidate_count * DEFAULT_FINGERPRINT_MAX_FRAMES,
+        )
+        self.assertEqual(report.audio_complexity_cost.recommendation, "retain")
+        self.assertGreater(report.audio_complexity_cost.estimated_sample_seconds, 0.0)
+
+    def test_plan_rejects_non_positive_frontier_limit(self) -> None:
+        with self.assertRaisesRegex(ValueError, "max_uncertainty_frontier must be greater than zero"):
+            plan_fingerprint_acquisition([self._item(1)], max_uncertainty_frontier=0)
+        self.assertGreater(DEFAULT_UNCERTAINTY_FRONTIER_LIMIT, 0)
+
+    @staticmethod
+    def _item(
+            index: int,
+            *,
+            measured: bool = True,
+            video_codec: str = "h264",
+            width: int = 1920,
+            height: int = 1080,
+            cadence_class: str = "progressive",
+            channels: int = 6,
+            media_traits: list[str] | None = None,
+    ) -> dict[str, Any]:
+        rel_path = f"tv/Example/Season 1/Episode {index:02d}.mkv"
+        traits = media_traits or ["typical"]
+        return {
+            "library_item_id": index,
+            "rel_path": rel_path,
+            "source_fingerprint": f"fingerprint-{index}",
+            "source_size_bytes": 1_000_000_000,
+            "video_codec": video_codec,
+            "width": width,
+            "height": height,
+            "cadence_class": cadence_class,
+            "duration_seconds": 2700,
+            "audio_summary": [{"codec_name": "eac3", "channels": channels}],
+            "media_fingerprint_decision": {
+                "status": "measured" if measured else "unknown",
+                "traits": traits,
+                "findings": [
+                    {"id": trait, "confidence": 0.9}
+                    for trait in traits
+                    if trait != "typical"
+                ],
+            },
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evidence_acquisition.py
+++ b/tests/test_evidence_acquisition.py
@@ -51,20 +51,19 @@ class EvidenceAcquisitionTests(unittest.TestCase):
 
     def test_plan_caps_the_uncertainty_frontier_and_stops_at_representative_coverage(self) -> None:
         items = [
-            self._item(1, media_traits=["typical"]),
-            self._item(2, media_traits=["dark_luma", "dark_gradient_banding_risk"]),
+            self._item(1, media_traits=["dark_luma"]),
+            self._item(2, media_traits=["dark_luma"]),
             self._item(3, media_traits=["high_motion"]),
             self._item(4, media_traits=["typical"]),
+            self._item(5, media_traits=["typical"]),
+            self._item(6, media_traits=["dark_gradient_banding_risk"]),
         ]
         technical_selection = select_representatives(
             items,
             prefix="tv/Example/Season 1",
             fingerprint_dimensions=(),
         )
-        all_dimension_selection = select_representatives(items, prefix="tv/Example/Season 1")
         technical_ids = tuple(item["source_id"] for item in technical_selection.payload["selected_items"])
-        all_dimension_ids = tuple(item["source_id"] for item in all_dimension_selection.payload["selected_items"])
-        frontier_ids = tuple(source_id for source_id in all_dimension_ids if source_id not in technical_ids)
 
         plan = plan_fingerprint_acquisition(
             items,
@@ -73,9 +72,8 @@ class EvidenceAcquisitionTests(unittest.TestCase):
             max_uncertainty_frontier=1,
         )
 
-        self.assertGreater(len(frontier_ids), 1)
         self.assertEqual(plan.phase, "uncertainty_frontier")
-        self.assertEqual(plan.candidate_ids, frontier_ids[:1])
+        self.assertEqual(plan.candidate_ids, (stable_source_id(items[1]),))
         self.assertEqual(plan.stop_reason, "uncertainty_frontier_capped")
         self.assertEqual(
             plan.intentionally_unqueued_count,
@@ -85,16 +83,14 @@ class EvidenceAcquisitionTests(unittest.TestCase):
         complete_plan = plan_fingerprint_acquisition(
             items,
             prefix="tv/Example/Season 1",
-            measured_source_ids=all_dimension_ids,
+            measured_source_ids=(*technical_ids, stable_source_id(items[1])),
         )
-        unselected_ids = {stable_source_id(item) for item in items} - set(all_dimension_ids)
 
         self.assertEqual(complete_plan.phase, "complete")
         self.assertEqual(complete_plan.candidate_ids, ())
         self.assertEqual(complete_plan.stop_reason, "representative_coverage_satisfied")
-        self.assertEqual(complete_plan.intentionally_unqueued_count, len(unselected_ids))
+        self.assertEqual(complete_plan.intentionally_unqueued_count, len(items) - 2)
         self.assertLess(complete_plan.coverage.global_fingerprint_coverage, 1.0)
-        self.assertEqual(complete_plan.coverage.all_dimension_representative_coverage, 1.0)
 
     def test_replay_reports_dimension_benefit_and_separate_audio_cost(self) -> None:
         items = [

--- a/tests/test_evidence_worker.py
+++ b/tests/test_evidence_worker.py
@@ -21,10 +21,11 @@ from mediaforce.encoding.cadence import CADENCE_EVIDENCE_KIND, analyze_cadence
 from mediaforce.encoding.fingerprint import MEDIA_FINGERPRINT_EVIDENCE_KIND
 from mediaforce.library.evidence_queue import cancel_evidence_queue, claim_next_evidence_work, \
     evidence_queue_summary, mark_evidence_attempt_started, pause_evidence_queue, recover_evidence_queue, \
-    resume_evidence_queue, start_evidence_work
+    queue_decision_evidence_work, resume_evidence_queue, start_evidence_work
 from mediaforce.library.evidence_state import EVIDENCE_STATE_CLASSIFICATION_REQUIRED, EVIDENCE_STATE_CURRENT, \
     load_library_item_evidence_states, rebuild_library_item_evidence_states, sync_library_item_evidence_state
 from mediaforce.library.evidence_worker import EvidenceWorkerDeps, process_evidence_queue_once
+from mediaforce.web.runtime.decision_evidence import cadence_evidence_blocker
 
 
 class EvidenceWorkerTests(unittest.TestCase):
@@ -113,6 +114,265 @@ class EvidenceWorkerTests(unittest.TestCase):
         self.assertEqual(summary["item_count"], 1)
         self.assertEqual(summary["counts"], {"queued": 1})
         self.assertEqual(summary["scope"]["work_limit"], 1)
+
+    def test_fingerprint_preparation_starts_with_bounded_technical_representatives(self) -> None:
+        item_ids = [
+            self._insert_item(
+                index,
+                cadence_summary_json=self._cadence_summary_json(),
+                media_fingerprint_json=None,
+            )[0]
+            for index in range(1, 4)
+        ]
+
+        with open_db(self.config.paths.db_path) as connection:
+            summary = start_evidence_work(
+                connection,
+                self.config,
+                "tv/show",
+                evidence_kinds=[MEDIA_FINGERPRINT_EVIDENCE_KIND],
+                limit=25,
+            )
+            queued_rows = connection.execute(
+                select(
+                    library_item_evidence_state.c.library_item_id,
+                    library_item_evidence_state.c.work_priority,
+                    library_item_evidence_state.c.work_reason,
+                ).where(
+                    library_item_evidence_state.c.library_item_id.in_(item_ids),
+                    library_item_evidence_state.c.evidence_kind == MEDIA_FINGERPRINT_EVIDENCE_KIND,
+                    library_item_evidence_state.c.work_status == "queued",
+                )
+            ).mappings().fetchall()
+
+        acquisition = summary["scope"]["fingerprint_acquisition"]
+        self.assertEqual(summary["item_count"], 1)
+        self.assertEqual(acquisition["phase"], "technical_representatives")
+        self.assertEqual(acquisition["candidate_count"], 1)
+        self.assertEqual(acquisition["intentionally_unqueued_count"], 2)
+        self.assertEqual(
+            [
+                (row["work_priority"], row["work_reason"])
+                for row in queued_rows
+            ],
+            [(70, "representative_technical_coverage")],
+        )
+
+    def test_decision_evidence_prepares_only_the_affected_item(self) -> None:
+        first_item_id, _path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        second_item_id, _path = self._insert_item(2, cadence_summary_json=None, media_fingerprint_json=None)
+
+        with open_db(self.config.paths.db_path) as connection:
+            prepared = queue_decision_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-2.mkv",
+                library_item_ids=[second_item_id],
+                evidence_kind=CADENCE_EVIDENCE_KIND,
+                work_reason="sample_safety",
+            )
+            rows = connection.execute(
+                select(
+                    library_item_evidence_state.c.library_item_id,
+                    library_item_evidence_state.c.evidence_kind,
+                    library_item_evidence_state.c.work_status,
+                    library_item_evidence_state.c.work_priority,
+                    library_item_evidence_state.c.work_reason,
+                )
+                .where(library_item_evidence_state.c.evidence_kind == CADENCE_EVIDENCE_KIND)
+                .order_by(library_item_evidence_state.c.library_item_id)
+            ).mappings().fetchall()
+
+        self.assertEqual(prepared["required_count"], 1)
+        self.assertEqual(prepared["work"]["status"], "paused")
+        self.assertEqual(prepared["work"]["item_count"], 1)
+        self.assertEqual(
+            [dict(row) for row in rows],
+            [
+                {
+                    "library_item_id": first_item_id,
+                    "evidence_kind": CADENCE_EVIDENCE_KIND,
+                    "work_status": None,
+                    "work_priority": 100,
+                    "work_reason": None,
+                },
+                {
+                    "library_item_id": second_item_id,
+                    "evidence_kind": CADENCE_EVIDENCE_KIND,
+                    "work_status": "queued",
+                    "work_priority": 0,
+                    "work_reason": "sample_safety",
+                },
+            ],
+        )
+
+    def test_cadence_decision_blocker_queues_only_missing_safety_evidence(self) -> None:
+        first_item_id, _path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        second_item_id, _path = self._insert_item(
+            2,
+            cadence_summary_json=self._cadence_summary_json(),
+            media_fingerprint_json=None,
+        )
+
+        with open_db(self.config.paths.db_path) as connection:
+            blocker = cadence_evidence_blocker(
+                connection,
+                self.config,
+                "tv/show",
+                library_item_ids=[first_item_id, second_item_id],
+                decision_label="queueing production",
+                work_reason="encode_safety",
+            )
+            rows = connection.execute(
+                select(
+                    library_item_evidence_state.c.library_item_id,
+                    library_item_evidence_state.c.work_status,
+                    library_item_evidence_state.c.work_reason,
+                )
+                .where(library_item_evidence_state.c.evidence_kind == CADENCE_EVIDENCE_KIND)
+                .order_by(library_item_evidence_state.c.library_item_id)
+            ).mappings().fetchall()
+
+        self.assertEqual(blocker["code"], "cadence_analysis_required")
+        self.assertEqual(blocker["affected_item_count"], 1)
+        self.assertEqual(blocker["next_route"], "/ops")
+        self.assertEqual(
+            [dict(row) for row in rows],
+            [
+                {
+                    "library_item_id": first_item_id,
+                    "work_status": "queued",
+                    "work_reason": "encode_safety",
+                },
+                {
+                    "library_item_id": second_item_id,
+                    "work_status": None,
+                    "work_reason": None,
+                },
+            ],
+        )
+
+    def test_cadence_decision_blocker_does_not_requeue_measured_blocked_cadence(self) -> None:
+        item_id, _path = self._insert_item(
+            1,
+            cadence_summary_json=self._blocked_cadence_summary_json(),
+            media_fingerprint_json=None,
+        )
+
+        with open_db(self.config.paths.db_path) as connection:
+            blocker = cadence_evidence_blocker(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                library_item_ids=[item_id],
+                decision_label="queueing this sample",
+                work_reason="sample_safety",
+            )
+            row = connection.execute(
+                select(
+                    library_item_evidence_state.c.work_status,
+                    library_item_evidence_state.c.work_reason,
+                ).where(
+                    library_item_evidence_state.c.library_item_id == item_id,
+                    library_item_evidence_state.c.evidence_kind == CADENCE_EVIDENCE_KIND,
+                )
+            ).mappings().one()
+
+        self.assertEqual(blocker["code"], "cadence_unresolved")
+        self.assertEqual(blocker["affected_item_count"], 1)
+        self.assertEqual(dict(row), {"work_status": None, "work_reason": None})
+
+    def test_decision_evidence_is_claimed_before_manual_backfill(self) -> None:
+        first_item_id, _path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        second_item_id, _path = self._insert_item(2, cadence_summary_json=None, media_fingerprint_json=None)
+        with open_db(self.config.paths.db_path) as connection:
+            start_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                evidence_kinds=[CADENCE_EVIDENCE_KIND],
+            )
+            queue_decision_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-2.mkv",
+                library_item_ids=[second_item_id],
+                evidence_kind=CADENCE_EVIDENCE_KIND,
+                work_reason="encode_safety",
+            )
+            resume_evidence_queue(connection)
+        with open_db(self.config.paths.db_path) as connection:
+            claim = claim_next_evidence_work(connection, worker_id="worker-a", lease_seconds=30)
+
+        self.assertIsNotNone(claim)
+        self.assertEqual(claim.library_item_id, second_item_id)
+        self.assertNotEqual(claim.library_item_id, first_item_id)
+
+    def test_decision_request_does_not_reset_same_source_failure_budget(self) -> None:
+        item_id, _path = self._insert_item(1, cadence_summary_json=None, media_fingerprint_json=None)
+        with open_db(self.config.paths.db_path) as connection:
+            source_fingerprint = connection.execute(
+                select(library_items.c.content_version_fingerprint).where(library_items.c.id == item_id)
+            ).scalar_one()
+            connection.execute(
+                update(library_item_evidence_state)
+                .where(
+                    library_item_evidence_state.c.library_item_id == item_id,
+                    library_item_evidence_state.c.evidence_kind == CADENCE_EVIDENCE_KIND,
+                )
+                .values(
+                    work_batch_id="old-batch",
+                    work_status="failed",
+                    work_source_fingerprint=source_fingerprint,
+                    attempt_count=3,
+                    last_error="decoder failed",
+                )
+            )
+            prepared = queue_decision_evidence_work(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                library_item_ids=[item_id],
+                evidence_kind=CADENCE_EVIDENCE_KIND,
+                work_reason="sample_safety",
+            )
+            row = connection.execute(
+                select(
+                    library_item_evidence_state.c.work_status,
+                    library_item_evidence_state.c.work_priority,
+                    library_item_evidence_state.c.attempt_count,
+                    library_item_evidence_state.c.last_error,
+                ).where(
+                    library_item_evidence_state.c.library_item_id == item_id,
+                    library_item_evidence_state.c.evidence_kind == CADENCE_EVIDENCE_KIND,
+                )
+            ).mappings().one()
+
+        self.assertEqual(prepared["work"]["status"], "idle")
+        self.assertEqual(prepared["prepared_count"], 0)
+        self.assertEqual(prepared["terminal_failure_count"], 1)
+        self.assertEqual(
+            dict(row),
+            {
+                "work_status": "failed",
+                "work_priority": 0,
+                "attempt_count": 3,
+                "last_error": "decoder failed",
+            },
+        )
+
+        with open_db(self.config.paths.db_path) as connection:
+            blocker = cadence_evidence_blocker(
+                connection,
+                self.config,
+                "tv/show/item-1.mkv",
+                library_item_ids=[item_id],
+                decision_label="queueing this sample",
+                work_reason="sample_safety",
+            )
+
+        self.assertEqual(blocker["code"], "cadence_analysis_failed")
+        self.assertEqual(blocker["affected_item_count"], 1)
 
     def test_zero_candidate_batch_completes_without_claims(self) -> None:
         self._insert_item(
@@ -682,6 +942,13 @@ class EvidenceWorkerTests(unittest.TestCase):
             separators=(",", ":"),
             sort_keys=True,
         )
+
+    @classmethod
+    def _blocked_cadence_summary_json(cls) -> str:
+        payload = json.loads(cls._cadence_summary_json())
+        payload["decision"]["status"] = "blocked"
+        payload["decision"]["reason"] = "fixture cadence requires operator review"
+        return json.dumps(payload, separators=(",", ":"), sort_keys=True)
 
     @staticmethod
     def _fingerprint_summary_json() -> str:

--- a/tests/test_quality_risk.py
+++ b/tests/test_quality_risk.py
@@ -90,6 +90,8 @@ class QualityRiskContractTests(unittest.TestCase):
         public = quality_risk_public_view(contract)
         assert public is not None
         self.assertEqual(public["verdict"], "blocked")
+        self.assertEqual(public["cadence_gate"], "progressive")
+        self.assertEqual(public["cadence_transform"], "none")
         self.assertEqual(public["operator_decision"]["status"], "rejected")
         self.assertTrue(public["operator_decision"]["effective_record"]["authoritative"])
 

--- a/tests/test_representative_selection.py
+++ b/tests/test_representative_selection.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from mediaforce.core.evidence import build_evidence_envelope, evidence_staleness
 from mediaforce.library.representatives import (
+    FINGERPRINT_DIMENSIONS,
+    TECHNICAL_PROFILE_DIMENSIONS,
     REPRESENTATIVE_SELECTION_TOOL,
     REPRESENTATIVE_SELECTION_TOOL_VERSION,
     evidence_sources,
@@ -249,6 +251,54 @@ class RepresentativeSelectionTests(unittest.TestCase):
         )
         self.assertEqual(profile["gradient"], "gradient_risk")
         self.assertEqual(profile["motion"], "high_motion")
+
+    def test_explicit_fingerprint_dimensions_limit_coverage_without_changing_default(self) -> None:
+        items = [
+            self._item(1, media_traits=["typical"]),
+            self._item(2, media_traits=["typical"]),
+            self._item(3, media_traits=["dark_gradient_banding_risk"]),
+        ]
+
+        default_selection = select_representatives(items, prefix="tv/Example/Season 1")
+        explicit_default = select_representatives(
+            items,
+            prefix="tv/Example/Season 1",
+            fingerprint_dimensions=FINGERPRINT_DIMENSIONS,
+        )
+        luma_only = select_representatives(
+            items,
+            prefix="tv/Example/Season 1",
+            fingerprint_dimensions=("luma",),
+        )
+        technical_only = select_representatives(
+            items,
+            prefix="tv/Example/Season 1",
+            fingerprint_dimensions=(),
+        )
+
+        self.assertEqual(default_selection.payload, explicit_default.payload)
+        self.assertIn(
+            "tv/Example/Season 1/Episode 03.mkv",
+            {item["rel_path"] for item in default_selection.payload["selected_items"]},
+        )
+        self.assertEqual(luma_only.payload["coverage"]["selected_item_count"], 1)
+        self.assertEqual(technical_only.payload["coverage"]["selected_item_count"], 1)
+        self.assertEqual(
+            set(luma_only.payload["coverage"]["dimensions"]),
+            {*TECHNICAL_PROFILE_DIMENSIONS, "luma"},
+        )
+        self.assertEqual(
+            technical_only.payload["evidence"]["result"]["selection_policy"]["fingerprint_dimensions"],
+            [],
+        )
+
+    def test_unknown_fingerprint_dimension_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unsupported fingerprint dimensions: color"):
+            select_representatives(
+                [self._item(1)],
+                prefix="tv/Example/Season 1",
+                fingerprint_dimensions=("color",),
+            )
 
     def test_missing_fingerprints_do_not_outvote_measured_primary_evidence(self) -> None:
         items = [self._item(1), self._item(2), self._item(3)]

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -701,6 +701,7 @@ class TuningRuntimeTests(unittest.TestCase):
             "notes": "Aim for 8%",
             "policy": {"video": {"target_vmaf": 93.5, "default_grain": 0}},
             "sample_item": {
+                "library_item_id": 1,
                 "rel_path": "tv/show/episode.mkv",
                 "source_path": str(self.root / "source" / "tv" / "show" / "episode.mkv"),
                 "source_size_bytes": 1234,
@@ -779,6 +780,7 @@ class TuningRuntimeTests(unittest.TestCase):
             "notes": "Aim for 8%",
             "policy": {"video": {"target_vmaf": 93.5, "default_grain": 0}},
             "sample_item": {
+                "library_item_id": 1,
                 "rel_path": "tv/show/episode.mkv",
                 "source_path": str(self.root / "source" / "tv" / "show" / "episode.mkv"),
                 "source_size_bytes": 1234,


### PR DESCRIPTION
## Summary

- prioritize evidence work by the decision it blocks, with exact-item cadence preparation for sample and encode actions
- keep catalog browsing read-only and fingerprint acquisition bounded: technical representatives first, then a capped uncertainty frontier
- preserve stored measurements for policy-only replay and add technical/all/leave-one-dimension-out cost reporting
- expose priority reasons and direct Activity recovery in the operator UI, including legacy cadence blockers
- add the evidence-work priority migration, regression coverage, and architecture documentation

## Validation

- `bash scripts/pre-commit-check.sh`
- 1,025 backend tests passed
- 216 frontend tests passed; Svelte check, Prettier, ESLint, build, CLI smoke, package build, and web route smoke passed
- browser acceptance at 1024×768 and 390×844, including the cadence-blocked season → Activity path
- JetBrains changed-files inspection reported zero findings; Svelte files were text-only in PyCharm and were covered by Svelte checks and browser acceptance

Closes #218
