### PR TITLE
Fix older-season review flow and inline comparison

### DIFF
--- a/frontend/src/lib/components/season/ComparisonWorkspace.svelte
+++ b/frontend/src/lib/components/season/ComparisonWorkspace.svelte
@@ -4,8 +4,11 @@
 	import {
 		alignedScrollOffset,
 		comparisonKeyboardAction,
+		comparisonSideMuted,
 		formatPlaybackTime,
 		frameAspectRatio,
+		mediaElementReady,
+		mediaSourceMatches,
 		normalizedScrollPosition,
 		reviewPairHasSound,
 		scrollOffsetForPosition,
@@ -64,8 +67,11 @@
 	let previewHeight = $state(0);
 	let sourceReady = $state(false);
 	let previewReady = $state(false);
+	let sourceError = $state(false);
+	let previewError = $state(false);
 	let previousBodyOverflow = '';
 	let scrollSyncPending = false;
+	let mediaGeneration = 0;
 	let picturePositionX = 0.5;
 	let picturePositionY = 0.5;
 
@@ -89,7 +95,9 @@
 
 	$effect(() => {
 		if (!pairKey) return;
+		mediaGeneration += 1;
 		pauseBoth();
+		preparing = false;
 		currentTime = 0;
 		duration = currentPair?.preview.durationSeconds || currentPair?.source.durationSeconds || 0;
 		sourceWidth = 0;
@@ -98,6 +106,8 @@
 		previewHeight = 0;
 		sourceReady = false;
 		previewReady = false;
+		sourceError = false;
+		previewError = false;
 		playbackError = '';
 		picturePositionX = 0.5;
 		picturePositionY = 0.5;
@@ -242,18 +252,34 @@
 	}
 
 	function handleMediaError(side: ComparisonSide) {
-		if (side === 'original') sourceReady = false;
-		else previewReady = false;
+		if (side === 'original') {
+			sourceReady = false;
+			sourceError = true;
+		} else {
+			previewReady = false;
+			previewError = true;
+		}
 		playbackError = `${side === 'original' ? 'The original' : 'The new'} clip could not be decoded in this browser.`;
 	}
 
 	function handleMediaLoaded(side: ComparisonSide, video: HTMLVideoElement) {
+		const expectedSource =
+			side === 'original' ? currentPair?.source.path : currentPair?.preview.path;
 		const loadedSource = video.currentSrc;
+		const generation = mediaGeneration;
 		requestAnimationFrame(() => {
 			requestAnimationFrame(() => {
+				if (generation !== mediaGeneration) return;
 				if (video.currentSrc !== loadedSource) return;
-				if (side === 'original') sourceReady = true;
-				else previewReady = true;
+				if (!mediaElementReady(video.readyState)) return;
+				if (!mediaSourceMatches(video.currentSrc, expectedSource ?? '', document.baseURI)) return;
+				if (side === 'original') {
+					sourceReady = true;
+					sourceError = false;
+				} else {
+					previewReady = true;
+					previewError = false;
+				}
 			});
 		});
 	}
@@ -469,7 +495,7 @@
 				</div>
 			{/if}
 
-			<div class="comparison-media" aria-live="off">
+			<div class="comparison-media">
 				<div
 					bind:this={sourcePane}
 					class="media-pane media-pane--original"
@@ -484,16 +510,26 @@
 						<video
 							bind:this={sourceVideo}
 							src={currentPair.source.path}
-							muted={!isOpen || !hasSound || audioChoice !== 'original'}
+							muted={comparisonSideMuted('original', audioChoice, hasSound)}
 							playsinline
-							preload={isOpen ? 'auto' : 'metadata'}
+							preload="auto"
 							aria-label="Original test moment"
 							tabindex="-1"
-							onloadedmetadata={handleSourceMetadata}
+							onloadedmetadata={(event) => {
+								handleSourceMetadata();
+								handleMediaLoaded('original', event.currentTarget);
+							}}
 							onloadeddata={(event) => handleMediaLoaded('original', event.currentTarget)}
+							oncanplay={(event) => handleMediaLoaded('original', event.currentTarget)}
 							onerror={() => handleMediaError('original')}
 						></video>
-						{#if !sourceReady}<span class="media-loading">Loading original picture…</span>{/if}
+						{#if sourceError}
+							<span class="media-loading media-loading--error" role="alert"
+								>Original clip could not load.</span
+							>
+						{:else if !sourceReady}
+							<span class="media-loading" aria-live="polite">Loading original picture…</span>
+						{/if}
 					</div>
 				</div>
 				<div
@@ -510,13 +546,17 @@
 						<video
 							bind:this={previewVideo}
 							src={currentPair.preview.path}
-							muted={!isOpen || !hasSound || audioChoice !== 'new'}
+							muted={comparisonSideMuted('new', audioChoice, hasSound)}
 							playsinline
-							preload={isOpen ? 'auto' : 'metadata'}
+							preload="auto"
 							aria-label="New test moment"
 							tabindex="-1"
-							onloadedmetadata={handlePreviewMetadata}
+							onloadedmetadata={(event) => {
+								handlePreviewMetadata();
+								handleMediaLoaded('new', event.currentTarget);
+							}}
 							onloadeddata={(event) => handleMediaLoaded('new', event.currentTarget)}
+							oncanplay={(event) => handleMediaLoaded('new', event.currentTarget)}
 							onerror={() => handleMediaError('new')}
 							onplaying={() => {
 								playing = true;
@@ -527,51 +567,69 @@
 							ontimeupdate={handleTimeUpdate}
 							onended={handleEnded}
 						></video>
-						{#if !previewReady}<span class="media-loading">Loading new picture…</span>{/if}
+						{#if previewError}
+							<span class="media-loading media-loading--error" role="alert"
+								>New clip could not load.</span
+							>
+						{:else if !previewReady}
+							<span class="media-loading" aria-live="polite">Loading new picture…</span>
+						{/if}
 					</div>
 				</div>
 			</div>
 
-			{#if isOpen}
-				<footer class="workspace-controls">
-					<button class="play-control" type="button" onclick={togglePlayback} disabled={preparing}>
-						{preparing ? 'Preparing…' : playing ? 'Pause' : 'Play'}
-					</button>
-					<label class="timeline-control">
-						<span class="sr-only">Playback position</span>
-						<input
-							type="range"
-							min="0"
-							max={Math.max(duration, 0.01)}
-							step="0.01"
-							value={currentTime}
-							oninput={handleTimeline}
-							aria-valuetext={timeText}
-						/>
-					</label>
-					<output class="time-display">{timeText}</output>
-					{#if hasSound}
-						<div class="sound-control" role="group" aria-label="Listen to">
-							<span>Listen to</span>
-							<button
-								type="button"
-								class:active={audioChoice === 'original'}
-								onclick={() => chooseSound('original')}
-								aria-pressed={audioChoice === 'original'}>Original</button
-							>
-							<button
-								type="button"
-								class:active={audioChoice === 'new'}
-								onclick={() => chooseSound('new')}
-								aria-pressed={audioChoice === 'new'}>New</button
-							>
-						</div>
-					{:else}
-						<p class="picture-only-note">These clips show picture only.</p>
-					{/if}
-					{#if playbackError}<p class="playback-error" role="alert">{playbackError}</p>{/if}
-				</footer>
-			{/if}
+			<footer class="workspace-controls" aria-label="Comparison playback controls">
+				<button
+					class="play-control"
+					type="button"
+					onclick={togglePlayback}
+					disabled={preparing || !sourceReady || !previewReady || sourceError || previewError}
+				>
+					{sourceError || previewError
+						? 'Unavailable'
+						: !sourceReady || !previewReady
+							? 'Loading…'
+							: preparing
+								? 'Preparing…'
+								: playing
+									? 'Pause'
+									: 'Play'}
+				</button>
+				<label class="timeline-control">
+					<span class="sr-only">Playback position</span>
+					<input
+						type="range"
+						min="0"
+						max={Math.max(duration, 0.01)}
+						step="0.01"
+						value={currentTime}
+						oninput={handleTimeline}
+						aria-valuetext={timeText}
+						disabled={!sourceReady || !previewReady || sourceError || previewError}
+					/>
+				</label>
+				<output class="time-display">{timeText}</output>
+				{#if hasSound}
+					<div class="sound-control" role="group" aria-label="Listen to">
+						<span>Listen to</span>
+						<button
+							type="button"
+							class:active={audioChoice === 'original'}
+							onclick={() => chooseSound('original')}
+							aria-pressed={audioChoice === 'original'}>Original</button
+						>
+						<button
+							type="button"
+							class:active={audioChoice === 'new'}
+							onclick={() => chooseSound('new')}
+							aria-pressed={audioChoice === 'new'}>New</button
+						>
+					</div>
+				{:else}
+					<p class="picture-only-note">These clips show picture only.</p>
+				{/if}
+				{#if playbackError}<p class="playback-error" role="alert">{playbackError}</p>{/if}
+			</footer>
 		</div>
 
 		<div class="comparison-entry">
@@ -809,6 +867,11 @@
 		grid-area: 1 / 1;
 		padding: 7px 10px;
 		pointer-events: none;
+	}
+
+	.media-loading--error {
+		background: rgb(52 20 18 / 90%);
+		color: #ffd1c8;
 	}
 
 	.is-open {

--- a/frontend/src/lib/components/season/SeasonExperience.svelte
+++ b/frontend/src/lib/components/season/SeasonExperience.svelte
@@ -42,6 +42,7 @@
 		reviewFeedbackRequest,
 		reviewSampleSizes,
 		seasonIdentity,
+		shouldPrioritizeScopeActivity,
 		sizeGoals,
 		targetConstraintSummary,
 		technicalVideoPolicy,
@@ -177,6 +178,7 @@
 	const reviewHasSound = $derived(reviewPairHasSound(currentPair));
 	const reviewSubject = $derived(reviewHasSound ? 'picture and sound' : 'picture');
 	const calibration = $derived(asRecord(folder.calibration));
+	const hasOwnCalibration = $derived(Object.keys(calibration).length > 0);
 	const sampleResult = $derived(asRecord(calibration.sample_result));
 	const encodeProgress = $derived(currentEncodeProgress(folder.encode_job));
 	const episodeCount = $derived(folder.summary?.item_count ?? 0);
@@ -282,6 +284,9 @@
 	const scopeActivityFailure = $derived(['failed', 'stopped'].includes(scopeActivityStatus));
 	const scopeActivityReady = $derived(
 		['completed', 'pending_review'].includes(scopeActivityStatus)
+	);
+	const showScopeActivity = $derived(
+		shouldPrioritizeScopeActivity(scopeActivity, hasOwnCalibration)
 	);
 	const scopeActivityScope = $derived(scopeActivityJob?.activity_scope ?? null);
 	const scopeActivityOwnerPrefix = $derived(scopeActivityJob?.prefix ?? '');
@@ -1032,7 +1037,7 @@
 					You can leave this page open. The next screen appears when it is ready.
 				</p>
 			</section>
-		{:else if scopeActivity && scopeActivityJob}
+		{:else if showScopeActivity && scopeActivity && scopeActivityJob}
 			<section
 				class="scope-activity-room"
 				aria-labelledby="scope-activity-heading"
@@ -1098,15 +1103,26 @@
 					<h1>
 						{retryMode
 							? 'Choose a size and settings'
-							: isSeriesScope
-								? `Choose one size for all ${seriesSeasonCount} ${seriesSeasonLabel}`
-								: `Choose a size for ${identity.season}`}
+							: isSeriesScope && olderSeasonOverride?.available
+								? `Choose one size for ${olderSeasonOverride.season_count} older ${olderSeasonOverride.season_count === 1 ? 'season' : 'seasons'}`
+								: isSeriesScope
+									? `Choose one size for all ${seriesSeasonCount} ${seriesSeasonLabel}`
+									: `Choose a size for ${identity.season}`}
 					</h1>
 					<p class="lede">
-						{episodeCount} episodes{isSeriesScope
-							? ` across ${seriesSeasonCount} ${seriesSeasonLabel}`
-							: ''} · {formatDecimalFileSize(originalSeasonSize)} now. You will compare one representative
-						test before Mediaforce makes the rest.
+						{#if isSeriesScope && olderSeasonOverride?.available}
+							{olderSeasonOverride.candidate_count} episodes across
+							{olderSeasonOverride.season_count} older
+							{olderSeasonOverride.season_count === 1 ? 'season' : 'seasons'} ·
+							{formatDecimalFileSize(olderSeasonOverride.current_size_bytes)} now.
+							{olderSeasonOverride.latest_season_label || 'The latest season'} stays original. You will
+							compare one representative test before Mediaforce makes the selected older seasons.
+						{:else}
+							{episodeCount} episodes{isSeriesScope
+								? ` across ${seriesSeasonCount} ${seriesSeasonLabel}`
+								: ''} · {formatDecimalFileSize(originalSeasonSize)} now. You will compare one representative
+							test before Mediaforce makes the rest.
+						{/if}
 					</p>
 				</div>
 

--- a/frontend/src/lib/season/comparison.test.ts
+++ b/frontend/src/lib/season/comparison.test.ts
@@ -3,9 +3,12 @@ import { describe, expect, it } from 'vitest';
 import {
 	alignedScrollOffset,
 	clampMomentIndex,
+	comparisonSideMuted,
 	comparisonKeyboardAction,
 	formatPlaybackTime,
 	frameAspectRatio,
+	mediaElementReady,
+	mediaSourceMatches,
 	normalizedScrollPosition,
 	reviewPairHasSound,
 	scrollOffsetForPosition
@@ -49,6 +52,31 @@ describe('comparison workspace helpers', () => {
 		const mislabeled = pair(true);
 		mislabeled.preview.audio = { trustworthy: true, role: 'original' };
 		expect(reviewPairHasSound(mislabeled)).toBe(false);
+	});
+
+	it('keeps only the chosen comparison side audible', () => {
+		expect(comparisonSideMuted('original', 'new', true)).toBe(true);
+		expect(comparisonSideMuted('new', 'new', true)).toBe(false);
+		expect(comparisonSideMuted('new', 'new', false)).toBe(true);
+	});
+
+	it('accepts only decoded data from the expected clip', () => {
+		expect(mediaElementReady(1)).toBe(false);
+		expect(mediaElementReady(2)).toBe(true);
+		expect(
+			mediaSourceMatches(
+				'http://localhost/review/moment-2.mp4',
+				'/review/moment-2.mp4',
+				'http://localhost/folders/show'
+			)
+		).toBe(true);
+		expect(
+			mediaSourceMatches(
+				'http://localhost/review/moment-1.mp4',
+				'/review/moment-2.mp4',
+				'http://localhost/folders/show'
+			)
+		).toBe(false);
 	});
 
 	it('keeps moments, time, and frame shape bounded and readable', () => {

--- a/frontend/src/lib/season/comparison.ts
+++ b/frontend/src/lib/season/comparison.ts
@@ -42,6 +42,31 @@ export function reviewPairHasSound(pair: ReviewPair | undefined): boolean {
 	);
 }
 
+export function comparisonSideMuted(
+	side: ComparisonSide,
+	audioChoice: ComparisonSide,
+	hasSound: boolean
+): boolean {
+	return !hasSound || side !== audioChoice;
+}
+
+export function mediaElementReady(readyState: number): boolean {
+	return readyState >= 2;
+}
+
+export function mediaSourceMatches(
+	currentSource: string,
+	expectedSource: string,
+	baseUrl: string
+): boolean {
+	if (!currentSource || !expectedSource) return false;
+	try {
+		return new URL(currentSource, baseUrl).href === new URL(expectedSource, baseUrl).href;
+	} catch {
+		return false;
+	}
+}
+
 export function clampMomentIndex(index: number, momentCount: number): number {
 	if (momentCount <= 0) return 0;
 	return Math.min(Math.max(index, 0), momentCount - 1);

--- a/frontend/src/lib/season/experience.test.ts
+++ b/frontend/src/lib/season/experience.test.ts
@@ -40,6 +40,7 @@ import {
 	reviewFeedbackRequest,
 	reviewSampleSizes,
 	seasonIdentity,
+	shouldPrioritizeScopeActivity,
 	sizeGoals,
 	targetConstraintSummary,
 	testRequestWithInstructions,
@@ -1165,6 +1166,27 @@ describe('season experience translation', () => {
 
 		expect(activity?.relation).toBe('ancestor');
 		expect(calibrationJobTargetContract(activity?.job)?.target_size_bytes).toBe(225_000_000);
+	});
+
+	it('does not hide an owned review behind completed related activity', () => {
+		const activity = {
+			schema_version: 1 as const,
+			relation: 'descendant' as const,
+			job: {
+				job_id: 'season-test',
+				prefix: 'tv/Big Brother (US)/Season 19',
+				status: 'completed'
+			}
+		};
+
+		expect(shouldPrioritizeScopeActivity(activity, true)).toBe(false);
+		expect(shouldPrioritizeScopeActivity(activity, false)).toBe(true);
+		expect(
+			shouldPrioritizeScopeActivity(
+				{ ...activity, job: { ...activity.job, status: 'running' } },
+				true
+			)
+		).toBe(true);
 	});
 
 	it('describes actual calibration stages, bounded work, and heartbeat state', () => {

--- a/frontend/src/lib/season/experience.ts
+++ b/frontend/src/lib/season/experience.ts
@@ -565,6 +565,15 @@ export function overlappingCalibrationActivity(
 	return activity;
 }
 
+export function shouldPrioritizeScopeActivity(
+	activity: CalibrationScopeActivityPayload | null | undefined,
+	hasOwnCalibration: boolean
+): boolean {
+	if (!activity) return false;
+	const status = activity.job.status ?? 'idle';
+	return ['queued', 'starting', 'running'].includes(status) || !hasOwnCalibration;
+}
+
 export function calibrationStageLabel(job: CalibrationJobPayload | null | undefined): string {
 	const stage = text(job?.progress?.stage);
 	const labels: Record<string, string> = {

--- a/mediaforce/library/workflow_state.py
+++ b/mediaforce/library/workflow_state.py
@@ -156,6 +156,21 @@ def build_folder_workflow_states(
     if not normalized_prefixes:
         return {}
     scopes = resolve_media_scopes(connection, normalized_prefixes, library_types=library_types)
+    return build_folder_workflow_states_for_scopes(
+        connection,
+        scopes,
+        candidate_eligibility=candidate_eligibility,
+    )
+
+
+def build_folder_workflow_states_for_scopes(
+        connection: DBClient,
+        scopes: list[MediaScope],
+        *,
+        candidate_eligibility: Mapping[int, EncodeEligibility] | None = None,
+) -> dict[str, FolderWorkflowState]:
+    if not scopes:
+        return {}
     rows = _load_item_rows_for_scopes(connection, scopes)
     rows_by_prefix = _group_item_rows_by_scope(scopes, rows)
     job_states = _load_encode_job_states(connection, scopes)

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -546,11 +546,27 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             return _load_scan_status(connection, config, prefix=None)
 
     def _dashboard_folders_payload(include_series_folders: bool = True) -> dict[str, Any]:
+        shared_decisions: list[CandidateDecision] | None = None
+
+        def folder_decisions(connection: DBClient) -> list[CandidateDecision]:
+            nonlocal shared_decisions
+            if shared_decisions is None:
+                shared_decisions = project_candidates(connection, config, prefixes=[])
+            return shared_decisions
+
         return dashboard_folders_payload(
             config,
             folder_card_cache_key=_folder_card_cache_key,
-            list_folder_cards=_list_folder_cards,
-            list_series_folder_cards=_list_series_folder_cards,
+            list_folder_cards=lambda active_config, connection: _list_folder_cards(
+                active_config,
+                connection,
+                candidate_decisions=folder_decisions(connection),
+            ),
+            list_series_folder_cards=lambda active_config, connection: _list_series_folder_cards(
+                active_config,
+                connection,
+                candidate_decisions=folder_decisions(connection),
+            ),
             include_series_folders=include_series_folders,
         )
 
@@ -2370,7 +2386,12 @@ def _list_library_detail_cards(config: MediaforceConfig, connection: DBClient) -
     )
 
 
-def _list_folder_cards(config: MediaforceConfig, connection: DBClient) -> list[FolderCard]:
+def _list_folder_cards(
+        config: MediaforceConfig,
+        connection: DBClient,
+        *,
+        candidate_decisions: list[CandidateDecision] | None = None,
+) -> list[FolderCard]:
     needs_attention_badges: dict[str, dict[str, str | None]] | None = None
     calibration_job_badges: dict[str, dict[str, str | None]] | None = None
     library_types = config.library_type_map
@@ -2396,11 +2417,17 @@ def _list_folder_cards(config: MediaforceConfig, connection: DBClient) -> list[F
         age_days=_age_days,
         estimate_savings_bytes=_estimate_savings_bytes,
         review_badge_for_prefix=review_badge_for_prefix,
+        candidate_decisions=candidate_decisions,
     )
     return _attach_media_scopes(connection, config, cards)
 
 
-def _list_series_folder_cards(config: MediaforceConfig, connection: DBClient) -> list[FolderCard]:
+def _list_series_folder_cards(
+        config: MediaforceConfig,
+        connection: DBClient,
+        *,
+        candidate_decisions: list[CandidateDecision] | None = None,
+) -> list[FolderCard]:
     library_types = config.library_type_map
     return _folder_cards_for_group(
         config,
@@ -2411,6 +2438,7 @@ def _list_series_folder_cards(config: MediaforceConfig, connection: DBClient) ->
         ),
         aggregate_badges=True,
         media_roots={root for root, library_type in config.library_type_map.items() if library_type == "tv"},
+        candidate_decisions=candidate_decisions,
     )
 
 
@@ -2495,12 +2523,15 @@ def _attach_media_scopes(
         config: MediaforceConfig,
         cards: list[FolderCard],
 ) -> list[FolderCard]:
+    missing_cards = [card for card in cards if card.media_scope is None]
+    if not missing_cards:
+        return cards
     scopes = resolve_media_scopes(
         connection,
-        [card.prefix for card in cards],
+        [card.prefix for card in missing_cards],
         library_types=config.library_type_map,
     )
-    for card, scope in zip(cards, scopes, strict=True):
+    for card, scope in zip(missing_cards, scopes, strict=True):
         card.media_scope = scope.to_payload()
     return cards
 

--- a/mediaforce/web/runtime/folder_cards.py
+++ b/mediaforce/web/runtime/folder_cards.py
@@ -13,7 +13,8 @@ from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_items, staged_artifacts
 from mediaforce.library.candidate_selection import CandidateDecision, project_candidates, \
     scope_lifecycle_payload_from_decisions, workflow_eligibility
-from mediaforce.library.workflow_state import build_folder_workflow_states
+from mediaforce.library.media_scopes import MediaScope, media_scope_from_prefix, resolve_media_scopes
+from mediaforce.library.workflow_state import build_folder_workflow_states_for_scopes
 from mediaforce.library.workflow_state import ENCODE_CANDIDATE_STATUSES
 from mediaforce.library.workflow_state import WorkflowPayload
 
@@ -103,6 +104,7 @@ def cached_folder_cards(
         age_days: Callable[[str], float],
         estimate_savings_bytes: Callable[..., int],
         review_badge_for_prefix: Callable[[str], FolderBadge],
+        candidate_decisions: list[CandidateDecision] | None = None,
 ) -> list[FolderCard]:
     global _FOLDER_CARD_CACHE_KEY, _FOLDER_CARD_CACHE_VALUE, _FOLDER_CARD_CACHE_GENERATION
 
@@ -125,6 +127,7 @@ def cached_folder_cards(
             age_days=age_days,
             estimate_savings_bytes=estimate_savings_bytes,
             review_badge_for_prefix=review_badge_for_prefix,
+            candidate_decisions=candidate_decisions,
         )
         with _FOLDER_CARD_CACHE_LOCK:
             current_cache_key = folder_card_cache_key(config)
@@ -532,15 +535,53 @@ def _apply_folder_workflow_states(
 ) -> None:
     if not cards:
         return
-    workflow_by_prefix = build_folder_workflow_states(
+    scopes = _folder_card_media_scopes(
         connection,
-        [card.prefix for card in cards],
-        candidate_eligibility=workflow_eligibility(decisions or []),
+        cards,
         library_types=config.library_type_map if config is not None else None,
     )
-    for card in cards:
+    workflow_by_prefix = build_folder_workflow_states_for_scopes(
+        connection,
+        scopes,
+        candidate_eligibility=workflow_eligibility(decisions or []),
+    )
+    for card, scope in zip(cards, scopes, strict=True):
         workflow = workflow_by_prefix.get(card.prefix)
         card.workflow_state = workflow.to_payload() if workflow is not None else None
+        card.media_scope = scope.to_payload()
+
+
+def _folder_card_media_scopes(
+        connection: DBClient,
+        cards: list[FolderCard],
+        *,
+        library_types: dict[str, str] | None,
+) -> list[MediaScope]:
+    scopes_by_prefix: dict[str, MediaScope] = {}
+    unresolved_prefixes: list[str] = []
+    for card in cards:
+        if card.scope_label in {"Library", "Series", "Season", "Folder"}:
+            match = "descendants"
+        elif card.scope_label == "File":
+            match = "exact_item"
+        else:
+            unresolved_prefixes.append(card.prefix)
+            continue
+        scopes_by_prefix[card.prefix] = media_scope_from_prefix(
+            card.prefix,
+            match=match,
+            library_types=library_types,
+        )
+    if unresolved_prefixes:
+        scopes_by_prefix.update(
+            (scope.prefix, scope)
+            for scope in resolve_media_scopes(
+                connection,
+                unresolved_prefixes,
+                library_types=library_types,
+            )
+        )
+    return [scopes_by_prefix[card.prefix] for card in cards]
 
 
 def _folder_delivery_badge(card: FolderCard) -> FolderBadge | None:
@@ -580,6 +621,7 @@ def _copy_folder_card(card: FolderCard, *, include_review_badges: bool = True) -
         review_badge_detail=card.review_badge_detail if include_review_badges else None,
         workflow_state=deepcopy(card.workflow_state),
         lifecycle=deepcopy(card.lifecycle),
+        media_scope=deepcopy(card.media_scope),
         details_loading=card.details_loading,
         estimate_unavailable_count=card.estimate_unavailable_count,
     )

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -5455,6 +5455,13 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                 "counts": {"ready_to_validate": 1},
                 "next_action": {"kind": "validate_outputs"},
             },
+            media_scope={
+                "schema_version": 1,
+                "prefix": "tv/show/Season 10",
+                "domain": "tv",
+                "kind": "tv_season",
+                "match": "descendants",
+            },
         )
         list_folder_cards = Mock(return_value=[cached_source_card])
 
@@ -5472,6 +5479,7 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
         first_cards[0].workflow_state["counts"]["ready_to_validate"] = 99
         first_cards[0].workflow_state["next_action"]["kind"] = "mutated"
+        first_cards[0].media_scope["kind"] = "mutated"
 
         with patch.object(folder_cards_runtime, "folder_card_cache_key", return_value=("cache", 1, 1)):
             with patch.object(folder_cards_runtime, "list_folder_cards", list_folder_cards):
@@ -5487,7 +5495,47 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
 
         self.assertEqual(second_cards[0].workflow_state["counts"]["ready_to_validate"], 1)
         self.assertEqual(second_cards[0].workflow_state["next_action"]["kind"], "validate_outputs")
+        self.assertEqual(second_cards[0].media_scope["kind"], "tv_season")
         folder_cards_runtime.reset_folder_card_cache()
+
+    def test_folder_cards_reuse_group_scope_when_building_workflow_state(self) -> None:
+        card = folder_cards_runtime.FolderCard(
+            prefix="tv/show/Season 10",
+            title="Season 10",
+            subtitle="TV",
+            scope_label="Season",
+            item_count=1,
+            pending_count=1,
+            total_size_bytes=2 * 1024 * 1024 * 1024,
+            estimated_savings_bytes=200 * 1024 * 1024,
+            known_saved_bytes=0,
+            projected_reclaim_bytes=200 * 1024 * 1024,
+            average_age_days=10.0,
+            sort_score=0.2,
+            statuses={"planned": 1},
+            video_codecs={"h264": 1},
+        )
+        workflow = Mock()
+        workflow.to_payload.return_value = {"state": "sample_and_approval"}
+
+        with patch.object(folder_cards_runtime, "resolve_media_scopes") as resolve_scopes:
+            with patch.object(
+                    folder_cards_runtime,
+                    "build_folder_workflow_states_for_scopes",
+                    return_value={card.prefix: workflow},
+            ) as build_states:
+                folder_cards_runtime._apply_folder_workflow_states(
+                    Mock(),
+                    [card],
+                    [],
+                    config=self.config,
+                )
+
+        resolve_scopes.assert_not_called()
+        scope = build_states.call_args.args[1][0]
+        self.assertEqual(scope.kind, "tv_season")
+        self.assertEqual(scope.match, "descendants")
+        self.assertEqual(card.media_scope["kind"], "tv_season")
 
     def test_folder_cards_require_multiple_labeled_samples_before_using_folder_history(self) -> None:
         pending = self._create_source_file("episode-pending.mkv")


### PR DESCRIPTION
## Summary
- show the series-owned review instead of letting a completed Season 19 activity hide it
- restore synchronized inline playback controls and robust loading/error states for every review moment
- reuse candidate and media-scope projections so the live library stays under its route latency gate

## Validation
- `bash scripts/pre-commit-check.sh`
- PyCharm changed-file inspection: GREEN, 0 findings
- live Big Brother series: all three moments reached `readyState 4`; synchronized playback drift <1 ms
- live desktop + 390px browser review; no horizontal overflow
- live route smoke: `/api/dashboard/folders` 1.398s and all routes passed