### PR TITLE
Fix encode queue CPU saturation

### DIFF
--- a/mediaforce/web/runtime/encode_runtime.py
+++ b/mediaforce/web/runtime/encode_runtime.py
@@ -447,9 +447,10 @@ def aggregate_encode_parent_job(
     active_hosts: list[dict[str, Any]] = []
     seen_host_keys: set[str] = set()
     current_items: list[str] = []
+    manifest_items_cache: dict[Path, list[dict[str, Any]] | None] = {}
     for child in children:
         progress = object_dict(child.get("progress"))
-        child_totals = encode_job_manifest_totals(child)
+        child_totals = encode_job_manifest_totals(child, manifest_items_cache=manifest_items_cache)
         child_total_duration_seconds = float_value(
             progress.get("total_duration_seconds") or child_totals.get("total_duration_seconds")
         )
@@ -607,24 +608,32 @@ def aggregate_encode_parent_job(
     return aggregated
 
 
-def encode_job_manifest_totals(job: dict[str, Any]) -> dict[str, Any]:
+def encode_job_manifest_totals(
+        job: dict[str, Any],
+        *,
+        manifest_items_cache: dict[Path, list[dict[str, Any]] | None] | None = None,
+) -> dict[str, Any]:
     manifest_path = Path(str(job.get("manifest_path") or "")).expanduser()
     fallback_item_count = int_value(job.get("item_count"))
-    if not manifest_path.exists():
+    if manifest_items_cache is not None and manifest_path in manifest_items_cache:
+        manifest_items = manifest_items_cache[manifest_path]
+    else:
+        manifest_items = None
+        if manifest_path.exists():
+            try:
+                payload = json.loads(manifest_path.read_text())
+            except (OSError, json.JSONDecodeError):
+                pass
+            else:
+                manifest_items = [object_dict(item) for item in object_list(payload.get("items"))]
+        if manifest_items_cache is not None:
+            manifest_items_cache[manifest_path] = manifest_items
+    if manifest_items is None:
         return {
             "total_item_count": fallback_item_count,
             "total_duration_seconds": 0.0,
             "total_source_size_bytes": 0,
         }
-    try:
-        payload = json.loads(manifest_path.read_text())
-    except (OSError, json.JSONDecodeError):
-        return {
-            "total_item_count": fallback_item_count,
-            "total_duration_seconds": 0.0,
-            "total_source_size_bytes": 0,
-        }
-    manifest_items = [object_dict(item) for item in object_list(payload.get("items"))]
     indexes = _manifest_indexes_for_job(job, manifest_items)
     items = [manifest_items[index] for index in indexes if 0 <= index < len(manifest_items)]
     return {
@@ -977,10 +986,12 @@ def select_encode_host(
         config: MediaforceConfig,
         job: dict[str, Any],
         deps: EncodeQueueRuntimeDeps,
+        *,
+        host_rows: list[dict[str, Any]] | None = None,
 ) -> tuple[dict[str, Any] | None, str | None]:
     library_key = _encode_job_library_key(job)
     host_rows = sorted(
-        deps.host_runtime_rows(connection, config),
+        host_rows if host_rows is not None else deps.host_runtime_rows(connection, config),
         key=lambda status: (-int(status["priority"]), str(status["label"])),
     )
     if library_key:
@@ -1281,6 +1292,15 @@ def _encode_job_library_key(job: dict[str, Any]) -> str:
     return prefix.split("/", 1)[0].strip().lower()
 
 
+def _encode_host_selection_key(job: dict[str, Any]) -> tuple[str, bool, str, str]:
+    return (
+        _encode_job_library_key(job),
+        bool(job.get("bypass_schedule")),
+        str(job.get("host_cooldown_until") or ""),
+        json.dumps(object_dict(job.get("last_host")), sort_keys=True, separators=(",", ":")),
+    )
+
+
 def _host_allows_library(host: dict[str, Any], library_key: str) -> bool:
     allowed_libraries = host.get("allowed_libraries")
     if not isinstance(allowed_libraries, list) or not allowed_libraries:
@@ -1408,12 +1428,28 @@ def load_next_runnable_encode_job(
         config: MediaforceConfig,
         deps: EncodeQueueRuntimeDeps,
 ) -> dict[str, Any] | None:
+    parent_sync_jobs: dict[str, dict[str, Any]] = {}
+
+    def defer_parent_sync(job: dict[str, Any]) -> None:
+        parent_job_id = str(job.get("parent_job_id") or "").strip()
+        if parent_job_id:
+            parent_sync_jobs[parent_job_id] = job
+
+    def sync_deferred_parents() -> None:
+        for pending_job in parent_sync_jobs.values():
+            sync_encode_job_parent(connection, pending_job, deps)
+
     rows = connection.execute(
         select(encode_jobs.c.job_id)
         .where(encode_jobs.c.status == "queued")
         .where(encode_jobs.c.job_kind.in_(RUNNABLE_ENCODE_JOB_KINDS))
         .order_by(encode_jobs.c.created_at, literal_column("rowid"))
     ).mappings().fetchall()
+    host_rows = deps.host_runtime_rows(connection, config) if rows else []
+    host_selection_cache: dict[
+        tuple[str, bool, str, str],
+        tuple[dict[str, Any] | None, str | None],
+    ] = {}
     for row in rows:
         job = load_encode_job(connection, str(row["job_id"]))
         if job is None:
@@ -1424,21 +1460,34 @@ def load_next_runnable_encode_job(
             if str(job.get("waiting_reason") or "") != waiting_reason:
                 job.update({"waiting_reason": waiting_reason, "updated_at": deps.now_iso()})
                 save_encode_job(connection, job)
-                sync_encode_job_parent(connection, job, deps)
+                defer_parent_sync(job)
             continue
-        host_payload, waiting_reason = select_encode_host(connection, config, job, deps)
+        selection_key = _encode_host_selection_key(job)
+        selection = host_selection_cache.get(selection_key)
+        if selection is None:
+            selection = select_encode_host(
+                connection,
+                config,
+                job,
+                deps,
+                host_rows=host_rows,
+            )
+            host_selection_cache[selection_key] = selection
+        host_payload, waiting_reason = selection
         if host_payload is None:
             if str(job.get("waiting_reason") or "") != str(waiting_reason or ""):
                 job.update({"waiting_reason": waiting_reason, "updated_at": deps.now_iso()})
                 save_encode_job(connection, job)
-                sync_encode_job_parent(connection, job, deps)
+                defer_parent_sync(job)
             continue
         persisted_host_payload = persisted_encode_host_payload(host_payload)
         if job.get("waiting_reason") or job.get("host") != persisted_host_payload:
             job.update({"waiting_reason": None, "host": persisted_host_payload, "updated_at": deps.now_iso()})
             save_encode_job(connection, job)
-            sync_encode_job_parent(connection, job, deps)
+            defer_parent_sync(job)
+        sync_deferred_parents()
         return job
+    sync_deferred_parents()
     return None
 
 

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -13632,6 +13632,140 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
             assert blocked is not None
             self.assertEqual(blocked["waiting_reason"], "Library is Browse only or Disabled in Settings.")
 
+    def test_load_next_runnable_encode_job_batches_parent_sync_and_manifest_read(self) -> None:
+        manifest_path = self._write_manifest(
+            "manifest-waiting-shards.json",
+            [
+                {"library_item_id": 1, "duration_seconds": 90.0, "source_size_bytes": 900},
+                {"library_item_id": 2, "duration_seconds": 120.0, "source_size_bytes": 1_200},
+                {"library_item_id": 3, "duration_seconds": 150.0, "source_size_bytes": 1_500},
+            ],
+        )
+        now = web_app._now_iso()
+
+        def job_payload(
+                *,
+                job_id: str,
+                job_kind: str,
+                parent_job_id: str | None,
+                manifest_indexes: list[int] | None,
+                item_count: int,
+                bypass_schedule: bool = False,
+        ) -> dict[str, object]:
+            return {
+                "job_id": job_id,
+                "prefix": "tv/show",
+                "job_kind": job_kind,
+                "parent_job_id": parent_job_id,
+                "status": "queued",
+                "manifest_path": str(manifest_path),
+                "manifest_indexes": manifest_indexes,
+                "item_count": item_count,
+                "saved_profile_path": None,
+                "host": {},
+                "last_host": {},
+                "notes": "",
+                "bypass_schedule": bypass_schedule,
+                "attempt_count": 0,
+                "process_pid": None,
+                "error": None,
+                "leased_at": None,
+                "lease_expires_at": None,
+                "heartbeat_at": None,
+                "worker_id": None,
+                "retry_not_before": None,
+                "waiting_reason": None,
+                "terminal_reason": None,
+                "last_failure_kind": None,
+                "last_failure_at": None,
+                "host_cooldown_until": None,
+                "created_at": now,
+                "started_at": None,
+                "finished_at": None,
+                "updated_at": now,
+            }
+
+        with open_db(self.config.paths.db_path) as connection:
+            save_encode_job(
+                connection,
+                job_payload(
+                    job_id="folder-waiting",
+                    job_kind="folder",
+                    parent_job_id=None,
+                    manifest_indexes=None,
+                    item_count=3,
+                ),
+            )
+            for index in range(3):
+                save_encode_job(
+                    connection,
+                    job_payload(
+                        job_id=f"shard-waiting-{index}",
+                        job_kind="shard",
+                        parent_job_id="folder-waiting",
+                        manifest_indexes=[index],
+                        item_count=1,
+                        bypass_schedule=index == 2,
+                    ),
+                )
+            connection.commit()
+
+            deps = Mock()
+            deps.now_iso.return_value = now
+            deps.host_runtime_rows = Mock(return_value=[])
+            manifest_reads: list[Path] = []
+            original_read_text = Path.read_text
+
+            def tracked_read_text(path: Path, *args: object, **kwargs: object) -> str:
+                if path == manifest_path:
+                    manifest_reads.append(path)
+                return original_read_text(path, *args, **kwargs)
+
+            with patch(
+                "mediaforce.web.runtime.encode_runtime.select_encode_host",
+                wraps=encode_runtime.select_encode_host,
+            ) as select_host, patch(
+                "mediaforce.web.runtime.encode_runtime.sync_encode_job_parent",
+                wraps=encode_runtime.sync_encode_job_parent,
+            ) as sync_parent, patch.object(Path, "read_text", tracked_read_text):
+                selected = encode_runtime.load_next_runnable_encode_job(connection, self.config, deps)
+
+            self.assertIsNone(selected)
+            deps.host_runtime_rows.assert_called_once_with(connection, self.config)
+            self.assertEqual(select_host.call_count, 2)
+            self.assertEqual(sync_parent.call_count, 1)
+            self.assertEqual(len(manifest_reads), 1)
+            parent = load_encode_job(connection, "folder-waiting")
+            shards = [load_encode_job(connection, f"shard-waiting-{index}") for index in range(3)]
+            self.assertIsNotNone(parent)
+            assert parent is not None
+            self.assertEqual(parent["waiting_reason"], "waiting for an available encode host")
+            self.assertTrue(all(shard is not None for shard in shards))
+            self.assertTrue(
+                all(shard["waiting_reason"] == "waiting for an available encode host" for shard in shards if shard)
+            )
+
+            manifest_reads.clear()
+            deps.host_runtime_rows.reset_mock()
+            with patch(
+                    "mediaforce.web.runtime.encode_runtime.select_encode_host",
+                    side_effect=[
+                        (None, "waiting for an available encode host"),
+                        ({"key": "local", "label": "Local", "mode": "local"}, None),
+                    ],
+            ), patch(
+                "mediaforce.web.runtime.encode_runtime.sync_encode_job_parent",
+                wraps=encode_runtime.sync_encode_job_parent,
+            ) as sync_parent, patch.object(Path, "read_text", tracked_read_text):
+                selected = encode_runtime.load_next_runnable_encode_job(connection, self.config, deps)
+
+            self.assertIsNotNone(selected)
+            assert selected is not None
+            self.assertEqual(selected["job_id"], "shard-waiting-2")
+            deps.host_runtime_rows.assert_called_once_with(connection, self.config)
+            self.assertEqual(sync_parent.call_count, 1)
+            self.assertEqual(len(manifest_reads), 1)
+
     def test_process_encode_queue_once_dispatches_multiple_jobs(self) -> None:
         manifest_path = self._write_manifest(
             "manifest-fanout.json",


### PR DESCRIPTION
## Summary
- batch parent synchronization when many encode shards enter the same waiting state
- cache shared manifest contents during parent aggregation
- reuse host runtime snapshots and equivalent host-selection results across one queue pass
- add regression coverage for waiting and runnable shard paths

## Diagnosis
A 269-shard Big Brother queue was waiting for its host schedule window, but the worker repeatedly reparsed the same 9.5 MB manifest and recomputed host state per shard while holding a SQLite transaction. This saturated one CPU core and caused the calibration worker to log lock errors.

## Validation
- `uv run --with pytest pytest -q` — 1050 passed, 21 subtests passed
- pre-commit acceptance checks passed
- PyCharm changed-files inspection passed
- frontend tests/check/build passed
- `uv build` passed
- live launch-agent verification: CPU reduced from ~100% to ~4%, no new SQLite lock errors, API returned HTTP 200, and all 270 queued rows correctly report `waiting for a host schedule window`
