### PR TITLE
Add focused full-screen media comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,12 @@ series instead of one season.
 
 Folder calibration now uses a size-first review flow by default. The checked-in
 defaults aim for roughly 300 MB per 45-minute episode at up to 1080p, then use
-sampled metrics as guardrails and visual review clips as the operator decision
-point. The first size note is measured before it becomes a ceiling; once a
+sampled metrics as guardrails and representative picture-and-sound clips as the
+operator decision point. The comparison can open in a focused full-screen
+workspace with side-by-side and instant Original/New views, shared playback,
+and actual-size inspection. Technical encoding evidence remains under Details,
+and approval stays on the calm folder page. The first size note is measured
+before it becomes a ceiling; once a
 follow-up target lands above the band, the next sample draft carries the learned
 size ceiling forward instead of repeating the oversized run. The current fast
 sample engine is still `ab-av1`; scene-aware engine work is tracked separately so

--- a/docs/development/browser-qa-matrix.md
+++ b/docs/development/browser-qa-matrix.md
@@ -68,7 +68,8 @@ The managed smoke seeds a compact but non-empty workflow dataset:
   deterministic target-search-bound failure that explains why the saved retry
   would repeat and routes the operator to a fresh settings review.
 - Review-ready state: `/folders/tv/Review%20Ready/Season%201`, with retained
-  review media, explicit target/band/sample-byte facts, and picture/sound risk.
+  review media, explicit target/band/sample-byte facts, picture/sound risk, and
+  trustworthy sound metadata for the focused comparison workspace.
 - Absolute-target state: `/folders/tv/Absolute%20Goal/Season%201`, proving an
   explicit 225 MB episode goal remains 225 MB for an 88-minute episode.
 - Under- and over-target states: `/folders/tv/Undershoot%20Show/Season%201` and
@@ -204,6 +205,14 @@ must say that the size goal was not met before presenting review media. It must
 distinguish review-clip byte savings from the full-episode estimate, make another
 same-target measured test the primary action, and require an explicit warning
 that accepting the tradeoff saves the profile and queues the full folder encode.
+
+When review media is ready, `Compare in full screen` must open paused in `Side by
+side` and `Fit`. `One at a time` must switch between `Original` and `New` without
+changing the selected moment, playback position, or picture position. Sound
+controls appear only when both clips carry trustworthy sound metadata; legacy or
+silent clips must say they show picture only and offer a plain-language path to
+make a new test when the source has sound. The normal UI must not expose codec,
+quality-score, synchronization, or other implementation vocabulary.
 
 While the review assistant or a representative sample is active, the first
 Folder Studio viewport must show a prominent live-operation state with the

--- a/frontend/src/lib/components/season/ComparisonWorkspace.svelte
+++ b/frontend/src/lib/components/season/ComparisonWorkspace.svelte
@@ -1,0 +1,1073 @@
+<script lang="ts">
+	import { onMount, tick } from 'svelte';
+
+	import {
+		alignedScrollOffset,
+		comparisonKeyboardAction,
+		formatPlaybackTime,
+		frameAspectRatio,
+		normalizedScrollPosition,
+		reviewPairHasSound,
+		scrollOffsetForPosition,
+		type ComparisonLayout,
+		type ComparisonScale,
+		type ComparisonSide
+	} from '$lib/season/comparison';
+	import type { ReviewPair } from '$lib/season/experience';
+
+	let {
+		pairs,
+		selectedMoment,
+		audioChoice,
+		episodeLabel,
+		originalSizeLabel,
+		newSizeLabel,
+		canMakeSoundTest,
+		soundTestDisabled,
+		onMomentChange,
+		onAudioChange,
+		onRequestSoundTest
+	}: {
+		pairs: ReviewPair[];
+		selectedMoment: number;
+		audioChoice: ComparisonSide;
+		episodeLabel: string;
+		originalSizeLabel: string;
+		newSizeLabel: string;
+		canMakeSoundTest: boolean;
+		soundTestDisabled: boolean;
+		onMomentChange: (index: number) => void;
+		onAudioChange: (side: ComparisonSide) => void;
+		onRequestSoundTest: () => void;
+	} = $props();
+
+	let workspaceElement = $state<HTMLElement | null>(null);
+	let sourceVideo = $state<HTMLVideoElement | null>(null);
+	let previewVideo = $state<HTMLVideoElement | null>(null);
+	let sourcePane = $state<HTMLElement | null>(null);
+	let previewPane = $state<HTMLElement | null>(null);
+	let closeButton = $state<HTMLButtonElement | null>(null);
+	let returnFocus = $state<HTMLElement | null>(null);
+	let isOpen = $state(false);
+	let nativeFullscreen = $state(false);
+	let layout = $state<ComparisonLayout>('side_by_side');
+	let visibleSide = $state<ComparisonSide>('new');
+	let scale = $state<ComparisonScale>('fit');
+	let playing = $state(false);
+	let preparing = $state(false);
+	let playbackError = $state('');
+	let currentTime = $state(0);
+	let duration = $state(0);
+	let sourceWidth = $state(0);
+	let sourceHeight = $state(0);
+	let previewWidth = $state(0);
+	let previewHeight = $state(0);
+	let previousBodyOverflow = '';
+	let scrollSyncPending = false;
+	let picturePositionX = 0.5;
+	let picturePositionY = 0.5;
+
+	const currentPair = $derived(pairs[Math.min(selectedMoment, pairs.length - 1)]);
+	const hasSound = $derived(reviewPairHasSound(currentPair));
+	const sourceFrameWidth = $derived(sourceWidth || previewWidth || 1920);
+	const sourceFrameHeight = $derived(sourceHeight || previewHeight || 1080);
+	const previewFrameWidth = $derived(previewWidth || sourceWidth || 1920);
+	const previewFrameHeight = $derived(previewHeight || sourceHeight || 1080);
+	const frameAspect = $derived(frameAspectRatio(sourceFrameWidth, sourceFrameHeight));
+	const workspaceTitle = $derived(hasSound ? 'Compare picture and sound' : 'Compare picture');
+	const timeText = $derived(`${formatPlaybackTime(currentTime)} / ${formatPlaybackTime(duration)}`);
+	const workspaceStyle = $derived(`--frame-aspect:${frameAspect}`);
+	const sourceFrameStyle = $derived(
+		`--media-width:${sourceFrameWidth}px;--media-height:${sourceFrameHeight}px`
+	);
+	const previewFrameStyle = $derived(
+		`--media-width:${previewFrameWidth}px;--media-height:${previewFrameHeight}px`
+	);
+	const pairKey = $derived(`${currentPair?.source.path ?? ''}|${currentPair?.preview.path ?? ''}`);
+
+	$effect(() => {
+		if (!pairKey) return;
+		pauseBoth();
+		currentTime = 0;
+		duration = currentPair?.preview.durationSeconds || currentPair?.source.durationSeconds || 0;
+		sourceWidth = 0;
+		sourceHeight = 0;
+		previewWidth = 0;
+		previewHeight = 0;
+		picturePositionX = 0.5;
+		picturePositionY = 0.5;
+		void tick().then(() => {
+			sourceVideo?.load();
+			previewVideo?.load();
+		});
+	});
+
+	onMount(() => {
+		const handleFullscreenChange = () => {
+			if (nativeFullscreen && document.fullscreenElement !== workspaceElement) finishClose();
+		};
+		document.addEventListener('fullscreenchange', handleFullscreenChange);
+		return () => {
+			document.removeEventListener('fullscreenchange', handleFullscreenChange);
+			document.body.style.overflow = previousBodyOverflow;
+		};
+	});
+
+	function chooseMoment(index: number) {
+		pauseBoth();
+		onMomentChange(index);
+	}
+
+	function chooseSound(side: ComparisonSide) {
+		if (!hasSound) return;
+		onAudioChange(side);
+	}
+
+	function showSide(side: ComparisonSide) {
+		chooseLayout('one_at_a_time');
+		visibleSide = side;
+		schedulePicturePosition();
+	}
+
+	function chooseLayout(nextLayout: ComparisonLayout) {
+		layout = nextLayout;
+		schedulePicturePosition();
+	}
+
+	function chooseScale(nextScale: ComparisonScale) {
+		scale = nextScale;
+		if (nextScale === 'actual') schedulePicturePosition();
+	}
+
+	function openWorkspace(event: MouseEvent) {
+		returnFocus = event.currentTarget as HTMLElement;
+		layout = 'side_by_side';
+		visibleSide = 'new';
+		scale = 'fit';
+		picturePositionX = 0.5;
+		picturePositionY = 0.5;
+		playbackError = '';
+		pauseBoth();
+		isOpen = true;
+		previousBodyOverflow = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		const fullscreenRequest = workspaceElement?.requestFullscreen?.();
+		if (fullscreenRequest) {
+			void fullscreenRequest
+				.then(() => (nativeFullscreen = true))
+				.catch(() => (nativeFullscreen = false));
+		}
+		void tick().then(() => closeButton?.focus());
+	}
+
+	async function closeWorkspace() {
+		if (document.fullscreenElement === workspaceElement) {
+			await document.exitFullscreen().catch(() => undefined);
+		}
+		finishClose();
+	}
+
+	function finishClose() {
+		if (!isOpen) return;
+		pauseBoth();
+		isOpen = false;
+		nativeFullscreen = false;
+		document.body.style.overflow = previousBodyOverflow;
+		void tick().then(() => returnFocus?.focus());
+	}
+
+	async function togglePlayback() {
+		if (!sourceVideo || !previewVideo) return;
+		playbackError = '';
+		if (!previewVideo.paused) {
+			pauseBoth();
+			return;
+		}
+		if (previewVideo.ended || previewVideo.currentTime >= previewVideo.duration) seekTo(0);
+		sourceVideo.currentTime = previewVideo.currentTime;
+		preparing = true;
+		try {
+			await Promise.all([sourceVideo.play(), previewVideo.play()]);
+			playing = true;
+		} catch {
+			pauseBoth();
+			playbackError = 'The clips could not start together. Try again.';
+		} finally {
+			preparing = false;
+		}
+	}
+
+	function pauseBoth() {
+		sourceVideo?.pause();
+		previewVideo?.pause();
+		playing = false;
+	}
+
+	function seekTo(value: number) {
+		const next = Math.min(Math.max(value, 0), duration || value);
+		if (sourceVideo) sourceVideo.currentTime = next;
+		if (previewVideo) previewVideo.currentTime = next;
+		currentTime = next;
+	}
+
+	function handleTimeline(event: Event) {
+		seekTo(Number((event.currentTarget as HTMLInputElement).value));
+	}
+
+	function handleTimeUpdate() {
+		if (!previewVideo || !sourceVideo) return;
+		currentTime = previewVideo.currentTime;
+		if (Math.abs(previewVideo.currentTime - sourceVideo.currentTime) > 0.08) {
+			sourceVideo.currentTime = previewVideo.currentTime;
+		}
+	}
+
+	function handlePreviewMetadata() {
+		if (!previewVideo) return;
+		previewWidth = previewVideo.videoWidth;
+		previewHeight = previewVideo.videoHeight;
+		duration = Number.isFinite(previewVideo.duration)
+			? previewVideo.duration
+			: currentPair?.preview.durationSeconds || 0;
+		if (scale === 'actual') void tick().then(centerActualSize);
+	}
+
+	function handleSourceMetadata() {
+		if (!sourceVideo) return;
+		sourceWidth = sourceVideo.videoWidth;
+		sourceHeight = sourceVideo.videoHeight;
+	}
+
+	function handleEnded() {
+		pauseBoth();
+		currentTime = duration;
+	}
+
+	function syncPaneScroll(source: HTMLElement, target: HTMLElement | null) {
+		if (!target || scrollSyncPending) return;
+		scrollSyncPending = true;
+		picturePositionX = normalizedScrollPosition(
+			source.scrollLeft,
+			source.scrollWidth,
+			source.clientWidth,
+			picturePositionX
+		);
+		picturePositionY = normalizedScrollPosition(
+			source.scrollTop,
+			source.scrollHeight,
+			source.clientHeight,
+			picturePositionY
+		);
+		target.scrollLeft = alignedScrollOffset(
+			source.scrollLeft,
+			source.scrollWidth,
+			source.clientWidth,
+			target.scrollWidth,
+			target.clientWidth
+		);
+		target.scrollTop = alignedScrollOffset(
+			source.scrollTop,
+			source.scrollHeight,
+			source.clientHeight,
+			target.scrollHeight,
+			target.clientHeight
+		);
+		requestAnimationFrame(() => (scrollSyncPending = false));
+	}
+
+	function centerActualSize() {
+		picturePositionX = 0.5;
+		picturePositionY = 0.5;
+		applyPicturePosition();
+	}
+
+	function applyPicturePosition() {
+		for (const pane of [sourcePane, previewPane]) {
+			if (!pane) continue;
+			pane.scrollLeft = scrollOffsetForPosition(
+				picturePositionX,
+				pane.scrollWidth,
+				pane.clientWidth
+			);
+			pane.scrollTop = scrollOffsetForPosition(
+				picturePositionY,
+				pane.scrollHeight,
+				pane.clientHeight
+			);
+		}
+	}
+
+	function schedulePicturePosition() {
+		void tick().then(() => requestAnimationFrame(applyPicturePosition));
+	}
+
+	function handleWorkspaceKeydown(event: KeyboardEvent) {
+		if (!isOpen) return;
+		if (event.key === 'Tab') {
+			trapFocus(event);
+			return;
+		}
+		const target = event.target;
+		if (
+			target instanceof HTMLInputElement ||
+			target instanceof HTMLTextAreaElement ||
+			target instanceof HTMLSelectElement ||
+			(target instanceof HTMLButtonElement && (event.key === ' ' || event.key === 'Enter'))
+		) {
+			return;
+		}
+		const action = comparisonKeyboardAction(event.key, pairs.length);
+		if (!action) return;
+		event.preventDefault();
+		if (action.kind === 'close') void closeWorkspace();
+		else if (action.kind === 'toggle_playback') void togglePlayback();
+		else if (action.kind === 'seek') seekTo(currentTime + action.seconds);
+		else if (action.kind === 'show') showSide(action.side);
+		else if (action.kind === 'toggle_layout') {
+			chooseLayout(layout === 'side_by_side' ? 'one_at_a_time' : 'side_by_side');
+		} else if (action.kind === 'toggle_scale') chooseScale(scale === 'fit' ? 'actual' : 'fit');
+		else if (action.kind === 'select_moment') chooseMoment(action.index);
+	}
+
+	function trapFocus(event: KeyboardEvent) {
+		if (!workspaceElement) return;
+		const focusable = Array.from(
+			workspaceElement.querySelectorAll<HTMLElement>(
+				'button:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+			)
+		).filter((element) => !element.hasAttribute('hidden'));
+		if (!focusable.length) return;
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+		if (event.shiftKey && document.activeElement === first) {
+			event.preventDefault();
+			last.focus();
+		} else if (!event.shiftKey && document.activeElement === last) {
+			event.preventDefault();
+			first.focus();
+		}
+	}
+</script>
+
+{#if currentPair}
+	<section class="comparison-block">
+		<div
+			bind:this={workspaceElement}
+			class="comparison-workspace"
+			class:is-open={isOpen}
+			class:is-native-fullscreen={nativeFullscreen}
+			class:one-at-a-time={layout === 'one_at_a_time'}
+			class:show-original={visibleSide === 'original'}
+			class:actual-size={scale === 'actual'}
+			style={workspaceStyle}
+			role={isOpen ? 'dialog' : 'group'}
+			aria-modal={isOpen ? 'true' : undefined}
+			aria-label={isOpen ? workspaceTitle : 'Original and new video comparison'}
+			onkeydown={handleWorkspaceKeydown}
+		>
+			{#if isOpen}
+				<header class="workspace-header">
+					<div>
+						<span class="workspace-kicker">{episodeLabel}</span>
+						<h2>{workspaceTitle}</h2>
+					</div>
+					<div class="workspace-moments" role="group" aria-label="Test moments">
+						{#each pairs as pair, index (`${pair.source.path}-${index}`)}
+							<button
+								type="button"
+								class:active={selectedMoment === index}
+								onclick={() => chooseMoment(index)}
+								aria-pressed={selectedMoment === index}
+							>
+								Moment {index + 1}
+							</button>
+						{/each}
+					</div>
+					<button
+						bind:this={closeButton}
+						class="close-comparison"
+						type="button"
+						onclick={closeWorkspace}
+					>
+						Close comparison
+					</button>
+				</header>
+			{/if}
+
+			{#if isOpen}
+				<div class="workspace-tools">
+					<div class="tool-group" role="group" aria-label="Picture arrangement">
+						<button
+							type="button"
+							class:active={layout === 'side_by_side'}
+							onclick={() => chooseLayout('side_by_side')}
+							aria-pressed={layout === 'side_by_side'}>Side by side</button
+						>
+						<button
+							type="button"
+							class:active={layout === 'one_at_a_time'}
+							onclick={() => chooseLayout('one_at_a_time')}
+							aria-pressed={layout === 'one_at_a_time'}>One at a time</button
+						>
+					</div>
+					{#if layout === 'one_at_a_time'}
+						<div class="tool-group" role="group" aria-label="Picture shown">
+							<button
+								type="button"
+								class:active={visibleSide === 'original'}
+								onclick={() => (visibleSide = 'original')}
+								aria-pressed={visibleSide === 'original'}>Original</button
+							>
+							<button
+								type="button"
+								class:active={visibleSide === 'new'}
+								onclick={() => (visibleSide = 'new')}
+								aria-pressed={visibleSide === 'new'}>New</button
+							>
+						</div>
+					{/if}
+					<div class="tool-group" role="group" aria-label="Picture size">
+						<button
+							type="button"
+							class:active={scale === 'fit'}
+							onclick={() => chooseScale('fit')}
+							aria-pressed={scale === 'fit'}>Fit</button
+						>
+						<button
+							type="button"
+							class:active={scale === 'actual'}
+							onclick={() => chooseScale('actual')}
+							aria-pressed={scale === 'actual'}>Actual size</button
+						>
+					</div>
+				</div>
+			{/if}
+
+			<div class="comparison-media" aria-live="off">
+				<div
+					bind:this={sourcePane}
+					class="media-pane media-pane--original"
+					aria-hidden={isOpen && layout === 'one_at_a_time' && visibleSide !== 'original'}
+					onscroll={(event) => syncPaneScroll(event.currentTarget, previewPane)}
+				>
+					<div class="media-label">
+						<div><strong>Original</strong><span>what you have now</span></div>
+						<small>{originalSizeLabel}</small>
+					</div>
+					<div class="media-frame" style={sourceFrameStyle}>
+						<video
+							bind:this={sourceVideo}
+							src={currentPair.source.path}
+							muted={!isOpen || !hasSound || audioChoice !== 'original'}
+							playsinline
+							preload={isOpen ? 'auto' : 'metadata'}
+							aria-label="Original test moment"
+							tabindex="-1"
+							onloadedmetadata={handleSourceMetadata}
+						></video>
+					</div>
+				</div>
+				<div
+					bind:this={previewPane}
+					class="media-pane media-pane--new"
+					aria-hidden={isOpen && layout === 'one_at_a_time' && visibleSide !== 'new'}
+					onscroll={(event) => syncPaneScroll(event.currentTarget, sourcePane)}
+				>
+					<div class="media-label">
+						<div><strong>New</strong><span>the test version</span></div>
+						<small>{newSizeLabel}</small>
+					</div>
+					<div class="media-frame" style={previewFrameStyle}>
+						<video
+							bind:this={previewVideo}
+							src={currentPair.preview.path}
+							muted={!isOpen || !hasSound || audioChoice !== 'new'}
+							playsinline
+							preload={isOpen ? 'auto' : 'metadata'}
+							aria-label="New test moment"
+							tabindex="-1"
+							onloadedmetadata={handlePreviewMetadata}
+							onplaying={() => {
+								playing = true;
+								preparing = false;
+							}}
+							onwaiting={() => (preparing = true)}
+							onpause={() => (playing = false)}
+							ontimeupdate={handleTimeUpdate}
+							onended={handleEnded}
+						></video>
+					</div>
+				</div>
+			</div>
+
+			{#if isOpen}
+				<footer class="workspace-controls">
+					<button class="play-control" type="button" onclick={togglePlayback} disabled={preparing}>
+						{preparing ? 'Preparing…' : playing ? 'Pause' : 'Play'}
+					</button>
+					<label class="timeline-control">
+						<span class="sr-only">Playback position</span>
+						<input
+							type="range"
+							min="0"
+							max={Math.max(duration, 0.01)}
+							step="0.01"
+							value={currentTime}
+							oninput={handleTimeline}
+							aria-valuetext={timeText}
+						/>
+					</label>
+					<output class="time-display">{timeText}</output>
+					{#if hasSound}
+						<div class="sound-control" role="group" aria-label="Listen to">
+							<span>Listen to</span>
+							<button
+								type="button"
+								class:active={audioChoice === 'original'}
+								onclick={() => chooseSound('original')}
+								aria-pressed={audioChoice === 'original'}>Original</button
+							>
+							<button
+								type="button"
+								class:active={audioChoice === 'new'}
+								onclick={() => chooseSound('new')}
+								aria-pressed={audioChoice === 'new'}>New</button
+							>
+						</div>
+					{:else}
+						<p class="picture-only-note">These clips show picture only.</p>
+					{/if}
+					{#if playbackError}<p class="playback-error" role="alert">{playbackError}</p>{/if}
+				</footer>
+			{/if}
+		</div>
+
+		<div class="comparison-entry">
+			{#if pairs.length > 1}
+				<div class="inline-moments" role="group" aria-label="Test moments">
+					{#each pairs as pair, index (`${pair.source.path}-${index}`)}
+						<button
+							type="button"
+							class:active={selectedMoment === index}
+							onclick={() => chooseMoment(index)}
+							aria-pressed={selectedMoment === index}
+						>
+							Moment {index + 1}
+						</button>
+					{/each}
+				</div>
+			{/if}
+			<div class="entry-action">
+				<button type="button" onclick={openWorkspace}>Compare in full screen</button>
+				<small>Opens side by side, paused. Nothing is changed.</small>
+			</div>
+		</div>
+		{#if !hasSound}
+			<div class="sound-unavailable">
+				<p>
+					{canMakeSoundTest
+						? 'These clips show picture only. A new test is needed to compare sound.'
+						: 'This episode does not have sound to compare.'}
+				</p>
+				{#if canMakeSoundTest}
+					<button type="button" onclick={onRequestSoundTest} disabled={soundTestDisabled}>
+						Make a new test with sound
+					</button>
+				{/if}
+			</div>
+		{/if}
+	</section>
+{/if}
+
+<style>
+	.comparison-block {
+		display: grid;
+		gap: 10px;
+	}
+
+	.comparison-workspace {
+		background: #090b0d;
+		border-radius: 12px;
+		box-shadow: 0 8px 28px rgb(20 22 25 / 16%);
+		color: #f4f5f2;
+		display: grid;
+		gap: 10px;
+		overflow: hidden;
+		padding: 10px;
+	}
+
+	.comparison-workspace.is-open {
+		background: #0c0f12;
+		border-radius: 0;
+		inset: 0;
+		padding: 16px;
+		position: fixed;
+		z-index: 1000;
+	}
+
+	.comparison-workspace:fullscreen {
+		height: 100%;
+		width: 100%;
+	}
+
+	.workspace-header {
+		align-items: center;
+		border-bottom: 1px solid rgb(255 255 255 / 11%);
+		display: grid;
+		gap: 16px;
+		grid-template-columns: minmax(220px, 1fr) auto minmax(220px, 1fr);
+		padding: 2px 2px 13px;
+	}
+
+	.is-native-fullscreen .workspace-header {
+		padding-left: 64px;
+	}
+
+	.workspace-header > div:first-child {
+		display: grid;
+		gap: 3px;
+	}
+
+	.workspace-header h2 {
+		font-size: 20px;
+		margin: 0;
+	}
+
+	.workspace-kicker {
+		color: #9aa4a0;
+		font-size: 11px;
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+	}
+
+	.workspace-moments,
+	.inline-moments,
+	.tool-group,
+	.sound-control {
+		align-items: center;
+		background: #151a1e;
+		border: 1px solid rgb(255 255 255 / 10%);
+		border-radius: 999px;
+		display: flex;
+		gap: 2px;
+		padding: 3px;
+	}
+
+	.workspace-moments button,
+	.inline-moments button,
+	.tool-group button,
+	.sound-control button {
+		background: transparent;
+		border: 0;
+		border-radius: 999px;
+		color: #aeb7b3;
+		cursor: pointer;
+		font: inherit;
+		font-size: 12px;
+		font-weight: 650;
+		min-height: 32px;
+		padding: 0 12px;
+		white-space: nowrap;
+	}
+
+	.workspace-moments button.active,
+	.inline-moments button.active,
+	.tool-group button.active,
+	.sound-control button.active {
+		background: #e8eeeb;
+		color: #17201c;
+	}
+
+	.close-comparison {
+		background: transparent;
+		border: 1px solid rgb(255 255 255 / 18%);
+		border-radius: 7px;
+		color: #f4f5f2;
+		cursor: pointer;
+		font: inherit;
+		font-size: 12px;
+		font-weight: 700;
+		justify-self: end;
+		min-height: 38px;
+		padding: 0 14px;
+	}
+
+	.workspace-tools {
+		align-items: center;
+		display: flex;
+		gap: 8px;
+		justify-content: center;
+	}
+
+	.comparison-media {
+		display: grid;
+		gap: 10px;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		min-height: 0;
+	}
+
+	.is-open .comparison-media {
+		flex: 1;
+		min-height: 0;
+	}
+
+	.media-pane {
+		background: #050607;
+		border: 1px solid rgb(255 255 255 / 12%);
+		border-radius: 8px;
+		display: grid;
+		grid-template-rows: auto minmax(0, 1fr);
+		min-width: 0;
+		overflow: hidden;
+	}
+
+	.media-pane--new {
+		border-color: rgb(120 208 190 / 62%);
+	}
+
+	.media-label {
+		align-items: center;
+		background: #111519;
+		display: flex;
+		gap: 16px;
+		justify-content: space-between;
+		min-height: 44px;
+		padding: 0 12px;
+	}
+
+	.media-label > div {
+		align-items: baseline;
+		display: flex;
+		gap: 8px;
+	}
+
+	.media-label strong {
+		font-size: 12px;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+	}
+
+	.media-label span,
+	.media-label small {
+		color: #9da7a3;
+		font-size: 11px;
+	}
+
+	.media-frame {
+		aspect-ratio: var(--frame-aspect);
+		display: grid;
+		min-height: 0;
+		place-items: center;
+	}
+
+	.media-frame video {
+		display: block;
+		height: 100%;
+		object-fit: contain;
+		width: 100%;
+	}
+
+	.is-open {
+		grid-template-rows: auto auto minmax(0, 1fr) auto;
+	}
+
+	.is-open .comparison-media {
+		overflow: hidden;
+	}
+
+	.is-open .media-frame {
+		aspect-ratio: auto;
+		height: 100%;
+	}
+
+	.one-at-a-time .comparison-media {
+		grid-template-columns: minmax(0, 1fr);
+	}
+
+	.one-at-a-time .media-pane {
+		grid-column: 1;
+		grid-row: 1;
+	}
+
+	.one-at-a-time.show-original .media-pane--new,
+	.one-at-a-time:not(.show-original) .media-pane--original {
+		opacity: 0;
+		pointer-events: none;
+		visibility: hidden;
+	}
+
+	.actual-size .media-pane {
+		overflow: auto;
+	}
+
+	.actual-size .media-frame {
+		display: block;
+		height: var(--media-height);
+		width: var(--media-width);
+	}
+
+	.actual-size .media-frame video {
+		height: var(--media-height);
+		max-width: none;
+		object-fit: contain;
+		width: var(--media-width);
+	}
+
+	.workspace-controls {
+		align-items: center;
+		border-top: 1px solid rgb(255 255 255 / 11%);
+		display: grid;
+		gap: 12px;
+		grid-template-columns: auto minmax(180px, 1fr) auto auto;
+		padding: 13px 2px 0;
+	}
+
+	.play-control,
+	.entry-action button {
+		background: #dfece6;
+		border: 1px solid #c2d8ce;
+		border-radius: 7px;
+		color: #183027;
+		cursor: pointer;
+		font: inherit;
+		font-size: 12px;
+		font-weight: 750;
+		min-height: 38px;
+		padding: 0 16px;
+	}
+
+	.play-control:disabled {
+		cursor: wait;
+		opacity: 0.68;
+	}
+
+	.timeline-control {
+		display: block;
+	}
+
+	.timeline-control input {
+		accent-color: #83c9b6;
+		width: 100%;
+	}
+
+	.time-display {
+		color: #abb4b0;
+		font-size: 12px;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.sound-control {
+		background: transparent;
+		border: 0;
+	}
+
+	.sound-control > span {
+		color: #aeb7b3;
+		font-size: 12px;
+		padding-inline: 5px;
+	}
+
+	.picture-only-note,
+	.playback-error {
+		color: #b9c0bd;
+		font-size: 12px;
+		margin: 0;
+	}
+
+	.playback-error {
+		color: #f0b7aa;
+		grid-column: 1 / -1;
+	}
+
+	.comparison-entry {
+		align-items: center;
+		display: flex;
+		gap: 12px;
+		justify-content: space-between;
+	}
+
+	.inline-moments {
+		background: var(--mf-bg-raised);
+		border-color: var(--mf-line);
+	}
+
+	.inline-moments button {
+		color: var(--mf-fg-secondary);
+	}
+
+	.inline-moments button.active {
+		background: var(--mf-bg-panel);
+		box-shadow: 0 1px 2px rgb(30 34 39 / 10%);
+		color: var(--mf-active-fg);
+	}
+
+	.entry-action {
+		align-items: flex-end;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.entry-action button {
+		min-width: 190px;
+		white-space: nowrap;
+	}
+
+	.entry-action small {
+		max-width: 230px;
+		text-align: right;
+	}
+
+	.entry-action small,
+	.sound-unavailable {
+		color: var(--mf-fg-tertiary);
+		font-size: 11px;
+	}
+
+	.sound-unavailable {
+		align-items: center;
+		background: var(--mf-wait-bg);
+		border: 1px solid var(--mf-wait-line);
+		border-radius: 7px;
+		display: flex;
+		gap: 12px;
+		justify-content: space-between;
+		padding: 9px 11px;
+	}
+
+	.sound-unavailable p {
+		margin: 0;
+	}
+
+	.sound-unavailable button {
+		background: transparent;
+		border: 1px solid var(--mf-wait-line);
+		border-radius: 6px;
+		color: var(--mf-wait-fg);
+		cursor: pointer;
+		font: inherit;
+		font-size: 11px;
+		font-weight: 700;
+		min-height: 32px;
+		padding: 0 11px;
+	}
+
+	.sound-unavailable button:disabled {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+
+	.sr-only {
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
+		padding: 0;
+		position: absolute;
+		width: 1px;
+		clip: rect(0, 0, 0, 0);
+	}
+
+	button:focus-visible,
+	input:focus-visible {
+		outline: 2px solid #86d8c2;
+		outline-offset: 2px;
+	}
+
+	@media (max-width: 760px) {
+		.comparison-workspace.is-open {
+			padding: 10px;
+		}
+
+		.workspace-header {
+			align-items: stretch;
+			grid-template-columns: 1fr auto;
+		}
+
+		.workspace-header > div:first-child {
+			grid-column: 1;
+		}
+
+		.workspace-moments {
+			grid-column: 1 / -1;
+			grid-row: 2;
+			justify-self: center;
+		}
+
+		.close-comparison {
+			grid-column: 2;
+			grid-row: 1;
+		}
+
+		.workspace-tools,
+		.comparison-entry {
+			align-items: stretch;
+			flex-wrap: wrap;
+		}
+
+		.comparison-entry {
+			flex-direction: column;
+		}
+
+		.sound-unavailable {
+			align-items: stretch;
+			flex-direction: column;
+		}
+
+		.inline-moments,
+		.entry-action {
+			justify-content: center;
+			width: 100%;
+		}
+
+		.entry-action {
+			align-items: center;
+			flex-direction: column;
+		}
+
+		.workspace-controls {
+			grid-template-columns: auto minmax(100px, 1fr) auto;
+		}
+
+		.sound-control,
+		.picture-only-note {
+			grid-column: 1 / -1;
+			justify-self: center;
+		}
+	}
+
+	@media (max-width: 520px) {
+		.comparison-media {
+			grid-template-columns: 1fr;
+		}
+
+		.is-open .comparison-media {
+			grid-template-columns: 1fr;
+		}
+
+		.is-open:not(.one-at-a-time) .comparison-media {
+			grid-template-rows: repeat(2, minmax(0, 1fr));
+		}
+
+		.is-open:not(.one-at-a-time) .media-pane {
+			min-height: 0;
+		}
+
+		.is-open:not(.one-at-a-time) .media-frame {
+			min-height: 90px;
+		}
+
+		.workspace-controls {
+			grid-template-columns: auto 1fr;
+		}
+
+		.timeline-control {
+			grid-column: 1 / -1;
+			grid-row: 2;
+		}
+
+		.time-display {
+			justify-self: end;
+		}
+	}
+</style>

--- a/frontend/src/lib/components/season/SeasonExperience.svelte
+++ b/frontend/src/lib/components/season/SeasonExperience.svelte
@@ -3,6 +3,7 @@
 	import { onMount, tick } from 'svelte';
 
 	import { ApiError, apiDownloadHref, postJson } from '$lib/api/client';
+	import ComparisonWorkspace from '$lib/components/season/ComparisonWorkspace.svelte';
 	import type {
 		FolderPayload,
 		FolderStatusPayload,
@@ -10,6 +11,7 @@
 		QualityRiskTag
 	} from '$lib/api/types';
 	import { folderRoutePath } from '$lib/folder-display';
+	import { reviewPairHasSound } from '$lib/season/comparison';
 	import {
 		REVIEW_CONCERNS,
 		approvalGuardFromMessage,
@@ -112,8 +114,6 @@
 	let operatorInstructions = $state('');
 	let selectedConcerns = $state<QualityRiskTag[]>([]);
 	let reviewFeedback = $state('');
-	let sourceVideo = $state<HTMLVideoElement | null>(null);
-	let previewVideo = $state<HTMLVideoElement | null>(null);
 	let goalButtons = $state<HTMLButtonElement[]>([]);
 	let safetyDialog = $state<SafetyDialog | null>(null);
 	let safetyDialogReturnFocus = $state<HTMLElement | null>(null);
@@ -168,9 +168,14 @@
 		((folder.sample_host_options ?? []) as HostOption[]).filter((host) => host.key)
 	);
 	const sampleItem = $derived(asRecord(folder.sample_item));
+	const sampleHasAudio = $derived(
+		Array.isArray(sampleItem.audio_summary) && sampleItem.audio_summary.length > 0
+	);
 	const sampleEpisode = $derived(episodeLabel(asText(sampleItem.rel_path)));
 	const reviewPairs = $derived(normalizeReviewPairs(folder));
 	const currentPair = $derived(reviewPairs[Math.min(selectedMoment, reviewPairs.length - 1)]);
+	const reviewHasSound = $derived(reviewPairHasSound(currentPair));
+	const reviewSubject = $derived(reviewHasSound ? 'picture and sound' : 'picture');
 	const calibration = $derived(asRecord(folder.calibration));
 	const sampleResult = $derived(asRecord(calibration.sample_result));
 	const encodeProgress = $derived(currentEncodeProgress(folder.encode_job));
@@ -815,28 +820,30 @@
 		const baselinePolicy = asRecord(asRecord(calibration.sample_item).resolved_policy);
 		const baselineVideo = asRecord(baselinePolicy.video);
 		const draftVideo = asRecord(asRecord(calibration.policy).video);
-		const fields: Array<[string, string, string]> = [
-			['quality_metric', 'Picture quality method', 'text'],
-			['target_vmaf', 'VMAF target', 'number'],
-			['min_target_vmaf', 'VMAF floor', 'number'],
-			['target_xpsnr', 'XPSNR target', 'number'],
-			['min_target_xpsnr', 'XPSNR floor', 'number'],
-			['max_encoded_percent', 'Largest allowed size', 'percent'],
-			['default_grain', 'Film grain', 'number']
-		];
-		return fields.flatMap(([key, label, kind]) => {
-			const before = baselineVideo[key];
-			const after = draftVideo[key];
-			if (JSON.stringify(before ?? null) === JSON.stringify(after ?? null)) return [];
-			return [`${label}: ${policyValue(before, kind)} → ${policyValue(after, kind)}`];
-		});
+		const changed = (key: string) =>
+			JSON.stringify(baselineVideo[key] ?? null) !== JSON.stringify(draftVideo[key] ?? null);
+		const changes: string[] = [];
+		if (
+			['quality_metric', 'target_vmaf', 'min_target_vmaf', 'target_xpsnr', 'min_target_xpsnr'].some(
+				changed
+			)
+		) {
+			changes.push('Picture quality checks will be updated.');
+		}
+		if (changed('max_encoded_percent')) {
+			changes.push(
+				`Largest allowed file: ${policyPercent(baselineVideo.max_encoded_percent)} → ${policyPercent(draftVideo.max_encoded_percent)}`
+			);
+		}
+		if (changed('default_grain')) {
+			changes.push('Natural texture handling will be updated.');
+		}
+		return changes;
 	}
 
-	function policyValue(value: unknown, kind: string): string {
+	function policyPercent(value: unknown): string {
 		if (value === null || value === undefined || value === '') return 'not set';
-		if (kind === 'percent') return `${asNumber(value)}% of the original`;
-		if (kind === 'number') return String(asNumber(value));
-		return asText(value).toUpperCase() || String(value);
+		return `${asNumber(value)}% of the original`;
 	}
 
 	async function focusSafetyDialog() {
@@ -907,37 +914,12 @@
 		goalButtons[nextIndex]?.focus();
 	}
 
-	async function chooseMoment(index: number) {
+	function chooseMoment(index: number) {
 		selectedMoment = index;
-		await tick();
-		previewVideo?.pause();
-		sourceVideo?.pause();
 	}
 
 	function downloadComparison() {
 		window.location.assign(apiDownloadHref(endpoint('review-compare/download')));
-	}
-
-	function syncPlay() {
-		if (!previewVideo || !sourceVideo) return;
-		sourceVideo.currentTime = previewVideo.currentTime;
-		void sourceVideo.play().catch(() => undefined);
-	}
-
-	function syncPause() {
-		sourceVideo?.pause();
-	}
-
-	function syncSeek() {
-		if (!previewVideo || !sourceVideo) return;
-		sourceVideo.currentTime = previewVideo.currentTime;
-	}
-
-	function keepVideosTogether() {
-		if (!previewVideo || !sourceVideo) return;
-		if (Math.abs(previewVideo.currentTime - sourceVideo.currentTime) > 0.18) {
-			sourceVideo.currentTime = previewVideo.currentTime;
-		}
 	}
 
 	function technicalPolicy() {
@@ -1323,23 +1305,9 @@
 									? 'Size goal not met'
 									: 'Looks good'}
 						</p>
-						<h1>{targetConstraint ? targetConstraint.title : 'Review picture and sound'}</h1>
+						<h1>{targetConstraint ? targetConstraint.title : `Review ${reviewSubject}`}</h1>
 						<p>{sampleEpisode} · Compare the same moment on both sides.</p>
 					</div>
-					{#if reviewPairs.length > 1}
-						<div class="moment-picker" role="group" aria-label="Test moments">
-							{#each reviewPairs as pair, index (`${pair.source.path}-${index}`)}
-								<button
-									type="button"
-									class:active={selectedMoment === index}
-									onclick={() => chooseMoment(index)}
-									aria-pressed={selectedMoment === index}
-								>
-									Moment {index + 1}
-								</button>
-							{/each}
-						</div>
-					{/if}
 				</div>
 
 				{#if targetConstraint}
@@ -1365,9 +1333,9 @@
 						</div>
 						<p>
 							{crfLimitReached
-								? `The search reached its CRF ${asNumber(sampleResult.chosen_crf)} limit before it reached your size goal.`
+								? 'The test reached its smallest practical setting before it reached your size goal.'
 								: 'The measured result stayed above your size goal.'}
-							Review this as a picture-and-sound checkpoint, then make a smaller test.
+							Review this as a {reviewSubject} checkpoint, then make a smaller test.
 						</p>
 					</div>
 				{:else if sizeTarget.status === 'under_target'}
@@ -1380,7 +1348,7 @@
 								{formatDecimalFileSize(sizeTarget.budgetBytes)} goal.</strong
 							>
 						</div>
-						<p>Make another test that spends the unused size on picture and sound quality.</p>
+						<p>Make another test that spends the unused size on {reviewSubject} quality.</p>
 					</div>
 				{:else if sizeTarget.status === 'missing_prediction'}
 					<div class="target-warning" role="status">
@@ -1393,67 +1361,21 @@
 				{/if}
 
 				{#if currentPair}
-					<div
-						class="video-stage"
-						role="group"
-						aria-label="Synchronized original and new video comparison. Use the controls on the new video to play both."
-					>
-						<div class="video-card">
-							<div class="video-label">
-								<span>Original</span><small
-									>{formatDecimalFileSize(asNumber(sampleItem.source_size_bytes))} episode</small
-								>
-							</div>
-							<video
-								bind:this={sourceVideo}
-								src={currentPair.source.path}
-								muted={audioChoice !== 'original'}
-								playsinline
-								preload="metadata"
-								aria-hidden="true"
-								tabindex="-1"
-							></video>
-						</div>
-						<div class="video-card video-card--new">
-							<div class="video-label">
-								<span>New</span>
-								<small
-									>{expectedEpisodeBytes
-										? `about ${formatDecimalFileSize(expectedEpisodeBytes)} episode`
-										: 'test version'}</small
-								>
-							</div>
-							<video
-								bind:this={previewVideo}
-								src={currentPair.preview.path}
-								muted={audioChoice !== 'new'}
-								playsinline
-								preload="metadata"
-								controls
-								aria-label="Play the synchronized original and new test videos"
-								onplay={syncPlay}
-								onpause={syncPause}
-								onseeking={syncSeek}
-								ontimeupdate={keepVideosTogether}
-							></video>
-						</div>
-					</div>
-					<div class="sound-choice" role="group" aria-label="Sound source">
-						<span>Listen to</span>
-						<button
-							type="button"
-							class:active={audioChoice === 'original'}
-							onclick={() => (audioChoice = 'original')}
-							aria-pressed={audioChoice === 'original'}>Original sound</button
-						>
-						<button
-							type="button"
-							class:active={audioChoice === 'new'}
-							onclick={() => (audioChoice = 'new')}
-							aria-pressed={audioChoice === 'new'}>New sound</button
-						>
-						<small>The right-hand controls play both videos together.</small>
-					</div>
+					<ComparisonWorkspace
+						pairs={reviewPairs}
+						{selectedMoment}
+						{audioChoice}
+						episodeLabel={sampleEpisode}
+						originalSizeLabel={`${formatDecimalFileSize(asNumber(sampleItem.source_size_bytes))} per episode`}
+						newSizeLabel={expectedEpisodeBytes
+							? `about ${formatDecimalFileSize(expectedEpisodeBytes)} per episode`
+							: 'test version'}
+						canMakeSoundTest={sampleHasAudio}
+						soundTestDisabled={actionPhase !== 'idle' || noAvailableHosts}
+						onMomentChange={chooseMoment}
+						onAudioChange={(side) => (audioChoice = side)}
+						onRequestSoundTest={() => void retryMeasuredTarget()}
+					/>
 				{:else}
 					<div class="missing-media">
 						<h2>The test finished, but the comparison clips are missing.</h2>
@@ -1464,7 +1386,7 @@
 				{#if riskSummary}
 					<div class={`risk-summary risk-summary--${riskSummary.tone}`}>
 						<div class="risk-summary__headline">
-							<span>Quality risk</span>
+							<span>What to check</span>
 							<strong>{riskSummary.verdict}</strong>
 						</div>
 						<div class="risk-summary__fact">
@@ -1478,7 +1400,7 @@
 							<small>{riskSummary.sound.level} · {riskSummary.sound.detail}</small>
 						</div>
 						<div class="risk-summary__fact">
-							<span>Authority</span>
+							<span>Decision</span>
 							<strong>{riskSummary.authority}</strong>
 							<small>{riskSummary.authorityDetail}</small>
 						</div>
@@ -1648,14 +1570,22 @@
 						{:else if sizeTarget.status === 'under_target'}
 							<h2>This result is smaller than requested.</h2>
 							<p>
-								Make another test that uses the available size for more picture and sound quality.
+								Make another test that uses the available size for more {reviewSubject} quality.
 							</p>
 						{:else if sizeTarget.status === 'missing_prediction'}
 							<h2>The size result is incomplete.</h2>
 							<p>Make another test before deciding whether to use this setting for the season.</p>
 						{:else}
-							<h2>Does the new version look and sound right?</h2>
-							<p>Look at faces, motion, dark scenes, and listen for anything distracting.</p>
+							<h2>
+								{reviewHasSound
+									? 'Does the new version look and sound right?'
+									: 'Does the new version look right?'}
+							</h2>
+							<p>
+								{reviewHasSound
+									? 'Look at faces, motion, dark scenes, and listen for anything distracting.'
+									: 'Look at faces, motion, dark scenes, and fine detail.'}
+							</p>
 						{/if}
 					</div>
 					<div class="decision-actions">
@@ -2549,16 +2479,14 @@
 	button:focus-visible,
 	a:focus-visible,
 	select:focus-visible,
-	summary:focus-visible,
-	video:focus-visible {
+	summary:focus-visible {
 		outline: 3px solid #4b8060;
 		outline-offset: 3px;
 	}
 
 	.cinematic button:focus-visible,
 	.cinematic a:focus-visible,
-	.cinematic summary:focus-visible,
-	.cinematic video:focus-visible {
+	.cinematic summary:focus-visible {
 		outline-color: #a8d7b9;
 	}
 
@@ -2844,102 +2772,6 @@
 		color: var(--muted);
 		font-size: 13px;
 		margin-bottom: 0;
-	}
-
-	.moment-picker {
-		background: rgb(255 255 255 / 5%);
-		border: 1px solid var(--line);
-		border-radius: 999px;
-		display: flex;
-		padding: 4px;
-	}
-
-	.moment-picker button,
-	.sound-choice button {
-		background: transparent;
-		border: 0;
-		border-radius: 999px;
-		color: var(--muted);
-		cursor: pointer;
-		font: inherit;
-		font-size: 11px;
-		font-weight: 700;
-		padding: 8px 12px;
-	}
-
-	.moment-picker button.active,
-	.sound-choice button.active {
-		background: #e8eee8;
-		color: #1d241f;
-	}
-
-	.video-stage {
-		display: grid;
-		gap: 13px;
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
-
-	.video-card {
-		background: #070908;
-		border: 1px solid rgb(255 255 255 / 10%);
-		border-radius: 18px;
-		overflow: hidden;
-	}
-
-	.video-card--new {
-		border-color: rgb(137 190 157 / 48%);
-		box-shadow:
-			0 0 0 1px rgb(137 190 157 / 10%),
-			0 28px 80px rgb(0 0 0 / 32%);
-	}
-
-	.video-label {
-		align-items: center;
-		color: #efede7;
-		display: flex;
-		justify-content: space-between;
-		min-height: 48px;
-		padding: 0 16px;
-	}
-
-	.video-label span {
-		font-size: 11px;
-		font-weight: 800;
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-	}
-
-	.video-label small {
-		color: #929792;
-		font-size: 11px;
-	}
-
-	.video-card video {
-		aspect-ratio: 16 / 9;
-		background: #000;
-		display: block;
-		object-fit: contain;
-		width: 100%;
-	}
-
-	.sound-choice {
-		align-items: center;
-		color: var(--muted);
-		display: flex;
-		font-size: 11px;
-		gap: 5px;
-		justify-content: center;
-		margin-top: 14px;
-	}
-
-	.sound-choice > span {
-		font-weight: 700;
-		margin-right: 3px;
-	}
-
-	.sound-choice small {
-		margin-left: 8px;
-		opacity: 0.7;
 	}
 
 	.missing-media {
@@ -3738,49 +3570,6 @@
 			font-size: 46px;
 		}
 
-		.moment-picker {
-			overflow-x: auto;
-			width: 100%;
-		}
-
-		.moment-picker button {
-			flex: 1 0 auto;
-		}
-
-		.sound-choice {
-			align-items: stretch;
-			flex-wrap: wrap;
-		}
-
-		.sound-choice > span {
-			flex-basis: 100%;
-			text-align: center;
-		}
-
-		.sound-choice button {
-			flex: 1;
-		}
-
-		.sound-choice small {
-			flex-basis: 100%;
-			margin: 5px 0 0;
-			text-align: center;
-		}
-
-		.video-stage {
-			gap: 6px;
-			grid-template-columns: repeat(2, minmax(0, 1fr));
-		}
-
-		.video-label {
-			min-height: 38px;
-			padding-inline: 8px;
-		}
-
-		.video-label small {
-			display: none;
-		}
-
 		.safety-dialog {
 			border-radius: 19px;
 			padding: 24px 20px;
@@ -4517,113 +4306,6 @@
 	.target-warning--under span,
 	.target-warning--under p {
 		color: var(--mf-wait-fg);
-	}
-
-	.moment-picker {
-		background: var(--mf-bg-raised);
-		border: 1px solid var(--mf-line);
-		border-radius: 999px;
-		gap: 2px;
-		padding: 3px;
-	}
-
-	.moment-picker button {
-		border-radius: 999px;
-		color: var(--mf-fg-secondary);
-		font-family: var(--mf-font-sans);
-		font-size: 12px;
-		font-weight: 600;
-		min-height: 32px;
-		padding: 0 12px;
-	}
-
-	.moment-picker button.active {
-		background: var(--mf-bg-panel);
-		box-shadow: 0 1px 2px rgb(30 34 39 / 10%);
-		color: var(--mf-active-fg);
-	}
-
-	.video-stage {
-		background: var(--mf-bg-stage);
-		border: 0;
-		border-radius: 12px;
-		box-shadow: 0 8px 28px rgb(20 22 25 / 16%);
-		display: grid;
-		gap: 10px;
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-		margin: 0;
-		overflow: hidden;
-		padding: 10px;
-	}
-
-	.video-card,
-	.video-card--new {
-		background: #090a0c;
-		border: 1px solid rgb(255 255 255 / 12%);
-		border-radius: 8px;
-		overflow: hidden;
-	}
-
-	.video-card--new {
-		border-color: rgb(120 208 190 / 62%);
-	}
-
-	.video-label {
-		background: #111316;
-		color: #f4f5f2;
-		font-family: var(--mf-font-sans);
-		min-height: 38px;
-		padding: 0 12px;
-	}
-
-	.video-label span {
-		font-size: 11px;
-		letter-spacing: 0.08em;
-	}
-
-	.video-label small {
-		color: #a8ada8;
-		font-size: 11px;
-	}
-
-	.video-card video {
-		aspect-ratio: 16 / 9;
-		display: block;
-		width: 100%;
-	}
-
-	.sound-choice {
-		align-items: center;
-		color: var(--mf-fg-secondary);
-		display: flex;
-		font-family: var(--mf-font-sans);
-		font-size: 12px;
-		gap: 4px;
-		justify-content: center;
-		margin: -7px 0 0;
-	}
-
-	.sound-choice button {
-		background: transparent;
-		border: 1px solid transparent;
-		border-radius: 999px;
-		color: var(--mf-fg-secondary);
-		font-size: 12px;
-		font-weight: 600;
-		min-height: 32px;
-		padding: 0 11px;
-	}
-
-	.sound-choice button.active {
-		background: var(--mf-active-bg);
-		border-color: #c6ddd7;
-		color: var(--mf-active-fg);
-	}
-
-	.sound-choice small {
-		color: var(--mf-fg-tertiary);
-		font-size: 11px;
-		margin-left: 7px;
 	}
 
 	.missing-media {
@@ -5478,31 +5160,6 @@
 		.finished-room,
 		.help-room {
 			padding: 18px;
-		}
-
-		.video-stage {
-			grid-template-columns: 1fr;
-			padding: 7px;
-		}
-
-		.sound-choice {
-			align-items: stretch;
-			flex-wrap: wrap;
-		}
-
-		.sound-choice > span {
-			flex-basis: 100%;
-			text-align: center;
-		}
-
-		.sound-choice button {
-			flex: 1;
-		}
-
-		.sound-choice small {
-			flex-basis: 100%;
-			margin: 4px 0 0;
-			text-align: center;
 		}
 
 		.comparison-ledger,

--- a/frontend/src/lib/season/comparison.test.ts
+++ b/frontend/src/lib/season/comparison.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	alignedScrollOffset,
+	clampMomentIndex,
+	comparisonKeyboardAction,
+	formatPlaybackTime,
+	frameAspectRatio,
+	normalizedScrollPosition,
+	reviewPairHasSound,
+	scrollOffsetForPosition
+} from './comparison';
+import type { ReviewPair } from './experience';
+
+function pair(sound: boolean): ReviewPair {
+	return {
+		source: {
+			path: '/source.mp4',
+			timestampSeconds: 0,
+			durationSeconds: 8,
+			sizeBytes: 100,
+			audio: sound ? { trustworthy: true, role: 'original' } : null
+		},
+		preview: {
+			path: '/preview.mp4',
+			timestampSeconds: 0,
+			durationSeconds: 8,
+			sizeBytes: 25,
+			audio: sound ? { trustworthy: true, role: 'new' } : null
+		},
+		comparePath: ''
+	};
+}
+
+describe('comparison workspace helpers', () => {
+	it('maps plain keyboard shortcuts to comparison actions', () => {
+		expect(comparisonKeyboardAction(' ', 3)).toEqual({ kind: 'toggle_playback' });
+		expect(comparisonKeyboardAction('o', 3)).toEqual({ kind: 'show', side: 'original' });
+		expect(comparisonKeyboardAction('N', 3)).toEqual({ kind: 'show', side: 'new' });
+		expect(comparisonKeyboardAction('2', 3)).toEqual({ kind: 'select_moment', index: 1 });
+		expect(comparisonKeyboardAction('4', 3)).toBeNull();
+	});
+
+	it('only offers sound when both clips are trustworthy', () => {
+		expect(reviewPairHasSound(pair(true))).toBe(true);
+		const incomplete = pair(true);
+		incomplete.preview.audio = null;
+		expect(reviewPairHasSound(incomplete)).toBe(false);
+		const mislabeled = pair(true);
+		mislabeled.preview.audio = { trustworthy: true, role: 'original' };
+		expect(reviewPairHasSound(mislabeled)).toBe(false);
+	});
+
+	it('keeps moments, time, and frame shape bounded and readable', () => {
+		expect(clampMomentIndex(4, 3)).toBe(2);
+		expect(clampMomentIndex(-1, 3)).toBe(0);
+		expect(formatPlaybackTime(68.9)).toBe('1:08');
+		expect(frameAspectRatio(1440, 1080)).toBeCloseTo(4 / 3);
+		expect(frameAspectRatio(0, 0)).toBeCloseTo(16 / 9);
+	});
+
+	it('keeps the same relative picture position across different frame sizes', () => {
+		expect(alignedScrollOffset(400, 1600, 800, 2400, 800)).toBe(800);
+		expect(alignedScrollOffset(900, 1600, 800, 1200, 800)).toBe(400);
+		expect(alignedScrollOffset(200, 600, 800, 1200, 800)).toBe(200);
+		expect(normalizedScrollPosition(400, 1600, 800)).toBe(0.5);
+		expect(normalizedScrollPosition(0, 600, 800)).toBe(0.5);
+		expect(scrollOffsetForPosition(0.5, 2400, 800)).toBe(800);
+	});
+});

--- a/frontend/src/lib/season/comparison.ts
+++ b/frontend/src/lib/season/comparison.ts
@@ -1,0 +1,94 @@
+import type { ReviewPair } from './experience';
+
+export type ComparisonLayout = 'side_by_side' | 'one_at_a_time';
+export type ComparisonSide = 'original' | 'new';
+export type ComparisonScale = 'fit' | 'actual';
+
+export type ComparisonKeyboardAction =
+	| { kind: 'close' }
+	| { kind: 'toggle_playback' }
+	| { kind: 'seek'; seconds: number }
+	| { kind: 'show'; side: ComparisonSide }
+	| { kind: 'toggle_layout' }
+	| { kind: 'toggle_scale' }
+	| { kind: 'select_moment'; index: number };
+
+export function comparisonKeyboardAction(
+	key: string,
+	momentCount: number
+): ComparisonKeyboardAction | null {
+	const normalized = key.toLowerCase();
+	if (key === 'Escape') return { kind: 'close' };
+	if (key === ' ' || normalized === 'k') return { kind: 'toggle_playback' };
+	if (key === 'ArrowLeft') return { kind: 'seek', seconds: -1 };
+	if (key === 'ArrowRight') return { kind: 'seek', seconds: 1 };
+	if (normalized === 'o') return { kind: 'show', side: 'original' };
+	if (normalized === 'n') return { kind: 'show', side: 'new' };
+	if (normalized === 's') return { kind: 'toggle_layout' };
+	if (normalized === 'f') return { kind: 'toggle_scale' };
+	if (/^[1-9]$/.test(key)) {
+		const index = Number(key) - 1;
+		if (index < momentCount) return { kind: 'select_moment', index };
+	}
+	return null;
+}
+
+export function reviewPairHasSound(pair: ReviewPair | undefined): boolean {
+	return Boolean(
+		pair?.source.audio?.trustworthy &&
+		pair.source.audio.role === 'original' &&
+		pair.preview.audio?.trustworthy &&
+		pair.preview.audio.role === 'new'
+	);
+}
+
+export function clampMomentIndex(index: number, momentCount: number): number {
+	if (momentCount <= 0) return 0;
+	return Math.min(Math.max(index, 0), momentCount - 1);
+}
+
+export function formatPlaybackTime(value: number): string {
+	const totalSeconds = Math.max(0, Math.floor(Number.isFinite(value) ? value : 0));
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+export function frameAspectRatio(width: number, height: number): number {
+	if (width <= 0 || height <= 0) return 16 / 9;
+	return width / height;
+}
+
+export function alignedScrollOffset(
+	sourceOffset: number,
+	sourceExtent: number,
+	sourceViewport: number,
+	targetExtent: number,
+	targetViewport: number
+): number {
+	return scrollOffsetForPosition(
+		normalizedScrollPosition(sourceOffset, sourceExtent, sourceViewport),
+		targetExtent,
+		targetViewport
+	);
+}
+
+export function normalizedScrollPosition(
+	offset: number,
+	extent: number,
+	viewport: number,
+	fallback = 0.5
+): number {
+	const travel = Math.max(extent - viewport, 0);
+	if (travel === 0) return fallback;
+	return Math.min(Math.max(offset / travel, 0), 1);
+}
+
+export function scrollOffsetForPosition(
+	position: number,
+	extent: number,
+	viewport: number
+): number {
+	const travel = Math.max(extent - viewport, 0);
+	return Math.min(Math.max(position, 0), 1) * travel;
+}

--- a/frontend/src/lib/season/experience.test.ts
+++ b/frontend/src/lib/season/experience.test.ts
@@ -416,27 +416,28 @@ describe('season experience translation', () => {
 		);
 
 		expect(summary).toEqual({
-			verdict: 'Request comparison',
+			verdict: 'Review recommended',
 			blocked: false,
 			requiresCadenceResolution: false,
 			tone: 'ready',
-			title: 'Grain / noise treatment',
-			detail: 'Low-confidence grain findings require comparison.',
-			topRisk: 'Grain / noise treatment',
-			topRiskLevel: 'medium risk',
-			topRiskDetail: 'Measured temporal noise may be grain rather than removable noise.',
-			authority: 'No current decision',
-			authorityDetail: 'Older, stale, or sibling evidence is not treated as authority here.',
-			focusMoments: ['Moment 2 · grain_noise_treatment'],
+			title: 'Texture and grain',
+			detail: 'Compare the selected moments before deciding.',
+			topRisk: 'Texture and grain',
+			topRiskLevel: 'Worth checking',
+			topRiskDetail:
+				'Check natural texture for waxiness, crawling noise, or an overly smooth look.',
+			authority: 'Not decided yet',
+			authorityDetail: 'No decision has been saved for this test.',
+			focusMoments: ['Moment 2 needs the closest look.'],
 			picture: {
-				label: 'Grain / noise treatment',
-				level: 'medium risk',
-				detail: 'Measured temporal noise may be grain rather than removable noise.'
+				label: 'Texture and grain',
+				level: 'Worth checking',
+				detail: 'Check natural texture for waxiness, crawling noise, or an overly smooth look.'
 			},
 			sound: {
 				label: 'No specific sound warning',
 				level: 'No specific warning',
-				detail: 'Listen for clarity, channel layout, balance, and anything distracting.'
+				detail: 'Listen for clear dialogue, balanced sound, and anything distracting.'
 			}
 		});
 	});
@@ -1071,17 +1072,43 @@ describe('season experience translation', () => {
 					path: '/source.mp4',
 					timestampSeconds: 0,
 					durationSeconds: 0,
-					sizeBytes: 120
+					sizeBytes: 120,
+					audio: null
 				},
 				preview: {
 					path: '/preview.mp4',
 					timestampSeconds: 0,
 					durationSeconds: 0,
-					sizeBytes: 35
+					sizeBytes: 35,
+					audio: null
 				},
 				comparePath: '/compare.mkv'
 			}
 		]);
+	});
+
+	it('preserves trustworthy sound metadata for review clips', () => {
+		const [pair] = normalizeReviewPairs(
+			folder({
+				calibration: {
+					review_pairs: [
+						{
+							source_clip: {
+								path: '/source.mp4',
+								audio: { trustworthy: true, role: 'original' }
+							},
+							preview_clip: {
+								path: '/preview.mp4',
+								audio: { trustworthy: true, role: 'new' }
+							}
+						}
+					]
+				}
+			})
+		);
+
+		expect(pair.source.audio).toEqual({ trustworthy: true, role: 'original' });
+		expect(pair.preview.audio).toEqual({ trustworthy: true, role: 'new' });
 	});
 
 	it('formats filenames and sizes for people', () => {

--- a/frontend/src/lib/season/experience.ts
+++ b/frontend/src/lib/season/experience.ts
@@ -80,6 +80,12 @@ export interface ReviewClip {
 	timestampSeconds: number;
 	durationSeconds: number;
 	sizeBytes: number;
+	audio: ReviewAudio | null;
+}
+
+export interface ReviewAudio {
+	trustworthy: boolean;
+	role: 'original' | 'new' | '';
 }
 
 export interface ReviewPair {
@@ -232,11 +238,11 @@ function qualityRisk(folder: FolderPayload): QualityRiskPayload | null {
 
 function riskVerdictCopy(verdict: string | null | undefined): string {
 	const normalized = text(verdict).toLowerCase();
-	if (normalized === 'blocked') return 'Blocked';
-	if (normalized === 'request_comparison') return 'Request comparison';
-	if (normalized === 'needs_operator_review') return 'Needs operator review';
-	if (normalized === 'safe_to_sample') return 'Safe to sample';
-	return 'Review evidence';
+	if (normalized === 'blocked') return 'Needs attention';
+	if (normalized === 'request_comparison') return 'Review recommended';
+	if (normalized === 'needs_operator_review') return 'Your review is needed';
+	if (normalized === 'safe_to_sample') return 'Ready for a test';
+	return 'Review recommended';
 }
 
 function riskTone(risk: QualityRiskPayload | null): HumanSeasonTone {
@@ -251,20 +257,61 @@ function riskAuthority(risk: QualityRiskPayload | null): { value: string; detail
 	const status = text(decision.status).toLowerCase();
 	if (status === 'rejected') {
 		return {
-			value: 'Current rejection',
-			detail: 'The latest matching rejection outranks any older approval.'
+			value: 'Not approved',
+			detail: 'This exact test was most recently marked as not acceptable.'
 		};
 	}
 	if (status === 'approved') {
 		return {
-			value: 'Current approval',
-			detail: 'The current sample, source, and policy hash have an authoritative approval.'
+			value: 'Approved',
+			detail: 'A decision has been saved for this exact test.'
 		};
 	}
 	return {
-		value: 'No current decision',
-		detail: 'Older, stale, or sibling evidence is not treated as authority here.'
+		value: 'Not decided yet',
+		detail: 'No decision has been saved for this test.'
 	};
+}
+
+function plainRiskCopy(tag: QualityRiskTag): { label: string; detail: string } {
+	const copy: Record<QualityRiskTag, { label: string; detail: string }> = {
+		softness_detail_loss: {
+			label: 'Fine detail',
+			detail: 'Check faces, text, hair, and fine textures for softness or missing detail.'
+		},
+		motion_breakup: {
+			label: 'Fast movement',
+			detail: 'Watch movement and busy scenes for blocks, smearing, or distracting edges.'
+		},
+		banding_dark_scene_damage: {
+			label: 'Dark scenes',
+			detail: 'Check shadows and smooth color changes for visible steps or lost detail.'
+		},
+		grain_noise_treatment: {
+			label: 'Texture and grain',
+			detail: 'Check natural texture for waxiness, crawling noise, or an overly smooth look.'
+		},
+		cadence_interlace_artifacts: {
+			label: 'Motion pattern',
+			detail: 'Watch movement for combing, judder, repeated frames, or an uneven rhythm.'
+		},
+		audio_quality_layout: {
+			label: 'Sound',
+			detail: 'Listen for clear dialogue, balanced sound, and anything distracting.'
+		},
+		other: {
+			label: 'Something to check',
+			detail: 'Compare the selected moments closely before deciding.'
+		}
+	};
+	return copy[tag];
+}
+
+function plainRiskLevel(level: unknown): string {
+	const normalized = text(level).toLowerCase();
+	if (normalized === 'high') return 'Check closely';
+	if (normalized === 'medium') return 'Worth checking';
+	return 'Review note';
 }
 
 function compareRiskFact(
@@ -280,10 +327,11 @@ function compareRiskFact(
 	if (!risk) {
 		return { label: fallbackLabel, level: 'No specific warning', detail: fallbackDetail };
 	}
+	const copy = plainRiskCopy(risk.tag);
 	return {
-		label: risk.label,
-		level: `${risk.level} risk`,
-		detail: risk.rationale
+		label: copy.label,
+		level: plainRiskLevel(risk.level),
+		detail: copy.detail
 	};
 }
 
@@ -312,32 +360,30 @@ export function compareRiskSummary(folder: FolderPayload): CompareRiskSummary | 
 		typedRisks,
 		(tag) => tag !== 'audio_quality_layout',
 		'No specific picture warning',
-		'Judge detail, motion, dark scenes, grain, and cadence in the selected moments.'
+		'Check detail, movement, dark scenes, and natural texture in the selected moments.'
 	);
 	const sound = compareRiskFact(
 		typedRisks,
 		(tag) => tag === 'audio_quality_layout',
 		'No specific sound warning',
-		'Listen for clarity, channel layout, balance, and anything distracting.'
+		'Listen for clear dialogue, balanced sound, and anything distracting.'
 	);
-	const focusMoments = (risk.pre_test_instruction?.moments ?? []).slice(0, 3).map((moment) => {
-		const labels = Array.isArray(moment.risk_tags) ? moment.risk_tags.join(', ') : 'review risk';
-		return `Moment ${moment.moment} · ${labels}`;
-	});
+	const focusMoments = (risk.pre_test_instruction?.moments ?? [])
+		.slice(0, 3)
+		.map((moment) => `Moment ${moment.moment} needs the closest look.`);
+	const topRiskCopy = topRisk ? plainRiskCopy(topRisk.tag) : null;
 	return {
 		verdict: riskVerdictCopy(risk.verdict),
 		blocked: Boolean(risk.blocked),
 		requiresCadenceResolution,
 		tone: riskTone(risk),
-		title: topRisk ? topRisk.label : riskVerdictCopy(risk.verdict),
-		detail:
-			(risk.blocking_reasons && risk.blocking_reasons[0]) ||
-			risk.comparison_reason ||
-			text(risk.interpretation?.summary) ||
-			'Measured evidence and review authority define the current risk state.',
-		topRisk: topRisk?.label ?? 'No elevated typed risk',
-		topRiskLevel: topRisk?.level ? `${topRisk.level} risk` : 'unknown risk',
-		topRiskDetail: topRisk?.rationale ?? 'No typed review focus was published for this sample.',
+		title: topRiskCopy?.label ?? riskVerdictCopy(risk.verdict),
+		detail: risk.blocked
+			? 'This test needs attention before it can be approved.'
+			: 'Compare the selected moments before deciding.',
+		topRisk: topRiskCopy?.label ?? 'No specific warning',
+		topRiskLevel: topRisk ? plainRiskLevel(topRisk.level) : 'Review note',
+		topRiskDetail: topRiskCopy?.detail ?? 'Compare the selected moments before deciding.',
 		authority: authority.value,
 		authorityDetail: authority.detail,
 		focusMoments,
@@ -1160,23 +1206,41 @@ export function normalizeReviewPairs(folder: FolderPayload): ReviewPair[] {
 			const source = record(pair.source_clip);
 			const preview = record(pair.preview_clip);
 			const compare = record(pair.compare_clip);
+			const sourceAudio = record(source.audio);
+			const previewAudio = record(preview.audio);
 			return {
 				source: {
 					path: text(source.path),
 					timestampSeconds: numberValue(source.timestamp_seconds),
 					durationSeconds: numberValue(source.duration_seconds),
-					sizeBytes: numberValue(source.size_bytes)
+					sizeBytes: numberValue(source.size_bytes),
+					audio: Object.keys(sourceAudio).length
+						? {
+								trustworthy: booleanValue(sourceAudio.trustworthy),
+								role: reviewAudioRole(sourceAudio.role)
+							}
+						: null
 				},
 				preview: {
 					path: text(preview.path),
 					timestampSeconds: numberValue(preview.timestamp_seconds),
 					durationSeconds: numberValue(preview.duration_seconds),
-					sizeBytes: numberValue(preview.size_bytes)
+					sizeBytes: numberValue(preview.size_bytes),
+					audio: Object.keys(previewAudio).length
+						? {
+								trustworthy: booleanValue(previewAudio.trustworthy),
+								role: reviewAudioRole(previewAudio.role)
+							}
+						: null
 				},
 				comparePath: text(compare.path)
 			};
 		})
 		.filter((pair) => pair.source.path && pair.preview.path);
+}
+
+function reviewAudioRole(value: unknown): ReviewAudio['role'] {
+	return value === 'original' || value === 'new' ? value : '';
 }
 
 export function predictedEpisodeSize(folder: FolderPayload): number {

--- a/mediaforce/review.py
+++ b/mediaforce/review.py
@@ -199,6 +199,7 @@ def encode_preview_clips(
         preset: int,
         crf: float,
         svt_params: list[str],
+        audio_plan: dict[str, Any] | None = None,
         video_filter: str | None = None,
         host: dict[str, Any] | None = None,
         process_controller: ManagedProcessController | None = None,
@@ -214,6 +215,7 @@ def encode_preview_clips(
         preset=preset,
         crf=crf,
         svt_params=svt_params,
+        audio_plan=audio_plan,
         video_filter=video_filter,
         host=host,
         process_controller=process_controller,
@@ -238,6 +240,7 @@ def _encode_preview_clips_remote(
         preset: int,
         crf: float,
         svt_params: list[str],
+        audio_plan: dict[str, Any] | None = None,
         video_filter: str | None = None,
 ) -> list[EncodedPreviewClip]:
     return _encode_preview_clips_remote_impl(
@@ -252,6 +255,7 @@ def _encode_preview_clips_remote(
         preset=preset,
         crf=crf,
         svt_params=svt_params,
+        audio_plan=audio_plan,
         video_filter=video_filter,
         remote_preview_timeout_seconds=REMOTE_PREVIEW_TIMEOUT_SECONDS,
         uuid_factory=uuid.uuid4,
@@ -314,6 +318,7 @@ def render_source_review_clips(
         output_dir: Path,
         timestamps: list[float],
         duration_seconds: float,
+        audio_plan: dict[str, Any] | None = None,
         process_controller: ManagedProcessController | None = None,
 ) -> list[BrowserReviewClip]:
     return render_source_review_clips_impl(
@@ -322,6 +327,7 @@ def render_source_review_clips(
         output_dir=output_dir,
         timestamps=timestamps,
         duration_seconds=duration_seconds,
+        audio_plan=audio_plan,
         process_controller=process_controller,
         render_source_review_clip=_render_source_review_clip,
         slug_seconds=_slug_seconds,
@@ -365,6 +371,7 @@ def _render_encoded_preview_clip(
         preset: int,
         crf: float,
         svt_params: list[str],
+        audio_plan: dict[str, Any] | None = None,
         video_filter: str | None = None,
         process_controller: ManagedProcessController | None = None,
 ) -> None:
@@ -379,6 +386,7 @@ def _render_encoded_preview_clip(
         preset=preset,
         crf=crf,
         svt_params=svt_params,
+        audio_plan=audio_plan,
         video_filter=video_filter,
         process_controller=process_controller,
         ffmpeg_binary=ffmpeg_binary,
@@ -401,6 +409,7 @@ def _render_encoded_preview_clip_remote(
         preset: int,
         crf: float,
         svt_params: list[str],
+        audio_plan: dict[str, Any] | None = None,
         video_filter: str | None = None,
 ) -> None:
     return _render_encoded_preview_clip_remote_impl(
@@ -415,6 +424,7 @@ def _render_encoded_preview_clip_remote(
         preset=preset,
         crf=crf,
         svt_params=svt_params,
+        audio_plan=audio_plan,
         video_filter=video_filter,
         remote_preview_timeout_seconds=REMOTE_PREVIEW_TIMEOUT_SECONDS,
         ffmpeg_binary=ffmpeg_binary,
@@ -455,6 +465,7 @@ def _render_source_review_clip(
         output_path: Path,
         clip_time: float,
         duration_seconds: float,
+        audio_plan: dict[str, Any] | None = None,
         process_controller: ManagedProcessController | None = None,
 ) -> None:
     return _render_source_review_clip_impl(
@@ -463,6 +474,7 @@ def _render_source_review_clip(
         output_path=output_path,
         clip_time=clip_time,
         duration_seconds=duration_seconds,
+        audio_plan=audio_plan,
         process_controller=process_controller,
         ffmpeg_binary=ffmpeg_binary,
         ffmpeg_hwaccel_input_args=ffmpeg_hwaccel_input_args,

--- a/mediaforce/reviewing/clips.py
+++ b/mediaforce/reviewing/clips.py
@@ -19,6 +19,7 @@ def encode_preview_clips(
         preset: int,
         crf: float,
         svt_params: list[str],
+        audio_plan: dict[str, Any] | None = None,
         video_filter: str | None = None,
         host: dict[str, Any] | None = None,
         process_controller: Any = None,
@@ -43,6 +44,7 @@ def encode_preview_clips(
             preset=preset,
             crf=crf,
             svt_params=svt_params,
+            audio_plan=audio_plan,
             video_filter=video_filter,
         )
 
@@ -60,6 +62,7 @@ def encode_preview_clips(
             preset=preset,
             crf=crf,
             svt_params=svt_params,
+            audio_plan=audio_plan,
             video_filter=video_filter,
             process_controller=process_controller,
         )
@@ -87,6 +90,7 @@ def encode_preview_clips_remote(
         preset: int,
         crf: float,
         svt_params: list[str],
+        audio_plan: dict[str, Any] | None = None,
         video_filter: str | None = None,
         remote_preview_timeout_seconds: int,
         uuid_factory: Callable[[], Any],
@@ -116,6 +120,7 @@ def encode_preview_clips_remote(
                 preset=preset,
                 crf=crf,
                 svt_params=svt_params,
+                audio_plan=audio_plan,
                 video_filter=video_filter,
             )
             copy_remote_file_to_local(host, remote_output_path, output_path, remote_preview_timeout_seconds)
@@ -259,6 +264,7 @@ def render_source_review_clips(
         output_dir: Path,
         timestamps: list[float],
         duration_seconds: float,
+        audio_plan: dict[str, Any] | None = None,
         process_controller: Any = None,
         render_source_review_clip: Callable[..., None],
         slug_seconds: Callable[[float], str],
@@ -274,6 +280,7 @@ def render_source_review_clips(
             output_path=output_path,
             clip_time=clip_time,
             duration_seconds=duration_seconds,
+            audio_plan=audio_plan,
             process_controller=process_controller,
         )
         rendered.append(

--- a/mediaforce/reviewing/renderers.py
+++ b/mediaforce/reviewing/renderers.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from typing import Any, Callable
 
@@ -8,6 +9,10 @@ NATIVE_COMPARE_FILTER = (
     "[left][right]xstack=inputs=2:layout=0_0|w0_0:fill=black[stacked];"
     "[stacked]pad=ceil(iw/2)*2:ceil(ih/2)*2[v]"
 )
+BROWSER_REVIEW_AUDIO_BITRATE = "256k"
+BROWSER_REVIEW_AUDIO_CHANNELS = 2
+BROWSER_REVIEW_AUDIO_SAMPLE_RATE = 48_000
+REMOTE_REVIEW_CLEANUP_TIMEOUT_SECONDS = 30
 
 
 def render_compare_clip(
@@ -72,6 +77,7 @@ def render_encoded_preview_clip(
         preset: int,
         crf: float,
         svt_params: list[str],
+        audio_plan: dict[str, Any] | None = None,
         video_filter: str | None = None,
         process_controller: Any = None,
         ffmpeg_binary: Callable[[], str],
@@ -79,24 +85,44 @@ def render_encoded_preview_clip(
         format_crf: Callable[[float], str],
         run_command: Callable[..., Any],
 ) -> None:
-    cmd = _preview_render_command(
-        source_path=source_path,
-        source_codec=source_codec,
-        output_path=output_path,
-        clip_time=clip_time,
-        duration_seconds=duration_seconds,
-        encoder=encoder,
-        pixel_format=pixel_format,
-        preset=preset,
-        crf=crf,
-        svt_params=svt_params,
-        video_filter=video_filter,
-        ffmpeg_binary=ffmpeg_binary,
-        ffmpeg_hwaccel_input_args=ffmpeg_hwaccel_input_args,
-        format_crf=format_crf,
-    )
-    result = run_command(cmd, process_controller=process_controller)
-    _raise_on_failure(result, "Preview sample encode failed")
+    production_audio_path = None
+    try:
+        if _requires_production_audio_render(audio_plan):
+            production_audio_path = output_path.with_name(f".{output_path.stem}-production-audio.opus")
+            audio_cmd = _production_audio_render_command(
+                source_path=source_path,
+                output_path=production_audio_path,
+                clip_time=clip_time,
+                duration_seconds=duration_seconds,
+                audio_plan=audio_plan or {},
+                ffmpeg_binary=ffmpeg_binary,
+            )
+            result = run_command(audio_cmd, process_controller=process_controller)
+            _raise_on_failure(result, "Preview audio render failed")
+
+        cmd = _preview_render_command(
+            source_path=source_path,
+            source_codec=source_codec,
+            output_path=output_path,
+            clip_time=clip_time,
+            duration_seconds=duration_seconds,
+            encoder=encoder,
+            pixel_format=pixel_format,
+            preset=preset,
+            crf=crf,
+            svt_params=svt_params,
+            audio_plan=audio_plan,
+            production_audio_path=production_audio_path,
+            video_filter=video_filter,
+            ffmpeg_binary=ffmpeg_binary,
+            ffmpeg_hwaccel_input_args=ffmpeg_hwaccel_input_args,
+            format_crf=format_crf,
+        )
+        result = run_command(cmd, process_controller=process_controller)
+        _raise_on_failure(result, "Preview sample encode failed")
+    finally:
+        if production_audio_path is not None:
+            production_audio_path.unlink(missing_ok=True)
 
 
 def render_encoded_preview_clip_remote(
@@ -112,6 +138,7 @@ def render_encoded_preview_clip_remote(
         preset: int,
         crf: float,
         svt_params: list[str],
+        audio_plan: dict[str, Any] | None = None,
         video_filter: str | None = None,
         remote_preview_timeout_seconds: int,
         ffmpeg_binary: Callable[[], str],
@@ -119,24 +146,53 @@ def render_encoded_preview_clip_remote(
         format_crf: Callable[[float], str],
         run_remote_command: Callable[..., Any],
 ) -> None:
-    cmd = _preview_render_command(
-        source_path=source_path,
-        source_codec=source_codec,
-        output_path=remote_output_path,
-        clip_time=clip_time,
-        duration_seconds=duration_seconds,
-        encoder=encoder,
-        pixel_format=pixel_format,
-        preset=preset,
-        crf=crf,
-        svt_params=svt_params,
-        video_filter=video_filter,
-        ffmpeg_binary=ffmpeg_binary,
-        ffmpeg_hwaccel_input_args=ffmpeg_hwaccel_input_args,
-        format_crf=format_crf,
-    )
-    result = run_remote_command(host, cmd, remote_preview_timeout_seconds)
-    _raise_on_failure(result, "Preview sample encode failed")
+    production_audio_path = None
+    try:
+        if _requires_production_audio_render(audio_plan):
+            production_audio_path = remote_output_path.with_name(
+                f".{remote_output_path.stem}-production-audio.opus"
+            )
+            audio_cmd = _production_audio_render_command(
+                source_path=source_path,
+                output_path=production_audio_path,
+                clip_time=clip_time,
+                duration_seconds=duration_seconds,
+                audio_plan=audio_plan or {},
+                ffmpeg_binary=ffmpeg_binary,
+            )
+            result = run_remote_command(host, audio_cmd, remote_preview_timeout_seconds)
+            _raise_on_failure(result, "Preview audio render failed")
+
+        cmd = _preview_render_command(
+            source_path=source_path,
+            source_codec=source_codec,
+            output_path=remote_output_path,
+            clip_time=clip_time,
+            duration_seconds=duration_seconds,
+            encoder=encoder,
+            pixel_format=pixel_format,
+            preset=preset,
+            crf=crf,
+            svt_params=svt_params,
+            audio_plan=audio_plan,
+            production_audio_path=production_audio_path,
+            video_filter=video_filter,
+            ffmpeg_binary=ffmpeg_binary,
+            ffmpeg_hwaccel_input_args=ffmpeg_hwaccel_input_args,
+            format_crf=format_crf,
+        )
+        result = run_remote_command(host, cmd, remote_preview_timeout_seconds)
+        _raise_on_failure(result, "Preview sample encode failed")
+    finally:
+        if production_audio_path is not None:
+            try:
+                run_remote_command(
+                    host,
+                    ["rm", "-f", str(production_audio_path)],
+                    min(remote_preview_timeout_seconds, REMOTE_REVIEW_CLEANUP_TIMEOUT_SECONDS),
+                )
+            except (OSError, RuntimeError, subprocess.SubprocessError):
+                pass
 
 
 def _preview_render_command(
@@ -151,6 +207,8 @@ def _preview_render_command(
         preset: int,
         crf: float,
         svt_params: list[str],
+        audio_plan: dict[str, Any] | None = None,
+        production_audio_path: Path | None = None,
         video_filter: str | None = None,
         ffmpeg_binary: Callable[[], str],
         ffmpeg_hwaccel_input_args: Callable[[str | None], list[str]],
@@ -170,9 +228,12 @@ def _preview_render_command(
         *ffmpeg_hwaccel_input_args(source_codec),
         "-i",
         str(source_path),
+    ]
+    if production_audio_path is not None:
+        cmd.extend(["-i", str(production_audio_path)])
+    cmd.extend([
         "-map",
         "0:v:0",
-        "-an",
         "-sn",
         "-c:v",
         encoder,
@@ -184,7 +245,26 @@ def _preview_render_command(
         str(preset),
         "-crf",
         format_crf(crf),
-    ]
+    ])
+    if audio_plan is None:
+        cmd.extend(["-an"])
+    else:
+        audio_input = "1:a:0" if production_audio_path is not None else f"0:{_audio_stream_index(audio_plan)}"
+        cmd.extend(
+            [
+                "-map",
+                audio_input,
+                "-c:a",
+                "aac",
+                "-b:a",
+                BROWSER_REVIEW_AUDIO_BITRATE,
+                "-ar",
+                str(BROWSER_REVIEW_AUDIO_SAMPLE_RATE),
+                "-ac",
+                str(BROWSER_REVIEW_AUDIO_CHANNELS),
+                "-shortest",
+            ]
+        )
     if encoder == "libsvtav1":
         cmd.extend(["-svtav1-params", ":".join(svt_params)])
     if video_filter:
@@ -246,6 +326,7 @@ def render_source_review_clip(
         output_path: Path,
         clip_time: float,
         duration_seconds: float,
+        audio_plan: dict[str, Any] | None = None,
         process_controller: Any = None,
         ffmpeg_binary: Callable[[], str],
         ffmpeg_hwaccel_input_args: Callable[[str | None], list[str]],
@@ -267,7 +348,6 @@ def render_source_review_clip(
         str(source_path),
         "-map",
         "0:v:0",
-        "-an",
         "-sn",
         "-c:v",
         "libx264",
@@ -277,10 +357,78 @@ def render_source_review_clip(
         "veryfast",
         "-movflags",
         "+faststart",
-        str(output_path),
     ]
+    if audio_plan is None:
+        cmd.extend(["-an"])
+    else:
+        cmd.extend(
+            [
+                "-map",
+                f"0:{_audio_stream_index(audio_plan)}",
+                "-c:a",
+                "aac",
+                "-b:a",
+                BROWSER_REVIEW_AUDIO_BITRATE,
+                "-ar",
+                str(BROWSER_REVIEW_AUDIO_SAMPLE_RATE),
+                "-ac",
+                str(BROWSER_REVIEW_AUDIO_CHANNELS),
+                "-shortest",
+            ]
+        )
+    cmd.append(str(output_path))
     result = run_command(cmd, process_controller=process_controller)
     _raise_on_failure(result, "Source review clip render failed")
+
+
+def _requires_production_audio_render(audio_plan: dict[str, Any] | None) -> bool:
+    if audio_plan is None:
+        return False
+    return str(audio_plan.get("production_action") or "") == "transcode"
+
+
+def _audio_stream_index(audio_plan: dict[str, Any]) -> int:
+    return int(audio_plan["source_stream_index"])
+
+
+def _production_audio_render_command(
+        *,
+        source_path: Path,
+        output_path: Path,
+        clip_time: float,
+        duration_seconds: float,
+        audio_plan: dict[str, Any],
+        ffmpeg_binary: Callable[[], str],
+) -> list[str]:
+    channels = int(audio_plan.get("source_channels") or 2)
+    cmd = [
+        ffmpeg_binary(),
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-nostdin",
+        "-y",
+        "-ss",
+        f"{clip_time:.3f}",
+        "-t",
+        f"{duration_seconds:.3f}",
+        "-i",
+        str(source_path),
+        "-map",
+        f"0:{_audio_stream_index(audio_plan)}",
+        "-vn",
+        "-sn",
+        "-c:a",
+        "libopus",
+        "-b:a",
+        str(audio_plan.get("production_bitrate_text") or "128k"),
+    ]
+    if channels >= 8:
+        cmd.extend(["-af", "channelmap=channel_layout=7.1", "-mapping_family", "1"])
+    elif channels >= 6:
+        cmd.extend(["-af", "channelmap=channel_layout=5.1", "-mapping_family", "1"])
+    cmd.append(str(output_path))
+    return cmd
 
 
 def _raise_on_failure(result: Any, prefix: str) -> None:

--- a/mediaforce/web/runtime/calibration_runtime.py
+++ b/mediaforce/web/runtime/calibration_runtime.py
@@ -17,8 +17,10 @@ from mediaforce.core.db import DBClient, open_db
 from mediaforce.core.db_tables import staged_artifacts
 from mediaforce.core.process_control import ManagedProcessController, ProcessCancelledError
 from mediaforce.core.type_defs import float_value, int_value, object_dict, object_list
+from mediaforce.encoding.helpers import resolve_item_source_path
 from mediaforce.encoding.quality import quality_error_message, resolve_local_quality_temp_root
 from mediaforce.encoding.video_filters import build_video_filter
+from mediaforce.hosts.config import host_media_access_for_host
 from mediaforce.state_cleanup import purge_transient_artifacts
 from mediaforce.tuning.target_size_search import TargetSizeSearchError
 
@@ -200,6 +202,38 @@ def _output_container(config: MediaforceConfig, sample_item: dict[str, Any]) -> 
         return item_container.removeprefix(".")
     source_suffix = Path(str(sample_item.get("source_path") or "")).suffix
     return source_suffix.removeprefix(".") or "mkv"
+
+
+def _review_audio_plan(stream_budget: Any) -> dict[str, Any] | None:
+    audio_streams = tuple(stream_budget.stream_plan.audio_streams)
+    if not audio_streams:
+        return None
+    stream = audio_streams[0]
+    if stream.action == "transcode" and stream.codec_argument != "libopus":
+        return None
+    if stream.action not in {"copy", "transcode"}:
+        return None
+    return {
+        "source_stream_index": stream.source_index,
+        "source_codec": stream.source_codec,
+        "source_channels": stream.channels or 2,
+        "production_action": stream.action,
+        "production_codec": stream.output_codec or stream.source_codec,
+        "production_bitrate_bps": stream.output_bitrate_bps,
+        "production_bitrate_text": stream.output_bitrate_text,
+    }
+
+
+def _review_audio_payload(audio_plan: dict[str, Any] | None, role: str) -> dict[str, Any] | None:
+    if audio_plan is None:
+        return None
+    return {
+        **audio_plan,
+        "trustworthy": True,
+        "role": role,
+        "review_codec": "aac",
+        "review_channels": 2,
+    }
 
 
 def snapshot_staged_artifact(
@@ -465,8 +499,14 @@ def run_sampled_calibration(
         progress_callback: Any | None = None,
 ) -> tuple[dict[str, Any], Path | None]:
     _ = prefix
-    source_path = Path(sample_item["source_path"])
+    controller_source_path = Path(sample_item["source_path"])
     quality_host = _quality_host_data(config, host_data)
+    quality_source_path = resolve_item_source_path(
+        config,
+        sample_item,
+        host=quality_host,
+        host_media_access_for_host=host_media_access_for_host,
+    )
     quality_temp_dir = _quality_temp_dir_for_host(config, quality_host)
     video_policy = object_dict(policy.get("video"))
     stream_budget = deps.resolve_stream_budget_ledger(
@@ -475,6 +515,7 @@ def run_sampled_calibration(
         output_container=_output_container(config, sample_item),
     )
     stream_budget.require_positive_target_video_budget()
+    review_audio_plan = _review_audio_plan(stream_budget)
     sample_item["stream_budget_ledger"] = stream_budget.to_payload()
     sample_item["output_container"] = _output_container(config, sample_item)
     width = int_value(sample_item.get("width")) or None
@@ -493,7 +534,7 @@ def run_sampled_calibration(
     if progress_callback is not None:
         progress_callback("inspecting_source")
     detected_crop = deps.detect_video_crop(
-        source_path,
+        quality_source_path,
         video_policy,
         source_codec=str(sample_item.get("video_codec") or ""),
         width=width,
@@ -529,11 +570,11 @@ def run_sampled_calibration(
         )
     if progress_callback is not None:
         progress_callback("searching_target")
-    quality_result = deps.search_quality_for_source(source_path, video_policy, **quality_kwargs)
+    quality_result = deps.search_quality_for_source(quality_source_path, video_policy, **quality_kwargs)
     if progress_callback is not None:
         progress_callback("measuring_quality")
     sample_result = deps.run_sample_encode(
-        source_path,
+        quality_source_path,
         source_codec=str(sample_item.get("video_codec") or ""),
         preferred_metric=str(video_policy.get("quality_metric", "auto")),
         crf=quality_result.crf,
@@ -553,7 +594,7 @@ def run_sampled_calibration(
         progress_callback("selecting_review_moments")
     if deps.recommend_review_moments is not None:
         review_moments = deps.recommend_review_moments(
-            source_path,
+            controller_source_path,
             float_value(sample_item.get("duration_seconds")),
             8.0,
             media_fingerprint=object_dict(sample_item.get("media_fingerprint")),
@@ -563,7 +604,7 @@ def run_sampled_calibration(
     timestamps = [moment.timestamp_seconds for moment in review_moments]
     if not timestamps:
         timestamps = deps.recommend_review_timestamps(
-            source_path,
+            controller_source_path,
             float_value(sample_item.get("duration_seconds")),
             8.0,
             process_controller=process_controller,
@@ -573,7 +614,7 @@ def run_sampled_calibration(
     if progress_callback is not None:
         progress_callback("building_review", completed=0, total=3)
     preview_clips = deps.encode_preview_clips(
-        source_path=source_path,
+        source_path=quality_source_path,
         source_codec=str(sample_item.get("video_codec") or ""),
         output_dir=output_dir,
         timestamps=timestamps,
@@ -583,24 +624,26 @@ def run_sampled_calibration(
         preset=preset,
         crf=quality_result.crf,
         svt_params=deps.build_svt_params(video_policy),
+        audio_plan=review_audio_plan,
         video_filter=video_filter,
-        host=host_data,
+        host=quality_host,
         process_controller=process_controller,
     )
     if progress_callback is not None:
         progress_callback("building_review", completed=1, total=3)
     source_clips = deps.render_source_review_clips(
-        source_path=source_path,
+        source_path=controller_source_path,
         source_codec=str(sample_item.get("video_codec") or ""),
         output_dir=output_dir,
         timestamps=timestamps,
         duration_seconds=8.0,
+        audio_plan=review_audio_plan,
         process_controller=process_controller,
     )
     if progress_callback is not None:
         progress_callback("building_review", completed=2, total=3)
     compare_clips = deps.generate_compare_clips_from_previews(
-        source_path=source_path,
+        source_path=controller_source_path,
         source_codec=str(sample_item.get("video_codec") or ""),
         previews=preview_clips,
         output_dir=output_dir,
@@ -668,6 +711,7 @@ def run_sampled_calibration(
                 "timestamp_seconds": clip.timestamp_seconds,
                 "duration_seconds": clip.duration_seconds,
                 "size_bytes": clip.size_bytes,
+                "audio": _review_audio_payload(review_audio_plan, "new"),
             }
             for clip in preview_clips
         ],
@@ -677,6 +721,7 @@ def run_sampled_calibration(
                 "timestamp_seconds": clip.timestamp_seconds,
                 "duration_seconds": clip.duration_seconds,
                 "size_bytes": clip.size_bytes,
+                "audio": _review_audio_payload(review_audio_plan, "original"),
             }
             for clip in source_clips
         ],

--- a/mediaforce/web/runtime/folder_ai_tuning.py
+++ b/mediaforce/web/runtime/folder_ai_tuning.py
@@ -74,6 +74,7 @@ class FolderAiTuneDeps:
 def _job_sample_item_payload(sample_item: dict[str, Any]) -> dict[str, Any]:
     return {
         "library_item_id": sample_item.get("library_item_id"),
+        "media_root": sample_item.get("media_root"),
         "rel_path": sample_item.get("rel_path"),
         "source_path": sample_item.get("source_path"),
         "source_fingerprint": sample_item.get("source_fingerprint"),

--- a/scripts/seed-web-smoke-fixtures.py
+++ b/scripts/seed-web-smoke-fixtures.py
@@ -554,12 +554,24 @@ def _write_review_sample_state(
                     "timestamp_seconds": 60,
                     "duration_seconds": 12,
                     "size_bytes": 96_000_000,
+                    "audio": {
+                        "trustworthy": True,
+                        "role": "original",
+                        "review_codec": "aac",
+                        "review_channels": 2,
+                    },
                 },
                 "preview_clip": {
                     "path": f"/review-media/{review_slug}/preview.mov",
                     "timestamp_seconds": 60,
                     "duration_seconds": 12,
                     "size_bytes": 12_000_000,
+                    "audio": {
+                        "trustworthy": True,
+                        "role": "new",
+                        "review_codec": "aac",
+                        "review_channels": 2,
+                    },
                 },
             }
         ],

--- a/scripts/smoke-web-routes.mjs
+++ b/scripts/smoke-web-routes.mjs
@@ -603,6 +603,63 @@ async function checkOlderSeasonConfirmation(baseUrl, timeoutMs) {
   }
 }
 
+async function checkComparisonWorkspace(baseUrl, route, timeoutMs) {
+  const browser = await chromium.launch({ channel: "chromium" });
+  try {
+    const page = await browser.newPage({
+      viewport: { width: 1440, height: 900 },
+    });
+    await page.goto(`${baseUrl}${route}`, {
+      waitUntil: "domcontentloaded",
+      timeout: timeoutMs,
+    });
+    const openButton = page.getByRole("button", {
+      name: "Compare in full screen",
+    });
+    await openButton.waitFor({ state: "visible", timeout: timeoutMs });
+    await openButton.click();
+    const workspace = page.getByRole("dialog", {
+      name: "Compare picture and sound",
+    });
+    await workspace.waitFor({ state: "visible", timeout: timeoutMs });
+    await workspace.getByRole("button", { name: "One at a time" }).click();
+    await workspace
+      .getByRole("group", { name: "Picture shown" })
+      .getByRole("button", { name: "Original", exact: true })
+      .click();
+    await workspace.getByRole("button", { name: "Actual size" }).click();
+    const state = await workspace.evaluate((element) => ({
+      text: element.textContent ?? "",
+      hasVisibleOriginal: Boolean(
+        element.querySelector(".show-original .media-pane--original"),
+      ),
+      hasSoundChoice: Boolean(
+        element.querySelector('[role="group"][aria-label="Listen to"]'),
+      ),
+    }));
+    if (!state.hasVisibleOriginal || !state.hasSoundChoice) {
+      throw new Error(
+        `Comparison workspace did not expose expected controls: ${JSON.stringify(state)}`,
+      );
+    }
+    if (
+      /\b(CRF|codec|bitrate|VMAF|XPSNR|synchroni[sz]ation)\b/i.test(state.text)
+    ) {
+      throw new Error("Comparison workspace exposed implementation language.");
+    }
+    await workspace.getByRole("button", { name: "Close comparison" }).click();
+    await page.waitForFunction(
+      () =>
+        document.activeElement?.textContent?.includes("Compare in full screen"),
+      undefined,
+      { timeout: timeoutMs },
+    );
+    console.log("route ok: Full-screen comparison workspace");
+  } finally {
+    await browser.close();
+  }
+}
+
 async function checkNarrowRoutes(baseUrl, routeChecksForNarrow, timeoutMs) {
   const browser = await chromium.launch({ channel: "chromium" });
   try {
@@ -785,6 +842,20 @@ async function main() {
       );
       await checkLifecyclePolicyShowIsolation(targetUrl, args.routeTimeoutMs);
       await checkOlderSeasonConfirmation(targetUrl, args.routeTimeoutMs);
+      const reviewReadyFixture = fixtures.folderRoutes.find(
+        (fixtureRoute) =>
+          fixtureRoute.route === "/folders/tv/Review%20Ready/Season%201",
+      );
+      if (!reviewReadyFixture) {
+        throw new Error(
+          "Fixture payload did not include the review-ready route.",
+        );
+      }
+      await checkComparisonWorkspace(
+        targetUrl,
+        reviewReadyFixture.route,
+        args.routeTimeoutMs,
+      );
     }
     if (args.narrow) {
       await checkNarrowRoutes(

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -6657,8 +6657,12 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             ):
                 with patch.object(web_app, "recommend_review_moments", return_value=[review_moment]):
                     with patch.object(web_app, "recommend_review_timestamps", return_value=[10.0]):
-                        with patch.object(web_app, "encode_preview_clips", return_value=[preview_clip]):
-                            with patch.object(web_app, "render_source_review_clips", return_value=[source_clip]):
+                        with patch.object(
+                                web_app, "encode_preview_clips", return_value=[preview_clip]
+                        ) as preview_mock:
+                            with patch.object(
+                                    web_app, "render_source_review_clips", return_value=[source_clip]
+                            ) as source_mock:
                                 with patch.object(web_app, "generate_compare_clips_from_previews",
                                                   return_value=[compare_clip]):
                                     payload, cleanup_path = web_app._run_sampled_calibration(
@@ -6676,7 +6680,13 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                                                 "sample_duration": "20s",
                                                 "preset": 4,
                                             },
-                                            "audio": {},
+                                            "audio": {
+                                                "copy_codecs": ["aac", "opus"],
+                                                "convert_to_opus_codecs": ["eac3"],
+                                                "stereo_opus_bitrate": "128k",
+                                                "surround_5_1_opus_bitrate": "256k",
+                                                "surround_7_1_opus_bitrate": "320k",
+                                            },
                                             "subtitle": {},
                                         },
                                         seed_metadata=None,
@@ -6685,6 +6695,26 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                                             "source_size_bytes": 200_000_000,
                                             "duration_seconds": 2600.0,
                                             "rel_path": "tv/show/episode-review.mkv",
+                                            "resolved_policy": {
+                                                "audio": {
+                                                    "copy_codecs": ["aac", "opus"],
+                                                    "convert_to_opus_codecs": ["eac3"],
+                                                    "stereo_opus_bitrate": "128k",
+                                                    "surround_5_1_opus_bitrate": "256k",
+                                                    "surround_7_1_opus_bitrate": "320k",
+                                                },
+                                                "subtitle": {},
+                                            },
+                                            "audio_summary": [
+                                                {
+                                                    "index": 1,
+                                                    "codec_name": "eac3",
+                                                    "channels": 2,
+                                                    "language": "eng",
+                                                    "default": 1,
+                                                    "bit_rate": 224_000,
+                                                }
+                                            ],
                                         },
                                         calibration_run_id="run-123",
                                         process_controller=Mock(),
@@ -6694,6 +6724,12 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertTrue(payload["preview_clips"][0]["path"].startswith("/review-media/run-123/"))
         self.assertTrue(payload["source_clips"][0]["path"].startswith("/review-media/run-123/"))
         self.assertTrue(payload["compare_clips"][0]["path"].startswith("/review-media/run-123/"))
+        self.assertTrue(payload["source_clips"][0]["audio"]["trustworthy"])
+        self.assertEqual(payload["source_clips"][0]["audio"]["role"], "original")
+        self.assertEqual(payload["preview_clips"][0]["audio"]["role"], "new")
+        self.assertEqual(payload["preview_clips"][0]["audio"]["production_action"], "transcode")
+        self.assertEqual(preview_mock.call_args.kwargs["audio_plan"]["source_stream_index"], 1)
+        self.assertEqual(source_mock.call_args.kwargs["audio_plan"]["production_codec"], "opus")
         self.assertEqual(payload["review_moments"][0]["role"], "hard")
         self.assertEqual(payload["review_moments"][0]["evidence_id"], "ev1_fingerprint")
         self.assertEqual(
@@ -7262,7 +7298,16 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             source_review_mock: Mock,
             compare_preview_mock: Mock,
     ) -> None:
+        self.config.raw["remote_hosts"] = [
+            {
+                "host": "cbusillo@m1-mini",
+                "label": "M1 mini",
+                "capabilities": ["sample_calibration", "encode_queue"],
+                "source_roots": {"tv": "/srv/media/tv"},
+            }
+        ]
         source_path = self._create_source_file("episode-remote.mkv")
+        remote_source_path = Path("/srv/media/tv/show/episode-remote.mkv")
         preview_path = self.root / "review" / "remote-run" / "item-00" / "encoded-01-12m-00s.mp4"
         source_review_path = self.root / "review" / "remote-run" / "item-00" / "source-01-12m-00s.mp4"
         compare_path = self.root / "review" / "remote-run" / "item-00" / "compare-01-12m-00s.mkv"
@@ -7288,6 +7333,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             "subtitle": {"prefer_text": True},
         }
         sample_item = {
+            "media_root": "tv",
             "source_path": str(source_path),
             "rel_path": "tv/show/episode-remote.mkv",
             "source_size_bytes": 1_000_000,
@@ -7360,27 +7406,26 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             process_controller=web_app.ManagedProcessController(),
         )
 
-        search_quality_mock.assert_called_once_with(
-            source_path,
-            policy["video"],
-            source_codec="h264",
-            width=None,
-            height=None,
-            detected_crop=None,
-            process_controller=unittest.mock.ANY,
-            host=host,
-            quality_temp_dir=self.config.staging_root,
-            stream_budget_ledger=unittest.mock.ANY,
-        )
+        self.assertEqual(search_quality_mock.call_args.args[0], remote_source_path)
+        self.assertEqual(search_quality_mock.call_args.args[1], policy["video"])
+        quality_host = search_quality_mock.call_args.kwargs["host"]
+        self.assertEqual(quality_host["key"], host["key"])
+        self.assertEqual(quality_host["source_roots"], {"tv": "/srv/media/tv"})
+        self.assertEqual(search_quality_mock.call_args.kwargs["source_codec"], "h264")
+        self.assertIsNone(search_quality_mock.call_args.kwargs["detected_crop"])
+        self.assertEqual(search_quality_mock.call_args.kwargs["quality_temp_dir"], self.config.staging_root)
         sample_encode_mock.assert_called_once()
-        self.assertEqual(sample_encode_mock.call_args.kwargs["host"], host)
+        self.assertEqual(sample_encode_mock.call_args.args[0], remote_source_path)
+        self.assertEqual(sample_encode_mock.call_args.kwargs["host"], quality_host)
         self.assertEqual(sample_encode_mock.call_args.kwargs["source_codec"], "h264")
         self.assertIsNone(sample_encode_mock.call_args.kwargs["video_filter"])
         self.assertEqual(sample_encode_mock.call_args.kwargs["quality_temp_dir"], self.config.staging_root)
         encode_preview_mock.assert_called_once()
-        self.assertEqual(encode_preview_mock.call_args.kwargs["host"], host)
+        self.assertEqual(encode_preview_mock.call_args.kwargs["source_path"], remote_source_path)
+        self.assertEqual(encode_preview_mock.call_args.kwargs["host"], quality_host)
         self.assertEqual(encode_preview_mock.call_args.kwargs["source_codec"], "h264")
         self.assertIsNone(encode_preview_mock.call_args.kwargs["video_filter"])
+        self.assertEqual(source_review_mock.call_args.kwargs["source_path"], source_path)
         self.assertEqual(payload["host"], host)
         self.assertEqual(payload["compare_clips"][0]["path"], "/review-media/remote-run/item-00/compare-01-12m-00s.mkv")
 
@@ -7577,6 +7622,8 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertEqual(sample_encode_mock.call_args.kwargs["host"]["mode"], "local")
         self.assertEqual(search_quality_mock.call_args.kwargs["host"]["media_access"], "stream")
         self.assertEqual(sample_encode_mock.call_args.kwargs["host"]["media_access"], "stream")
+        self.assertEqual(encode_preview_mock.call_args.kwargs["host"]["mode"], "local")
+        self.assertEqual(encode_preview_mock.call_args.kwargs["source_path"], source_path)
 
     def test_purge_transient_artifacts_prunes_ab_av1_dirs_in_host_specific_staging_roots(self) -> None:
         host_staging_root = self.root / "custom-local-staging"
@@ -11059,6 +11106,78 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertIn("tune=0:film-grain=0", cmd)
         self.assertIn("28.25", cmd)
 
+    def test_render_encoded_preview_clip_normalizes_copied_audio_for_browser_review(self) -> None:
+        with patch("mediaforce.review.ffmpeg_binary", return_value="/tmp/ffmpeg"), patch(
+                "mediaforce.review.ffmpeg_hwaccel_input_args", return_value=[]
+        ), patch(
+            "mediaforce.review.run_command",
+            return_value=subprocess.CompletedProcess(args=["ffmpeg"], returncode=0, stdout="", stderr=""),
+        ) as run_mock:
+            review._render_encoded_preview_clip(
+                source_path=Path("/tmp/input.mkv"),
+                output_path=Path("/tmp/preview.mp4"),
+                clip_time=12.0,
+                duration_seconds=8.0,
+                encoder="libsvtav1",
+                pixel_format="yuv420p10le",
+                preset=4,
+                crf=28.0,
+                svt_params=["tune=0"],
+                audio_plan={
+                    "source_stream_index": 2,
+                    "source_channels": 2,
+                    "production_action": "copy",
+                    "production_codec": "aac",
+                },
+            )
+
+        self.assertEqual(run_mock.call_count, 1)
+        cmd = run_mock.call_args.args[0]
+        self.assertIn("0:2", cmd)
+        self.assertEqual(cmd[cmd.index("-c:a") + 1], "aac")
+        self.assertEqual(cmd[cmd.index("-b:a") + 1], "256k")
+        self.assertEqual(cmd[cmd.index("-ar") + 1], "48000")
+        self.assertEqual(cmd[cmd.index("-ac") + 1], "2")
+        self.assertNotIn("-an", cmd)
+
+    def test_render_encoded_preview_clip_applies_production_opus_before_browser_audio(self) -> None:
+        output_path = self.root / "preview-with-audio.mp4"
+        with patch("mediaforce.review.ffmpeg_binary", return_value="/tmp/ffmpeg"), patch(
+                "mediaforce.review.ffmpeg_hwaccel_input_args", return_value=[]
+        ), patch(
+            "mediaforce.review.run_command",
+            return_value=subprocess.CompletedProcess(args=["ffmpeg"], returncode=0, stdout="", stderr=""),
+        ) as run_mock:
+            review._render_encoded_preview_clip(
+                source_path=Path("/tmp/input.mkv"),
+                output_path=output_path,
+                clip_time=12.0,
+                duration_seconds=8.0,
+                encoder="libsvtav1",
+                pixel_format="yuv420p10le",
+                preset=4,
+                crf=28.0,
+                svt_params=["tune=0"],
+                audio_plan={
+                    "source_stream_index": 3,
+                    "source_channels": 6,
+                    "production_action": "transcode",
+                    "production_codec": "opus",
+                    "production_bitrate_text": "256k",
+                },
+            )
+
+        self.assertEqual(run_mock.call_count, 2)
+        production_audio_cmd = run_mock.call_args_list[0].args[0]
+        browser_preview_cmd = run_mock.call_args_list[1].args[0]
+        self.assertEqual(production_audio_cmd[production_audio_cmd.index("-map") + 1], "0:3")
+        self.assertEqual(production_audio_cmd[production_audio_cmd.index("-c:a") + 1], "libopus")
+        self.assertEqual(production_audio_cmd[production_audio_cmd.index("-b:a") + 1], "256k")
+        self.assertIn("channelmap=channel_layout=5.1", production_audio_cmd)
+        self.assertEqual(browser_preview_cmd[browser_preview_cmd.index("-map", 1) + 1], "0:v:0")
+        self.assertIn("1:a:0", browser_preview_cmd)
+        self.assertFalse((self.root / ".preview-with-audio-production-audio.opus").exists())
+
     def test_resolve_item_paths_use_host_overrides(self) -> None:
         item = {
             "source_path": "/Volumes/media/tv/show/episode.mkv",
@@ -12459,6 +12578,33 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertIn("-hwaccel", cmd)
         self.assertIn("videotoolbox", cmd)
 
+    def test_render_source_review_clip_adds_truthful_browser_audio(self) -> None:
+        with patch("mediaforce.review.ffmpeg_binary", return_value="/tmp/ffmpeg"), patch(
+                "mediaforce.review.ffmpeg_hwaccel_input_args", return_value=[]
+        ), patch(
+            "mediaforce.review.run_command",
+            return_value=subprocess.CompletedProcess(args=["ffmpeg"], returncode=0, stdout="", stderr=""),
+        ) as run_mock:
+            review._render_source_review_clip(
+                source_path=Path("/tmp/input.mkv"),
+                output_path=Path("/tmp/review.mp4"),
+                clip_time=12.0,
+                duration_seconds=8.0,
+                audio_plan={
+                    "source_stream_index": 4,
+                    "source_channels": 6,
+                    "production_action": "transcode",
+                    "production_codec": "opus",
+                },
+            )
+
+        cmd = run_mock.call_args.args[0]
+        self.assertIn("0:4", cmd)
+        self.assertEqual(cmd[cmd.index("-c:a") + 1], "aac")
+        self.assertEqual(cmd[cmd.index("-ar") + 1], "48000")
+        self.assertEqual(cmd[cmd.index("-ac") + 1], "2")
+        self.assertNotIn("-an", cmd)
+
     def test_render_compare_clip_preserves_native_resolution(self) -> None:
         with patch("mediaforce.review.ffmpeg_binary", return_value="/tmp/ffmpeg"), patch(
                 "mediaforce.review.ffmpeg_hwaccel_input_args", return_value=[]
@@ -12699,6 +12845,75 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         self.assertIn("tune=0:film-grain=0", cmd)
         self.assertIn("28.25", cmd)
         self.assertEqual(cmd[-1], "/tmp/output.mp4")
+
+    def test_render_encoded_preview_clip_remote_cleans_up_production_audio(self) -> None:
+        with patch("mediaforce.review.ffmpeg_binary", return_value="/tmp/ffmpeg"), patch(
+                "mediaforce.review.ffmpeg_hwaccel_input_args", return_value=[]
+        ), patch(
+            "mediaforce.review.run_remote_command",
+            return_value=subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="", stderr=""),
+        ) as remote_mock:
+            review._render_encoded_preview_clip_remote(
+                host={"key": "cbusillo@studio", "mode": "ssh"},
+                source_path=Path("/tmp/input.mkv"),
+                remote_output_path=Path("/tmp/output.mp4"),
+                clip_time=12.0,
+                duration_seconds=8.0,
+                encoder="libsvtav1",
+                pixel_format="yuv420p10le",
+                preset=4,
+                crf=28.0,
+                svt_params=["tune=0"],
+                audio_plan={
+                    "source_stream_index": 3,
+                    "source_channels": 8,
+                    "production_action": "transcode",
+                    "production_codec": "opus",
+                    "production_bitrate_text": "320k",
+                },
+            )
+
+        self.assertEqual(remote_mock.call_count, 3)
+        production_audio_cmd = remote_mock.call_args_list[0].args[1]
+        browser_preview_cmd = remote_mock.call_args_list[1].args[1]
+        cleanup_cmd = remote_mock.call_args_list[2].args[1]
+        self.assertIn("channelmap=channel_layout=7.1", production_audio_cmd)
+        self.assertIn("1:a:0", browser_preview_cmd)
+        self.assertEqual(cleanup_cmd[:2], ["rm", "-f"])
+        self.assertEqual(remote_mock.call_args_list[2].args[2], 30)
+
+    def test_render_encoded_preview_clip_remote_preserves_preview_failure_when_cleanup_times_out(self) -> None:
+        success = subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="", stderr="")
+        preview_failure = subprocess.CompletedProcess(
+            args=["ssh"], returncode=1, stdout="", stderr="preview failed"
+        )
+        cleanup_timeout = subprocess.TimeoutExpired(cmd=["ssh"], timeout=30)
+        with patch("mediaforce.review.ffmpeg_binary", return_value="/tmp/ffmpeg"), patch(
+                "mediaforce.review.ffmpeg_hwaccel_input_args", return_value=[]
+        ), patch(
+            "mediaforce.review.run_remote_command",
+            side_effect=[success, preview_failure, cleanup_timeout],
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Preview sample encode failed: preview failed"):
+                review._render_encoded_preview_clip_remote(
+                    host={"key": "cbusillo@studio", "mode": "ssh"},
+                    source_path=Path("/tmp/input.mkv"),
+                    remote_output_path=Path("/tmp/output.mp4"),
+                    clip_time=12.0,
+                    duration_seconds=8.0,
+                    encoder="libsvtav1",
+                    pixel_format="yuv420p10le",
+                    preset=4,
+                    crf=28.0,
+                    svt_params=["tune=0"],
+                    audio_plan={
+                        "source_stream_index": 3,
+                        "source_channels": 6,
+                        "production_action": "transcode",
+                        "production_codec": "opus",
+                        "production_bitrate_text": "256k",
+                    },
+                )
 
     def test_generate_compare_clips_uses_staged_artifacts_and_auto_timestamps(self) -> None:
         source_path = self._create_source_file("episode-compare.mkv")

--- a/tests/test_tuning_runtime.py
+++ b/tests/test_tuning_runtime.py
@@ -4426,6 +4426,7 @@ class TuningRuntimeTests(unittest.TestCase):
             load_job_state=lambda *_args, **_kwargs: None,
             load_retryable_sample_job_state=lambda *_args, **_kwargs: None,
             sample_item=lambda *_args, **_kwargs: {
+                "media_root": "tv",
                 "rel_path": "tv/show/episode.mkv",
                 "resolved_policy": {"video": {"encoder": "libx264"}},
             },
@@ -4526,6 +4527,7 @@ class TuningRuntimeTests(unittest.TestCase):
             load_job_state=lambda *_args, **_kwargs: None,
             load_retryable_sample_job_state=lambda *_args, **_kwargs: None,
             sample_item=lambda *_args, **_kwargs: {
+                "media_root": "tv",
                 "rel_path": "tv/show/episode.mkv",
                 "source_path": str(self.root / "source" / "tv" / "show" / "episode.mkv"),
                 "source_size_bytes": 4_000_000_000,
@@ -4606,6 +4608,7 @@ class TuningRuntimeTests(unittest.TestCase):
 
         self.assertTrue(confirm_result["ok"])
         self.assertEqual(saved_jobs[0]["policy"], proposal["preview_policy"])
+        self.assertEqual(saved_jobs[0]["sample_item"]["media_root"], "tv")
         queued_ledger = saved_jobs[0]["sample_item"]["stream_budget_ledger"]
         self.assertEqual(queued_ledger["totals"]["total_target_bytes"], 225_000_000)
         self.assertEqual(queued_ledger["totals"]["remaining_video_bytes"], 217_000_000)


### PR DESCRIPTION
# Full-Screen Comparison

## Summary

- add browser-safe Original/New review clips with truthful production-audio
  comparison, including remote source-path and cleanup hardening
- add a focused full-screen workspace with Side by side, One at a time, Fit,
  Actual size, shared playback, moment switching, and deliberate sound selection
- keep legacy clips honest with picture-only messaging, keep approval outside
  the workspace, and remove codec/metric language from the normal review flow
- extend managed smoke coverage and documentation for desktop and narrow
  comparison behavior

## Validation

- `bash scripts/pre-commit-check.sh` — 1042 backend tests, 229 frontend
  tests, CLI smoke, frontend lint/check/build, package build, and managed
  desktop+narrow route smoke passed
- live browser — desktop native full screen and fallback overlay; Side by side;
  One at a time; Original/New position continuity; Fit/Actual size; close/focus
  return; narrow 390px layout
- independent backend/media, product-language, and live-browser review agents
  completed; actionable findings were fixed
- PyCharm changed-files inspection reported zero findings, but its Svelte files
  were classified as plain text, so semantic Svelte coverage remained
  inconclusive; `svelte-check`, ESLint, Vitest, build, smoke, and live browser
  validation passed

Closes #236
