### PR TITLE
Improve calibration progress and restore size-first target search

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ and dark or stylized TV material. Direct operator instructions and accepted
 visual samples outrank generic bitrate guidance; real sample evidence decides
 whether a particular folder needs adjustment.
 
+`video.max_crf` is the initial quality-search range, not a hidden veto on an
+approved size goal. Size-directed tests may expand in measured steps up to
+`video.target_search_max_crf` (63 by default) while still enforcing the metric
+floor and requiring operator review. Saved jobs created before that ceiling was
+recorded replay their original CRF range exactly; make a fresh test to use the
+new search contract.
+
 For scene-aware engine research, generate a repeatable bakeoff plan from an
 existing manifest instead of replacing the production engine path directly:
 

--- a/config/defaults.toml
+++ b/config/defaults.toml
@@ -47,6 +47,7 @@ sample_every = "8m"
 sample_duration = "20s"
 min_crf = 18
 max_crf = 38
+target_search_max_crf = 63
 max_encoded_percent = 80
 default_grain = 8
 grain_denoise = 0

--- a/config/web-smoke.toml
+++ b/config/web-smoke.toml
@@ -85,6 +85,7 @@ sample_every = "8m"
 sample_duration = "20s"
 min_crf = 18
 max_crf = 38
+target_search_max_crf = 63
 max_encoded_percent = 80
 default_grain = 8
 grain_denoise = 0

--- a/docs/architecture/stream-budget-ledger.md
+++ b/docs/architecture/stream-budget-ledger.md
@@ -44,12 +44,16 @@ The ledger distinguishes four deterministic states:
 
 - `feasible`: a positive video budget remains with sufficiently bounded
   non-video costs
-- `aggressive_but_measurable`: the remaining video budget is positive but low
-  enough that measured search is required
 - `arithmetically_infeasible`: even the minimum production stream plan leaves
   no positive video budget
 - `requires_measurement`: an unknown stream cost or missing runtime prevents a
   trustworthy total
+
+Historical ledgers may still contain `aggressive_but_measurable`. New ledgers
+do not infer likely damage from source-size percentages or generic bitrate
+thresholds: any known positive video budget is `feasible`, and the measured
+quality search plus operator review decides whether the requested tradeoff is
+acceptable.
 
 Arithmetic infeasibility is never delegated to an LLM. Quality risk remains a
 separate measured outcome for target-size search and operator review.
@@ -75,9 +79,15 @@ container bytes. The search records a typed trace containing:
 - the selected CRF, measured quality score, quality floor, sample target band,
   source cap, ledger identity, stream-plan identity, and transform-plan identity
 
-The search may only choose among CRFs inside the approved policy range. It does
-not relax max size caps, lower quality floors, pick cadence transforms, change
-stream selection, or rewrite an operator's size goal. Monotonic curves select a
+`video.max_crf` defines the initial search range. Size-directed search may
+expand beyond that inherited default in measured steps, but never beyond the
+explicit `video.target_search_max_crf` ceiling. The trace records both bounds
+and whether expansion was measured or selected. Legacy saved jobs without the
+explicit ceiling retain their original `max_crf` as the hard replay bound.
+
+The search does not relax max size caps, lower quality floors, pick cadence
+transforms, change stream selection, or rewrite an operator's size goal.
+Monotonic curves select a
 candidate inside the sample band when one exists. Arithmetic impossibility,
 quality-floor conflict, and exhausted or noisy non-monotonic searches surface as
 structured infeasibility, quality-conflict, or needs-review outcomes.

--- a/docs/development/browser-qa-matrix.md
+++ b/docs/development/browser-qa-matrix.md
@@ -55,10 +55,18 @@ The managed smoke seeds a compact but non-empty workflow dataset:
 - Folder Studio: `/folders/tv/Example%20Show/Season%201`, including enough item
   metadata to render policy comparison, sample facts, queue state, and side
   context.
-- Sampling state: `/folders/tv/Sampling%20Show/Season%201`, with a queued
-  sample job.
+- Sampling state: `/folders/tv/Sampling%20Show/Season%201`, with persisted stage,
+  heartbeat, bounded review-step progress, and a historical ETA range.
+- Shared-scope sampling state:
+  `/folders/tv/Shared%20Test%20Show/Season%201`, where a 225 MB show-level test
+  must outrank a stale 314.6 MB season result without pretending the job belongs
+  to the season route.
 - Retryable state: `/folders/tv/Retry%20Show/Season%201`, with a failed sample
-  job that exposes retry copy.
+  job that shows the immutable saved target/settings, `Retry same test`, and a
+  separate path to choose different settings.
+- Search-limit state: `/folders/tv/Search%20Limit/Season%201`, with a
+  deterministic target-search-bound failure that explains why the saved retry
+  would repeat and routes the operator to a fresh settings review.
 - Review-ready state: `/folders/tv/Review%20Ready/Season%201`, with retained
   review media, explicit target/band/sample-byte facts, and picture/sound risk.
 - Absolute-target state: `/folders/tv/Absolute%20Goal/Season%201`, proving an
@@ -110,6 +118,8 @@ For changes to catalog or evidence controls, verify these visible states in a
 real browser at desktop and 390px widths:
 
 - idle: `Quiet`, no repeating network refresh, manual refresh available
+- manual refresh: always issues a fresh read even if a quiet poll is already in
+  flight, and the freshness note reflects the newest completed refresh
 - prepared: explicit scope/count, `Start analysis`, and `Cancel batch`
 - running: current path/evidence kind, completed/remaining counts, and elapsed
   progress with `Pause after this item`
@@ -138,6 +148,7 @@ Every browser QA pass should cover these routes:
 - `/folders/tv/Overshoot%20Show/Season%201`: over-target comparison state.
 - `/folders/tv/Undershoot%20Show/Season%201`: under-target comparison state.
 - `/folders/tv/Infeasible%20Goal/Season%201`: arithmetic infeasibility state.
+- `/folders/tv/Search%20Limit/Season%201`: target-search-bound state.
 - `/folders/tv/Quality%20Conflict/Season%201`: quality-floor conflict state.
 - `/folders/tv/Approved%20Show/Season%201`: approved, not-yet-queued state.
 - `/folders/tv/Encoding%20Show/Season%201`: running processing state.

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -430,6 +430,75 @@ export interface EncodeQueueJob {
 	progress?: EncodeJobProgressTelemetry | null;
 }
 
+export interface CalibrationTargetContract {
+	schema_version: 1;
+	target_size_bytes: number;
+	mode: string;
+	source: string;
+	target_runtime_minutes?: number | null;
+	sample_tolerance_percent?: number | null;
+	final_tolerance_percent?: number | null;
+	resolution_mode: string;
+	max_height?: number | null;
+}
+
+export interface CalibrationProgressEstimate {
+	kind: 'historical_range';
+	sample_size: number;
+	remaining_seconds_low: number;
+	remaining_seconds_high: number;
+	total_seconds_low: number;
+	total_seconds_high: number;
+	longer_than_recent_runs: boolean;
+	confidence: 'limited' | 'moderate';
+	basis: string;
+}
+
+export interface CalibrationJobProgress {
+	schema_version: 1;
+	stage?: string;
+	stage_started_at?: string | null;
+	last_progress_at?: string | null;
+	compatibility_key?: string;
+	heartbeat_at?: string | null;
+	heartbeat_age_seconds?: number | null;
+	elapsed_seconds?: number | null;
+	liveness?: 'queued' | 'starting' | 'reporting' | 'delayed' | 'not_reporting';
+	work?: { completed: number; total: number } | null;
+	estimate?: CalibrationProgressEstimate | null;
+	terminal_status?: string;
+	total_elapsed_seconds?: number;
+}
+
+export interface CalibrationJobPayload {
+	job_id?: string;
+	prefix?: string;
+	status: string;
+	lane?: string;
+	mode?: string;
+	action?: string;
+	host?: Record<string, unknown>;
+	notes?: string;
+	policy?: Record<string, unknown>;
+	sample_item?: Record<string, unknown>;
+	result?: Record<string, unknown> | null;
+	error?: string | null;
+	created_at?: string | null;
+	started_at?: string | null;
+	finished_at?: string | null;
+	updated_at?: string | null;
+	heartbeat_at?: string | null;
+	progress?: CalibrationJobProgress | null;
+	activity_scope?: MediaScopePayload;
+	target_contract?: CalibrationTargetContract | null;
+}
+
+export interface CalibrationScopeActivityPayload {
+	schema_version: 1;
+	relation: 'ancestor' | 'descendant';
+	job: CalibrationJobPayload;
+}
+
 export interface EncodeQueueTelemetry {
 	aggregate_speed?: number | null;
 	eta_seconds?: number | null;
@@ -1146,7 +1215,7 @@ export interface QualityRiskOperatorRecord {
 export interface QualityRiskTargetSizeSearch {
 	trace_id?: string;
 	schema_version?: number;
-	status?: 'selected' | 'infeasible' | 'quality_conflict' | 'needs_review';
+	status?: 'selected' | 'infeasible' | 'bound_exhausted' | 'quality_conflict' | 'needs_review';
 	selection_reason?: string | null;
 	curve_shape?: 'single_point' | 'monotonic' | 'non_monotonic' | null;
 	candidate_count?: number;
@@ -1162,6 +1231,11 @@ export interface QualityRiskTargetSizeSearch {
 	predicted_whole_episode_bytes?: number | null;
 	within_sample_band?: boolean | null;
 	transform_plan_id?: string | null;
+	configured_max_crf?: number | null;
+	search_max_crf?: number | null;
+	range_expanded?: boolean;
+	measured_beyond_configured?: boolean;
+	selected_beyond_configured?: boolean;
 }
 
 export interface QualityRiskPreTestInstruction {
@@ -1228,12 +1302,13 @@ export interface FolderPayload {
 	stream_budget_ledger?: StreamBudgetLedgerPayload;
 	size_goal_options?: SizeGoalOptionPayload[];
 	quality_risk?: QualityRiskPayload | null;
+	failed_target_size_search?: QualityRiskTargetSizeSearch | null;
 	approved_season_shortcut?: Record<string, unknown> | null;
 	series_context?: { prefix: string; title: string } | null;
 	pending_proposal?: Record<string, unknown> | null;
 	review_gate?: Record<string, unknown>;
 	calibration_queue?: Record<string, unknown>;
-	calibration_job?: Record<string, unknown> | null;
+	calibration_job?: CalibrationJobPayload | null;
 	folder_scan_job?: Record<string, unknown> | null;
 	metric_support: MetricSupport;
 	metric_status_copy: string;
@@ -1273,9 +1348,13 @@ export interface FolderStatusPayload {
 	media_scope: MediaScopePayload;
 	polling_active: boolean;
 	calibration_status: string;
+	exact_calibration_status?: string;
+	scope_activity_status?: string;
 	folder_scan_status: string;
-	calibration_job: Record<string, unknown> | null;
-	retryable_sample_job?: Record<string, unknown> | null;
+	calibration_job: CalibrationJobPayload | null;
+	exact_calibration_job?: CalibrationJobPayload | null;
+	scope_activity?: CalibrationScopeActivityPayload | null;
+	retryable_sample_job?: CalibrationJobPayload | null;
 	folder_scan_job: Record<string, unknown> | null;
 	workflow_state?: FolderWorkflowState | null;
 }

--- a/frontend/src/lib/components/season/SeasonExperience.svelte
+++ b/frontend/src/lib/components/season/SeasonExperience.svelte
@@ -9,9 +9,17 @@
 		OperatorIntentRequestPayload,
 		QualityRiskTag
 	} from '$lib/api/types';
+	import { folderRoutePath } from '$lib/folder-display';
 	import {
 		REVIEW_CONCERNS,
 		approvalGuardFromMessage,
+		calibrationEtaSummary,
+		calibrationJobTargetContract,
+		calibrationLivenessLabel,
+		calibrationResolutionLabel,
+		calibrationStageLabel,
+		calibrationTargetModeLabel,
+		calibrationWorkLabel,
 		compareRiskSummary,
 		currentEncodeProgress,
 		currentOperatorIntent,
@@ -24,6 +32,7 @@
 		isSeriesPrefix,
 		measuredFollowupRequest,
 		normalizeReviewPairs,
+		overlappingCalibrationActivity,
 		plainFailureMessage,
 		predictedEpisodeSize,
 		resolvedTargetSummary,
@@ -181,11 +190,25 @@
 	const actualSampleSizes = $derived(reviewSampleSizes(folder));
 	const sizeTarget = $derived(folderSizeTargetAnalysis(folder));
 	const targetSummary = $derived(resolvedTargetSummary(folder));
-	const targetConstraint = $derived(targetConstraintSummary(folder));
+	const targetConstraint = $derived(targetConstraintSummary(folder, status));
 	const technicalVideo = $derived(technicalVideoPolicy(folder));
 	const expectedSeasonBytes = $derived(expectedEpisodeBytes * productionEpisodeCount);
+	const exactCalibrationJob = $derived(
+		status.exact_calibration_job !== undefined
+			? status.exact_calibration_job
+			: (status.calibration_job ?? folder.calibration_job ?? null)
+	);
+	const exactTargetContract = $derived(calibrationJobTargetContract(exactCalibrationJob));
+	const scopeActivity = $derived(overlappingCalibrationActivity(status, folder.prefix));
+	const scopeActivityJob = $derived(scopeActivity?.job ?? null);
+	const scopeTargetContract = $derived(calibrationJobTargetContract(scopeActivityJob));
+	const activeJobTargetBytes = $derived(exactTargetContract?.target_size_bytes ?? 0);
 	const currentTargetBytes = $derived(
-		targetSummary?.targetBytes || sizeTarget.budgetBytes || selectedGoal?.targetSizeBytes || 0
+		activeJobTargetBytes ||
+			targetSummary?.targetBytes ||
+			sizeTarget.budgetBytes ||
+			selectedGoal?.targetSizeBytes ||
+			0
 	);
 	const sizeTargetLabel = $derived(
 		currentTargetBytes > 0 ? formatDecimalFileSize(currentTargetBytes) : 'the requested size'
@@ -225,7 +248,7 @@
 	const noAvailableHosts = $derived(
 		hostOptions.length > 0 && !hostOptions.some((host) => host.available !== false)
 	);
-	const activeSampleJob = $derived(asRecord(status.calibration_job ?? folder.calibration_job));
+	const activeSampleJob = $derived(asRecord(exactCalibrationJob));
 	const finishedEpisodeCount = $derived(
 		asNumber(folder.summary?.statuses.encoded) +
 			asNumber(folder.summary?.statuses.validated) +
@@ -249,6 +272,51 @@
 	const actionElapsed = $derived(elapsedCopy(actionStartedAt ? clock - actionStartedAt : 0));
 	const backendElapsed = $derived(
 		elapsedCopy(clock - parseTimestamp(activeSampleJob.started_at ?? activeSampleJob.created_at))
+	);
+	const scopeActivityStatus = $derived(scopeActivityJob?.status ?? 'idle');
+	const scopeActivityFailure = $derived(['failed', 'stopped'].includes(scopeActivityStatus));
+	const scopeActivityReady = $derived(
+		['completed', 'pending_review'].includes(scopeActivityStatus)
+	);
+	const scopeActivityScope = $derived(scopeActivityJob?.activity_scope ?? null);
+	const scopeActivityOwnerPrefix = $derived(scopeActivityJob?.prefix ?? '');
+	const scopeActivityOwnerTitle = $derived(
+		scopeActivityScope?.title || seasonIdentity(scopeActivityOwnerPrefix).show || 'Related work'
+	);
+	const scopeActivityOwnerKind = $derived(
+		scopeActivityScope?.kind === 'tv_series'
+			? 'show'
+			: scopeActivityScope?.kind === 'tv_season'
+				? 'season'
+				: 'scope'
+	);
+	const scopeActivityTargetLabel = $derived(
+		scopeTargetContract
+			? formatDecimalFileSize(scopeTargetContract.target_size_bytes)
+			: 'Saved target unavailable'
+	);
+	const scopeActivityWorker = $derived(
+		asText(asRecord(scopeActivityJob?.host).label) || 'Choosing a computer'
+	);
+	const scopeActivityElapsed = $derived(
+		elapsedCopy(
+			clock - parseTimestamp(scopeActivityJob?.started_at ?? scopeActivityJob?.created_at ?? null)
+		)
+	);
+	const scopeActivityHref = $derived(
+		scopeActivityOwnerPrefix ? resolve(folderRoutePath(scopeActivityOwnerPrefix)) : resolve('/ops')
+	);
+	const scopeActivityStage = $derived(calibrationStageLabel(scopeActivityJob));
+	const scopeActivityWork = $derived(calibrationWorkLabel(scopeActivityJob));
+	const scopeActivityLiveness = $derived(calibrationLivenessLabel(scopeActivityJob));
+	const scopeActivityEta = $derived(calibrationEtaSummary(scopeActivityJob));
+	const activeSampleStage = $derived(calibrationStageLabel(exactCalibrationJob));
+	const activeSampleWork = $derived(calibrationWorkLabel(exactCalibrationJob));
+	const activeSampleLiveness = $derived(calibrationLivenessLabel(exactCalibrationJob));
+	const activeSampleEta = $derived(calibrationEtaSummary(exactCalibrationJob));
+	const recoveryScopeTitle = $derived(exactCalibrationJob?.activity_scope?.title || scopeTitle);
+	const recoveryWorker = $derived(
+		asText(asRecord(exactCalibrationJob?.host).label) || 'Saved computer preference'
 	);
 	const showGoalScreen = $derived(humanState.key === 'needs_test' || retryMode);
 	const actionPending = $derived(actionPhase !== 'idle');
@@ -875,15 +943,6 @@
 	function technicalPolicy() {
 		return technicalVideo;
 	}
-
-	function jobStageLabel(value: unknown): string {
-		const currentStatus = typeof value === 'string' ? value.toLowerCase() : '';
-		if (currentStatus === 'queued') return 'Waiting for a computer';
-		if (currentStatus === 'starting') return 'Opening the episode';
-		if (currentStatus === 'running') return 'Making test moments';
-		if (currentStatus === 'stopping') return 'Stopping safely';
-		return 'Preparing the test';
-	}
 </script>
 
 <svelte:head>
@@ -991,13 +1050,72 @@
 					You can leave this page open. The next screen appears when it is ready.
 				</p>
 			</section>
+		{:else if scopeActivity && scopeActivityJob}
+			<section
+				class="scope-activity-room"
+				aria-labelledby="scope-activity-heading"
+				aria-live="polite"
+			>
+				<div class="scope-activity-room__copy">
+					<p class="eyebrow">
+						{scopeActivityFailure
+							? 'Related sample needs attention'
+							: scopeActivityReady
+								? 'Related sample ready'
+								: 'Related sample in progress'}
+					</p>
+					<h1 id="scope-activity-heading">
+						{scopeActivityFailure
+							? `The ${scopeActivityOwnerTitle} sample needs attention`
+							: scopeActivityReady
+								? `The ${scopeActivityOwnerTitle} sample is ready`
+								: scopeActivityOwnerKind === 'show'
+									? 'A show-level sample is running'
+									: 'A season sample is running'}
+					</h1>
+					<p class="lede">
+						{scopeActivityOwnerTitle} owns this shared test. {scopeName} has no separate sample running,
+						so its saved settings are not being used for this work.
+					</p>
+				</div>
+				<div class="scope-activity-facts">
+					<div><span>Activity scope</span><strong>{scopeActivityOwnerTitle}</strong></div>
+					<div><span>Requested target</span><strong>{scopeActivityTargetLabel}</strong></div>
+					<div>
+						<span>Target mode</span><strong
+							>{calibrationTargetModeLabel(scopeTargetContract)}</strong
+						>
+					</div>
+					<div>
+						<span>Resolution</span><strong>{calibrationResolutionLabel(scopeTargetContract)}</strong
+						>
+					</div>
+					<div><span>Current step</span><strong>{scopeActivityStage}</strong></div>
+					<div>
+						<span>Step progress</span><strong>{scopeActivityWork || scopeActivityLiveness}</strong>
+					</div>
+					<div class:telemetry-attention={scopeActivityEta.tone === 'attention'}>
+						<span>Estimated remaining</span><strong>{scopeActivityEta.value}</strong>
+						<small>{scopeActivityEta.detail}</small>
+					</div>
+					<div><span>Computer</span><strong>{scopeActivityWorker}</strong></div>
+					<div><span>Time so far</span><strong>{scopeActivityElapsed}</strong></div>
+				</div>
+				<div class="scope-activity-actions">
+					<a class="primary-button" href={scopeActivityHref}
+						>Open {scopeActivityOwnerKind} test
+						<svg viewBox="0 0 20 20" aria-hidden="true"><path d="M4 10h11M11 5l5 5-5 5" /></svg>
+					</a>
+					<a class="secondary-button" href={resolve('/ops')}>Open Activity</a>
+				</div>
+			</section>
 		{:else if showGoalScreen}
 			<section class="goal-room">
 				<div class="goal-intro">
 					<p class="eyebrow">{scopeTitle}</p>
 					<h1>
 						{retryMode
-							? 'Choose a different size'
+							? 'Choose a size and settings'
 							: isSeriesScope
 								? `Choose one size for all ${seriesSeasonCount} ${seriesSeasonLabel}`
 								: `Choose a size for ${identity.season}`}
@@ -1162,8 +1280,16 @@
 								>
 							</div>
 						{/if}
+						<div><span>Current step</span><strong>{activeSampleStage}</strong></div>
 						<div>
-							<span>Current step</span><strong>{jobStageLabel(activeSampleJob.status)}</strong>
+							<span>Step progress</span><strong>{activeSampleWork || activeSampleLiveness}</strong>
+						</div>
+						<div
+							class="active-fact--eta"
+							class:telemetry-attention={activeSampleEta.tone === 'attention'}
+						>
+							<span>Estimated remaining</span><strong>{activeSampleEta.value}</strong>
+							<small>{activeSampleEta.detail}</small>
 						</div>
 						<div>
 							<span>Computer</span><strong
@@ -1801,24 +1927,50 @@
 						>
 					{/if}
 				</div>
+				{#if humanState.recoveryKind === 'test' && !targetConstraint}
+					<div class="recovery-plan" aria-label="Saved test plan">
+						<div><span>Test scope</span><strong>{recoveryScopeTitle}</strong></div>
+						<div><span>Saved target</span><strong>{sizeTargetLabel}</strong></div>
+						<div>
+							<span>Target mode</span><strong
+								>{calibrationTargetModeLabel(exactTargetContract)}</strong
+							>
+						</div>
+						<div>
+							<span>Resolution</span><strong
+								>{calibrationResolutionLabel(exactTargetContract)}</strong
+							>
+						</div>
+						<div class="recovery-plan__computer">
+							<span>Computer</span><strong>{recoveryWorker}</strong>
+						</div>
+					</div>
+				{/if}
 				{#if humanState.recoveryKind === 'season' && finishedEpisodeCount > 0}
 					<div class="recovery-count">
 						<strong>{finishedEpisodeCount} of {episodeCount}</strong>
 						<span>episodes already made</span>
 					</div>
 				{/if}
-				<button
-					class="primary-button"
-					type="button"
-					onclick={() => (targetConstraint ? chooseDifferentSize() : recoverSeason())}
-				>
-					{targetConstraint?.recoveryLabel ||
-						(recoveryNeedsAdjustment
-							? 'Review retry'
-							: humanState.recoveryKind === 'test'
-								? 'Retry the sample'
-								: 'Retry unfinished episodes')}
-				</button>
+				<div class="help-actions">
+					<button
+						class="primary-button"
+						type="button"
+						onclick={() => (targetConstraint ? chooseDifferentSize() : recoverSeason())}
+					>
+						{targetConstraint?.recoveryLabel ||
+							(recoveryNeedsAdjustment
+								? 'Review retry'
+								: humanState.recoveryKind === 'test'
+									? 'Retry same test'
+									: 'Retry unfinished episodes')}
+					</button>
+					{#if humanState.recoveryKind === 'test' && !targetConstraint}
+						<button class="secondary-button" type="button" onclick={chooseDifferentSize}>
+							Choose a different size or settings
+						</button>
+					{/if}
+				</div>
 			</section>
 		{/if}
 
@@ -3877,6 +4029,7 @@
 	.loading-room,
 	.working-room,
 	.goal-room,
+	.scope-activity-room,
 	.active-room,
 	.compare-room,
 	.ready-room,
@@ -3892,6 +4045,69 @@
 		max-width: none;
 		min-height: 0;
 		padding: 24px;
+	}
+
+	.scope-activity-room {
+		display: grid;
+		gap: 20px;
+	}
+
+	.scope-activity-room__copy {
+		display: grid;
+		gap: 8px;
+		max-width: 760px;
+	}
+
+	.scope-activity-facts,
+	.recovery-plan {
+		background: var(--mf-line-muted);
+		border: 1px solid var(--mf-line-muted);
+		border-radius: var(--mf-radius-3);
+		display: grid;
+		gap: 1px;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+		overflow: hidden;
+	}
+
+	.scope-activity-facts div,
+	.recovery-plan div {
+		background: var(--mf-bg-panel-2);
+		display: grid;
+		gap: 3px;
+		min-width: 0;
+		padding: 13px 14px;
+	}
+
+	.scope-activity-facts span,
+	.recovery-plan span {
+		color: var(--mf-fg-tertiary);
+		font-size: 11px;
+	}
+
+	.scope-activity-facts strong,
+	.recovery-plan strong {
+		color: var(--mf-fg-primary);
+		font-size: 13px;
+		overflow-wrap: anywhere;
+	}
+
+	.scope-activity-facts small,
+	.active-facts small {
+		color: var(--mf-fg-tertiary);
+		font-size: 10px;
+		line-height: 1.4;
+	}
+
+	.scope-activity-facts .telemetry-attention,
+	.active-facts .telemetry-attention {
+		background: var(--mf-wait-bg);
+	}
+
+	.scope-activity-actions,
+	.help-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
 	}
 
 	.loading-room {
@@ -4170,25 +4386,21 @@
 	}
 
 	.active-facts {
-		background: var(--mf-bg-panel-2);
+		background: var(--mf-line-muted);
 		border: 1px solid var(--mf-line-muted);
 		border-radius: var(--mf-radius-3);
 		display: grid;
-		gap: 0;
+		gap: 1px;
 		grid-template-columns: repeat(3, minmax(0, 1fr));
 		margin-top: 8px;
 		padding: 0;
 	}
 
 	.active-facts div {
-		border-right: 1px solid var(--mf-line-muted);
+		background: var(--mf-bg-panel-2);
 		display: grid;
 		gap: 3px;
 		padding: 13px 14px;
-	}
-
-	.active-facts div:last-child {
-		border-right: 0;
 	}
 
 	.active-facts span,
@@ -4884,7 +5096,17 @@
 	}
 
 	.active-facts {
-		grid-template-columns: repeat(5, minmax(0, 1fr));
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+	}
+
+	@media (min-width: 761px) {
+		.active-facts .active-fact--eta {
+			grid-column: span 2;
+		}
+
+		.recovery-plan__computer {
+			grid-column: span 2;
+		}
 	}
 
 	.target-warning--constraint {
@@ -5187,6 +5409,8 @@
 		}
 
 		.active-facts,
+		.scope-activity-facts,
+		.recovery-plan,
 		.ready-summary {
 			grid-template-columns: 1fr;
 		}
@@ -5197,12 +5421,15 @@
 		}
 
 		.active-facts div,
+		.scope-activity-facts div,
+		.recovery-plan div,
 		.ready-summary div {
-			border-bottom: 1px solid var(--mf-line-muted);
 			border-right: 0;
 		}
 
 		.active-facts div:last-child,
+		.scope-activity-facts div:last-child,
+		.recovery-plan div:last-child,
 		.ready-summary div:last-child {
 			border-bottom: 0;
 		}
@@ -5243,6 +5470,7 @@
 		.loading-room,
 		.working-room,
 		.goal-room,
+		.scope-activity-room,
 		.active-room,
 		.compare-room,
 		.ready-room,

--- a/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
+++ b/frontend/src/lib/components/workstation/OpsWorkstationView.svelte
@@ -28,6 +28,7 @@
 		opsWorkLabel,
 		rowRecoveryLabel,
 		rowRecoveryTitle,
+		RefreshCoordinator,
 		workerCapabilitiesSummary,
 		type OpsActionId,
 		type OpsQueueRow
@@ -79,7 +80,8 @@
 	let confirmationAction = $state<OpsActionId | null>(null);
 	let actionMessage = $state('');
 	let actionError = $state('');
-	let refreshPending = $state(false);
+	const refreshCoordinator = new RefreshCoordinator();
+	let manualRefreshPending = $state(false);
 	let refreshError = $state('');
 	let lastRefreshAt = $state<Date | null>(null);
 	let hostPasswords = $state<Record<string, string>>({});
@@ -214,27 +216,33 @@
 	}
 
 	async function refreshOps({ quiet = false }: { quiet?: boolean } = {}) {
-		if (refreshPending) return;
-		refreshPending = true;
+		const refreshKind = quiet ? 'quiet' : 'manual';
+		const refreshId = refreshCoordinator.start(refreshKind);
+		if (refreshId === null) return;
+
 		if (!quiet) {
+			manualRefreshPending = true;
 			actionMessage = '';
 			actionError = '';
 		}
+
 		refreshError = '';
 		try {
 			await onRefresh();
+			if (!refreshCoordinator.finish(refreshKind, refreshId)) return;
 			lastRefreshAt = new Date();
 			if (!quiet) actionMessage = 'Activity refreshed.';
 		} catch (error) {
+			if (!refreshCoordinator.finish(refreshKind, refreshId)) return;
 			refreshError = error instanceof Error ? error.message : 'Refresh failed.';
 			if (!quiet) actionError = refreshError;
 		} finally {
-			refreshPending = false;
+			if (!quiet) manualRefreshPending = false;
 		}
 	}
 
 	function refreshCopy(): string {
-		if (refreshPending) return 'refreshing';
+		if (manualRefreshPending) return 'refreshing';
 		if (!lastRefreshAt)
 			return liveRefreshInterval ? 'watching active work' : 'manual refresh while idle';
 		const refreshedAt = lastRefreshAt.toLocaleTimeString([], {
@@ -324,10 +332,10 @@
 					<button
 						type="button"
 						class="control control--compact ops-header__mobile-refresh"
-						disabled={refreshPending}
+						disabled={manualRefreshPending}
+						aria-busy={manualRefreshPending}
 						title="Refresh activity now"
-						onclick={() => refreshOps()}
-						>{refreshPending ? 'Refreshing' : 'Refresh activity'}</button
+						onclick={() => refreshOps()}>Refresh activity</button
 					>
 				</div>
 				<div class="ops-header__status ops-header__status--{readiness.tone}">
@@ -339,9 +347,10 @@
 					<button
 						type="button"
 						class="control control--compact"
-						disabled={refreshPending}
+						disabled={manualRefreshPending}
+						aria-busy={manualRefreshPending}
 						title="Refresh activity now"
-						onclick={() => refreshOps()}>{refreshPending ? 'Refreshing' : 'Refresh'}</button
+						onclick={() => refreshOps()}>Refresh</button
 					>
 				</div>
 			</header>

--- a/frontend/src/lib/components/workstation/ops-workstation.test.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.test.ts
@@ -12,11 +12,40 @@ import {
 	hostTone,
 	hostWorkReason,
 	opsWorkLabel,
+	RefreshCoordinator,
 	rowRecoveryLabel,
 	rowRecoveryTitle,
 	retryableEncodeJobIds,
 	workerCapabilitiesSummary
 } from './ops-workstation';
+
+describe('RefreshCoordinator', () => {
+	it('lets a manual refresh supersede an in-flight quiet poll', () => {
+		const coordinator = new RefreshCoordinator();
+
+		const quietId = coordinator.start('quiet');
+		expect(quietId).toBe(1);
+		expect(coordinator.start('quiet')).toBeNull();
+
+		const manualId = coordinator.start('manual');
+		expect(manualId).toBe(2);
+		expect(coordinator.start('quiet')).toBeNull();
+
+		expect(coordinator.finish('quiet', quietId ?? 0)).toBe(false);
+		expect(coordinator.finish('manual', manualId ?? 0)).toBe(true);
+		expect(coordinator.start('quiet')).toBe(3);
+	});
+
+	it('blocks overlapping manual refreshes', () => {
+		const coordinator = new RefreshCoordinator();
+
+		const firstManualId = coordinator.start('manual');
+		expect(firstManualId).toBe(1);
+		expect(coordinator.start('manual')).toBeNull();
+		expect(coordinator.finish('manual', firstManualId ?? 0)).toBe(true);
+		expect(coordinator.start('manual')).toBe(2);
+	});
+});
 
 function dashboardFixture(): DashboardSummaryPayload {
 	return {

--- a/frontend/src/lib/components/workstation/ops-workstation.ts
+++ b/frontend/src/lib/components/workstation/ops-workstation.ts
@@ -7,6 +7,7 @@ import type {
 import type { FooterSignal, ShellTone, StatusTile } from './shell-types';
 
 export type OpsQueueKind = 'encode' | 'sample' | 'proof';
+export type RefreshKind = 'quiet' | 'manual';
 export type OpsActionId =
 	| 'pause-encode'
 	| 'resume-encode'
@@ -48,6 +49,30 @@ export type OpsReadinessSummary = {
 	metricLabel: string;
 	metricValue: string;
 };
+
+export class RefreshCoordinator {
+	#nextId = 0;
+	#latestId = 0;
+	#quietInFlight = 0;
+	#manualInFlight = 0;
+
+	start(kind: RefreshKind): number | null {
+		if (kind === 'manual' && this.#manualInFlight > 0) return null;
+		if (kind === 'quiet' && (this.#quietInFlight > 0 || this.#manualInFlight > 0)) return null;
+
+		const id = ++this.#nextId;
+		this.#latestId = id;
+		if (kind === 'quiet') this.#quietInFlight += 1;
+		else this.#manualInFlight += 1;
+		return id;
+	}
+
+	finish(kind: RefreshKind, id: number): boolean {
+		if (kind === 'quiet') this.#quietInFlight = Math.max(0, this.#quietInFlight - 1);
+		else this.#manualInFlight = Math.max(0, this.#manualInFlight - 1);
+		return id === this.#latestId;
+	}
+}
 
 type CalibrationJob = Record<string, unknown>;
 

--- a/frontend/src/lib/folders/studio.ts
+++ b/frontend/src/lib/folders/studio.ts
@@ -377,7 +377,7 @@ export type QualityRiskPreTestInstruction = {
 
 export type QualityRiskTargetSizeSearch = {
 	trace_id?: string;
-	status?: 'selected' | 'infeasible' | 'quality_conflict' | 'needs_review';
+	status?: 'selected' | 'infeasible' | 'bound_exhausted' | 'quality_conflict' | 'needs_review';
 	selection_reason?: string | null;
 	curve_shape?: 'single_point' | 'monotonic' | 'non_monotonic' | null;
 	candidate_count?: number;
@@ -390,6 +390,11 @@ export type QualityRiskTargetSizeSearch = {
 	predicted_whole_episode_bytes?: number | null;
 	within_sample_band?: boolean | null;
 	transform_plan_id?: string | null;
+	configured_max_crf?: number | null;
+	search_max_crf?: number | null;
+	range_expanded?: boolean;
+	measured_beyond_configured?: boolean;
+	selected_beyond_configured?: boolean;
 };
 
 export type FolderQualityRisk = {

--- a/frontend/src/lib/season/experience.test.ts
+++ b/frontend/src/lib/season/experience.test.ts
@@ -14,6 +14,11 @@ import type {
 import {
 	activeSeasonCards,
 	approvalGuardFromMessage,
+	calibrationEtaSummary,
+	calibrationJobTargetContract,
+	calibrationLivenessLabel,
+	calibrationStageLabel,
+	calibrationWorkLabel,
 	catalogWarningNotice,
 	compareRiskSummary,
 	currentOperatorIntent,
@@ -28,6 +33,8 @@ import {
 	measuredFollowupRequest,
 	librarySeasonState,
 	normalizeReviewPairs,
+	overlappingCalibrationActivity,
+	plainFailureMessage,
 	resolvedTargetSummary,
 	reviewFeedbackIntent,
 	reviewFeedbackRequest,
@@ -935,6 +942,42 @@ describe('season experience translation', () => {
 			recoveryLabel: 'Choose a roomier goal',
 			detail: expect.stringContaining('VMAF floor of 93')
 		});
+
+		expect(
+			targetConstraintSummary(
+				folder({
+					quality_risk: {
+						target_size_search: {
+							status: 'bound_exhausted',
+							selection_reason: 'smallest_quality_safe_candidate_over_target_band'
+						}
+					}
+				})
+			)
+		).toMatchObject({
+			kind: 'bound_exhausted',
+			recoveryLabel: 'Review size and settings',
+			detail: expect.stringContaining('Retrying that saved test would repeat the same limit')
+		});
+	});
+
+	it('recognizes legacy CRF-bound failures before the generic missing-review message', () => {
+		const failedFolder = folder({
+			calibration: { job_id: 'legacy-bound-failure' },
+			review_gate: { status: 'missing_review_media' },
+			failed_target_size_search: {
+				status: 'infeasible',
+				selection_reason: 'smallest_quality_safe_candidate_over_target_band'
+			}
+		});
+
+		expect(targetConstraintSummary(failedFolder, status)).toMatchObject({
+			kind: 'bound_exhausted',
+			title: 'The test reached a configured limit.'
+		});
+		expect(plainFailureMessage(failedFolder, status)).toContain(
+			'Retrying that saved test would repeat the same limit'
+		);
 	});
 
 	it('preserves typed size intent while recording structured review feedback', () => {
@@ -1066,5 +1109,102 @@ describe('season experience translation', () => {
 			confirmHighImpact: true,
 			confirmSizeTradeoff: true
 		});
+	});
+
+	it('keeps related show activity separate from a season target', () => {
+		const activity = overlappingCalibrationActivity(
+			{
+				...status,
+				scope_activity_status: 'running',
+				scope_activity: {
+					schema_version: 1,
+					relation: 'ancestor',
+					job: {
+						job_id: 'show-test',
+						prefix: 'tv/Big Brother (US)',
+						status: 'running',
+						target_contract: {
+							schema_version: 1,
+							target_size_bytes: 225_000_000,
+							mode: 'absolute',
+							source: 'operator',
+							resolution_mode: 'source'
+						}
+					}
+				}
+			},
+			card.prefix
+		);
+
+		expect(activity?.relation).toBe('ancestor');
+		expect(calibrationJobTargetContract(activity?.job)?.target_size_bytes).toBe(225_000_000);
+	});
+
+	it('describes actual calibration stages, bounded work, and heartbeat state', () => {
+		const job = {
+			job_id: 'test-1',
+			prefix: card.prefix,
+			status: 'running',
+			progress: {
+				schema_version: 1 as const,
+				stage: 'building_review',
+				liveness: 'reporting' as const,
+				work: { completed: 2, total: 3 }
+			}
+		};
+
+		expect(calibrationStageLabel(job)).toBe('Building comparison clips');
+		expect(calibrationWorkLabel(job)).toBe('2 of 3 review steps');
+		expect(calibrationLivenessLabel(job)).toBe('Computer is reporting normally');
+	});
+
+	it('renders historical ETA ranges without false precision', () => {
+		const summary = calibrationEtaSummary({
+			job_id: 'test-2',
+			prefix: card.prefix,
+			status: 'running',
+			progress: {
+				schema_version: 1,
+				liveness: 'reporting',
+				estimate: {
+					kind: 'historical_range',
+					sample_size: 5,
+					remaining_seconds_low: 480,
+					remaining_seconds_high: 1020,
+					total_seconds_low: 1200,
+					total_seconds_high: 1800,
+					longer_than_recent_runs: false,
+					confidence: 'moderate',
+					basis: 'Comparable completed tests'
+				}
+			}
+		});
+
+		expect(summary.value).toBe('8 min–20 min left');
+		expect(summary.detail).toContain('5 comparable completed tests');
+		expect(summary.tone).toBe('quiet');
+	});
+
+	it('calls out missing heartbeats instead of inventing an ETA', () => {
+		expect(
+			calibrationEtaSummary({
+				job_id: 'test-3',
+				prefix: card.prefix,
+				status: 'running',
+				progress: { schema_version: 1, liveness: 'not_reporting' }
+			})
+		).toMatchObject({ value: 'Progress signal lost', tone: 'attention' });
+	});
+
+	it('uses terminal copy instead of stale heartbeat language', () => {
+		const completed = {
+			job_id: 'test-4',
+			prefix: card.prefix,
+			status: 'completed',
+			progress: { schema_version: 1 as const, liveness: 'not_reporting' as const }
+		};
+
+		expect(calibrationLivenessLabel(completed)).toBe('Test finished');
+		expect(calibrationEtaSummary(completed)).toMatchObject({ value: 'Finished', tone: 'quiet' });
 	});
 });

--- a/frontend/src/lib/season/experience.ts
+++ b/frontend/src/lib/season/experience.ts
@@ -1,4 +1,7 @@
 import type {
+	CalibrationJobPayload,
+	CalibrationScopeActivityPayload,
+	CalibrationTargetContract,
 	DashboardScanJob,
 	DashboardSummaryPayload,
 	EncodeQueueJob,
@@ -124,10 +127,16 @@ export interface ResolvedTargetSummary {
 }
 
 export interface TargetConstraintSummary {
-	kind: 'arithmetic_infeasible' | 'quality_conflict';
+	kind: 'arithmetic_infeasible' | 'bound_exhausted' | 'quality_conflict';
 	title: string;
 	detail: string;
 	recoveryLabel: string;
+}
+
+export interface CalibrationEtaSummary {
+	value: string;
+	detail: string;
+	tone: 'quiet' | 'attention';
 }
 
 export interface ReviewConcern {
@@ -457,6 +466,165 @@ export function formatDecimalFileSize(bytes: number | null | undefined): string 
 	return `${Math.round(value / 1_000)} KB`;
 }
 
+export function calibrationJobTargetContract(
+	job: CalibrationJobPayload | null | undefined
+): CalibrationTargetContract | null {
+	if (!job) return null;
+	if (job.target_contract) return job.target_contract;
+	const video = record(record(job.policy).video);
+	const explicitBytes = numberValue(video.target_size_bytes);
+	const targetSizeBytes =
+		explicitBytes > 0 ? explicitBytes : Math.round(numberValue(video.target_size_mb) * 1_000_000);
+	if (targetSizeBytes <= 0) return null;
+	const maxHeight = numberValue(video.max_height);
+	return {
+		schema_version: 1,
+		target_size_bytes: targetSizeBytes,
+		mode: text(video.size_goal_mode) || 'legacy',
+		source: text(video.size_goal_source) || 'legacy',
+		target_runtime_minutes: numberValue(video.target_runtime_minutes) || null,
+		sample_tolerance_percent: numberValue(video.sample_projection_tolerance_percent) || null,
+		final_tolerance_percent: numberValue(video.final_output_tolerance_percent) || null,
+		resolution_mode:
+			text(video.resolution_intent_mode) || (maxHeight > 0 ? 'max_height' : 'source'),
+		max_height: maxHeight > 0 ? maxHeight : null
+	};
+}
+
+export function calibrationTargetModeLabel(
+	target: CalibrationTargetContract | null | undefined
+): string {
+	if (target?.mode === 'absolute') return 'Absolute per episode';
+	if (target?.mode === 'normalized') return 'Scaled by episode runtime';
+	return 'Saved episode target';
+}
+
+export function calibrationResolutionLabel(
+	target: CalibrationTargetContract | null | undefined
+): string {
+	if (!target) return 'Saved resolution';
+	if (target.resolution_mode === 'source') return 'Keep source resolution';
+	if (target.resolution_mode === 'max_height' && target.max_height) {
+		return `Up to ${target.max_height}p`;
+	}
+	return 'Saved resolution';
+}
+
+export function overlappingCalibrationActivity(
+	status: FolderStatusPayload,
+	routePrefix: string
+): CalibrationScopeActivityPayload | null {
+	const activity = status.scope_activity ?? null;
+	if (!activity || (activity.job.prefix ?? '') === routePrefix) return null;
+	return activity;
+}
+
+export function calibrationStageLabel(job: CalibrationJobPayload | null | undefined): string {
+	const stage = text(job?.progress?.stage);
+	const labels: Record<string, string> = {
+		preparing_host: 'Starting the computer',
+		preparing_source: 'Preparing the source',
+		inspecting_source: 'Inspecting the picture',
+		searching_target: 'Searching for the size target',
+		measuring_quality: 'Measuring picture quality',
+		selecting_review_moments: 'Choosing review moments',
+		building_review: 'Building comparison clips',
+		encoding_full_calibration: 'Encoding the full calibration',
+		saving_results: 'Saving test results',
+		completed: 'Complete'
+	};
+	if (labels[stage]) return labels[stage];
+	if (job?.status === 'queued') return 'Waiting for a computer';
+	if (job?.status === 'running') return 'Making test moments';
+	return job?.status ? job.status.replaceAll('_', ' ') : 'Preparing the test';
+}
+
+export function calibrationWorkLabel(job: CalibrationJobPayload | null | undefined): string {
+	const work = job?.progress?.work;
+	if (!work || work.total <= 0) return '';
+	return `${Math.max(0, Math.min(work.completed, work.total))} of ${work.total} review steps`;
+}
+
+export function calibrationLivenessLabel(job: CalibrationJobPayload | null | undefined): string {
+	if (job?.status === 'completed' || job?.status === 'pending_review') return 'Test finished';
+	if (job?.status === 'failed' || job?.status === 'stopped') return 'Test is not running';
+	const liveness = job?.progress?.liveness;
+	if (liveness === 'reporting') return 'Computer is reporting normally';
+	if (liveness === 'delayed') return 'Computer updates are arriving slowly';
+	if (liveness === 'not_reporting') return 'Computer has stopped reporting progress';
+	if (liveness === 'queued') return 'Waiting in the test queue';
+	return 'Waiting for the first progress update';
+}
+
+export function calibrationEtaSummary(
+	job: CalibrationJobPayload | null | undefined
+): CalibrationEtaSummary {
+	if (job?.status === 'completed' || job?.status === 'pending_review') {
+		return {
+			value: 'Finished',
+			detail: 'This test is no longer running.',
+			tone: 'quiet'
+		};
+	}
+	if (job?.status === 'failed' || job?.status === 'stopped') {
+		return {
+			value: 'Stopped',
+			detail: 'Open the owning scope to review the failure or retry the saved plan.',
+			tone: 'attention'
+		};
+	}
+	const progress = job?.progress;
+	if (progress?.liveness === 'not_reporting') {
+		return {
+			value: 'Progress signal lost',
+			detail: 'The job still exists, but its computer has not sent a recent heartbeat.',
+			tone: 'attention'
+		};
+	}
+	const estimate = progress?.estimate;
+	if (!estimate) {
+		return {
+			value: 'Not enough history for an ETA',
+			detail: 'A remaining-time range appears after three comparable tests have finished.',
+			tone: progress?.liveness === 'delayed' ? 'attention' : 'quiet'
+		};
+	}
+	if (estimate.longer_than_recent_runs) {
+		return {
+			value: 'Longer than recent tests',
+			detail: `Comparable tests usually finished within ${coarseDuration(estimate.total_seconds_high)}. The computer can still be reporting normally.`,
+			tone: 'attention'
+		};
+	}
+	const low = coarseDuration(estimate.remaining_seconds_low);
+	const high = coarseDuration(estimate.remaining_seconds_high);
+	const value =
+		estimate.remaining_seconds_low <= 0
+			? `Up to ${high} left`
+			: low === high
+				? `About ${high} left`
+				: `${low}–${high} left`;
+	return {
+		value,
+		detail: `Based on ${estimate.sample_size} comparable completed tests; this range is not a guarantee.`,
+		tone: progress?.liveness === 'delayed' ? 'attention' : 'quiet'
+	};
+}
+
+function coarseDuration(seconds: number): string {
+	if (!Number.isFinite(seconds) || seconds <= 0) return 'less than 1 min';
+	const minutes = Math.max(1, Math.ceil(seconds / 60));
+	if (minutes < 10) return `${minutes} min`;
+	if (minutes < 60) return `${Math.ceil(minutes / 5) * 5} min`;
+	const hours = Math.floor(minutes / 60);
+	const remaining = Math.ceil((minutes % 60) / 15) * 15;
+	return remaining >= 60
+		? `${hours + 1} hr`
+		: remaining > 0
+			? `${hours} hr ${remaining} min`
+			: `${hours} hr`;
+}
+
 export function formatDuration(seconds: number | null | undefined): string {
 	const value = numberValue(seconds);
 	if (value <= 0) return '';
@@ -527,10 +695,31 @@ export function resolvedTargetSummary(folder: FolderPayload): ResolvedTargetSumm
 	};
 }
 
-export function targetConstraintSummary(folder: FolderPayload): TargetConstraintSummary | null {
-	const search = folder.quality_risk?.target_size_search;
+export function targetConstraintSummary(
+	folder: FolderPayload,
+	status?: FolderStatusPayload
+): TargetConstraintSummary | null {
+	const search = folder.failed_target_size_search ?? folder.quality_risk?.target_size_search;
 	const feasibility = folder.stream_budget_ledger?.feasibility;
-	if (feasibility?.arithmetic_infeasible || search?.status === 'infeasible') {
+	const sourceCap = folder.stream_budget_ledger?.source_relative_cap;
+	const sampleJob = record(status?.calibration_job ?? folder.calibration_job);
+	const jobResult = record(sampleJob.result);
+	const jobTrace = record(jobResult.target_size_trace);
+	const searchStatus =
+		text(search?.status) || text(jobResult.target_size_status) || text(jobTrace.status);
+	const selectionReason = text(search?.selection_reason) || text(jobTrace.selection_reason);
+	const legacyBoundExhaustion =
+		searchStatus === 'infeasible' &&
+		[
+			'smallest_quality_safe_candidate_over_target_band',
+			'largest_quality_safe_candidate_under_target_band',
+			'target_lower_bound_exceeds_source_relative_cap',
+			'source_relative_cap_consumed_by_non_video_budget'
+		].includes(selectionReason);
+	if (
+		feasibility?.arithmetic_infeasible ||
+		(searchStatus === 'infeasible' && !legacyBoundExhaustion)
+	) {
 		return {
 			kind: 'arithmetic_infeasible',
 			title: 'This size cannot fit the required streams.',
@@ -539,9 +728,24 @@ export function targetConstraintSummary(folder: FolderPayload): TargetConstraint
 			recoveryLabel: 'Choose a size that can fit'
 		};
 	}
-	if (search?.status === 'quality_conflict') {
-		const metric = text(search.selected_metric).toUpperCase();
-		const minimum = numberValue(search.minimum_metric_score);
+	if (
+		searchStatus === 'bound_exhausted' ||
+		legacyBoundExhaustion ||
+		sourceCap?.status === 'arithmetically_infeasible'
+	) {
+		return {
+			kind: 'bound_exhausted',
+			title: 'The test reached a configured limit.',
+			detail:
+				'The previous test stopped at an inherited search or source-size limit before it could measure your requested size. Retrying that saved test would repeat the same limit; make a fresh test with updated settings instead.',
+			recoveryLabel: 'Review size and settings'
+		};
+	}
+	if (searchStatus === 'quality_conflict') {
+		const metric = text(search?.selected_metric).toUpperCase();
+		const minimum = numberValue(
+			search?.minimum_metric_score || record(jobTrace.quality_floor).minimum
+		);
 		const floor =
 			metric && minimum > 0 ? ` the ${metric} floor of ${minimum}` : ' the quality floor';
 		return {
@@ -1036,6 +1240,8 @@ export function currentEncodeProgress(job: EncodeQueueJob | null | undefined) {
 }
 
 export function plainFailureMessage(folder: FolderPayload, status: FolderStatusPayload): string {
+	const targetConstraint = targetConstraintSummary(folder, status);
+	if (targetConstraint) return targetConstraint.detail;
 	const retryable = record(status.retryable_sample_job);
 	const sampleJob = record(status.calibration_job ?? folder.calibration_job);
 	const encodeJob = record(folder.encode_job);

--- a/mediaforce/advising/policy.py
+++ b/mediaforce/advising/policy.py
@@ -353,7 +353,7 @@ def normalize_video_policy_value(key: str, value: JSONValue, base_value: JSONVal
         return round(clamp_float(value, minimum=0.1, maximum=5.0), 2)
     if key in {"sample_every", "sample_duration"}:
         return normalize_duration_like(value, fallback=str(base_value or ""))
-    if key in {"min_crf", "max_crf"}:
+    if key in {"min_crf", "max_crf", "target_search_max_crf"}:
         return clamp_int(value, minimum=0, maximum=63)
     if key == "max_encoded_percent":
         return clamp_int(value, minimum=1, maximum=100)
@@ -453,11 +453,15 @@ def finalize_video_policy_updates(updates: dict[str, Any], base_video: dict[str,
         floor = float_value(finalized.get("min_target_xpsnr", base_video.get("min_target_xpsnr", target)))
         finalized["target_xpsnr"] = round(clamp_float(target, minimum=25.0, maximum=41.0), 2)
         finalized["min_target_xpsnr"] = round(min(clamp_float(floor, minimum=20.0, maximum=40.0), finalized["target_xpsnr"]), 2)
-    if "min_crf" in finalized or "max_crf" in finalized:
+    if "min_crf" in finalized or "max_crf" in finalized or "target_search_max_crf" in finalized:
         min_crf = int_value(finalized.get("min_crf", base_video.get("min_crf", 18)))
         max_crf = int_value(finalized.get("max_crf", base_video.get("max_crf", 38)))
+        target_search_max_crf = int_value(
+            finalized.get("target_search_max_crf", base_video.get("target_search_max_crf", max_crf))
+        )
         finalized["min_crf"] = min(min_crf, max_crf)
         finalized["max_crf"] = max(min_crf, max_crf)
+        finalized["target_search_max_crf"] = max(finalized["max_crf"], target_search_max_crf)
     return finalized
 
 

--- a/mediaforce/advisor.py
+++ b/mediaforce/advisor.py
@@ -655,7 +655,7 @@ def request_run_verdict(
         quality_target = _optional_number(operator_request.get("target"))
     quality_met = None if quality_score is None or quality_target is None else quality_score >= quality_target
 
-    if size_status in {"infeasible", "quality_conflict", "over_target"} or quality_met is False:
+    if size_status in {"infeasible", "bound_exhausted", "quality_conflict", "over_target"} or quality_met is False:
         outcome = "needs_review"
     elif size_status in {"inside_target_band", "under_target"}:
         outcome = "strong_match"
@@ -707,6 +707,8 @@ def _deterministic_run_verdict_summary(
 ) -> str:
     if size_status == "infeasible":
         return "The approved stream plan cannot fit inside the requested size budget."
+    if size_status == "bound_exhausted":
+        return "The measured search reached its configured limit before it found the requested size."
     if size_status == "quality_conflict":
         return "The measured sample reached a quality-floor conflict before it could satisfy the requested size."
     if size_status == "over_target":

--- a/mediaforce/core/db_migration_scripts/versions/20260719_0015_calibration_progress.py
+++ b/mediaforce/core/db_migration_scripts/versions/20260719_0015_calibration_progress.py
@@ -1,0 +1,36 @@
+"""Add calibration heartbeat and progress telemetry.
+
+Revision ID: 20260719_0015
+Revises: 20260719_0014
+Create Date: 2026-07-19 23:45:00
+"""
+
+import sqlalchemy as sa
+# noinspection PyPackageRequirements
+from alembic import op
+
+revision = "20260719_0015"
+down_revision = "20260719_0014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if not _has_column("calibration_jobs", "heartbeat_at"):
+        op.add_column("calibration_jobs", sa.Column("heartbeat_at", sa.Text(), nullable=True))
+    if not _has_column("calibration_jobs", "progress_json"):
+        op.add_column("calibration_jobs", sa.Column("progress_json", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    if _has_column("calibration_jobs", "progress_json"):
+        op.drop_column("calibration_jobs", "progress_json")
+    if _has_column("calibration_jobs", "heartbeat_at"):
+        op.drop_column("calibration_jobs", "heartbeat_at")
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    return any(
+        str(column.get("name") or "") == column_name
+        for column in sa.inspect(op.get_bind()).get_columns(table_name)
+    )

--- a/mediaforce/core/db_tables.py
+++ b/mediaforce/core/db_tables.py
@@ -234,6 +234,8 @@ calibration_jobs = Table(
     Column("owner_pid", Integer),
     Column("created_at", Text, nullable=False),
     Column("started_at", Text),
+    Column("heartbeat_at", Text),
+    Column("progress_json", Text),
     Column("finished_at", Text),
     Column("updated_at", Text, nullable=False),
 )

--- a/mediaforce/core/sql/schema.sql
+++ b/mediaforce/core/sql/schema.sql
@@ -89,6 +89,8 @@ CREATE TABLE IF NOT EXISTS calibration_jobs
     owner_pid                 INTEGER,
     created_at                TEXT NOT NULL,
     started_at                TEXT,
+    heartbeat_at              TEXT,
+    progress_json             TEXT,
     finished_at               TEXT,
     updated_at                TEXT NOT NULL
 );

--- a/mediaforce/encoding/quality_search.py
+++ b/mediaforce/encoding/quality_search.py
@@ -62,6 +62,7 @@ def search_quality(
     attempted_target = context.metric_target
     last_error: Exception | None = None
     configured_max_crf = int(video_policy["max_crf"])
+    target_search_max_crf = int(video_policy.get("target_search_max_crf", configured_max_crf))
     max_encoded_percent = float(video_policy["max_encoded_percent"])
     if stream_budget_ledger is not None:
         if run_sample_encode is None:
@@ -87,6 +88,7 @@ def search_quality(
             host=context.host,
             quality_temp_dir=quality_temp_dir,
             run_sample_encode=run_sample_encode,
+            search_max_crf=target_search_max_crf,
         )
 
     while attempted_target >= context.min_metric_score:

--- a/mediaforce/tuning/calibration_jobs.py
+++ b/mediaforce/tuning/calibration_jobs.py
@@ -17,7 +17,7 @@ from mediaforce.library.media_scopes import resolve_media_scope, scope_prefix_ov
 
 T = TypeVar("T")
 
-ACTIVE_JOB_STATUSES = {"queued", "running", "pending_review"}
+ACTIVE_JOB_STATUSES = {"queued", "starting", "running", "pending_review"}
 
 
 def load_latest_job(connection: DBClient, prefix: str) -> dict[str, Any] | None:
@@ -71,7 +71,7 @@ def load_latest_failed_target_size_sample_job(connection: DBClient, prefix: str)
         trace = result.get("target_size_trace")
         trace_status = trace.get("status") if isinstance(trace, dict) else None
         target_status = str(result.get("target_size_status") or trace_status or "").strip().lower()
-        if target_status in {"infeasible", "quality_conflict"}:
+        if target_status in {"infeasible", "bound_exhausted", "quality_conflict"}:
             return payload
     return None
 
@@ -117,6 +117,23 @@ def load_active_overlapping_job(connection: DBClient, prefix: str) -> dict[str, 
         .limit(1)
     ).mappings().fetchone()
     return _hydrate_job(row) if row is not None else None
+
+
+def load_recent_completed_sample_jobs(
+        connection: DBClient,
+        *,
+        limit: int = 50,
+) -> list[dict[str, Any]]:
+    rows = connection.execute(
+        _calibration_job_select()
+        .where(calibration_jobs.c.lane == "sample")
+        .where(calibration_jobs.c.status == "completed")
+        .where(calibration_jobs.c.started_at.is_not(None))
+        .where(calibration_jobs.c.finished_at.is_not(None))
+        .order_by(calibration_jobs.c.finished_at.desc(), _rowid_column().desc())
+        .limit(limit)
+    ).mappings().fetchall()
+    return [_hydrate_job(row) for row in rows]
 
 
 def list_queued_jobs(connection: DBClient) -> list[dict[str, Any]]:
@@ -166,7 +183,7 @@ def claim_next_queued_calibration_job(
 def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict[str, Any]:
     active_rows = connection.execute(
         _calibration_job_select()
-        .where(calibration_jobs.c.status.in_(("queued", "running", "pending_review")))
+        .where(calibration_jobs.c.status.in_(tuple(ACTIVE_JOB_STATUSES)))
         .order_by(calibration_jobs.c.created_at.asc(), _rowid_column().asc())
     ).mappings().fetchall()
     recent_terminal_counts = {
@@ -204,13 +221,14 @@ def list_queue_summary(connection: DBClient, *, limit_per_lane: int = 6) -> dict
         lane = str(payload.get("lane") or "sample")
         lane_summary = summary[lane]
         status = str(payload.get("status") or "queued")
-        key = f"{status}_count"
+        bucket = "running" if status == "starting" else status
+        key = f"{bucket}_count"
         if key in lane_summary:
             lane_summary[key] += 1
-        if status in {"queued", "running", "pending_review"}:
+        if status in ACTIVE_JOB_STATUSES:
             summary["active_count"] += 1
-        if status in lane_summary and len(lane_summary[status]) < limit_per_lane:
-            lane_summary[status].append(payload)
+        if bucket in lane_summary and len(lane_summary[bucket]) < limit_per_lane:
+            lane_summary[bucket].append(payload)
     for lane in ("sample", "full"):
         count = recent_terminal_counts.get(lane, 0)
         summary[lane]["recent_failed_count"] = count
@@ -274,8 +292,25 @@ def save_job(connection: DBClient, payload: dict[str, Any]) -> None:
     )
 
 
+def update_job_telemetry(
+        connection: DBClient,
+        job_id: str,
+        *,
+        heartbeat_at: str,
+        progress: dict[str, Any] | None = None,
+) -> None:
+    values: dict[str, Any] = {"heartbeat_at": heartbeat_at, "updated_at": heartbeat_at}
+    if progress is not None:
+        values["progress_json"] = json.dumps(progress, sort_keys=True)
+    connection.execute(
+        update(calibration_jobs)
+        .where(calibration_jobs.c.job_id == job_id)
+        .values(**values)
+    )
+
+
 def _serialize_job(payload: dict[str, Any]) -> dict[str, Any]:
-    return {
+    values = {
         "job_id": str(payload["job_id"]),
         "prefix": str(payload["prefix"]),
         "status": str(payload.get("status") or "queued"),
@@ -301,6 +336,7 @@ def _serialize_job(payload: dict[str, Any]) -> dict[str, Any]:
             payload.get("updated_at") or payload.get("finished_at") or payload.get("started_at") or payload["created_at"]
         ),
     }
+    return values
 
 
 def _hydrate_job(row: DBRow) -> dict[str, Any]:
@@ -326,6 +362,8 @@ def _hydrate_job(row: DBRow) -> dict[str, Any]:
         "owner_pid": row["owner_pid"],
         "created_at": row["created_at"],
         "started_at": row["started_at"],
+        "heartbeat_at": row["heartbeat_at"],
+        "progress": _loads_optional(row["progress_json"], default=None),
         "finished_at": row["finished_at"],
         "updated_at": row["updated_at"],
     }

--- a/mediaforce/tuning/quality_risk.py
+++ b/mediaforce/tuning/quality_risk.py
@@ -104,6 +104,7 @@ ALLOW_LISTED_VIDEO_TRANSFORM_KEYS = frozenset(
         "grain_denoise",
         "min_crf",
         "max_crf",
+        "target_search_max_crf",
         "max_encoded_percent",
         "quality_metric",
         "target_vmaf",
@@ -589,6 +590,7 @@ def target_size_search_public_view(trace: Mapping[str, Any] | None) -> dict[str,
     quality_floor = object_dict(payload.get("quality_floor"))
     selected = object_dict(payload.get("selected_candidate"))
     transform_plan = object_dict(payload.get("transform_plan"))
+    crf_bounds = object_dict(payload.get("crf_bounds"))
     return {
         "trace_id": f"tss1_{stable_json_hash(payload)[:24]}",
         "schema_version": int_value(payload.get("schema_version")),
@@ -608,6 +610,11 @@ def target_size_search_public_view(trace: Mapping[str, Any] | None) -> dict[str,
         "predicted_whole_episode_bytes": int_value(selected.get("predicted_whole_episode_bytes")) or None,
         "within_sample_band": bool(selected.get("within_sample_band")) if selected else None,
         "transform_plan_id": str(transform_plan.get("transform_plan_id") or "") or None,
+        "configured_max_crf": int_value(crf_bounds.get("configured_max_crf")) or None,
+        "search_max_crf": int_value(crf_bounds.get("search_max_crf")) or None,
+        "range_expanded": bool(crf_bounds.get("range_expanded")),
+        "measured_beyond_configured": bool(crf_bounds.get("measured_beyond_configured")),
+        "selected_beyond_configured": bool(crf_bounds.get("selected_beyond_configured")),
     }
 
 
@@ -1024,6 +1031,9 @@ def _deterministic_gates(
     feasibility_status = str(object_dict(stream_budget.get("feasibility")).get("status") or "")
     if feasibility_status == "arithmetically_infeasible":
         blocking_reasons.append("The resolved stream budget leaves no positive video budget.")
+    source_cap_status = str(object_dict(stream_budget.get("source_relative_cap")).get("status") or "")
+    if source_cap_status == "arithmetically_infeasible":
+        blocking_reasons.append("The preserved streams consume the configured source-size cap.")
     if rejected_transform_keys:
         blocking_reasons.append(
             "The requested transform includes non-allow-listed keys: " + ", ".join(sorted(rejected_transform_keys))
@@ -1065,7 +1075,7 @@ def _deterministic_gates(
             blocking_reasons.append(
                 str(target_size_trace.get("selection_reason") or "The requested target size is arithmetically infeasible.")
             )
-        elif target_size_status in {"quality_conflict", "needs_review"}:
+        elif target_size_status in {"bound_exhausted", "quality_conflict", "needs_review"}:
             comparison_reason = str(
                 target_size_trace.get("selection_reason")
                 or "The target-size search needs operator review before this policy can be reused."
@@ -1173,14 +1183,6 @@ def _typed_quality_risks(
         )
     feasibility = object_dict(stream_budget.get("feasibility"))
     feasibility_status = str(feasibility.get("status") or "")
-    if feasibility_status == "aggressive_but_measurable":
-        _add_risk(
-            risks_by_tag,
-            tag="softness_detail_loss",
-            level="medium",
-            rationale="The remaining video budget is aggressive enough that detail loss is more likely at the requested size.",
-            evidence_ids=[],
-        )
     if feasibility_status == "requires_measurement":
         _add_risk(
             risks_by_tag,
@@ -1189,16 +1191,6 @@ def _typed_quality_risks(
             rationale="Non-video cost uncertainty still requires measurement before trusting the size tradeoff.",
             evidence_ids=[],
         )
-    if sample_result:
-        predicted_percent = float_value(sample_result.get("predicted_encode_percent"))
-        if predicted_percent > 0 and predicted_percent <= 8.0:
-            _add_risk(
-                risks_by_tag,
-                tag="softness_detail_loss",
-                level="medium",
-                rationale="The sampled result projects to a very small fraction of the source size, so preserved detail should be checked directly.",
-                evidence_ids=[],
-            )
     target_size_status = str(target_size_trace.get("status") or "")
     target_size_reason = str(target_size_trace.get("selection_reason") or "").strip()
     if target_size_status == "quality_conflict":
@@ -1209,11 +1201,11 @@ def _typed_quality_risks(
             rationale=target_size_reason or "The measured target cannot be reached without crossing the quality floor.",
             evidence_ids=[],
         )
-    elif target_size_status in {"needs_review", "infeasible"}:
+    elif target_size_status in {"bound_exhausted", "needs_review", "infeasible"}:
         _add_risk(
             risks_by_tag,
             tag="other",
-            level="high" if target_size_status == "infeasible" else "medium",
+            level="high" if target_size_status in {"bound_exhausted", "infeasible"} else "medium",
             rationale=target_size_reason or "The measured target-size search needs operator review.",
             evidence_ids=[],
         )

--- a/mediaforce/tuning/stream_budget.py
+++ b/mediaforce/tuning/stream_budget.py
@@ -14,10 +14,6 @@ DEFAULT_CONTAINER_OVERHEAD_BYTES = 4_000_000
 DEFAULT_TEXT_SUBTITLE_BYTES = 128 * 1024
 DEFAULT_IMAGE_SUBTITLE_BYTES = 4 * 1024 * 1024
 DEFAULT_UNKNOWN_ATTACHMENT_BYTES = 4_000_000
-AGGRESSIVE_VIDEO_BITRATE_BPS = 500_000
-AGGRESSIVE_TOTAL_SOURCE_PERCENT = 10.0
-AGGRESSIVE_SOURCE_VIDEO_RATIO = 0.20
-
 BudgetCategory = Literal["audio", "subtitle", "attachment", "container"]
 EstimateConfidence = Literal["exact", "high", "medium", "low", "unknown"]
 FeasibilityStatus = Literal[
@@ -425,10 +421,7 @@ def build_stream_budget_ledger(
         minimum_non_video_bytes=minimum_non_video_bytes,
         non_video_bytes=non_video_bytes,
         remaining_video_bytes=remaining_video_bytes,
-        remaining_video_bitrate_bps=remaining_video_bitrate_bps,
         duration_seconds=duration_seconds,
-        source_size_bytes=source_size_bytes,
-        source_video_bitrate_bps=source_video_bitrate_bps,
         entries=entries,
     )
     confidence = _aggregate_confidence(entries)
@@ -805,10 +798,7 @@ def _feasibility(
         minimum_non_video_bytes: int,
         non_video_bytes: int | None,
         remaining_video_bytes: int | None,
-        remaining_video_bitrate_bps: int | None,
         duration_seconds: float | None,
-        source_size_bytes: int | None,
-        source_video_bitrate_bps: int | None,
         entries: list[StreamBudgetEntry],
 ) -> tuple[FeasibilityStatus, tuple[str, ...]]:
     if total_target_bytes is not None and total_target_bytes <= minimum_non_video_bytes:
@@ -830,21 +820,6 @@ def _feasibility(
         measurement_reasons.append("non_video_total_unknown")
     if measurement_reasons:
         return "requires_measurement", tuple(dict.fromkeys(measurement_reasons))
-
-    aggressive_reasons: list[str] = []
-    total_source_percent = _percent_of_source(total_target_bytes, source_size_bytes)
-    if total_source_percent is not None and total_source_percent <= AGGRESSIVE_TOTAL_SOURCE_PERCENT:
-        aggressive_reasons.append("target_at_or_below_10_percent_of_source")
-    if remaining_video_bitrate_bps is not None and remaining_video_bitrate_bps <= AGGRESSIVE_VIDEO_BITRATE_BPS:
-        aggressive_reasons.append("remaining_video_bitrate_at_or_below_500_kbps")
-    if (
-            remaining_video_bitrate_bps is not None
-            and source_video_bitrate_bps is not None
-            and remaining_video_bitrate_bps <= source_video_bitrate_bps * AGGRESSIVE_SOURCE_VIDEO_RATIO
-    ):
-        aggressive_reasons.append("remaining_video_bitrate_at_or_below_20_percent_of_source_video")
-    if aggressive_reasons:
-        return "aggressive_but_measurable", tuple(dict.fromkeys(aggressive_reasons))
     return "feasible", ()
 
 

--- a/mediaforce/tuning/target_size_search.py
+++ b/mediaforce/tuning/target_size_search.py
@@ -18,11 +18,12 @@ from mediaforce.tuning.stream_budget import (
 TARGET_SIZE_SEARCH_SCHEMA_VERSION = 1
 TARGET_SIZE_TRANSFORM_PLAN_SCHEMA_VERSION = 1
 MAX_TARGET_SIZE_CANDIDATES = 6
+TARGET_SIZE_BOUND_EXPANSION_STEP = 8
 MAX_FINAL_OUTPUT_RETRIES = 1
 MIN_FINAL_RETRY_CALIBRATION_FACTOR = 0.5
 MAX_FINAL_RETRY_CALIBRATION_FACTOR = 2.0
 
-SearchStatus = Literal["selected", "infeasible", "quality_conflict", "needs_review"]
+SearchStatus = Literal["selected", "infeasible", "bound_exhausted", "quality_conflict", "needs_review"]
 CurveShape = Literal["single_point", "monotonic", "non_monotonic"]
 FinalSizeStatus = Literal["inside_target_band", "over_target", "under_target", "missing_target"]
 
@@ -130,9 +131,11 @@ def search_target_size(
         host: dict[str, Any] | None,
         quality_temp_dir: Path | None,
         run_sample_encode: Callable[..., SampleEncodeResult],
+        search_max_crf: int | None = None,
 ) -> QualitySearchResult:
     _validate_search_inputs(stream_budget_ledger)
-    normalized_min_crf, normalized_max_crf = _normalized_crf_bounds(min_crf, max_crf)
+    normalized_min_crf, configured_max_crf = _normalized_crf_bounds(min_crf, max_crf)
+    normalized_max_crf = _normalized_search_max_crf(configured_max_crf, search_max_crf)
     if not target_size_transform_plan_valid(transform_plan):
         trace = _trace_payload(
             status="needs_review",
@@ -145,6 +148,7 @@ def search_target_size(
             metric_target=metric_target,
             min_crf=normalized_min_crf,
             max_crf=normalized_max_crf,
+            configured_max_crf=configured_max_crf,
             transform_plan=object_dict(transform_plan) or None,
         )
         raise TargetSizeSearchError(
@@ -156,7 +160,7 @@ def search_target_size(
     source_cap_blocker = _source_cap_blocker(stream_budget_ledger)
     if source_cap_blocker is not None:
         trace = _trace_payload(
-            status="infeasible",
+            status="bound_exhausted",
             reason=source_cap_blocker.code,
             ledger=stream_budget_ledger,
             candidates=[],
@@ -166,17 +170,18 @@ def search_target_size(
             metric_target=metric_target,
             min_crf=normalized_min_crf,
             max_crf=normalized_max_crf,
+            configured_max_crf=configured_max_crf,
             transform_plan=validated_transform_plan,
         )
         raise TargetSizeSearchError(
             source_cap_blocker.message,
-            status="infeasible",
+            status="bound_exhausted",
             trace=trace,
         )
 
     candidates: list[TargetSizeCandidate] = []
     measured_crfs: set[int] = set()
-    seed_crf = _seed_crf(stream_budget_ledger, min_crf=normalized_min_crf, max_crf=normalized_max_crf)
+    seed_crf = _seed_crf(stream_budget_ledger, min_crf=normalized_min_crf, max_crf=configured_max_crf)
 
     def measure(crf: int, role: str) -> None:
         normalized_crf = _clamp_int(crf, normalized_min_crf, normalized_max_crf)
@@ -218,7 +223,7 @@ def search_target_size(
         next_crf = _next_crf(candidates, measured_crfs, normalized_min_crf, normalized_max_crf, stream_budget_ledger)
         if next_crf is None:
             break
-        measure(next_crf, "refine")
+        measure(next_crf, "expanded_bound" if next_crf > configured_max_crf else "refine")
 
     selected = _select_candidate(candidates)
     if selected is not None:
@@ -233,6 +238,7 @@ def search_target_size(
             metric_target=metric_target,
             min_crf=normalized_min_crf,
             max_crf=normalized_max_crf,
+            configured_max_crf=configured_max_crf,
             transform_plan=validated_transform_plan,
         )
         return QualitySearchResult(
@@ -244,7 +250,12 @@ def search_target_size(
             target_size_trace=trace,
         )
 
-    status, reason = _failure_status(candidates, stream_budget_ledger)
+    status, reason = _failure_status(
+        candidates,
+        stream_budget_ledger,
+        min_crf=normalized_min_crf,
+        max_crf=normalized_max_crf,
+    )
     trace = _trace_payload(
         status=status,
         reason=reason,
@@ -256,6 +267,7 @@ def search_target_size(
         metric_target=metric_target,
         min_crf=normalized_min_crf,
         max_crf=normalized_max_crf,
+        configured_max_crf=configured_max_crf,
         transform_plan=validated_transform_plan,
     )
     raise TargetSizeSearchError(_failure_message(status, reason, trace), status=status, trace=trace)
@@ -851,6 +863,12 @@ def _normalized_crf_bounds(min_crf: int, max_crf: int) -> tuple[int, int]:
     return lower, upper
 
 
+def _normalized_search_max_crf(configured_max_crf: int, search_max_crf: int | None) -> int:
+    if search_max_crf is None:
+        return configured_max_crf
+    return min(63, max(configured_max_crf, int(search_max_crf)))
+
+
 def _seed_crf(ledger: StreamBudgetLedger, *, min_crf: int, max_crf: int) -> int:
     if min_crf >= max_crf:
         return min_crf
@@ -944,12 +962,18 @@ def _next_crf(
                 pairs.append((int(round(left.crf)), int(round(right.crf))))
         for left, right in sorted(pairs, key=lambda pair: (abs(pair[1] - pair[0]), pair[0])):
             midpoint = round((left + right) / 2)
-            candidate = _nearest_unmeasured(midpoint, measured_crfs, min_crf, max_crf)
+            candidate = _nearest_unmeasured(midpoint, measured_crfs, left + 1, right - 1)
             if candidate is not None:
                 return candidate
     if above:
-        return _nearest_unmeasured(max_crf, measured_crfs, min_crf, max_crf)
+        highest_measured = max(measured_crfs)
+        if highest_measured >= max_crf:
+            return None
+        expansion_probe = min(max_crf, highest_measured + TARGET_SIZE_BOUND_EXPANSION_STEP)
+        return _nearest_unmeasured(expansion_probe, measured_crfs, highest_measured + 1, max_crf)
     if below:
+        if min(measured_crfs) <= min_crf:
+            return None
         return _nearest_unmeasured(min_crf, measured_crfs, min_crf, max_crf)
     closest = min(candidates, key=lambda candidate: _candidate_distance(candidate), default=None)
     if closest is None:
@@ -965,10 +989,25 @@ def _nearest_unmeasured(seed: int, measured: set[int], min_crf: int, max_crf: in
     return None
 
 
-def _failure_status(candidates: list[TargetSizeCandidate], ledger: StreamBudgetLedger) -> tuple[SearchStatus, str]:
+def _failure_status(
+        candidates: list[TargetSizeCandidate],
+        ledger: StreamBudgetLedger,
+        *,
+        min_crf: int,
+        max_crf: int,
+) -> tuple[SearchStatus, str]:
     in_band = [candidate for candidate in candidates if candidate.within_sample_band and not candidate.violates_source_cap]
     if in_band and not any(candidate.quality_floor_met for candidate in in_band):
         return "quality_conflict", "target_band_violates_quality_floor"
+    _, upper = _sample_bounds(ledger)
+    size_reachable = [
+        candidate for candidate in candidates
+        if candidate.predicted_whole_episode_bytes is not None
+        and candidate.predicted_whole_episode_bytes <= upper
+        and not candidate.violates_source_cap
+    ]
+    if size_reachable and not any(candidate.quality_floor_met for candidate in size_reachable):
+        return "quality_conflict", "target_requires_crossing_quality_floor"
     if not any(candidate.quality_floor_met for candidate in candidates):
         return "quality_conflict", "all_candidates_violate_quality_floor"
     shape = _curve_shape(candidates)
@@ -977,12 +1016,16 @@ def _failure_status(candidates: list[TargetSizeCandidate], ledger: StreamBudgetL
     lower, upper = _sample_bounds(ledger)
     quality_safe = [candidate for candidate in candidates if candidate.quality_floor_met and not candidate.violates_source_cap]
     if quality_safe and all((candidate.predicted_whole_episode_bytes or 0) > upper for candidate in quality_safe):
-        return "infeasible", "smallest_quality_safe_candidate_over_target_band"
+        if any(math.isclose(candidate.crf, max_crf) for candidate in candidates):
+            return "bound_exhausted", "smallest_quality_safe_candidate_over_target_band"
+        return "needs_review", "bounded_search_exhausted_before_upper_bound"
     if quality_safe and all(
             candidate.predicted_whole_episode_bytes is not None and candidate.predicted_whole_episode_bytes < lower
             for candidate in quality_safe
     ):
-        return "infeasible", "largest_quality_safe_candidate_under_target_band"
+        if any(math.isclose(candidate.crf, min_crf) for candidate in candidates):
+            return "bound_exhausted", "largest_quality_safe_candidate_under_target_band"
+        return "needs_review", "bounded_search_exhausted_before_lower_bound"
     return "needs_review", "bounded_search_exhausted"
 
 
@@ -995,11 +1038,13 @@ def _failure_message(status: SearchStatus, reason: str, trace: dict[str, Any]) -
             f"({reason}); target={target.get('total_target_bytes')} bytes, "
             f"best_reachable={best.get('predicted_whole_episode_bytes')} bytes."
         )
-    if status == "infeasible":
+    if status == "bound_exhausted":
         return (
-            "The approved target size is not reachable within the approved CRF range and caps "
+            "The approved target size was not reached before the configured search bound "
             f"({reason}); target={target.get('total_target_bytes')} bytes."
         )
+    if status == "infeasible":
+        return "The approved target size leaves no positive production video budget."
     return f"Target-size search needs review after bounded measurements ({reason})."
 
 
@@ -1015,10 +1060,13 @@ def _trace_payload(
         metric_target: float,
         min_crf: int,
         max_crf: int,
+        configured_max_crf: int | None = None,
         transform_plan: dict[str, Any] | None,
 ) -> dict[str, Any]:
     best = _best_reachable(candidates)
     lower, upper = _sample_bounds(ledger)
+    resolved_configured_max_crf = max_crf if configured_max_crf is None else configured_max_crf
+    measured_beyond_configured = any(candidate.crf > resolved_configured_max_crf for candidate in candidates)
     return {
         "schema_version": TARGET_SIZE_SEARCH_SCHEMA_VERSION,
         "status": status,
@@ -1048,7 +1096,15 @@ def _trace_payload(
             "target": metric_target,
             "minimum": min_metric_score,
         },
-        "crf_bounds": {"min_crf": min_crf, "max_crf": max_crf},
+        "crf_bounds": {
+            "min_crf": min_crf,
+            "configured_max_crf": resolved_configured_max_crf,
+            "search_max_crf": max_crf,
+            "max_crf": max_crf,
+            "range_expanded": max_crf > resolved_configured_max_crf,
+            "measured_beyond_configured": measured_beyond_configured,
+            "selected_beyond_configured": selected is not None and selected.crf > resolved_configured_max_crf,
+        },
         "transform_plan": transform_plan,
         "curve": {
             "shape": _curve_shape(candidates),

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -32,7 +32,7 @@ from sqlalchemy import select
 from mediaforce.advisor import TuningPolicyResponse
 from mediaforce.advising.routing import advisor_routing_from_config
 from mediaforce.tuning.calibration_jobs import load_active_job, load_job, \
-    list_queue_summary
+    list_queue_summary, update_job_telemetry
 from mediaforce.core.config import DEFAULT_CONFIG_PATH, MediaforceConfig, load_config, update_runtime_settings, \
     update_runtime_folder_policy_values, upsert_runtime_folder_policy_override
 from mediaforce.core.binaries import ffmpeg_binary
@@ -109,7 +109,8 @@ from mediaforce.tuning.tuning_memory import (
     record_visual_approval_artifact,
     sibling_approved_season_memory,
 )
-from mediaforce.tuning.quality_risk import build_quality_risk_contract, quality_risk_public_view
+from mediaforce.tuning.quality_risk import build_quality_risk_contract, quality_risk_public_view, \
+    target_size_search_public_view
 from mediaforce.tuning.size_goals import guided_size_goal_options, operator_intent_from_policy
 from mediaforce.core.type_defs import JSONValue, float_value, mapping_dict, object_dict, object_list
 from mediaforce.web.routes import register_completed_routes, register_dashboard_routes, register_folder_routes, \
@@ -202,6 +203,8 @@ from mediaforce.web.runtime.catalog_signature import (
 from mediaforce.web.runtime.job_runtime import JobRuntimeDeps, active_scan_from_db as runtime_active_scan_from_db, \
     CalibrationQueueRuntimeDeps, calibration_queue_worker_loop as runtime_calibration_queue_worker_loop, \
     calibration_job_belongs_to_current_process as runtime_calibration_job_belongs_to_current_process, \
+    calibration_job_compatibility_key as runtime_calibration_job_compatibility_key, \
+    calibration_job_public_payload as runtime_calibration_job_public_payload, \
     dispatch_calibration_job as runtime_dispatch_calibration_job, \
     expire_calibration_job as runtime_expire_calibration_job, \
     latest_scan_completed_at as runtime_latest_scan_completed_at, \
@@ -251,6 +254,7 @@ CALIBRATION_JOB_NOTICE_AFTER = timedelta(hours=1)
 SAMPLE_CALIBRATION_CONCURRENCY = 2
 FULL_CALIBRATION_CONCURRENCY = 1
 CALIBRATION_QUEUE_POLL_SECONDS = 2.0
+CALIBRATION_HEARTBEAT_SECONDS = 5.0
 ENCODE_QUEUE_POLL_SECONDS = 2.0
 ENCODE_JOB_LEASE_SECONDS = 45
 ENCODE_JOB_HEARTBEAT_SECONDS = 10.0
@@ -675,7 +679,8 @@ def create_app(config_path: Path | None = None) -> FastAPI:
         return folder_status_payload(
             config,
             normalized_prefix,
-            load_job_state=_load_overlapping_job_state,
+            load_exact_job_state=_load_job_state,
+            load_overlapping_job_state=_load_overlapping_job_state,
             load_retryable_sample_job_state=_load_retryable_sample_job_state,
             load_scan_status=_load_scan_status,
             load_active_encode_job_for_prefix=load_active_encode_job_for_prefix,
@@ -1038,7 +1043,11 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                     metrics_by_prefix={card.prefix: asdict(card) for card in movie_cards},
                     candidate_decisions=movie_decisions,
                 )
-            calibration_job = _load_job_state(connection, config, normalized_prefix)
+            calibration_job = runtime_calibration_job_public_payload(
+                connection,
+                config,
+                _load_job_state(connection, config, normalized_prefix),
+            )
             folder_scan_job = _load_scan_status(connection, config, prefix=normalized_prefix)
             summary = inspect_prefix(connection, config, normalized_prefix)
             metric_support = _metric_support()
@@ -1128,7 +1137,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 else None
             )
             latest_failed_sample_job_payload = object_dict(
-                _load_latest_failed_sample_job_state(connection, config, normalized_prefix)
+                _load_latest_failed_target_size_job_state(connection, config, normalized_prefix)
             ) or None
         policy = _folder_display_policy(
             sample_item=sample_item,
@@ -1195,6 +1204,11 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 else None
             ),
         )
+        latest_failed_result = object_dict(object_dict(latest_failed_sample_job_payload).get("result"))
+        latest_failed_target_trace = (
+            object_dict(latest_failed_result.get("target_size_trace"))
+            or object_dict(object_dict(latest_failed_result.get("sample_result")).get("target_size_trace"))
+        )
         resolved_metric, _ = select_quality_metric(str(video_policy.get("quality_metric", "auto")))
         sample_host_statuses = _cached_sample_calibration_host_statuses(config)
         sample_host_choices = _sample_host_options_from_statuses(config, sample_host_statuses)
@@ -1219,6 +1233,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 "stream_budget_ledger": stream_budget.to_payload(),
                 "size_goal_options": size_goal_options,
                 "quality_risk": quality_risk_public_view(quality_risk_contract),
+                "failed_target_size_search": target_size_search_public_view(latest_failed_target_trace),
                 "pending_proposal": pending_proposal,
                 "recent_tuning_sessions": recent_sessions,
                 "approved_season_shortcut": approved_season_shortcut,
@@ -1615,6 +1630,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             record_visual_approval_artifact=record_visual_approval_artifact,
             merge_advice_state=_merge_advice_state,
             upsert_override=_upsert_override,
+            load_latest_failed_target_size_job_state=_load_latest_failed_target_size_job_state,
             confirm_high_impact=confirm_high_impact,
             confirm_size_tradeoff=confirm_size_tradeoff,
             reviewed_draft_hash=reviewed_draft_hash,
@@ -3272,6 +3288,9 @@ def _calibration_run_deps() -> CalibrationRunDeps:
         load_job_state=_load_job_state,
         sample_item=_sample_item,
         save_job_state=_save_job_state,
+        update_job_telemetry=update_job_telemetry,
+        calibration_job_compatibility_key=runtime_calibration_job_compatibility_key,
+        calibration_heartbeat_seconds=CALIBRATION_HEARTBEAT_SECONDS,
         save_calibration_state=_save_calibration_state,
         record_run_verdict=_record_run_verdict,
         summarize_calibration_result=_summarize_calibration_result,
@@ -3814,10 +3833,39 @@ def _active_calibration_process_controllers() -> list[ManagedProcessController]:
         return list(CALIBRATION_QUEUE_PROCESSES.values())
 
 
-def _submission_cleanup_callback(job_id: str) -> Callable[[Future[object]], None]:
-    def _callback(_future: Future[object]) -> None:
-        _mark_calibration_submission_complete(job_id)
-        _unregister_calibration_process_controller(job_id)
+def _submission_cleanup_callback(
+        config: MediaforceConfig,
+        job_payload: dict[str, Any],
+) -> Callable[[Future[object]], None]:
+    job_id = str(job_payload["job_id"])
+    prefix = str(job_payload["prefix"])
+
+    def _callback(future: Future[object]) -> None:
+        try:
+            escaped_error = future.exception()
+        except BaseException as exc:
+            escaped_error = exc
+        try:
+            if escaped_error is not None:
+                with open_db(config.paths.db_path) as connection:
+                    current = load_job(connection, job_id)
+                    if current is not None and str(current.get("status") or "") in {"starting", "running"}:
+                        _save_job_state(
+                            connection,
+                            config,
+                            prefix,
+                            {
+                                **current,
+                                "status": "failed",
+                                "finished_at": _now_iso(),
+                                "error": str(escaped_error),
+                            },
+                        )
+        except Exception:
+            LOGGER.exception("Unable to mark escaped calibration job %s failed", job_id)
+        finally:
+            _mark_calibration_submission_complete(job_id)
+            _unregister_calibration_process_controller(job_id)
 
     return _callback
 

--- a/mediaforce/web/runtime/calibration_runtime.py
+++ b/mediaforce/web/runtime/calibration_runtime.py
@@ -1,5 +1,8 @@
 import json
+import logging
 import shutil
+import threading
+import time
 import uuid
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -19,6 +22,8 @@ from mediaforce.encoding.video_filters import build_video_filter
 from mediaforce.state_cleanup import purge_transient_artifacts
 from mediaforce.tuning.target_size_search import TargetSizeSearchError
 
+LOGGER = logging.getLogger(__name__)
+
 
 @dataclass(slots=True)
 class CalibrationRunDeps:
@@ -27,6 +32,9 @@ class CalibrationRunDeps:
     load_job_state: Any
     sample_item: Any
     save_job_state: Any
+    update_job_telemetry: Any
+    calibration_job_compatibility_key: Any
+    calibration_heartbeat_seconds: float
     save_calibration_state: Any
     record_run_verdict: Any
     summarize_calibration_result: Any
@@ -48,6 +56,97 @@ class CalibrationRunDeps:
     staged_artifact_columns: tuple[str, ...]
     recommend_review_moments: Any | None = None
     review_moment_payload: Any | None = None
+
+
+class _CalibrationTelemetry:
+    def __init__(
+            self,
+            config: MediaforceConfig,
+            job_id: str,
+            payload: dict[str, Any],
+            deps: CalibrationRunDeps,
+    ) -> None:
+        self.config = config
+        self.job_id = job_id
+        self.deps = deps
+        self.started_monotonic = time.monotonic()
+        self.stop_event = threading.Event()
+        self.write_lock = threading.Lock()
+        self.thread: threading.Thread | None = None
+        now = deps.now_iso()
+        self.progress: dict[str, Any] = {
+            "schema_version": 1,
+            "stage": "preparing_source",
+            "stage_started_at": now,
+            "last_progress_at": now,
+            "compatibility_key": deps.calibration_job_compatibility_key(payload),
+        }
+
+    def start(self) -> None:
+        self._persist(progress=self.progress)
+        self.thread = threading.Thread(
+            target=self._heartbeat_loop,
+            name=f"calibration-heartbeat-{self.job_id[:8]}",
+            daemon=True,
+        )
+        self.thread.start()
+
+    def update(self, stage: str, *, completed: int | None = None, total: int | None = None) -> None:
+        now = self.deps.now_iso()
+        if self.progress.get("stage") != stage:
+            self.progress["stage"] = stage
+            self.progress["stage_started_at"] = now
+        self.progress["last_progress_at"] = now
+        if completed is not None and total is not None and total > 0:
+            self.progress["work"] = {
+                "completed": max(0, min(completed, total)),
+                "total": total,
+            }
+        else:
+            self.progress.pop("work", None)
+        self._persist(progress=self.progress)
+
+    def refresh_compatibility(self, payload: dict[str, Any]) -> None:
+        compatibility_key = self.deps.calibration_job_compatibility_key(payload)
+        if self.progress.get("compatibility_key") == compatibility_key:
+            return
+        self.progress["compatibility_key"] = compatibility_key
+        self.progress["last_progress_at"] = self.deps.now_iso()
+        self._persist(progress=self.progress)
+
+    def finish(self, terminal_status: str | None) -> None:
+        self.stop_event.set()
+        if self.thread is not None:
+            self.thread.join()
+        if terminal_status is None:
+            return
+        now = self.deps.now_iso()
+        self.progress["terminal_status"] = terminal_status
+        self.progress["last_progress_at"] = now
+        self.progress["total_elapsed_seconds"] = max(0, round(time.monotonic() - self.started_monotonic))
+        if terminal_status == "completed":
+            self.progress["stage"] = "completed"
+            self.progress["stage_started_at"] = now
+            self.progress.pop("work", None)
+        self._persist(progress=self.progress)
+
+    def _heartbeat_loop(self) -> None:
+        while not self.stop_event.wait(self.deps.calibration_heartbeat_seconds):
+            self._persist()
+
+    def _persist(self, *, progress: dict[str, Any] | None = None) -> None:
+        with self.write_lock:
+            heartbeat_at = self.deps.now_iso()
+            try:
+                with open_db(self.config.paths.db_path) as connection:
+                    self.deps.update_job_telemetry(
+                        connection,
+                        self.job_id,
+                        heartbeat_at=heartbeat_at,
+                        progress=dict(progress) if progress is not None else None,
+                    )
+            except Exception:
+                LOGGER.warning("Unable to persist calibration telemetry for %s", self.job_id, exc_info=True)
 
 
 def _stored_sample_item_payload(sample_item: dict[str, Any]) -> dict[str, Any]:
@@ -173,14 +272,31 @@ def run_calibration_job(
                     "updated_at": deps.now_iso()})
         deps.save_job_state(connection, config, prefix, job)
 
+    telemetry = _CalibrationTelemetry(
+        config,
+        job_id,
+        {
+            **job,
+            "job_id": job_id,
+            "prefix": prefix,
+            "host": host_data,
+            "policy": policy,
+        },
+        deps,
+    )
+    telemetry.start()
+
     calibration_dir: Path | None = None
     manifest_path: Path | None = None
     library_item_id: int | None = None
     staged_artifact_snapshot: dict[str, Any] | None = None
+    terminal_status: str | None = None
 
     try:
+        telemetry.update("preparing_host")
         ready_host = deps.ensure_sample_host_ready(config, host_data)
         host_data = {**host_data, **asdict(ready_host)}
+        telemetry.update("preparing_source")
         with open_db(config.paths.db_path) as connection:
             sample_item = _job_sample_item(job)
             if sample_item is None:
@@ -199,6 +315,14 @@ def run_calibration_job(
             )
             sample_item["stream_budget_ledger"] = stream_budget.to_payload()
             job["sample_item"] = _stored_sample_item_payload(sample_item)
+            telemetry.refresh_compatibility(
+                {
+                    **job,
+                    "host": host_data,
+                    "policy": policy,
+                    "sample_item": job["sample_item"],
+                }
+            )
             deps.save_job_state(connection, config, prefix, job)
             current_library_item_id = int_value(sample_item.get("library_item_id"))
             library_item_id = current_library_item_id
@@ -211,6 +335,7 @@ def run_calibration_job(
 
             calibration_run_id = uuid.uuid4().hex[:12]
             if deps.calibration_mode_for_action(action) == "full":
+                telemetry.update("encoding_full_calibration")
                 calibration_payload, manifest_path, calibration_dir = run_full_calibration(
                     connection=connection,
                     config=config,
@@ -238,8 +363,10 @@ def run_calibration_job(
                     calibration_run_id=calibration_run_id,
                     process_controller=process_controller,
                     deps=deps,
+                    progress_callback=telemetry.update,
                 )
 
+        telemetry.update("saving_results")
         calibration_payload["job_id"] = job_id
         deps.save_calibration_state(config, prefix, calibration_payload)
         deps.record_run_verdict(config, prefix, calibration_payload)
@@ -257,7 +384,9 @@ def run_calibration_job(
                     "result": deps.summarize_calibration_result(calibration_payload),
                 },
             )
+        terminal_status = "completed"
     except ProcessCancelledError:
+        terminal_status = "stopped"
         with open_db(config.paths.db_path) as connection:
             deps.save_job_state(
                 connection,
@@ -272,6 +401,7 @@ def run_calibration_job(
                 },
             )
     except TargetSizeSearchError as exc:
+        terminal_status = "failed"
         with open_db(config.paths.db_path) as connection:
             deps.save_job_state(
                 connection,
@@ -290,6 +420,7 @@ def run_calibration_job(
                 },
             )
     except Exception as exc:
+        terminal_status = "failed"
         with open_db(config.paths.db_path) as connection:
             deps.save_job_state(
                 connection,
@@ -304,6 +435,7 @@ def run_calibration_job(
                 },
             )
     finally:
+        telemetry.finish(terminal_status)
         if library_item_id is not None:
             with open_db(config.paths.db_path) as connection:
                 restore_staged_artifact(
@@ -330,6 +462,7 @@ def run_sampled_calibration(
         calibration_run_id: str,
         process_controller: ManagedProcessController,
         deps: CalibrationRunDeps,
+        progress_callback: Any | None = None,
 ) -> tuple[dict[str, Any], Path | None]:
     _ = prefix
     source_path = Path(sample_item["source_path"])
@@ -357,6 +490,8 @@ def run_sampled_calibration(
         else None
     )
     preset = deps.effective_video_preset(video_policy, width=width, height=height)
+    if progress_callback is not None:
+        progress_callback("inspecting_source")
     detected_crop = deps.detect_video_crop(
         source_path,
         video_policy,
@@ -392,7 +527,11 @@ def run_sampled_calibration(
         quality_kwargs["cadence_source_fingerprint"] = (
             str(sample_item.get("source_fingerprint") or "") or None
         )
+    if progress_callback is not None:
+        progress_callback("searching_target")
     quality_result = deps.search_quality_for_source(source_path, video_policy, **quality_kwargs)
+    if progress_callback is not None:
+        progress_callback("measuring_quality")
     sample_result = deps.run_sample_encode(
         source_path,
         source_codec=str(sample_item.get("video_codec") or ""),
@@ -410,6 +549,8 @@ def run_sampled_calibration(
     )
 
     review_moments = []
+    if progress_callback is not None:
+        progress_callback("selecting_review_moments")
     if deps.recommend_review_moments is not None:
         review_moments = deps.recommend_review_moments(
             source_path,
@@ -429,6 +570,8 @@ def run_sampled_calibration(
         )
         review_moments = []
     output_dir = config.paths.review_dir / calibration_run_id / "item-00"
+    if progress_callback is not None:
+        progress_callback("building_review", completed=0, total=3)
     preview_clips = deps.encode_preview_clips(
         source_path=source_path,
         source_codec=str(sample_item.get("video_codec") or ""),
@@ -444,6 +587,8 @@ def run_sampled_calibration(
         host=host_data,
         process_controller=process_controller,
     )
+    if progress_callback is not None:
+        progress_callback("building_review", completed=1, total=3)
     source_clips = deps.render_source_review_clips(
         source_path=source_path,
         source_codec=str(sample_item.get("video_codec") or ""),
@@ -452,6 +597,8 @@ def run_sampled_calibration(
         duration_seconds=8.0,
         process_controller=process_controller,
     )
+    if progress_callback is not None:
+        progress_callback("building_review", completed=2, total=3)
     compare_clips = deps.generate_compare_clips_from_previews(
         source_path=source_path,
         source_codec=str(sample_item.get("video_codec") or ""),
@@ -459,6 +606,8 @@ def run_sampled_calibration(
         output_dir=output_dir,
         process_controller=process_controller,
     )
+    if progress_callback is not None:
+        progress_callback("building_review", completed=3, total=3)
     estimated_total_size_bytes = (
         sample_result.predicted_encode_size_bytes + stream_budget.non_video_bytes
         if stream_budget.non_video_bytes is not None

--- a/mediaforce/web/runtime/dashboard_payloads.py
+++ b/mediaforce/web/runtime/dashboard_payloads.py
@@ -12,6 +12,7 @@ from mediaforce.library.media_scopes import resolve_media_scope
 from mediaforce.library.movie_library import adapt_movie_workflow_payload, load_movie_scope_payload
 from mediaforce.library.workflow_state import build_folder_workflow_state
 from mediaforce.library.candidate_selection import encode_candidate_decisions, project_candidates, workflow_eligibility
+from mediaforce.web.runtime.job_runtime import calibration_job_public_payload, calibration_scope_relation
 
 
 def dashboard_summary_payload(
@@ -100,7 +101,8 @@ def folder_status_payload(
         config: MediaforceConfig,
         normalized_prefix: str,
         *,
-        load_job_state: Any,
+        load_exact_job_state: Any,
+        load_overlapping_job_state: Any,
         load_retryable_sample_job_state: Any,
         load_scan_status: Any,
         load_active_encode_job_for_prefix: Any,
@@ -111,7 +113,22 @@ def folder_status_payload(
             normalized_prefix,
             library_types=config.library_type_map,
         )
-        calibration_job = load_job_state(connection, config, normalized_prefix)
+        exact_calibration_job = calibration_job_public_payload(
+            connection,
+            config,
+            load_exact_job_state(connection, config, normalized_prefix),
+        )
+        overlapping_calibration_job = calibration_job_public_payload(
+            connection,
+            config,
+            load_overlapping_job_state(connection, config, normalized_prefix),
+        )
+        scope_activity = _scope_activity_payload(
+            normalized_prefix,
+            exact_calibration_job,
+            overlapping_calibration_job,
+        )
+        legacy_calibration_job = overlapping_calibration_job or exact_calibration_job
         retryable_sample_job = load_retryable_sample_job_state(connection, config, normalized_prefix)
         active_encode_job = load_active_encode_job_for_prefix(connection, normalized_prefix)
         folder_scan_job = load_scan_status(connection, config, normalized_prefix)
@@ -138,7 +155,11 @@ def folder_status_payload(
                     members=list(movie_context.get("members") or []),
                 ) or workflow_state
     polling_active = bool(
-        (calibration_job and calibration_job.get("status") in {"queued", "running"})
+        (exact_calibration_job and exact_calibration_job.get("status") in {"queued", "starting", "running"})
+        or (
+            scope_activity
+            and scope_activity["job"].get("status") in {"queued", "starting", "running"}
+        )
         or (active_encode_job and active_encode_job.get("status") in {"queued", "retry_backoff", "running"})
         or (folder_scan_job and folder_scan_job.get("status") in {"queued", "running"})
     )
@@ -146,12 +167,36 @@ def folder_status_payload(
         "prefix": normalized_prefix,
         "media_scope": media_scope.to_payload(),
         "polling_active": polling_active,
-        "calibration_status": calibration_job.get("status") if calibration_job else "idle",
+        "calibration_status": legacy_calibration_job.get("status") if legacy_calibration_job else "idle",
+        "exact_calibration_status": exact_calibration_job.get("status") if exact_calibration_job else "idle",
+        "scope_activity_status": scope_activity["job"].get("status") if scope_activity else "idle",
         "folder_scan_status": folder_scan_job.get("status") if folder_scan_job else "idle",
-        "calibration_job": calibration_job,
+        "calibration_job": legacy_calibration_job,
+        "exact_calibration_job": exact_calibration_job,
+        "scope_activity": scope_activity,
         "retryable_sample_job": retryable_sample_job,
         "folder_scan_job": folder_scan_job,
         "workflow_state": workflow_state,
+    }
+
+
+def _scope_activity_payload(
+        route_prefix: str,
+        exact_job: dict[str, Any] | None,
+        overlapping_job: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if overlapping_job is None:
+        return None
+    if exact_job and overlapping_job.get("job_id") == exact_job.get("job_id"):
+        return None
+    owner_prefix = str(overlapping_job.get("prefix") or "")
+    relation = calibration_scope_relation(route_prefix, owner_prefix)
+    if relation not in {"ancestor", "descendant"}:
+        return None
+    return {
+        "schema_version": 1,
+        "relation": relation,
+        "job": overlapping_job,
     }
 
 

--- a/mediaforce/web/runtime/folder_actions.py
+++ b/mediaforce/web/runtime/folder_actions.py
@@ -102,6 +102,10 @@ def _high_impact_policy_change(current_policy: ActionPayload, draft_policy: Acti
             draft_video.get("max_encoded_percent")
     ):
         return True
+    if _normalized_number(current_video.get("target_search_max_crf")) != _normalized_number(
+            draft_video.get("target_search_max_crf")
+    ):
+        return True
     if _normalized_number(current_video.get("default_grain")) != _normalized_number(draft_video.get("default_grain")):
         return True
     return False
@@ -247,7 +251,7 @@ def queue_folder_encode_action(
                 detail="Confirm the older-season selection before starting production.",
             )
         existing_job = load_job_state(connection, config, normalized_prefix)
-        if existing_job and existing_job.get("status") in {"queued", "running", "pending_review"}:
+        if existing_job and existing_job.get("status") in {"queued", "starting", "running", "pending_review"}:
             return {"ok": False, "message": "A calibration job is already active for this folder."}
         calibration = load_calibration_state(config, normalized_prefix)
         gate = review_gate(calibration)
@@ -1282,6 +1286,7 @@ def save_profile_action(
         record_visual_approval_artifact: RecordVisualApprovalArtifactFn,
         merge_advice_state: MergeAdviceStateFn,
         upsert_override: UpsertOverrideFn,
+        load_latest_failed_target_size_job_state: LoadJobStateFn | None = None,
         confirm_high_impact: bool = False,
         confirm_size_tradeoff: bool = False,
         reviewed_draft_hash: str = "",
@@ -1370,6 +1375,20 @@ def save_profile_action(
                 status_code=409,
                 detail="This draft changed after the size tradeoff review. Review the result and confirm approval again.",
             )
+    latest_failed_sample_job = None
+    if load_latest_failed_target_size_job_state is not None:
+        with open_db(config.paths.db_path) as connection:
+            latest_failed_sample_job = load_latest_failed_target_size_job_state(
+                connection,
+                config,
+                normalized_prefix,
+            )
+        failed_target_reason = _failed_target_size_job_blocking_reason(
+            latest_failed_sample_job,
+            calibration_payload,
+        )
+        if failed_target_reason is not None:
+            raise HTTPException(status_code=409, detail=failed_target_reason)
     quality_risk_contract = build_quality_risk_contract(
         prefix=normalized_prefix,
         sample_item=object_dict(calibration_payload.get("sample_item")),
@@ -1378,6 +1397,7 @@ def save_profile_action(
         operator_request=operator_request or None,
         calibration=calibration_payload,
         advice_state=advice_state,
+        latest_failed_sample_job=latest_failed_sample_job,
     )
     blocking_reason = _quality_risk_blocking_reason(quality_risk_contract)
     if blocking_reason is not None:
@@ -1486,7 +1506,15 @@ def _failed_target_size_job_blocking_reason(
     result = object_dict(job_payload.get("result"))
     trace = object_dict(result.get("target_size_trace"))
     target_status = str(result.get("target_size_status") or trace.get("status") or "").strip().lower()
-    if target_status not in {"infeasible", "quality_conflict"}:
+    selection_reason = str(trace.get("selection_reason") or "").strip().lower()
+    if target_status == "infeasible" and selection_reason in {
+        "smallest_quality_safe_candidate_over_target_band",
+        "largest_quality_safe_candidate_under_target_band",
+        "target_lower_bound_exceeds_source_relative_cap",
+        "source_relative_cap_consumed_by_non_video_budget",
+    }:
+        target_status = "bound_exhausted"
+    if target_status not in {"infeasible", "bound_exhausted", "quality_conflict"}:
         return None
     accepted_at = _parse_state_timestamp(calibration.get("accepted_at"))
     failed_at = _parse_state_timestamp(
@@ -1500,6 +1528,12 @@ def _failed_target_size_job_blocking_reason(
         return (
             "The latest size-directed test found that this target cannot fit the required streams. "
             "Choose a different size and approve a fresh test before starting production."
+        )
+    if target_status == "bound_exhausted":
+        return (
+            "The latest size-directed test reached a configured search or source-size limit before it found this "
+            "target. "
+            "Choose updated settings and approve a fresh test before starting production."
         )
     return (
         "The latest size-directed test could not reach this target without crossing the quality floor. "

--- a/mediaforce/web/runtime/folder_ai_tuning.py
+++ b/mediaforce/web/runtime/folder_ai_tuning.py
@@ -585,7 +585,7 @@ def folder_ai_tune_preview_action(
     with open_db(config.paths.db_path) as connection:
         connection.exec_driver_sql("BEGIN IMMEDIATE")
         existing_job = deps.load_job_state(connection, config, normalized_prefix)
-        if existing_job and existing_job.get("status") in {"queued", "running", "pending_review"}:
+        if existing_job and existing_job.get("status") in {"queued", "starting", "running", "pending_review"}:
             return {"ok": False, "message": "A calibration job is already active for this folder."}
         latest_failed_sample_job_loader = deps.load_latest_failed_sample_job_state or deps.load_retryable_sample_job_state
         latest_failed_sample_job = _latest_failed_sample_job_payload(
@@ -606,7 +606,12 @@ def folder_ai_tune_preview_action(
         if cadence_blocker is not None:
             return cadence_blocker
         calibration = deps.load_calibration_state(config, normalized_prefix)
-        current_policy = object_dict(calibration.get("policy")) if calibration else object_dict(sample_item.get("resolved_policy"))
+        resolved_policy = object_dict(sample_item.get("resolved_policy"))
+        current_policy = (
+            merge_policy_fragments(resolved_policy, object_dict(calibration.get("policy")))
+            if calibration
+            else resolved_policy
+        )
     if object_dict(operator_intent):
         try:
             operator_request = operator_request_from_intent(
@@ -710,7 +715,7 @@ def folder_ai_tune_confirm_action(
     with open_db(config.paths.db_path) as connection:
         connection.exec_driver_sql("BEGIN IMMEDIATE")
         existing_job = deps.load_job_state(connection, config, normalized_prefix)
-        if existing_job and existing_job.get("status") in {"queued", "running", "pending_review"}:
+        if existing_job and existing_job.get("status") in {"queued", "starting", "running", "pending_review"}:
             return {"ok": False, "message": "A calibration job is already active for this folder."}
         sample_item = deps.sample_item(connection, config, normalized_prefix)
         if sample_item is None:
@@ -734,7 +739,12 @@ def folder_ai_tune_confirm_action(
         if action == "ai_tune" and calibration is None:
             return {"ok": False, "message": "The folder needs a first sample before the bench can tune a retry."}
 
-        policy_source = object_dict(calibration.get("policy")) if calibration else object_dict(sample_item.get("resolved_policy"))
+        resolved_policy = object_dict(sample_item.get("resolved_policy"))
+        policy_source = (
+            merge_policy_fragments(resolved_policy, object_dict(calibration.get("policy")))
+            if calibration
+            else resolved_policy
+        )
         final_policy = deps.apply_policy_fragment(policy_source, applied_policy)
         legacy_size_issue = _unconfirmed_legacy_size_issue(config, final_policy)
         if legacy_size_issue is not None:
@@ -850,7 +860,7 @@ def _retry_latest_sample_job(
         if existing_job is None:
             return {"ok": False, "message": "Ask the bench for a draft first."}
         status = str(existing_job.get("status") or "").strip()
-        if status in {"queued", "running", "pending_review"}:
+        if status in {"queued", "starting", "running", "pending_review"}:
             return {"ok": False, "message": "A calibration job is already active for this folder."}
         if status not in {"failed", "stopped"}:
             return {"ok": False, "message": "Ask the bench for a draft first."}
@@ -910,6 +920,8 @@ def _retry_latest_sample_job(
         }
         job_payload.pop("queue_position", None)
         job_payload.pop("queue_depth", None)
+        job_payload.pop("heartbeat_at", None)
+        job_payload.pop("progress", None)
         deps.save_job_state(connection, config, normalized_prefix, job_payload)
 
     return {
@@ -1187,7 +1199,12 @@ def _tuned_preview_action(
 ) -> dict[str, Any]:
     if not trimmed_note:
         raise HTTPException(status_code=400, detail="Add a note so the tuner knows what to change before running another sample.")
-    current_policy = object_dict(calibration.get("policy")) if calibration else object_dict(sample_item.get("resolved_policy"))
+    resolved_policy = object_dict(sample_item.get("resolved_policy"))
+    current_policy = (
+        merge_policy_fragments(resolved_policy, object_dict(calibration.get("policy")))
+        if calibration
+        else resolved_policy
+    )
     quality_risk_feedback_state = _persist_quality_risk_feedback(
         config,
         deps,

--- a/mediaforce/web/runtime/folder_tuning_helpers.py
+++ b/mediaforce/web/runtime/folder_tuning_helpers.py
@@ -18,7 +18,7 @@ def video_quality_improvement_change(current_video: dict[str, Any], preview_vide
         preview_value = _number_or_none(preview.get(key))
         if current_value is not None and preview_value is not None and preview_value > current_value + 0.01:
             return True
-    for key in ("min_crf", "max_crf", "grain_denoise", "preset"):
+    for key in ("min_crf", "max_crf", "target_search_max_crf", "grain_denoise", "preset"):
         current_value = _number_or_none(current.get(key))
         preview_value = _number_or_none(preview.get(key))
         if current_value is not None and preview_value is not None and preview_value < current_value - 0.01:
@@ -317,7 +317,14 @@ def proposal_alignment_issue(
         if tradeoff_issue is not None:
             return tradeoff_issue
         if not allow_measured_size_quality_tradeoff and not allow_evidence_backed_video_tradeoff:
-            for key in ("default_grain", "grain_denoise", "min_crf", "max_crf", "preset"):
+            for key in (
+                    "default_grain",
+                    "grain_denoise",
+                    "min_crf",
+                    "max_crf",
+                    "target_search_max_crf",
+                    "preset",
+            ):
                 if key in requested_video:
                     continue
                 current_value = current_video.get(key)
@@ -355,7 +362,14 @@ def proposal_alignment_issue(
             if tradeoff_issue is not None:
                 return tradeoff_issue
             if not allow_measured_size_quality_tradeoff and not allow_evidence_backed_video_tradeoff:
-                for key in ("default_grain", "grain_denoise", "min_crf", "max_crf", "preset"):
+                for key in (
+                        "default_grain",
+                        "grain_denoise",
+                        "min_crf",
+                        "max_crf",
+                        "target_search_max_crf",
+                        "preset",
+                ):
                     if key in requested_video:
                         continue
                     current_value = current_video.get(key)

--- a/mediaforce/web/runtime/job_runtime.py
+++ b/mediaforce/web/runtime/job_runtime.py
@@ -1,4 +1,5 @@
 import errno
+import hashlib
 import json
 import os
 import threading
@@ -15,9 +16,10 @@ from sqlalchemy import literal_column
 from sqlalchemy import select
 from sqlalchemy import update
 
-from mediaforce.tuning.calibration_jobs import claim_next_queued_calibration_job, load_latest_failed_sample_job, \
+from mediaforce.tuning.calibration_jobs import claim_next_queued_calibration_job, load_active_overlapping_job, \
+    load_latest_failed_sample_job, \
     load_latest_failed_target_size_sample_job, load_latest_job, load_latest_overlapping_job, \
-    load_latest_retryable_sample_job, load_latest_sample_job, queue_position, save_job
+    load_latest_retryable_sample_job, load_latest_sample_job, load_recent_completed_sample_jobs, queue_position, save_job
 from mediaforce.core.config import MediaforceConfig, load_config
 from mediaforce.core.db import DBClient, DBRow, open_db
 from mediaforce.core.db_tables import calibration_jobs
@@ -29,7 +31,7 @@ from mediaforce.library.background_work import background_work_is_paused
 from mediaforce.library.metadata_sync import sync_external_metadata
 from mediaforce.library.scanner import scan_library
 from mediaforce.state_cleanup import purge_transient_artifacts
-from mediaforce.core.type_defs import JSONValue, object_dict
+from mediaforce.core.type_defs import JSONValue, float_value, int_value, object_dict
 from mediaforce.web.runtime.worker_supervision import run_supervised_worker_loop
 
 _MISSING = object()
@@ -63,13 +65,265 @@ class CalibrationQueueRuntimeDeps:
     mark_calibration_submission_complete: Any
     register_calibration_process_controller: Any
     unregister_calibration_process_controller: Any
-    submission_cleanup_callback: Callable[[str], Callable[[Future[object]], None]]
+    submission_cleanup_callback: Callable[[MediaforceConfig, dict[str, Any]], Callable[[Future[object]], None]]
     calibration_submissions: set[str]
     calibration_submissions_lock: Any
     calibration_executors: dict[str, ThreadPoolExecutor]
     sample_calibration_concurrency: int
     full_calibration_concurrency: int
     calibration_queue_poll_seconds: float
+
+
+def calibration_job_public_payload(
+        connection: DBClient,
+        config: MediaforceConfig,
+        payload: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if payload is None:
+        return None
+    owner_prefix = str(payload.get("prefix") or "").strip()
+    if not owner_prefix:
+        return dict(payload)
+    scope = resolve_media_scope(
+        connection,
+        owner_prefix,
+        library_types=config.library_type_map,
+    )
+    return {
+        **payload,
+        "activity_scope": scope.to_payload(),
+        "target_contract": calibration_job_target_contract(payload),
+        "progress": calibration_job_progress_payload(connection, payload),
+    }
+
+
+def calibration_job_target_contract(payload: dict[str, Any]) -> dict[str, Any] | None:
+    video = object_dict(object_dict(payload.get("policy")).get("video"))
+    target_size_bytes = int_value(video.get("target_size_bytes"))
+    target_size_mb = float_value(video.get("target_size_mb"))
+    if target_size_bytes <= 0 and target_size_mb > 0:
+        target_size_bytes = round(target_size_mb * 1_000_000)
+    if target_size_bytes <= 0:
+        return None
+    max_height = int_value(video.get("max_height"))
+    resolution_mode = str(video.get("resolution_intent_mode") or "").strip()
+    if not resolution_mode:
+        resolution_mode = "source" if max_height <= 0 else "max_height"
+    return {
+        "schema_version": 1,
+        "target_size_bytes": target_size_bytes,
+        "mode": str(video.get("size_goal_mode") or "legacy"),
+        "source": str(video.get("size_goal_source") or "legacy"),
+        "target_runtime_minutes": float_value(video.get("target_runtime_minutes")) or None,
+        "sample_tolerance_percent": float_value(video.get("sample_projection_tolerance_percent")) or None,
+        "final_tolerance_percent": float_value(video.get("final_output_tolerance_percent")) or None,
+        "resolution_mode": resolution_mode,
+        "max_height": max_height if max_height > 0 else None,
+    }
+
+
+def calibration_scope_relation(route_prefix: str, owner_prefix: str) -> str | None:
+    normalized_route = route_prefix.strip("/")
+    normalized_owner = owner_prefix.strip("/")
+    if not normalized_route or not normalized_owner:
+        return None
+    if normalized_route == normalized_owner:
+        return "exact"
+    if normalized_route.startswith(f"{normalized_owner}/"):
+        return "ancestor"
+    if normalized_owner.startswith(f"{normalized_route}/"):
+        return "descendant"
+    return None
+
+
+def calibration_job_compatibility_key(payload: dict[str, Any]) -> str:
+    host = object_dict(payload.get("host"))
+    video = object_dict(object_dict(payload.get("policy")).get("video"))
+    sample_item = object_dict(payload.get("sample_item"))
+    height = int_value(sample_item.get("height"))
+    duration_seconds = float_value(sample_item.get("duration_seconds"))
+    width = int_value(sample_item.get("width"))
+    target_size_bytes = int_value(video.get("target_size_bytes"))
+    if target_size_bytes <= 0:
+        target_size_bytes = round(float_value(video.get("target_size_mb")) * 1_000_000)
+    signature = {
+        "schema_version": 2,
+        "pipeline": "sample-calibration-v1",
+        "host": str(host.get("key") or host.get("host") or host.get("label") or "local"),
+        "encoder": str(video.get("encoder") or ""),
+        "preset": str(video.get("preset") or video.get("speed") or ""),
+        "pixel_format": str(video.get("pixel_format") or ""),
+        "quality_engine": str(video.get("quality_engine") or ""),
+        "quality_metric": str(video.get("quality_metric") or ""),
+        "target_vmaf": float_value(video.get("target_vmaf")),
+        "target_xpsnr": float_value(video.get("target_xpsnr")),
+        "min_target_vmaf": float_value(video.get("min_target_vmaf")),
+        "min_target_xpsnr": float_value(video.get("min_target_xpsnr")),
+        "min_crf": int_value(video.get("min_crf")),
+        "max_crf": int_value(video.get("max_crf")),
+        "target_search_max_crf": int_value(video.get("target_search_max_crf")),
+        "max_encoded_percent": float_value(video.get("max_encoded_percent")),
+        "thorough": bool(video.get("thorough", False)),
+        "sample_every": str(video.get("sample_every") or ""),
+        "sample_duration": str(video.get("sample_duration") or ""),
+        "target_size_search": target_size_bytes > 0,
+        "target_size_bucket_mb": round(target_size_bytes / 25_000_000) * 25 if target_size_bytes > 0 else 0,
+        "source_codec": str(sample_item.get("video_codec") or ""),
+        "source_width_class": _resolution_class(width),
+        "resolution_class": _resolution_class(height),
+        "cadence_class": str(sample_item.get("cadence_class") or ""),
+        "runtime_bucket_minutes": round(duration_seconds / 900) * 15 if duration_seconds > 0 else 0,
+    }
+    encoded = json.dumps(signature, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+def calibration_job_progress_payload(
+        connection: DBClient,
+        payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    stored = object_dict(payload.get("progress"))
+    status = str(payload.get("status") or "").strip()
+    if not stored and status not in {"queued", "starting", "running"}:
+        return None
+    now = datetime.now(tz=UTC)
+    compatibility_key = str(stored.get("compatibility_key") or calibration_job_compatibility_key(payload))
+    heartbeat_at = _parse_job_timestamp(payload.get("heartbeat_at"))
+    started_at = _parse_job_timestamp(payload.get("started_at") or payload.get("created_at"))
+    finished_at = _parse_job_timestamp(payload.get("finished_at"))
+    active_status = status in {"starting", "running"}
+    terminal_elapsed_seconds = int_value(stored.get("total_elapsed_seconds"))
+    if terminal_elapsed_seconds <= 0 and started_at and finished_at and finished_at >= started_at:
+        terminal_elapsed_seconds = round((finished_at - started_at).total_seconds())
+    elapsed_seconds = (
+        max(0, round((now - started_at).total_seconds()))
+        if active_status and started_at
+        else terminal_elapsed_seconds or None
+    )
+    heartbeat_age_seconds = (
+        max(0, round((now - heartbeat_at).total_seconds()))
+        if active_status and heartbeat_at
+        else None
+    )
+    estimate = (
+        _calibration_history_estimate(
+            connection,
+            payload,
+            compatibility_key=compatibility_key,
+            elapsed_seconds=elapsed_seconds,
+        )
+        if status in {"queued", "starting", "running"}
+        else None
+    )
+    public_progress = {
+        **stored,
+        "schema_version": 1,
+        "compatibility_key": compatibility_key,
+        "elapsed_seconds": elapsed_seconds,
+        "estimate": estimate,
+    }
+    if status == "queued":
+        public_progress["liveness"] = "queued"
+    elif active_status:
+        if heartbeat_age_seconds is None:
+            public_progress["liveness"] = (
+                "starting" if elapsed_seconds is not None and elapsed_seconds <= 45 else "not_reporting"
+            )
+        elif heartbeat_age_seconds <= 15:
+            public_progress["liveness"] = "reporting"
+        elif heartbeat_age_seconds <= 45:
+            public_progress["liveness"] = "delayed"
+        else:
+            public_progress["liveness"] = "not_reporting"
+        public_progress["heartbeat_at"] = payload.get("heartbeat_at")
+        public_progress["heartbeat_age_seconds"] = heartbeat_age_seconds
+    else:
+        public_progress.pop("heartbeat_at", None)
+        public_progress.pop("heartbeat_age_seconds", None)
+        public_progress.pop("liveness", None)
+    return public_progress
+
+
+def _calibration_history_estimate(
+        connection: DBClient,
+        payload: dict[str, Any],
+        *,
+        compatibility_key: str,
+        elapsed_seconds: int | None,
+) -> dict[str, Any] | None:
+    if str(payload.get("status") or "") not in {"running", "starting"} or elapsed_seconds is None:
+        return None
+    durations = []
+    current_job_id = str(payload.get("job_id") or "")
+    for completed in load_recent_completed_sample_jobs(connection):
+        if str(completed.get("job_id") or "") == current_job_id:
+            continue
+        if calibration_job_compatibility_key(completed) != compatibility_key:
+            continue
+        started_at = _parse_job_timestamp(completed.get("started_at"))
+        finished_at = _parse_job_timestamp(completed.get("finished_at"))
+        if started_at is None or finished_at is None or finished_at <= started_at:
+            continue
+        durations.append((finished_at - started_at).total_seconds())
+    if len(durations) < 3:
+        return None
+    ordered = sorted(durations[:30])
+    total_low = _quantize_seconds(_percentile(ordered, 0.10), round_up=False)
+    total_high = _quantize_seconds(_percentile(ordered, 0.90), round_up=True)
+    total_high = max(total_high, total_low + 300)
+    return {
+        "kind": "historical_range",
+        "sample_size": len(ordered),
+        "remaining_seconds_low": max(0, total_low - elapsed_seconds),
+        "remaining_seconds_high": max(0, total_high - elapsed_seconds),
+        "total_seconds_low": total_low,
+        "total_seconds_high": total_high,
+        "longer_than_recent_runs": elapsed_seconds > total_high,
+        "confidence": "moderate" if len(ordered) >= 8 else "limited",
+        "basis": "Comparable completed tests on the same computer and encode profile",
+    }
+
+
+def _parse_job_timestamp(value: Any) -> datetime | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+
+def _resolution_class(height: int) -> str:
+    if height <= 0:
+        return "unknown"
+    if height <= 576:
+        return "sd"
+    if height <= 900:
+        return "720p"
+    if height <= 1440:
+        return "1080p"
+    return "uhd"
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    if len(values) == 1:
+        return values[0]
+    position = (len(values) - 1) * fraction
+    lower_index = int(position)
+    upper_index = min(lower_index + 1, len(values) - 1)
+    weight = position - lower_index
+    return values[lower_index] * (1 - weight) + values[upper_index] * weight
+
+
+def _quantize_seconds(value: float, *, round_up: bool) -> int:
+    step = 300 if value >= 900 else 60
+    units = value / step
+    whole_units = int(units)
+    if round_up and units > whole_units:
+        whole_units += 1
+    return max(step, whole_units * step)
 
 
 def load_job_state(
@@ -88,7 +342,7 @@ def load_overlapping_job_state(
         prefix: str,
         deps: JobRuntimeDeps,
 ) -> dict[str, Any] | None:
-    payload = load_latest_overlapping_job(connection, prefix)
+    payload = load_active_overlapping_job(connection, prefix) or load_latest_overlapping_job(connection, prefix)
     save_prefix = str(payload.get("prefix") or prefix) if payload is not None else prefix
     return _job_state_from_payload(connection, config, save_prefix, payload, deps)
 
@@ -143,6 +397,8 @@ def load_retryable_sample_job_state(
         if position is not None:
             payload["queue_position"] = position[0]
             payload["queue_depth"] = position[1]
+    if status in {"failed", "stopped"} and not retryable_saved_sample_job(payload):
+        return None
     if status in {"failed", "completed", "stopped"}:
         finished_at = deps.parse_iso(payload.get("finished_at") or payload.get("started_at") or payload.get("created_at"))
         if (
@@ -171,7 +427,16 @@ def load_latest_failed_target_size_job_state(
         deps: JobRuntimeDeps,
 ) -> dict[str, Any] | None:
     _ = config, deps
-    return load_latest_failed_target_size_sample_job(connection, prefix)
+    payload = load_latest_failed_target_size_sample_job(connection, prefix)
+    if payload is None:
+        return None
+    latest_sample_payload = load_latest_sample_job(connection, prefix)
+    if (
+            latest_sample_payload is not None
+            and str(latest_sample_payload.get("job_id") or "") != str(payload.get("job_id") or "")
+    ):
+        return None
+    return payload
 
 
 def save_job_state(
@@ -196,6 +461,11 @@ def retryable_saved_sample_job(job: dict[str, Any]) -> bool:
         return False
     mode = str(job.get("mode") or job.get("lane") or "sample").strip()
     if mode != "sample":
+        return False
+    result = object_dict(job.get("result"))
+    trace = object_dict(result.get("target_size_trace"))
+    target_status = str(result.get("target_size_status") or trace.get("status") or "").strip().lower()
+    if target_status in {"infeasible", "bound_exhausted", "quality_conflict"}:
         return False
     action = str(job.get("action") or "").strip()
     return action in {"baseline", "ai_tune"}
@@ -436,7 +706,7 @@ def dispatch_calibration_job(
         deps.mark_calibration_submission_complete(job_id)
         deps.unregister_calibration_process_controller(job_id)
         raise
-    future.add_done_callback(deps.submission_cleanup_callback(job_id))
+    future.add_done_callback(deps.submission_cleanup_callback(config, job_payload))
 
 
 def calibration_queue_worker_loop(
@@ -467,7 +737,7 @@ def process_calibration_queue_once(*, config_path: Any, deps: CalibrationQueueRu
                 calibration_jobs.c.prefix,
                 calibration_jobs.c.status,
             )
-            .where(calibration_jobs.c.status.in_(("running", "pending_review")))
+            .where(calibration_jobs.c.status.in_(("starting", "running", "pending_review")))
             .order_by(calibration_jobs.c.created_at, literal_column("rowid"))
         ).mappings().fetchall()
         running_by_lane = {lane: 0 for lane in capacities}
@@ -477,7 +747,7 @@ def process_calibration_queue_once(*, config_path: Any, deps: CalibrationQueueRu
             status = str(row["status"])
             prefix = str(row["prefix"])
             active_prefixes.add(prefix)
-            if status == "running" and lane in running_by_lane:
+            if status in {"starting", "running"} and lane in running_by_lane:
                 running_by_lane[lane] += 1
 
         for lane, capacity in capacities.items():

--- a/mediaforce/web/runtime/queue_actions.py
+++ b/mediaforce/web/runtime/queue_actions.py
@@ -201,13 +201,13 @@ def stop_calibration_queue_action(
     with connection_factory() as connection:
         active_rows = connection.execute(
             select(calibration_jobs.c.prefix)
-            .where(calibration_jobs.c.status.in_(("queued", "running")))
+            .where(calibration_jobs.c.status.in_(("queued", "starting", "running")))
             .order_by(calibration_jobs.c.created_at, literal_column("rowid"))
         ).mappings().fetchall()
         active_prefixes = [str(row["prefix"]) for row in active_rows]
         for prefix in active_prefixes:
             payload = load_job_state(connection, config, prefix)
-            if payload is None or str(payload.get("status") or "") not in {"queued", "running"}:
+            if payload is None or str(payload.get("status") or "") not in {"queued", "starting", "running"}:
                 continue
             save_job_state(
                 connection,

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -39,6 +39,8 @@ LEGACY_FIXTURE_SCAN_IDS = ("fixture-scan",)
 FOLDER_PREFIX = "tv/Example Show/Season 1"
 SAMPLING_PREFIX = "tv/Sampling Show/Season 1"
 RETRY_PREFIX = "tv/Retry Show/Season 1"
+SHARED_TEST_PREFIX = "tv/Shared Test Show/Season 1"
+SHARED_TEST_SERIES_PREFIX = "tv/Shared Test Show"
 COMPLETED_PREFIX = "movies/Archive Ready"
 BLOCKED_COMPLETED_PREFIX = "movies/Blocked Cleanup"
 REVIEW_READY_PREFIX = "tv/Review Ready/Season 1"
@@ -47,6 +49,7 @@ APPROVED_PREFIX = "tv/Approved Show/Season 1"
 MISSED_TARGET_PREFIX = "tv/Overshoot Show/Season 1"
 UNDER_TARGET_PREFIX = "tv/Undershoot Show/Season 1"
 INFEASIBLE_PREFIX = "tv/Infeasible Goal/Season 1"
+BOUND_EXHAUSTED_PREFIX = "tv/Search Limit/Season 1"
 QUALITY_CONFLICT_PREFIX = "tv/Quality Conflict/Season 1"
 ENCODE_RUNNING_PREFIX = "tv/Encoding Show/Season 1"
 ENCODE_RETRY_PREFIX = "tv/Failed Encode/Season 1"
@@ -75,6 +78,7 @@ FIXTURE_PREFIXES = (
     FOLDER_PREFIX,
     SAMPLING_PREFIX,
     RETRY_PREFIX,
+    SHARED_TEST_PREFIX,
     COMPLETED_PREFIX,
     BLOCKED_COMPLETED_PREFIX,
     REVIEW_READY_PREFIX,
@@ -83,6 +87,7 @@ FIXTURE_PREFIXES = (
     MISSED_TARGET_PREFIX,
     UNDER_TARGET_PREFIX,
     INFEASIBLE_PREFIX,
+    BOUND_EXHAUSTED_PREFIX,
     QUALITY_CONFLICT_PREFIX,
     ENCODE_RUNNING_PREFIX,
     ENCODE_RETRY_PREFIX,
@@ -287,6 +292,11 @@ def _job(
     sample_item: dict[str, Any],
     error: str | None = None,
     result: dict[str, Any] | None = None,
+    created_at: str | None = None,
+    started_at: str | None = None,
+    heartbeat_at: str | None = None,
+    finished_at: str | None = None,
+    progress: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     timestamp = _now()
     return {
@@ -301,13 +311,33 @@ def _job(
         "sample_item_json": json.dumps(sample_item, sort_keys=True),
         "result_json": json.dumps(result, sort_keys=True) if result is not None else None,
         "error": error,
-        "created_at": timestamp,
-        "started_at": timestamp if status in {"running", "failed", "stopped"} else None,
-        "finished_at": timestamp
-        if status in {"failed", "stopped", "completed"}
-        else None,
+        "created_at": created_at or timestamp,
+        "started_at": started_at
+        if started_at is not None
+        else timestamp if status in {"running", "failed", "stopped"} else None,
+        "heartbeat_at": heartbeat_at,
+        "progress_json": json.dumps(progress, sort_keys=True) if progress is not None else None,
+        "finished_at": finished_at
+        if finished_at is not None
+        else timestamp if status in {"failed", "stopped", "completed"} else None,
         "updated_at": timestamp,
     }
+
+
+def _policy_with_target(policy: dict[str, Any], target_size_mb: float) -> dict[str, Any]:
+    resolved = json.loads(json.dumps(policy))
+    video = resolved.setdefault("video", {})
+    video.update(
+        {
+            "target_size_mb": target_size_mb,
+            "target_size_bytes": round(target_size_mb * 1_000_000),
+            "size_goal_mode": "absolute",
+            "size_goal_source": "operator",
+            "resolution_intent_mode": "source",
+            "target_runtime_minutes": 45,
+        }
+    )
+    return resolved
 
 
 def _target_search_failure(status: str, selection_reason: str) -> dict[str, Any]:
@@ -935,6 +965,17 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
             _library_item(
                 project_root=project_root,
                 media_root="tv",
+                rel_path="tv/Search Limit/Season 1/Episode 01.mkv",
+                size_bytes=7 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=81,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture target-search bound state for browser QA.",
+            ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
                 rel_path="tv/Encoding Show/Season 1/Episode 01.mkv",
                 size_bytes=9 * 1024**3,
                 status="approved",
@@ -1216,6 +1257,17 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 recommendation_reason="Fixture Other promotion state for browser QA.",
                 age_days=760,
             ),
+            _library_item(
+                project_root=project_root,
+                media_root="tv",
+                rel_path="tv/Shared Test Show/Season 1/Episode 01.mkv",
+                size_bytes=7 * 1024**3,
+                status="discovered",
+                video_codec="h264",
+                priority_score=84,
+                recommendation="priority_encode",
+                recommendation_reason="Fixture show-level sample shown from a season route.",
+            ),
         ]
         rows.extend(
             _library_item(
@@ -1437,6 +1489,11 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
         )
 
         policy = config.resolve_policy(rows[0]["rel_path"])
+        sampling_policy = _policy_with_target(policy, 225)
+        retry_policy = _policy_with_target(policy, 225)
+        fixture_now = datetime.now(UTC)
+        active_started_at = (fixture_now - timedelta(minutes=15)).isoformat(timespec="seconds")
+        heartbeat_at = fixture_now.isoformat(timespec="seconds")
         for item_id, row, job in (
             (
                 inserted_ids[4],
@@ -1449,7 +1506,20 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                         "library_item_id": inserted_ids[4],
                         **rows[4],
                         "source_size_bytes": rows[4]["size_bytes"],
-                        "resolved_policy": policy,
+                        "resolved_policy": sampling_policy,
+                    },
+                    started_at=active_started_at,
+                    heartbeat_at=heartbeat_at,
+                    progress={
+                        "schema_version": 1,
+                        "stage": "building_review",
+                        "stage_started_at": (
+                            fixture_now - timedelta(minutes=3)
+                        ).isoformat(timespec="seconds"),
+                        "last_progress_at": (
+                            fixture_now - timedelta(seconds=20)
+                        ).isoformat(timespec="seconds"),
+                        "work": {"completed": 2, "total": 3},
                     },
                 ),
             ),
@@ -1464,7 +1534,7 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                         "library_item_id": inserted_ids[5],
                         **rows[5],
                         "source_size_bytes": rows[5]["size_bytes"],
-                        "resolved_policy": policy,
+                        "resolved_policy": retry_policy,
                     },
                     error="Fixture sample failed so retry state is inspectable.",
                 ),
@@ -1513,9 +1583,102 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                     ),
                 ),
             ),
+            (
+                ids_by_rel_path["tv/Search Limit/Season 1/Episode 01.mkv"],
+                rows_by_prefix[BOUND_EXHAUSTED_PREFIX],
+                _job(
+                    job_id="web-smoke-bound-exhausted",
+                    prefix=BOUND_EXHAUSTED_PREFIX,
+                    status="failed",
+                    sample_item={
+                        "library_item_id": ids_by_rel_path[
+                            "tv/Search Limit/Season 1/Episode 01.mkv"
+                        ],
+                        **rows_by_prefix[BOUND_EXHAUSTED_PREFIX],
+                        "source_size_bytes": rows_by_prefix[BOUND_EXHAUSTED_PREFIX]["size_bytes"],
+                        "resolved_policy": policy,
+                    },
+                    error="The configured target-size search bound was exhausted.",
+                    result=_target_search_failure(
+                        "bound_exhausted",
+                        "smallest_quality_safe_candidate_over_target_band",
+                    ),
+                ),
+            ),
         ):
             _ = item_id, row
             connection.execute(calibration_jobs.insert().values(**job))
+
+        sampling_sample_item = {
+            "library_item_id": inserted_ids[4],
+            **rows[4],
+            "source_size_bytes": rows[4]["size_bytes"],
+            "resolved_policy": sampling_policy,
+        }
+        for index, duration_minutes in enumerate((20, 30, 40), start=1):
+            history_started = fixture_now - timedelta(days=index, minutes=duration_minutes)
+            history_finished = history_started + timedelta(minutes=duration_minutes)
+            connection.execute(
+                calibration_jobs.insert().values(
+                    **_job(
+                        job_id=f"web-smoke-sampling-history-{index}",
+                        prefix=f"tv/Sampling History {index}/Season 1",
+                        status="completed",
+                        sample_item=sampling_sample_item,
+                        created_at=history_started.isoformat(timespec="seconds"),
+                        started_at=history_started.isoformat(timespec="seconds"),
+                        finished_at=history_finished.isoformat(timespec="seconds"),
+                    )
+                )
+            )
+
+        shared_row = rows_by_prefix[SHARED_TEST_PREFIX]
+        shared_id = ids_by_rel_path[str(shared_row["rel_path"])]
+        shared_sample_item = {
+            "library_item_id": shared_id,
+            **shared_row,
+            "source_size_bytes": shared_row["size_bytes"],
+            "resolved_policy": _policy_with_target(policy, 314.6),
+        }
+        stale_started = fixture_now - timedelta(minutes=45)
+        stale_finished = fixture_now - timedelta(minutes=30)
+        connection.execute(
+            calibration_jobs.insert().values(
+                **_job(
+                    job_id="web-smoke-shared-stale-season",
+                    prefix=SHARED_TEST_PREFIX,
+                    status="completed",
+                    sample_item=shared_sample_item,
+                    created_at=stale_started.isoformat(timespec="seconds"),
+                    started_at=stale_started.isoformat(timespec="seconds"),
+                    finished_at=stale_finished.isoformat(timespec="seconds"),
+                )
+            )
+        )
+        shared_sample_item["resolved_policy"] = sampling_policy
+        connection.execute(
+            calibration_jobs.insert().values(
+                **_job(
+                    job_id="web-smoke-shared-show-active",
+                    prefix=SHARED_TEST_SERIES_PREFIX,
+                    status="starting",
+                    sample_item=shared_sample_item,
+                    created_at=active_started_at,
+                    started_at=active_started_at,
+                    heartbeat_at=heartbeat_at,
+                    progress={
+                        "schema_version": 1,
+                        "stage": "searching_target",
+                        "stage_started_at": (
+                            fixture_now - timedelta(minutes=8)
+                        ).isoformat(timespec="seconds"),
+                        "last_progress_at": (
+                            fixture_now - timedelta(seconds=10)
+                        ).isoformat(timespec="seconds"),
+                    },
+                )
+            )
+        )
 
         encode_rows = [
             _encode_job(
@@ -1693,13 +1856,19 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 "label": "Folder Studio sampling fixture",
                 "route": "/folders/tv/Sampling%20Show/Season%201",
                 "marker": "Sampling Show",
-                "stageMarker": "Making your test",
+                "stageMarker": "ESTIMATED REMAINING",
+            },
+            {
+                "label": "Folder Studio shared-scope sample fixture",
+                "route": "/folders/tv/Shared%20Test%20Show/Season%201",
+                "marker": "Shared Test Show",
+                "stageMarker": "A show-level sample is running",
             },
             {
                 "label": "Folder Studio retry fixture",
                 "route": "/folders/tv/Retry%20Show/Season%201",
                 "marker": "Retry Show",
-                "stageMarker": "The test stopped",
+                "stageMarker": "Retry same test",
             },
             {
                 "label": "Completed cleanup fixture",
@@ -1764,6 +1933,12 @@ def seed(config_path: Path, *, profile: str = "default") -> dict[str, Any]:
                 "route": "/folders/tv/Quality%20Conflict/Season%201",
                 "marker": "Quality Conflict",
                 "stageMarker": "This size conflicts with the quality floor",
+            },
+            {
+                "label": "Folder Studio target-search-bound fixture",
+                "route": "/folders/tv/Search%20Limit/Season%201",
+                "marker": "Search Limit",
+                "stageMarker": "The test reached a configured limit",
             },
             {
                 "label": "Folder Studio active processing fixture",

--- a/tests/test_db_runtime.py
+++ b/tests/test_db_runtime.py
@@ -27,7 +27,7 @@ from mediaforce.core.type_defs import object_dict
 from mediaforce.encoding.cadence import cadence_policy_snapshot
 from mediaforce.encoding.fingerprint import media_fingerprint_policy_snapshot
 
-CURRENT_DB_REVISION = "20260719_0014"
+CURRENT_DB_REVISION = "20260719_0015"
 
 
 class DatabaseRuntimeTests(unittest.TestCase):
@@ -137,6 +137,36 @@ class DatabaseRuntimeTests(unittest.TestCase):
             self.assertEqual(version, CURRENT_DB_REVISION)
             self.assertEqual(stored["prefix"], "tv/show")
             self.assertIn("idx_encode_jobs_status_retry_ready", indexes)
+
+    def test_open_db_adds_calibration_progress_columns_to_previous_revision(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "library.sqlite3"
+            with open_db(db_path):
+                pass
+            reset_engine_cache()
+
+            raw_connection = sqlite3.connect(db_path)
+            try:
+                raw_connection.execute("ALTER TABLE calibration_jobs DROP COLUMN heartbeat_at")
+                raw_connection.execute("ALTER TABLE calibration_jobs DROP COLUMN progress_json")
+                raw_connection.execute(
+                    "UPDATE alembic_version SET version_num = ?",
+                    ("20260719_0014",),
+                )
+                raw_connection.commit()
+            finally:
+                raw_connection.close()
+
+            with open_db(db_path) as connection:
+                version = connection.execute(select(alembic_version.c.version_num)).scalar_one()
+                calibration_columns = {
+                    str(column["name"])
+                    for column in inspect(connection).get_columns("calibration_jobs")
+                }
+
+            self.assertEqual(version, CURRENT_DB_REVISION)
+            self.assertIn("heartbeat_at", calibration_columns)
+            self.assertIn("progress_json", calibration_columns)
 
     def test_open_db_supports_sqlalchemy_mapping_results(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -13,6 +13,7 @@ import threading
 import tomllib
 import unittest
 from collections.abc import Mapping
+from concurrent.futures import Future
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -55,7 +56,8 @@ from mediaforce.remote import HostStatus
 from mediaforce.tuning.calibration_jobs import list_queue_summary, \
     load_active_overlapping_job as load_active_overlapping_calibration_job, \
     load_latest_job as load_latest_calibration_job, \
-    load_latest_overlapping_job as load_latest_overlapping_calibration_job
+    load_latest_overlapping_job as load_latest_overlapping_calibration_job, \
+    save_job as save_calibration_job, update_job_telemetry as update_calibration_job_telemetry
 from mediaforce.review import BrowserReviewClip, CompareClip, EncodedPreviewClip
 from mediaforce.reviewing.helpers import ReviewMoment
 from mediaforce.web import app as web_app
@@ -5961,6 +5963,48 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 select(func.count()).select_from(encode_jobs).where(encode_jobs.c.prefix == "tv/show")
             )
         self.assertEqual(queued_count, 0)
+
+    def test_save_profile_action_blocks_current_failed_target_search_before_approval(self) -> None:
+        calibration_payload: folder_actions_runtime.ActionPayload = {
+            "mode": "sample",
+            "job_id": "failed-target-sample",
+            "review_media_ready": True,
+            "policy": {"video": {"target_vmaf": 85.0, "target_size_bytes": 225_000_000}},
+            "sample_item": {
+                "library_item_id": 1,
+                "resolved_policy": {"video": {"target_vmaf": 85.0, "target_size_bytes": 225_000_000}},
+            },
+        }
+
+        with self.assertRaises(HTTPException) as exc:
+            folder_actions_runtime.save_profile_action(
+                self.config,
+                "tv/show",
+                now_iso=web_app._now_iso,
+                load_sample_item=lambda *_args, **_kwargs: None,
+                load_calibration_state=lambda *_args, **_kwargs: dict(calibration_payload),
+                calibration_draft_hash=web_app._calibration_draft_hash,
+                save_calibration_state=lambda *_args, **_kwargs: None,
+                load_advice_state=lambda *_args, **_kwargs: None,
+                record_visual_approval_artifact=lambda *_args, **_kwargs: None,
+                merge_advice_state=lambda *_args, **_kwargs: {},
+                upsert_override=web_app._upsert_override,
+                load_latest_failed_target_size_job_state=lambda *_args, **_kwargs: {
+                    "job_id": "failed-target-sample",
+                    "status": "failed",
+                    "finished_at": web_app._now_iso(),
+                    "result": {
+                        "target_size_status": "infeasible",
+                        "target_size_trace": {
+                            "status": "infeasible",
+                            "selection_reason": "smallest_quality_safe_candidate_over_target_band",
+                        },
+                    },
+                },
+            )
+
+        self.assertEqual(exc.exception.status_code, 409)
+        self.assertIn("configured search or source-size limit", str(exc.exception.detail))
 
     def test_retry_failed_encode_queue_action_retries_latest_approved_failures_only(self) -> None:
         with open_db(self.config.paths.db_path) as connection:
@@ -15322,13 +15366,49 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         payload = dashboard_payloads.folder_status_payload(
             self.config,
             "tv/show",
-            load_job_state=web_app._load_overlapping_job_state,
+            load_exact_job_state=web_app._load_job_state,
+            load_overlapping_job_state=web_app._load_overlapping_job_state,
             load_retryable_sample_job_state=web_app._load_retryable_sample_job_state,
             load_scan_status=web_app._load_scan_status,
             load_active_encode_job_for_prefix=load_active_encode_job_for_prefix,
         )
 
         self.assertTrue(payload["polling_active"])
+
+    def test_submission_cleanup_marks_escaped_calibration_task_failed(self) -> None:
+        now = web_app._now_iso()
+        with open_db(self.config.paths.db_path) as connection:
+            save_calibration_job(
+                connection,
+                {
+                    "job_id": "escaped-calibration-task",
+                    "prefix": "tv/show",
+                    "status": "running",
+                    "lane": "sample",
+                    "action": "ai_tune",
+                    "host": {"key": "local"},
+                    "policy": {},
+                    "sample_item": {},
+                    "owner_pid": os.getpid(),
+                    "created_at": now,
+                    "started_at": now,
+                    "updated_at": now,
+                },
+            )
+
+        future: Future[object] = Future()
+        future.set_exception(RuntimeError("worker escaped"))
+        web_app._submission_cleanup_callback(
+            self.config,
+            {"job_id": "escaped-calibration-task", "prefix": "tv/show"},
+        )(future)
+
+        with open_db(self.config.paths.db_path) as connection:
+            stored = load_latest_calibration_job(connection, "tv/show")
+
+        self.assertEqual(stored["status"], "failed")
+        self.assertEqual(stored["error"], "worker escaped")
+        self.assertIsNotNone(stored["finished_at"])
 
     def test_folder_status_payload_polls_while_descendant_calibration_is_active(self) -> None:
         now = web_app._now_iso()
@@ -15354,7 +15434,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         payload = dashboard_payloads.folder_status_payload(
             self.config,
             "tv/show",
-            load_job_state=web_app._load_overlapping_job_state,
+            load_exact_job_state=web_app._load_job_state,
+            load_overlapping_job_state=web_app._load_overlapping_job_state,
             load_retryable_sample_job_state=web_app._load_retryable_sample_job_state,
             load_scan_status=web_app._load_scan_status,
             load_active_encode_job_for_prefix=load_active_encode_job_for_prefix,
@@ -15362,7 +15443,183 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
         self.assertTrue(payload["polling_active"])
         self.assertEqual(payload["calibration_status"], "running")
+        self.assertEqual(payload["exact_calibration_status"], "idle")
+        self.assertEqual(payload["scope_activity_status"], "running")
         self.assertEqual(payload["calibration_job"]["job_id"], "descendant-calibration-active")
+        self.assertEqual(payload["scope_activity"]["relation"], "descendant")
+        self.assertEqual(payload["scope_activity"]["job"]["job_id"], "descendant-calibration-active")
+
+    def test_folder_status_separates_active_show_test_from_stale_season_result(self) -> None:
+        now = datetime.now(tz=UTC)
+        older = (now - timedelta(minutes=10)).isoformat(timespec="seconds")
+        newer = now.isoformat(timespec="seconds")
+        source = self._create_source_file("scope-target.mkv")
+        with open_db(self.config.paths.db_path) as connection:
+            self._insert_library_item(
+                connection,
+                source,
+                rel_path="tv/show/Season 1/scope-target.mkv",
+            )
+            for job_id, prefix, status, target_size_mb, timestamp in (
+                    ("stale-season-test", "tv/show/Season 1", "completed", 314.6, newer),
+                    ("active-show-test", "tv/show", "running", 225, older),
+            ):
+                save_calibration_job(
+                    connection,
+                    {
+                        "job_id": job_id,
+                        "prefix": prefix,
+                        "status": status,
+                        "lane": "sample",
+                        "action": "ai_tune",
+                        "host": {"key": "local", "label": "This Mac"},
+                        "policy": {
+                            "video": {
+                                "target_size_mb": target_size_mb,
+                                "size_goal_mode": "absolute",
+                            }
+                        },
+                        "sample_item": {"height": 1080, "duration_seconds": 2700},
+                        "owner_pid": os.getpid(),
+                        "created_at": timestamp,
+                        "started_at": timestamp,
+                        "finished_at": timestamp if status == "completed" else None,
+                        "updated_at": timestamp,
+                    },
+                )
+
+        payload = dashboard_payloads.folder_status_payload(
+            self.config,
+            "tv/show/Season 1",
+            load_exact_job_state=web_app._load_job_state,
+            load_overlapping_job_state=web_app._load_overlapping_job_state,
+            load_retryable_sample_job_state=web_app._load_retryable_sample_job_state,
+            load_scan_status=web_app._load_scan_status,
+            load_active_encode_job_for_prefix=load_active_encode_job_for_prefix,
+        )
+
+        self.assertEqual(payload["exact_calibration_job"]["job_id"], "stale-season-test")
+        self.assertEqual(payload["exact_calibration_job"]["target_contract"]["target_size_bytes"], 314_600_000)
+        self.assertEqual(payload["scope_activity"]["relation"], "ancestor")
+        self.assertEqual(payload["scope_activity"]["job"]["job_id"], "active-show-test")
+        self.assertEqual(payload["scope_activity"]["job"]["target_contract"]["target_size_bytes"], 225_000_000)
+
+    def test_calibration_progress_uses_comparable_history_for_eta_range(self) -> None:
+        now = datetime.now(tz=UTC)
+        policy = {
+            "video": {
+                "encoder": "libsvtav1",
+                "preset": 4,
+                "pixel_format": "yuv420p10le",
+                "sample_every": "8m",
+                "sample_duration": "10s",
+                "target_size_mb": 225,
+            }
+        }
+        sample_item = {"height": 1080, "duration_seconds": 2700}
+        with open_db(self.config.paths.db_path) as connection:
+            for index, duration_seconds in enumerate((1200, 1800, 2400), start=1):
+                started_at = now - timedelta(days=index, seconds=duration_seconds)
+                finished_at = started_at + timedelta(seconds=duration_seconds)
+                save_calibration_job(
+                    connection,
+                    {
+                        "job_id": f"history-{index}",
+                        "prefix": f"tv/history/Season {index}",
+                        "status": "completed",
+                        "lane": "sample",
+                        "action": "ai_tune",
+                        "host": {"key": "local"},
+                        "policy": policy,
+                        "sample_item": sample_item,
+                        "created_at": started_at.isoformat(timespec="seconds"),
+                        "started_at": started_at.isoformat(timespec="seconds"),
+                        "finished_at": finished_at.isoformat(timespec="seconds"),
+                        "updated_at": finished_at.isoformat(timespec="seconds"),
+                    },
+                )
+            active_started_at = now - timedelta(minutes=10)
+            save_calibration_job(
+                connection,
+                {
+                    "job_id": "active-history-test",
+                    "prefix": "tv/show",
+                    "status": "running",
+                    "lane": "sample",
+                    "action": "ai_tune",
+                    "host": {"key": "local"},
+                    "policy": policy,
+                    "sample_item": sample_item,
+                    "owner_pid": os.getpid(),
+                    "created_at": active_started_at.isoformat(timespec="seconds"),
+                    "started_at": active_started_at.isoformat(timespec="seconds"),
+                    "heartbeat_at": now.isoformat(timespec="seconds"),
+                    "progress": {
+                        "schema_version": 1,
+                        "stage": "searching_target",
+                        "last_progress_at": now.isoformat(timespec="seconds"),
+                    },
+                    "updated_at": now.isoformat(timespec="seconds"),
+                },
+            )
+            update_calibration_job_telemetry(
+                connection,
+                "active-history-test",
+                heartbeat_at=now.isoformat(timespec="seconds"),
+                progress={
+                    "schema_version": 1,
+                    "stage": "searching_target",
+                    "last_progress_at": now.isoformat(timespec="seconds"),
+                },
+            )
+            active = load_latest_calibration_job(connection, "tv/show")
+            public = job_runtime.calibration_job_public_payload(connection, self.config, active)
+
+        estimate = public["progress"]["estimate"]
+        self.assertEqual(public["progress"]["liveness"], "reporting")
+        self.assertEqual(estimate["kind"], "historical_range")
+        self.assertEqual(estimate["sample_size"], 3)
+        self.assertGreater(estimate["remaining_seconds_high"], estimate["remaining_seconds_low"])
+        self.assertFalse(estimate["longer_than_recent_runs"])
+
+    def test_terminal_calibration_progress_drops_live_eta_and_liveness(self) -> None:
+        now = datetime.now(tz=UTC)
+        with open_db(self.config.paths.db_path) as connection:
+            save_calibration_job(
+                connection,
+                {
+                    "job_id": "completed-progress-test",
+                    "prefix": "tv/show",
+                    "status": "completed",
+                    "lane": "sample",
+                    "action": "ai_tune",
+                    "host": {"key": "local"},
+                    "policy": {"video": {"target_size_mb": 225}},
+                    "sample_item": {"height": 1080, "duration_seconds": 2700},
+                    "created_at": (now - timedelta(minutes=20)).isoformat(timespec="seconds"),
+                    "started_at": (now - timedelta(minutes=20)).isoformat(timespec="seconds"),
+                    "finished_at": (now - timedelta(minutes=5)).isoformat(timespec="seconds"),
+                    "updated_at": (now - timedelta(minutes=5)).isoformat(timespec="seconds"),
+                },
+            )
+            update_calibration_job_telemetry(
+                connection,
+                "completed-progress-test",
+                heartbeat_at=(now - timedelta(minutes=5)).isoformat(timespec="seconds"),
+                progress={
+                    "schema_version": 1,
+                    "stage": "completed",
+                    "liveness": "reporting",
+                    "total_elapsed_seconds": 900,
+                },
+            )
+            completed = load_latest_calibration_job(connection, "tv/show")
+            public = job_runtime.calibration_job_public_payload(connection, self.config, completed)
+
+        self.assertEqual(public["progress"]["elapsed_seconds"], 900)
+        self.assertIsNone(public["progress"]["estimate"])
+        self.assertNotIn("liveness", public["progress"])
+        self.assertNotIn("heartbeat_at", public["progress"])
 
     def test_latest_calibration_lookup_matches_overlapping_series_and_season_scopes(self) -> None:
         older = (datetime.now(tz=UTC) - timedelta(seconds=5)).isoformat(timespec="seconds")
@@ -15457,7 +15714,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         payload = dashboard_payloads.folder_status_payload(
             self.config,
             "tv/show",
-            load_job_state=web_app._load_job_state,
+            load_exact_job_state=web_app._load_job_state,
+            load_overlapping_job_state=web_app._load_overlapping_job_state,
             load_retryable_sample_job_state=web_app._load_retryable_sample_job_state,
             load_scan_status=web_app._load_scan_status,
             load_active_encode_job_for_prefix=load_active_encode_job_for_prefix,
@@ -15483,7 +15741,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         payload = dashboard_payloads.folder_status_payload(
             self.config,
             "other/Foo.mkv",
-            load_job_state=lambda _connection, _config, _prefix: None,
+            load_exact_job_state=lambda _connection, _config, _prefix: None,
+            load_overlapping_job_state=lambda _connection, _config, _prefix: None,
             load_retryable_sample_job_state=lambda _connection, _config, _prefix: None,
             load_scan_status=lambda _connection, _config, _prefix: None,
             load_active_encode_job_for_prefix=lambda _connection, _prefix: None,
@@ -17625,6 +17884,55 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(latest_payload["job_id"], "completed-sample-job")
         self.assertIsNone(retryable_payload)
 
+    def test_load_retryable_sample_job_state_hides_deterministic_target_failure(self) -> None:
+        prefix = "tv/show/season-1-target-bound"
+        finished_at = (datetime.now(tz=UTC) - timedelta(minutes=1)).isoformat()
+        with open_db(self.config.paths.db_path) as connection:
+            connection.execute(
+                calibration_jobs.insert().values(
+                    job_id="bound-exhausted-sample-job",
+                    prefix=prefix,
+                    status="failed",
+                    lane="sample",
+                    action="ai_tune",
+                    host_json=json.dumps({"key": "cbusillo@localhost", "label": "M4 Studio"}, sort_keys=True),
+                    notes="225 MB per episode",
+                    policy_json=json.dumps({"video": {"target_size_bytes": 225_000_000}}, sort_keys=True),
+                    sample_item_json=json.dumps({"rel_path": "tv/show/season-1/episode.mkv"}, sort_keys=True),
+                    result_json=json.dumps(
+                        {
+                            "target_size_status": "bound_exhausted",
+                            "target_size_trace": {
+                                "status": "bound_exhausted",
+                                "selection_reason": "smallest_quality_safe_candidate_over_target_band",
+                            },
+                        },
+                        sort_keys=True,
+                    ),
+                    created_at=finished_at,
+                    started_at=finished_at,
+                    finished_at=finished_at,
+                    updated_at=finished_at,
+                    error="The configured target-size search bound was exhausted.",
+                )
+            )
+
+            latest_payload = web_app._load_job_state(connection, self.config, prefix)
+            retryable_payload = web_app._load_retryable_sample_job_state(connection, self.config, prefix)
+            failed_target_payload = web_app._load_latest_failed_target_size_job_state(
+                connection,
+                self.config,
+                prefix,
+            )
+
+        self.assertIsNotNone(latest_payload)
+        assert latest_payload is not None
+        self.assertEqual(latest_payload["job_id"], "bound-exhausted-sample-job")
+        self.assertIsNone(retryable_payload)
+        self.assertIsNotNone(failed_target_payload)
+        assert failed_target_payload is not None
+        self.assertEqual(failed_target_payload["job_id"], "bound-exhausted-sample-job")
+
     def test_load_latest_failed_sample_job_state_keeps_context_after_newer_sample_run(self) -> None:
         prefix = "tv/show/season-1-bench-failure-context"
         older_finished_at = (
@@ -17642,6 +17950,16 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                     notes="what can we do about the failure?",
                     policy_json=json.dumps({"video": {"target_vmaf": 97.0}}, sort_keys=True),
                     sample_item_json=json.dumps({"rel_path": "tv/show/season-1/episode.mkv"}, sort_keys=True),
+                    result_json=json.dumps(
+                        {
+                            "target_size_status": "bound_exhausted",
+                            "target_size_trace": {
+                                "status": "bound_exhausted",
+                                "selection_reason": "smallest_quality_safe_candidate_over_target_band",
+                            },
+                        },
+                        sort_keys=True,
+                    ),
                     created_at=older_finished_at,
                     started_at=older_finished_at,
                     finished_at=older_finished_at,
@@ -17670,8 +17988,14 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
             retryable_payload = web_app._load_retryable_sample_job_state(connection, self.config, prefix)
             failed_payload = web_app._load_latest_failed_sample_job_state(connection, self.config, prefix)
+            failed_target_payload = web_app._load_latest_failed_target_size_job_state(
+                connection,
+                self.config,
+                prefix,
+            )
 
         self.assertIsNone(retryable_payload)
+        self.assertIsNone(failed_target_payload)
         self.assertIsNotNone(failed_payload)
         assert failed_payload is not None
         self.assertEqual(failed_payload["job_id"], "failed-sample-job")

--- a/tests/test_quality_risk.py
+++ b/tests/test_quality_risk.py
@@ -165,10 +165,35 @@ class QualityRiskContractTests(unittest.TestCase):
         self.assertEqual(public["verdict"], "request_comparison")
         self.assertEqual(public["target_size_search"]["status"], "quality_conflict")
         self.assertEqual(public["target_size_search"]["selected_crf"], 31.0)
+        self.assertEqual(public["target_size_search"]["configured_max_crf"], 38)
+        self.assertEqual(public["target_size_search"]["search_max_crf"], 63)
+        self.assertTrue(public["target_size_search"]["range_expanded"])
+        self.assertTrue(public["target_size_search"]["measured_beyond_configured"])
         self.assertNotIn("candidates", public["target_size_search"])
         self.assertIn(
             "softness_detail_loss",
             [risk["tag"] for risk in public["typed_risks"]],
+        )
+
+    def test_source_cap_consumed_by_preserved_streams_is_a_deterministic_blocker(self) -> None:
+        sample = self._sample()
+        sample["stream_budget_ledger"] = {
+            "feasibility": {"status": "feasible"},
+            "source_relative_cap": {"status": "arithmetically_infeasible"},
+        }
+
+        contract = build_quality_risk_contract(
+            prefix="tv/House/Season 2",
+            sample_item=sample,
+            current_policy={"video": {"target_vmaf": 90.0}},
+            preview_policy={"video": {"target_vmaf": 90.0}},
+            calibration={"job_id": "job-current", "sample_result": {}},
+        )
+
+        self.assertTrue(contract["deterministic_gates"]["blocked"])
+        self.assertIn(
+            "The preserved streams consume the configured source-size cap.",
+            contract["deterministic_gates"]["blocking_reasons"],
         )
 
     def test_old_failed_target_trace_does_not_block_newer_successful_calibration(self) -> None:
@@ -406,6 +431,15 @@ class QualityRiskContractTests(unittest.TestCase):
                 "sample_upper_bound_bytes": 247_500_000,
             },
             "quality_floor": {"metric": "VMAF", "minimum": 85.0},
+            "crf_bounds": {
+                "min_crf": 18,
+                "configured_max_crf": 38,
+                "search_max_crf": 63,
+                "max_crf": 63,
+                "range_expanded": True,
+                "measured_beyond_configured": True,
+                "selected_beyond_configured": False,
+            },
             "curve": {"shape": "monotonic", "candidate_count": 4, "max_candidates": 6},
             "transform_plan": transform_plan,
             "selected_candidate": {

--- a/tests/test_stream_budget.py
+++ b/tests/test_stream_budget.py
@@ -161,7 +161,7 @@ class StreamBudgetTests(unittest.TestCase):
         self.assertEqual(ledger.remaining_video_bytes, -1_000_001)
         self.assertEqual(ledger.feasibility_status, "arithmetically_infeasible")
 
-    def test_small_positive_budget_is_aggressive_but_measurable(self) -> None:
+    def test_small_positive_budget_remains_measurable_without_source_ratio_judgment(self) -> None:
         ledger = self._ledger(
             target_bytes=250_000_000,
             source_size_bytes=4_000_000_000,
@@ -176,8 +176,8 @@ class StreamBudgetTests(unittest.TestCase):
         )
 
         self.assertGreater(ledger.remaining_video_bytes or 0, 0)
-        self.assertEqual(ledger.feasibility_status, "aggressive_but_measurable")
-        self.assertIn("target_at_or_below_10_percent_of_source", ledger.feasibility_reasons)
+        self.assertEqual(ledger.feasibility_status, "feasible")
+        self.assertEqual(ledger.feasibility_reasons, ())
 
     def test_missing_runtime_keeps_bitrate_unknown(self) -> None:
         ledger = self._ledger(
@@ -407,6 +407,47 @@ class StreamBudgetTests(unittest.TestCase):
         self.assertIn("0:t?", command)
         self.assertIn("-c:t", command)
         self.assertEqual(ledger.stream_plan.plan_id, StreamBudgetLedger.from_payload(ledger.to_payload()).stream_plan.plan_id)
+
+    def test_target_search_ceiling_is_explicit_and_legacy_jobs_keep_their_saved_bound(self) -> None:
+        ledger = self._ledger(
+            audio={
+                "index": 1,
+                "codec_name": "aac",
+                "channels": 2,
+                "language": "eng",
+                "default": 1,
+                "bit_rate": 128_000,
+            }
+        )
+        expected = QualitySearchResult(
+            crf=45.0,
+            metric="VMAF",
+            target=85.0,
+            score=91.0,
+            stdout="target-size-search",
+        )
+        for configured_ceiling, expected_ceiling in ((63, 63), (None, 38)):
+            policy = dict(self._policy()["video"])
+            if configured_ceiling is not None:
+                policy["target_search_max_crf"] = configured_ceiling
+            with self.subTest(configured_ceiling=configured_ceiling), patch(
+                "mediaforce.encoding.quality_search.search_target_size",
+                return_value=expected,
+            ) as search_target_size_mock:
+                result = quality_search.search_quality(
+                    Path("/tmp/input.mkv"),
+                    policy,
+                    stream_budget_ledger=ledger,
+                    host_media_access_for_host=Mock(return_value="mounted"),
+                    select_quality_metric=Mock(return_value=("vmaf", 85.0)),
+                    build_svt_params=Mock(return_value=[]),
+                    effective_video_preset=Mock(return_value=4),
+                    run_crf_search=Mock(),
+                    run_sample_encode=Mock(),
+                )
+
+                self.assertIs(result, expected)
+                self.assertEqual(search_target_size_mock.call_args.kwargs["search_max_crf"], expected_ceiling)
 
     def test_retry_measurement_reuses_quality_search_context(self) -> None:
         sample = SampleEncodeResult(

--- a/tests/test_target_size_search.py
+++ b/tests/test_target_size_search.py
@@ -106,7 +106,7 @@ class TargetSizeSearchTests(unittest.TestCase):
         self.assertEqual(trace["best_reachable_candidate"]["predicted_whole_episode_bytes"], 332_000_000)
         self.assertIn("quality floor", str(context.exception).lower())
 
-    def test_source_cap_below_target_band_is_infeasible_without_sampling(self) -> None:
+    def test_source_cap_below_target_band_reports_bound_exhaustion_without_sampling(self) -> None:
         ledger = self._ledger(target_bytes=300_000_000, source_size_bytes=1_000_000_000, max_encoded_percent=20)
         calls = 0
 
@@ -140,8 +140,93 @@ class TargetSizeSearchTests(unittest.TestCase):
             )
 
         self.assertEqual(calls, 0)
-        self.assertEqual(context.exception.status, "infeasible")
+        self.assertEqual(context.exception.status, "bound_exhausted")
         self.assertEqual(context.exception.trace["selection_reason"], "target_lower_bound_exceeds_source_relative_cap")
+
+    def test_size_search_expands_beyond_configured_crf_range_when_measurements_require_it(self) -> None:
+        ledger = self._ledger(target_bytes=225_000_000, source_size_bytes=3_000_000_000)
+        seen: list[int] = []
+
+        def run_sample(_source_path: Path, *, crf: float, **_: Any) -> SampleEncodeResult:
+            crf_int = int(crf)
+            seen.append(crf_int)
+            predicted_video_bytes = max(50_000_000, 2_025_000_000 - 40_000_000 * crf_int)
+            return SampleEncodeResult(
+                "VMAF",
+                94.0 - max(0, crf_int - 38) * 0.2,
+                predicted_video_bytes / 30_000_000,
+                30.0,
+                predicted_video_bytes,
+                f"crf {crf_int}",
+            )
+
+        result = search_target_size(
+            Path("/tmp/source.mkv"),
+            self._policy(),
+            source_codec="h264",
+            metric_name="vmaf",
+            metric_target=85.0,
+            min_metric_score=80.0,
+            preset=4,
+            pixel_format="yuv420p10le",
+            sample_every="8m",
+            sample_duration="20s",
+            min_crf=18,
+            max_crf=38,
+            search_max_crf=63,
+            svt_params=[],
+            video_filter=None,
+            stream_budget_ledger=ledger,
+            transform_plan=self._transform_plan(),
+            process_controller=None,
+            host=None,
+            quality_temp_dir=None,
+            run_sample_encode=run_sample,
+        )
+
+        self.assertEqual(result.crf, 45.0)
+        self.assertIn(45, seen)
+        trace = result.target_size_trace or {}
+        self.assertEqual(trace["crf_bounds"]["configured_max_crf"], 38)
+        self.assertEqual(trace["crf_bounds"]["search_max_crf"], 63)
+        self.assertTrue(trace["crf_bounds"]["range_expanded"])
+        self.assertTrue(trace["crf_bounds"]["measured_beyond_configured"])
+        self.assertTrue(trace["crf_bounds"]["selected_beyond_configured"])
+
+    def test_legacy_target_search_without_explicit_ceiling_preserves_saved_bound(self) -> None:
+        ledger = self._ledger(target_bytes=225_000_000, source_size_bytes=3_000_000_000)
+        seen: list[int] = []
+
+        with self.assertRaises(TargetSizeSearchError) as context:
+            search_target_size(
+                Path("/tmp/source.mkv"),
+                self._policy(),
+                source_codec="h264",
+                metric_name="vmaf",
+                metric_target=85.0,
+                min_metric_score=80.0,
+                preset=4,
+                pixel_format="yuv420p10le",
+                sample_every="8m",
+                sample_duration="20s",
+                min_crf=18,
+                max_crf=38,
+                svt_params=[],
+                video_filter=None,
+                stream_budget_ledger=ledger,
+                transform_plan=self._transform_plan(),
+                process_controller=None,
+                host=None,
+                quality_temp_dir=None,
+                run_sample_encode=lambda _path, *, crf, **_kwargs: (
+                    seen.append(int(crf))
+                    or SampleEncodeResult("VMAF", 92.0, 50.0, 30.0, 500_000_000, "")
+                ),
+            )
+
+        self.assertEqual(context.exception.status, "bound_exhausted")
+        self.assertLessEqual(max(seen), 38)
+        self.assertFalse(context.exception.trace["crf_bounds"]["range_expanded"])
 
     def test_arithmetic_impossible_budget_reports_structured_infeasibility(self) -> None:
         ledger = self._ledger(target_bytes=3_000_000, source_size_bytes=1_000_000_000)
@@ -177,7 +262,14 @@ class TargetSizeSearchTests(unittest.TestCase):
 
     def test_non_monotonic_curve_exhausts_bounded_search_as_needs_review(self) -> None:
         ledger = self._ledger(target_bytes=300_000_000, source_size_bytes=1_000_000_000)
-        sizes = {31: 100_000_000, 18: 500_000_000, 24: 360_000_000, 28: 370_000_000, 30: 380_000_000, 29: 390_000_000}
+        sizes = {
+            18: 500_000_000,
+            24: 360_000_000,
+            28: 370_000_000,
+            30: 380_000_000,
+            31: 100_000_000,
+            38: 400_000_000,
+        }
 
         with self.assertRaises(TargetSizeSearchError) as context:
             search_target_size(

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -60,7 +60,8 @@ from mediaforce.tuning.tuning_memory import (
 )
 from mediaforce.tuning.quality_risk import build_quality_risk_contract, quality_risk_public_view, \
     with_quality_risk_intent
-from mediaforce.tuning.calibration_jobs import load_latest_failed_target_size_sample_job, save_job
+from mediaforce.tuning.calibration_jobs import load_job, load_latest_failed_target_size_sample_job, save_job, \
+    update_job_telemetry
 from mediaforce.tuning.target_size_search import TargetSizeSearchError
 from mediaforce.web.app import (
     _advice_file,
@@ -602,6 +603,8 @@ class TuningRuntimeTests(unittest.TestCase):
             "started_at": "2026-04-11T15:18:10+00:00",
             "finished_at": "2026-04-11T15:18:21+00:00",
             "updated_at": "2026-04-11T15:18:21+00:00",
+            "heartbeat_at": "2026-04-11T15:18:20+00:00",
+            "progress": {"schema_version": 1, "stage": "searching_quality"},
             "error": "Calibration queue job was stopped and cleaned up.",
         }
 
@@ -656,6 +659,8 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIsNone(saved_jobs[0]["finished_at"])
         self.assertIsNone(saved_jobs[0]["error"])
         self.assertIsNone(saved_jobs[0]["result"])
+        self.assertNotIn("heartbeat_at", saved_jobs[0])
+        self.assertNotIn("progress", saved_jobs[0])
         self.assertNotEqual(saved_jobs[0]["job_id"], retryable_job["job_id"])
 
     def test_saved_sample_work_blocks_unconfirmed_legacy_size_goal(self) -> None:
@@ -3987,10 +3992,10 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(request["request_type"], "size_budget")
         self.assertTrue(request["operator_confirmed"])
         self.assertEqual(request["budget_label"], "200 MB per episode")
-        self.assertEqual(request["feasibility"], "aggressive_but_measurable")
+        self.assertEqual(request["feasibility"], "feasible")
         self.assertEqual(
             request["stream_budget_ledger"]["feasibility"]["status"],
-            "aggressive_but_measurable",
+            "feasible",
         )
         self.assertFalse(request["requires_confirmation"])
         self.assertFalse(request["hard_size_cap"])
@@ -4111,7 +4116,7 @@ class TuningRuntimeTests(unittest.TestCase):
         assert request is not None
         self.assertEqual(request["request_type"], "combined_experiment")
         self.assertEqual(request["evidence_authority"], "operator_observed")
-        self.assertEqual(request["feasibility"], "aggressive_but_measurable")
+        self.assertEqual(request["feasibility"], "feasible")
         self.assertEqual(request["scale_height"], 0)
 
     def test_operator_requested_experiment_preserves_visual_rejection(self) -> None:
@@ -4402,7 +4407,7 @@ class TuningRuntimeTests(unittest.TestCase):
         )
 
         assert request is not None
-        self.assertEqual(request["feasibility"], "aggressive_but_measurable")
+        self.assertEqual(request["feasibility"], "feasible")
         self.assertFalse(request["requires_confirmation"])
 
     def test_folder_ai_tune_preview_uses_calibration_policy_for_operator_budget_request(self) -> None:
@@ -4654,6 +4659,12 @@ class TuningRuntimeTests(unittest.TestCase):
                 "max_height": 1080,
             }
         }
+        resolved_policy = {
+            "video": {
+                **base_policy["video"],
+                "target_search_max_crf": 63,
+            }
+        }
         sample_item = {
             "rel_path": "tv/show/episode.mkv",
             "source_path": str(self.root / "source" / "tv" / "show" / "episode.mkv"),
@@ -4662,7 +4673,7 @@ class TuningRuntimeTests(unittest.TestCase):
             "duration_seconds": 5279.774,
             "audio_summary": [],
             "subtitle_summary": [],
-            "resolved_policy": dict(base_policy),
+            "resolved_policy": resolved_policy,
         }
         operator_request = {
             "request_type": "combined_experiment",
@@ -4794,7 +4805,7 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertEqual(proposal["applied_policy"], expected_fragment)
         self.assertEqual(
             proposal["preview_policy"],
-            {"video": {**base_policy["video"], **expected_fragment["video"]}},
+            {"video": {**resolved_policy["video"], **expected_fragment["video"]}},
         )
 
         deps.load_pending_proposal = lambda *_args, **_kwargs: proposal
@@ -4808,6 +4819,7 @@ class TuningRuntimeTests(unittest.TestCase):
 
         self.assertTrue(confirm_result["ok"])
         self.assertEqual(saved_jobs[0]["policy"], proposal["preview_policy"])
+        self.assertEqual(saved_jobs[0]["policy"]["video"]["target_search_max_crf"], 63)
 
     def test_folder_ai_tune_preview_applies_size_target_when_seed_worker_fails(self) -> None:
         saved_proposals: list[dict[str, Any]] = []
@@ -5578,7 +5590,13 @@ class TuningRuntimeTests(unittest.TestCase):
             "duration_seconds": 2400.0,
             "audio_summary": [{"codec_name": "eac3", "channels": 6}],
             "subtitle_summary": [],
-            "resolved_policy": {"video": {"target_vmaf": 95.0, "max_encoded_percent": 30}},
+            "resolved_policy": {
+                "video": {
+                    "target_vmaf": 95.0,
+                    "max_encoded_percent": 30,
+                    "target_search_max_crf": 63,
+                }
+            },
         }
         host = HostStatus(
             key="host-1",
@@ -5666,6 +5684,7 @@ class TuningRuntimeTests(unittest.TestCase):
 
         self.assertTrue(result["ok"])
         self.assertEqual(len(captured_payloads), 1)
+        self.assertEqual(saved_proposals[0]["current_policy"]["video"]["target_search_max_crf"], 63)
         latest_failed = captured_payloads[0]["latest_failed_sample_job"]
         self.assertIsInstance(latest_failed, dict)
         assert isinstance(latest_failed, dict)
@@ -7863,6 +7882,55 @@ class TuningRuntimeTests(unittest.TestCase):
         self.assertIsNotNone(job)
         self.assertEqual(job["job_id"], "target-failed")
 
+    def test_calibration_job_telemetry_round_trips(self) -> None:
+        timestamp = "2026-07-19T23:50:00+00:00"
+        with open_db(self.config.paths.db_path) as connection:
+            save_job(
+                connection,
+                {
+                    "job_id": "telemetry-job",
+                    "prefix": "tv/show/Season 1",
+                    "status": "running",
+                    "lane": "sample",
+                    "action": "ai_tune",
+                    "host": {"key": "local"},
+                    "policy": {"video": {"target_size_mb": 225}},
+                    "sample_item": {"height": 1080, "duration_seconds": 2700},
+                    "created_at": timestamp,
+                    "started_at": timestamp,
+                    "updated_at": timestamp,
+                },
+            )
+            update_job_telemetry(
+                connection,
+                "telemetry-job",
+                heartbeat_at=timestamp,
+                progress={
+                    "schema_version": 1,
+                    "stage": "building_review",
+                    "work": {"completed": 2, "total": 3},
+                },
+            )
+            stored = load_job(connection, "telemetry-job")
+            assert stored is not None
+            save_job(
+                connection,
+                {
+                    **stored,
+                    "status": "completed",
+                    "finished_at": timestamp,
+                    "updated_at": timestamp,
+                },
+            )
+            stored = load_job(connection, "telemetry-job")
+
+        self.assertIsNotNone(stored)
+        assert stored is not None
+        self.assertEqual(stored["status"], "completed")
+        self.assertEqual(stored["heartbeat_at"], timestamp)
+        self.assertEqual(stored["progress"]["stage"], "building_review")
+        self.assertEqual(stored["progress"]["work"], {"completed": 2, "total": 3})
+
     def test_run_calibration_job_records_storage_recovery_failure_before_sampling(self) -> None:
         saved_payloads: list[dict[str, object]] = []
         sample_item = Mock()
@@ -7878,6 +7946,9 @@ class TuningRuntimeTests(unittest.TestCase):
             load_job_state=lambda *_args, **_kwargs: {"job_id": "job-1", "status": "queued"},
             sample_item=sample_item,
             save_job_state=lambda _connection, _config, _prefix, payload: saved_payloads.append(dict(payload)),
+            update_job_telemetry=lambda *_args, **_kwargs: None,
+            calibration_job_compatibility_key=lambda _payload: "test-profile",
+            calibration_heartbeat_seconds=60.0,
             save_calibration_state=lambda *_args, **_kwargs: None,
             record_run_verdict=lambda *_args, **_kwargs: None,
             summarize_calibration_result=lambda payload: payload,
@@ -7939,6 +8010,9 @@ class TuningRuntimeTests(unittest.TestCase):
                 "duration_seconds": 120.0,
             },
             save_job_state=_save_job_state,
+            update_job_telemetry=lambda *_args, **_kwargs: None,
+            calibration_job_compatibility_key=lambda _payload: "test-profile",
+            calibration_heartbeat_seconds=60.0,
             save_calibration_state=lambda *_args, **_kwargs: None,
             record_run_verdict=lambda *_args, **_kwargs: None,
             summarize_calibration_result=lambda payload: payload,
@@ -8017,6 +8091,9 @@ class TuningRuntimeTests(unittest.TestCase):
                 "subtitle_summary": [],
             },
             save_job_state=lambda _connection, _config, _prefix, payload: saved_payloads.append(dict(payload)),
+            update_job_telemetry=lambda *_args, **_kwargs: None,
+            calibration_job_compatibility_key=lambda _payload: "test-profile",
+            calibration_heartbeat_seconds=60.0,
             save_calibration_state=lambda *_args, **_kwargs: None,
             record_run_verdict=lambda *_args, **_kwargs: None,
             summarize_calibration_result=lambda payload: payload,
@@ -8100,6 +8177,9 @@ class TuningRuntimeTests(unittest.TestCase):
             load_job_state=lambda *_args, **_kwargs: {"job_id": "job-1", "status": "queued", "sample_item": dict(saved_sample_item)},
             sample_item=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not reselect sample item")),
             save_job_state=_save_job_state,
+            update_job_telemetry=lambda *_args, **_kwargs: None,
+            calibration_job_compatibility_key=lambda _payload: "test-profile",
+            calibration_heartbeat_seconds=60.0,
             save_calibration_state=lambda *_args, **_kwargs: None,
             record_run_verdict=lambda *_args, **_kwargs: None,
             summarize_calibration_result=lambda payload: payload,
@@ -8228,6 +8308,9 @@ class TuningRuntimeTests(unittest.TestCase):
             load_job_state=lambda *_args, **_kwargs: dict(job),
             sample_item=lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("saved sample required")),
             save_job_state=save_job_state,
+            update_job_telemetry=lambda *_args, **_kwargs: None,
+            calibration_job_compatibility_key=lambda _payload: "test-profile",
+            calibration_heartbeat_seconds=60.0,
             save_calibration_state=lambda *_args, **_kwargs: None,
             record_run_verdict=lambda *_args, **_kwargs: None,
             summarize_calibration_result=lambda payload: payload,


### PR DESCRIPTION
## Summary
- stabilize Activity refresh state and add durable calibration progress, ETA, scope, and recovery context
- separate the initial CRF range from the explicit target-size search ceiling, with legacy replay compatibility and typed bound/quality/arithmetic outcomes
- route deterministic failures to fresh size/settings review, suppress misleading retries, and publish actionable failed-search context to Folder Studio
- add migration, browser fixtures, documentation, and regression coverage across backend and frontend paths

## Validation
- `bash scripts/pre-commit-check.sh` (1,037 backend tests, 224 frontend tests, typecheck, lint, build, package, CLI, desktop/narrow route smoke)
- real browser review at 1024px and 390px
- Big Brother (US) real-media job `f037388e86f2`: CRF 53, predicted 239.2 MB inside the 202.5–247.5 MB band, VMAF 85.90, 543 seconds
- JetBrains inspection reported zero findings but was inconclusive for Svelte/SQL semantic coverage because those plugins were unavailable

## Planning
- completes #231
- completes #232
- completes #233
- completes #234