### PR TITLE
Fix active queue progress scope

### DIFF
--- a/frontend/src/lib/components/season/SeasonExperience.svelte
+++ b/frontend/src/lib/components/season/SeasonExperience.svelte
@@ -23,7 +23,6 @@
 		calibrationTargetModeLabel,
 		calibrationWorkLabel,
 		compareRiskSummary,
-		currentEncodeProgress,
 		currentOperatorIntent,
 		detailSeasonState,
 		episodeLabel,
@@ -41,6 +40,7 @@
 		reviewFeedbackIntent,
 		reviewFeedbackRequest,
 		reviewSampleSizes,
+		scopedEncodeProgress,
 		seasonIdentity,
 		shouldPrioritizeScopeActivity,
 		sizeGoals,
@@ -189,7 +189,6 @@
 	const calibration = $derived(asRecord(folder.calibration));
 	const hasOwnCalibration = $derived(Object.keys(calibration).length > 0);
 	const sampleResult = $derived(asRecord(calibration.sample_result));
-	const encodeProgress = $derived(currentEncodeProgress(folder.encode_job));
 	const episodeCount = $derived(folder.summary?.item_count ?? 0);
 	const productionEpisodeCount = $derived(isSeriesScope ? eligibleEpisodeCount : episodeCount);
 	const originalSeasonSize = $derived(folder.summary?.total_size_bytes ?? 0);
@@ -270,14 +269,18 @@
 			asNumber(folder.summary?.statuses.validated) +
 			asNumber(folder.summary?.statuses.promoted)
 	);
-	const seasonProgressCompleted = $derived(
-		Math.max(finishedEpisodeCount, encodeProgress.completed)
+	const encodeProgress = $derived(
+		scopedEncodeProgress(folder.encode_job, finishedEpisodeCount, episodeCount)
 	);
-	const seasonProgressPercent = $derived(
-		Math.max(
-			encodeProgress.percent,
-			episodeCount > 0 ? (finishedEpisodeCount / episodeCount) * 100 : 0
-		)
+	const seasonProgressCompleted = $derived(encodeProgress.completed);
+	const seasonProgressPercent = $derived(encodeProgress.percent);
+	const activeOlderSeasonCount = $derived(
+		isSeriesScope &&
+			olderSeasonOverride &&
+			encodeProgress.total > 0 &&
+			encodeProgress.total === olderSeasonOverride.candidate_count
+			? olderSeasonOverride.season_count
+			: 0
 	);
 	const recoveryNeedsAdjustment = $derived(
 		humanState.recoveryKind === 'season' && Boolean(folder.encode_job?.progress?.failure_analysis)
@@ -1815,9 +1818,11 @@
 				<div class="progress-copy">
 					<p class="eyebrow">In progress</p>
 					<h1>
-						{isSeriesScope
-							? `Making all ${seriesSeasonCount} ${seriesSeasonLabel}`
-							: `Making ${identity.season}`}
+						{activeOlderSeasonCount > 0
+							? `Making ${activeOlderSeasonCount} older ${activeOlderSeasonCount === 1 ? 'season' : 'seasons'}`
+							: isSeriesScope
+								? `Making all ${seriesSeasonCount} ${seriesSeasonLabel}`
+								: `Making ${identity.season}`}
 					</h1>
 					<p class="lede">
 						{encodeProgress.currentEpisode === 'A representative episode'
@@ -1825,7 +1830,7 @@
 							: `${encodeProgress.currentEpisode} is being made now.`}
 					</p>
 					<div class="progress-facts">
-						<strong>{seasonProgressCompleted} of {episodeCount || encodeProgress.total}</strong>
+						<strong>{seasonProgressCompleted} of {encodeProgress.total}</strong>
 						<span>episodes finished</span>
 						{#if encodeProgress.eta}<small>{encodeProgress.eta}</small>{/if}
 					</div>

--- a/frontend/src/lib/season/experience.test.ts
+++ b/frontend/src/lib/season/experience.test.ts
@@ -4,6 +4,7 @@ import type {
 	DashboardScanJob,
 	DashboardScanWarning,
 	DashboardSummaryPayload,
+	EncodeQueueJob,
 	FolderCard,
 	FolderPayload,
 	FolderStatusPayload,
@@ -39,6 +40,7 @@ import {
 	reviewFeedbackIntent,
 	reviewFeedbackRequest,
 	reviewSampleSizes,
+	scopedEncodeProgress,
 	seasonIdentity,
 	shouldPrioritizeScopeActivity,
 	sizeGoals,
@@ -350,6 +352,29 @@ describe('season experience translation', () => {
 			show: 'Big Brother (US)',
 			season: 'Season 19',
 			showPrefix: 'tv/Big Brother (US)'
+		});
+	});
+
+	it('uses the active encode job scope for progress counts', () => {
+		const activeJob: EncodeQueueJob = {
+			job_id: 'folder-encode',
+			prefix: 'tv/Big Brother (US)',
+			status: 'queued',
+			progress: {
+				total_item_count: 269,
+				completed_item_count: 0,
+				percent_complete: 0
+			}
+		};
+
+		expect(scopedEncodeProgress(activeJob, 90, 359)).toMatchObject({
+			total: 269,
+			completed: 0,
+			percent: 0
+		});
+		expect(scopedEncodeProgress(null, 90, 359)).toMatchObject({
+			total: 359,
+			completed: 90
 		});
 	});
 

--- a/frontend/src/lib/season/experience.ts
+++ b/frontend/src/lib/season/experience.ts
@@ -1312,6 +1312,27 @@ export function currentEncodeProgress(job: EncodeQueueJob | null | undefined) {
 	};
 }
 
+export function scopedEncodeProgress(
+	job: EncodeQueueJob | null | undefined,
+	fallbackCompleted: number,
+	fallbackTotal: number
+) {
+	const progress = currentEncodeProgress(job);
+	const usesActiveJob = progress.total > 0;
+	const total = usesActiveJob ? progress.total : Math.max(0, fallbackTotal);
+	const completed = Math.min(
+		total,
+		Math.max(0, usesActiveJob ? progress.completed : fallbackCompleted)
+	);
+	const completedPercent = total > 0 ? (completed / total) * 100 : 0;
+	return {
+		...progress,
+		total,
+		completed,
+		percent: Math.min(100, Math.max(progress.percent, completedPercent))
+	};
+}
+
 export function plainFailureMessage(folder: FolderPayload, status: FolderStatusPayload): string {
 	const targetConstraint = targetConstraintSummary(folder, status);
 	if (targetConstraint) return targetConstraint.detail;


### PR DESCRIPTION
## Summary
- prefer the active encode job's item total and completion count over the full folder inventory
- label older-season production work with the exact active season scope
- add regression coverage for a 269-item job inside a 359-episode series

## Live result
The Big Brother production card now shows:
- `Making 12 older seasons`
- `0 of 269 episodes finished`

This matches the active parent job and its 269 queued shards instead of the full 359-episode folder inventory.

## Validation
- `bash scripts/pre-commit-check.sh`
  - 1,050 backend tests
  - 235 frontend tests
  - frontend check/lint/build
  - full and narrow route smoke
- live browser review at 1024x768: exact active scope/counts render correctly; Details expands correctly; console has no errors
- PyCharm inspection returned UNKNOWN only because Svelte is plain-text PSI; native Svelte check and ESLint/Prettier are clean
