### PR TITLE
Explain quality-search memory in TV Studio

### DIFF
--- a/docs/architecture/quality-search-memory.md
+++ b/docs/architecture/quality-search-memory.md
@@ -153,6 +153,23 @@ real hint probe behind the unchanged fallback. The safety counters describe
 production outcomes during the shadow window, not an unexecuted hint's quality
 or size.
 
+## Folder Studio Projection
+
+Folder Studio reads the newest current, learning-eligible selected observation
+inside the active media scope and projects its immutable shadow record. The
+surface keeps the production result and the counterfactual recommendation
+separate: chosen CRF, measured quality, final size, candidate count, and search
+time describe what actually ran; the shadow first CRF, evidence scope, sample
+count, confidence, dispersion, and comparison describe what memory would have
+tried first.
+
+When no recommendation was safe, Folder Studio shows the stored typed fallback
+as sparse, stale, or conflicting evidence instead of recomputing guidance in the
+web layer. A folder with no shadow-bearing observation gets a compact empty
+state. Every state says that the evidence is observation-only: quality floors,
+saved policy, production search order, bounds, and fallback behavior remain
+unchanged.
+
 ## Cohorts And Confidence
 
 Compatible outcomes are evaluated in this order:
@@ -181,5 +198,5 @@ aggregate metric evidence counts and never produces CRF guidance.
 - historical backfill can reconstruct only accepted successes and cannot recover
   unavailable policy hashes, search wall time, or ambiguous historical failures.
 
-Operator explainability and active warm starts remain separate later phases.
-Passive evidence must prove useful before any encode behavior changes.
+Active warm starts remain a separate later phase. Passive evidence must prove
+useful before any encode behavior changes.

--- a/docs/design/basic-user-vocabulary.md
+++ b/docs/design/basic-user-vocabulary.md
@@ -70,6 +70,15 @@ debugging a worker, or comparing logs against backend output.
 - Encode queued or running: `Processing`. Folder-wide work is underway.
 - Encode failed or stopped: `Processing needs attention`. The user must inspect
   or retry from the route that owns recovery.
+- Quality memory has no prior observation: `No memory yet`.
+- Quality memory lacks enough compatible runs: `Sparse memory`.
+- Quality memory no longer matches source or settings: `Memory invalidated`.
+- Quality-memory evaluation failed without affecting production search: `Memory
+  unavailable`.
+- Quality-memory evidence disagrees or is unstable: `Evidence conflict`.
+- A stable recommendation has ten or more item/season observations: `High
+  confidence`. Always pair these states with `quality floors and saved policy
+  remain unchanged` while memory is observation-only.
 
 ### Ops
 
@@ -144,7 +153,9 @@ debugging a worker, or comparing logs against backend output.
   `worker`, and `next action`. Avoid `calibration`, `proof`, and `host` in
   basic table columns.
 - Folder Studio should say `Review assistant`, `sample`, `proposal`, `approved`,
-  and `processing`. Keep `Bench` out of visible labels unless a product naming
+  `processing`, and `quality memory`. Use `measured production run` for what
+  actually encoded and `shadow recommendation` for the observation-only first
+  CRF suggestion. Keep `Bench` out of visible labels unless a product naming
   decision intentionally keeps it.
 - Ops may expose more technical detail, but first-level headings should still
   use `workers`, `sample queue`, `processing queue`, and `retry available`.

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -1317,6 +1317,60 @@ export interface QualityRiskPayload {
 	pre_test_instruction?: QualityRiskPreTestInstruction | null;
 }
 
+export type QualityMemoryScope = 'item' | 'season' | 'series';
+export type QualityMemoryConfidence = 'none' | 'limited' | 'moderate' | 'high';
+export type QualityMemoryFallbackReason =
+	| 'no_history'
+	| 'stale_evidence'
+	| 'stale_signature'
+	| 'source_fingerprint_unavailable'
+	| 'source_fingerprint_changed'
+	| 'sparse_cohort'
+	| 'high_dispersion'
+	| 'search_target_changed'
+	| 'non_monotonic_trace'
+	| 'conflicting_quality_evidence'
+	| 'shadow_evaluation_error';
+
+export interface FolderQualityMemoryPayload {
+	schema_version: number;
+	algorithm_version: string;
+	observation_id: string | null;
+	source_rel_path: string | null;
+	recorded_at: string | null;
+	evidence_cutoff_at: string | null;
+	measured: {
+		selected_crf: number | null;
+		quality_metric: string | null;
+		quality_score: number | null;
+		quality_target: number | null;
+		quality_floor: number | null;
+		quality_margin: number | null;
+		output_bytes: number | null;
+		size_error_percent: number | null;
+		candidate_count: number;
+		search_duration_seconds: number | null;
+	};
+	recommendation: {
+		first_crf: number;
+		scope: QualityMemoryScope;
+		confidence: QualityMemoryConfidence;
+		sample_count: number;
+		evidence_count: number;
+		minimum_crf: number | null;
+		maximum_crf: number | null;
+		iqr: number | null;
+		median_absolute_deviation: number | null;
+	} | null;
+	comparison: {
+		crf_delta: number | null;
+		within_one_crf: boolean | null;
+	};
+	fallback_reason: QualityMemoryFallbackReason | null;
+	reason: string;
+	production_search_changed: boolean;
+}
+
 export interface FolderPayload {
 	prefix: string;
 	media_scope: MediaScopePayload;
@@ -1333,6 +1387,7 @@ export interface FolderPayload {
 	stream_budget_ledger?: StreamBudgetLedgerPayload;
 	size_goal_options?: SizeGoalOptionPayload[];
 	quality_risk?: QualityRiskPayload | null;
+	quality_memory?: FolderQualityMemoryPayload | null;
 	failed_target_size_search?: QualityRiskTargetSizeSearch | null;
 	approved_season_shortcut?: Record<string, unknown> | null;
 	series_context?: { prefix: string; title: string } | null;

--- a/frontend/src/lib/components/season/SeasonExperience.svelte
+++ b/frontend/src/lib/components/season/SeasonExperience.svelte
@@ -36,6 +36,7 @@
 		overlappingCalibrationActivity,
 		plainFailureMessage,
 		predictedEpisodeSize,
+		qualityMemoryView,
 		resolvedTargetSummary,
 		reviewFeedbackIntent,
 		reviewFeedbackRequest,
@@ -232,6 +233,7 @@
 		['over_target', 'under_target', 'missing_prediction'].includes(sizeTarget.status)
 	);
 	const riskSummary = $derived(compareRiskSummary(folder));
+	const qualityMemory = $derived(qualityMemoryView(folder));
 	const approvalBlocked = $derived(Boolean(targetConstraint || riskSummary?.blocked));
 	const hasReviewFeedback = $derived(
 		selectedConcerns.length > 0 || reviewFeedback.trim().length > 0
@@ -1998,6 +2000,58 @@
 				</div>
 			</div>
 		{/if}
+
+		<section
+			class="quality-memory"
+			class:quality-memory--empty={qualityMemory.state === 'empty'}
+			class:quality-memory--attention={qualityMemory.tone === 'attention'}
+			aria-labelledby="quality-memory-title"
+		>
+			<header class="quality-memory__header">
+				<div>
+					<span>Quality memory</span>
+					<h2 id="quality-memory-title">{qualityMemory.title}</h2>
+					{#if qualityMemory.source}<small>{qualityMemory.source}</small>{/if}
+				</div>
+				<strong class="quality-memory__badge quality-memory__badge--{qualityMemory.tone}"
+					>{qualityMemory.badge}</strong
+				>
+			</header>
+
+			{#if qualityMemory.state !== 'empty'}
+				<div class="quality-memory__comparison">
+					<div class="quality-memory__measured">
+						<span>Measured production run</span>
+						<div class="quality-memory__facts">
+							{#each qualityMemory.measured as fact (fact.label)}
+								<div>
+									<small>{fact.label}</small>
+									<strong>{fact.value}</strong>
+									<p>{fact.detail}</p>
+								</div>
+							{/each}
+						</div>
+					</div>
+
+					<div class="quality-memory__recommendation">
+						<span>{qualityMemory.recommendation.label}</span>
+						<strong>{qualityMemory.recommendation.value}</strong>
+						<p>{qualityMemory.recommendation.detail}</p>
+						<dl>
+							<dt>Comparison</dt>
+							<dd>{qualityMemory.comparison}</dd>
+							<dt>Spread</dt>
+							<dd>{qualityMemory.dispersion}</dd>
+						</dl>
+					</div>
+				</div>
+			{/if}
+
+			<p class="quality-memory__reason">{qualityMemory.reason}</p>
+			{#if qualityMemory.state !== 'empty'}
+				<p class="quality-memory__policy">{qualityMemory.policyCopy}</p>
+			{/if}
+		</section>
 
 		<details class="details-drawer">
 			<summary>
@@ -4624,6 +4678,158 @@
 		font-size: 12px;
 	}
 
+	.quality-memory {
+		background: var(--mf-bg-panel);
+		border: 1px solid var(--mf-line);
+		border-left: 3px solid var(--mf-ready-fg);
+		border-radius: var(--mf-radius-3);
+		display: grid;
+		gap: 13px;
+		margin: 18px 0 0;
+		padding: 16px;
+	}
+
+	.quality-memory--empty {
+		border-left-color: var(--mf-idle-fg);
+		gap: 8px;
+	}
+
+	.quality-memory--attention {
+		border-left-color: var(--mf-wait-fg);
+	}
+
+	.quality-memory__header {
+		align-items: start;
+		display: flex;
+		gap: 14px;
+		justify-content: space-between;
+	}
+
+	.quality-memory__header > div {
+		display: grid;
+		gap: 3px;
+	}
+
+	.quality-memory__header span,
+	.quality-memory__measured > span,
+	.quality-memory__recommendation > span,
+	.quality-memory__facts small,
+	.quality-memory__recommendation dt {
+		color: var(--mf-fg-tertiary);
+		font-size: 10px;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+	}
+
+	.quality-memory__header h2 {
+		font-size: 15px;
+		margin: 0;
+	}
+
+	.quality-memory__header small {
+		color: var(--mf-fg-tertiary);
+		font-size: 11px;
+	}
+
+	.quality-memory__badge {
+		border-radius: 999px;
+		font-size: 11px;
+		font-weight: 700;
+		padding: 6px 9px;
+		white-space: nowrap;
+	}
+
+	.quality-memory__badge--quiet {
+		background: var(--mf-idle-bg);
+		color: var(--mf-idle-fg);
+	}
+
+	.quality-memory__badge--ready,
+	.quality-memory__badge--success {
+		background: var(--mf-ready-bg);
+		color: var(--mf-ready-fg);
+	}
+
+	.quality-memory__badge--attention {
+		background: var(--mf-wait-bg);
+		color: var(--mf-wait-fg);
+	}
+
+	.quality-memory__comparison {
+		border: 1px solid var(--mf-line-muted);
+		display: grid;
+		grid-template-columns: minmax(0, 1.45fr) minmax(250px, 0.75fr);
+	}
+
+	.quality-memory__measured,
+	.quality-memory__recommendation {
+		display: grid;
+		gap: 10px;
+		min-width: 0;
+		padding: 13px;
+	}
+
+	.quality-memory__recommendation {
+		background: var(--mf-bg-panel-2);
+		border-left: 1px solid var(--mf-line-muted);
+	}
+
+	.quality-memory__facts {
+		display: grid;
+		gap: 12px;
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	.quality-memory__facts div {
+		display: grid;
+		gap: 3px;
+		min-width: 0;
+	}
+
+	.quality-memory__facts strong,
+	.quality-memory__recommendation > strong,
+	.quality-memory__recommendation dd {
+		color: var(--mf-fg-primary);
+		font-family: var(--mf-font-mono), monospace;
+	}
+
+	.quality-memory__facts p,
+	.quality-memory__recommendation p,
+	.quality-memory__reason,
+	.quality-memory__policy {
+		font-size: 12px;
+		margin: 0;
+	}
+
+	.quality-memory__recommendation > strong {
+		font-size: 22px;
+	}
+
+	.quality-memory__recommendation dl {
+		display: grid;
+		gap: 4px 10px;
+		grid-template-columns: max-content minmax(0, 1fr);
+		margin: 0;
+	}
+
+	.quality-memory__recommendation dd {
+		font-size: 11px;
+		margin: 0;
+		overflow-wrap: anywhere;
+	}
+
+	.quality-memory__reason {
+		border-left: 2px solid var(--mf-line-strong);
+		color: var(--mf-fg-secondary);
+		padding-left: 10px;
+	}
+
+	.quality-memory__policy {
+		color: var(--mf-fg-tertiary);
+		font-weight: 600;
+	}
+
 	.details-drawer,
 	.cinematic .details-drawer {
 		background: transparent;
@@ -5160,6 +5366,21 @@
 		.older-season-option {
 			align-items: stretch;
 			flex-direction: column;
+		}
+
+		.quality-memory__header {
+			align-items: flex-start;
+			flex-direction: column;
+		}
+
+		.quality-memory__comparison,
+		.quality-memory__facts {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		.quality-memory__recommendation {
+			border-left: 0;
+			border-top: 1px solid var(--mf-line-muted);
 		}
 
 		.active-facts div,

--- a/frontend/src/lib/season/experience.test.ts
+++ b/frontend/src/lib/season/experience.test.ts
@@ -6,6 +6,7 @@ import type {
 	DashboardSummaryPayload,
 	EncodeQueueJob,
 	FolderCard,
+	FolderQualityMemoryPayload,
 	FolderPayload,
 	FolderStatusPayload,
 	FolderWorkflowState,
@@ -36,6 +37,7 @@ import {
 	normalizeReviewPairs,
 	overlappingCalibrationActivity,
 	plainFailureMessage,
+	qualityMemoryView,
 	resolvedTargetSummary,
 	reviewFeedbackIntent,
 	reviewFeedbackRequest,
@@ -278,6 +280,117 @@ function folder(overrides: Partial<FolderPayload> = {}): FolderPayload {
 		...overrides
 	};
 }
+
+function qualityMemoryPayload(): FolderQualityMemoryPayload {
+	return {
+		schema_version: 1,
+		algorithm_version: 'qsh1',
+		observation_id: 'qso1_fixture',
+		source_rel_path: 'tv/Big Brother (US)/Season 19/Episode 03.mkv',
+		recorded_at: '2026-07-24T17:00:00+00:00',
+		evidence_cutoff_at: '2026-07-24T16:00:00+00:00',
+		measured: {
+			selected_crf: 51,
+			quality_metric: 'VMAF',
+			quality_score: 86.5,
+			quality_target: 85,
+			quality_floor: 84,
+			quality_margin: 2.5,
+			output_bytes: 510_000_000,
+			size_error_percent: 2,
+			candidate_count: 5,
+			search_duration_seconds: 100
+		},
+		recommendation: {
+			first_crf: 50,
+			scope: 'season',
+			confidence: 'high',
+			sample_count: 12,
+			evidence_count: 12,
+			minimum_crf: 48,
+			maximum_crf: 52,
+			iqr: 2,
+			median_absolute_deviation: 1
+		},
+		comparison: { crf_delta: 1, within_one_crf: true },
+		fallback_reason: null,
+		reason: 'Season memory stayed within one CRF of the production result.',
+		production_search_changed: false
+	};
+}
+
+describe('quality memory explanation', () => {
+	it('keeps the empty state compact and explicit about unchanged policy', () => {
+		const view = qualityMemoryView(folder({ quality_memory: null }));
+
+		expect(view).toMatchObject({
+			state: 'empty',
+			tone: 'quiet',
+			badge: 'No memory yet',
+			measured: []
+		});
+		expect(view.reason).toContain('No completed quality search');
+		expect(view.policyCopy).toContain('Quality floors and saved policy remain unchanged');
+	});
+
+	it('separates a measured production run from a high-confidence recommendation', () => {
+		const view = qualityMemoryView(folder({ quality_memory: qualityMemoryPayload() }));
+
+		expect(view).toMatchObject({
+			state: 'high-confidence',
+			tone: 'success',
+			badge: 'High confidence',
+			source: 'Episode 03',
+			recommendation: {
+				label: 'Shadow first CRF',
+				value: '50.0',
+				detail: '12 observations · season · high confidence'
+			},
+			comparison: 'Within 1 CRF · Δ +1.0',
+			dispersion: 'CRF 48.0–52.0 · IQR 2.0 · MAD 1.0'
+		});
+		expect(view.measured).toEqual([
+			{ label: 'Chosen CRF', value: '51.0', detail: '5 candidates · 1m 40s' },
+			{
+				label: 'Measured VMAF',
+				value: '86.5',
+				detail: 'target 85.0 · floor 84.0 · margin +2.5'
+			},
+			{ label: 'Final size', value: '510 MB', detail: '2% over saved size target' }
+		]);
+	});
+
+	it('flags a high-confidence recommendation that differed from production', () => {
+		const payload = qualityMemoryPayload();
+		payload.comparison = { crf_delta: 3, within_one_crf: false };
+
+		const view = qualityMemoryView(folder({ quality_memory: payload }));
+
+		expect(view.tone).toBe('attention');
+		expect(view.badge).toBe('High confidence · differed');
+		expect(view.comparison).toBe('Outside 1 CRF · Δ +3.0');
+	});
+
+	it.each([
+		['sparse_cohort', 'sparse', 'Sparse memory'],
+		['stale_signature', 'stale', 'Memory invalidated'],
+		['shadow_evaluation_error', 'unavailable', 'Memory unavailable'],
+		['conflicting_quality_evidence', 'conflicting', 'Evidence conflict']
+	] as const)('maps %s into a compact %s state', (fallbackReason, state, badge) => {
+		const payload = qualityMemoryPayload();
+		payload.recommendation = null;
+		payload.comparison = { crf_delta: null, within_one_crf: null };
+		payload.fallback_reason = fallbackReason;
+
+		const view = qualityMemoryView(folder({ quality_memory: payload }));
+
+		expect(view.state).toBe(state);
+		expect(view.badge).toBe(badge);
+		expect(view.recommendation.value).toBe('Held back');
+		expect(view.reason.length).toBeGreaterThan(20);
+		expect(view.policyCopy).toContain('saved policy remain unchanged');
+	});
+});
 
 function sizeOption(
 	key: string,

--- a/frontend/src/lib/season/experience.ts
+++ b/frontend/src/lib/season/experience.ts
@@ -145,6 +145,30 @@ export interface CalibrationEtaSummary {
 	tone: 'quiet' | 'attention';
 }
 
+export type QualityMemoryState =
+	'empty' | 'sparse' | 'stale' | 'conflicting' | 'unavailable' | 'available' | 'high-confidence';
+
+export interface QualityMemoryFact {
+	label: string;
+	value: string;
+	detail: string;
+}
+
+export interface QualityMemoryView {
+	state: QualityMemoryState;
+	tone: HumanSeasonTone;
+	badge: string;
+	title: string;
+	source: string;
+	measured: QualityMemoryFact[];
+	recommendation: QualityMemoryFact;
+	evidence: string;
+	dispersion: string;
+	comparison: string;
+	reason: string;
+	policyCopy: string;
+}
+
 export interface ReviewConcern {
 	tag: QualityRiskTag;
 	label: string;
@@ -510,6 +534,214 @@ export function formatDecimalFileSize(bytes: number | null | undefined): string 
 		}
 	}
 	return `${Math.round(value / 1_000)} KB`;
+}
+
+function formatQualityMemoryNumber(value: number | null | undefined): string {
+	if (value == null || !Number.isFinite(value)) return '—';
+	return value.toLocaleString('en-US', {
+		minimumFractionDigits: 1,
+		maximumFractionDigits: 1
+	});
+}
+
+function formatSignedQualityMemoryNumber(value: number | null | undefined): string {
+	if (value == null || !Number.isFinite(value)) return '—';
+	return `${value >= 0 ? '+' : '−'}${formatQualityMemoryNumber(Math.abs(value))}`;
+}
+
+function formatQualityMemoryDuration(value: number | null): string {
+	if (value === null || !Number.isFinite(value) || value <= 0) return '';
+	const totalSeconds = Math.round(value);
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	if (minutes && seconds) return `${minutes}m ${seconds}s`;
+	if (minutes) return `${minutes}m`;
+	return `${seconds}s`;
+}
+
+function qualityMemorySizeDetail(value: number | null): string {
+	if (value === null || !Number.isFinite(value)) return 'No saved size target for this run';
+	if (Math.abs(value) < 0.05) return 'On saved size target';
+	const percent = Math.abs(value).toLocaleString('en-US', { maximumFractionDigits: 1 });
+	return `${percent}% ${value > 0 ? 'over' : 'under'} saved size target`;
+}
+
+function qualityMemoryFallbackCopy(reason: string | null, storedReason: string): string {
+	const copy: Record<string, string> = {
+		no_history: 'No compatible prior runs were available for this search.',
+		stale_evidence: 'Matching runs are older than the quality-memory age limit.',
+		stale_signature: 'The recorded search signature or saved policy no longer matches.',
+		source_fingerprint_unavailable: 'The source identity could not be verified for item memory.',
+		source_fingerprint_changed: 'The source changed, so item memory was invalidated.',
+		sparse_cohort: 'Compatible runs exist, but the cohort is still too small.',
+		high_dispersion: 'Prior chosen CRFs vary too much for a stable recommendation.',
+		search_target_changed: 'Prior searches changed their quality target and were excluded.',
+		non_monotonic_trace: 'Prior measurements were non-monotonic and were excluded.',
+		conflicting_quality_evidence: 'Prior runs disagree about the quality floor.',
+		shadow_evaluation_error: 'Memory evaluation failed; production search continued normally.'
+	};
+	return copy[reason ?? ''] ?? (storedReason || 'No shadow recommendation was available.');
+}
+
+function qualityMemoryState(reason: string | null, confidence: string | null): QualityMemoryState {
+	if (confidence === 'high') return 'high-confidence';
+	if (confidence) return 'available';
+	if (reason === 'no_history' || reason === 'sparse_cohort') return 'sparse';
+	if (reason === 'shadow_evaluation_error') return 'unavailable';
+	if (
+		reason === 'stale_evidence' ||
+		reason === 'stale_signature' ||
+		reason === 'source_fingerprint_unavailable' ||
+		reason === 'source_fingerprint_changed'
+	) {
+		return 'stale';
+	}
+	return 'conflicting';
+}
+
+export function qualityMemoryView(folder: FolderPayload): QualityMemoryView {
+	const memory = folder.quality_memory;
+	const policyCopy =
+		'Quality floors and saved policy remain unchanged. Memory is observation-only; production search ran normally.';
+	if (!memory) {
+		return {
+			state: 'empty',
+			tone: 'quiet',
+			badge: 'No memory yet',
+			title: 'No recorded runs yet',
+			source: '',
+			measured: [],
+			recommendation: {
+				label: 'Shadow recommendation',
+				value: 'Not available',
+				detail: 'A completed quality search will create the first observation.'
+			},
+			evidence: '0 observations',
+			dispersion: '—',
+			comparison: '—',
+			reason:
+				'No completed quality search has been recorded for this folder yet. Quality floors and saved policy remain unchanged.',
+			policyCopy
+		};
+	}
+
+	const recommendation = memory.recommendation;
+	const state = qualityMemoryState(memory.fallback_reason, recommendation?.confidence ?? null);
+	const withinOne = memory.comparison.within_one_crf;
+	const tone: HumanSeasonTone = recommendation
+		? withinOne === false
+			? 'attention'
+			: state === 'high-confidence'
+				? 'success'
+				: 'ready'
+		: state === 'sparse'
+			? 'quiet'
+			: 'attention';
+	const badge = recommendation
+		? state === 'high-confidence'
+			? withinOne === false
+				? 'High confidence · differed'
+				: 'High confidence'
+			: withinOne === false
+				? 'Memory differed'
+				: withinOne
+					? 'Memory agreed'
+					: 'Recommendation recorded'
+		: state === 'sparse'
+			? 'Sparse memory'
+			: state === 'stale'
+				? 'Memory invalidated'
+				: state === 'unavailable'
+					? 'Memory unavailable'
+					: 'Evidence conflict';
+	const measured = memory.measured;
+	const metric = text(measured.quality_metric).toUpperCase() || 'Quality';
+	const qualityDetail = [
+		measured.quality_target === null
+			? ''
+			: `target ${formatQualityMemoryNumber(measured.quality_target)}`,
+		measured.quality_floor === null
+			? ''
+			: `floor ${formatQualityMemoryNumber(measured.quality_floor)}`,
+		measured.quality_margin === null
+			? ''
+			: `margin ${formatSignedQualityMemoryNumber(measured.quality_margin)}`
+	]
+		.filter(Boolean)
+		.join(' · ');
+	const searchDetail = [
+		measured.candidate_count > 0
+			? `${measured.candidate_count} candidate${measured.candidate_count === 1 ? '' : 's'}`
+			: '',
+		formatQualityMemoryDuration(measured.search_duration_seconds)
+	]
+		.filter(Boolean)
+		.join(' · ');
+	const evidence = recommendation
+		? `${recommendation.sample_count.toLocaleString('en-US')} observation${recommendation.sample_count === 1 ? '' : 's'} · ${recommendation.scope} · ${recommendation.confidence} confidence`
+		: 'No qualifying evidence cohort';
+	const dispersion = recommendation
+		? [
+				recommendation.minimum_crf === null || recommendation.maximum_crf === null
+					? ''
+					: `CRF ${formatQualityMemoryNumber(recommendation.minimum_crf)}–${formatQualityMemoryNumber(recommendation.maximum_crf)}`,
+				recommendation.iqr === null ? '' : `IQR ${formatQualityMemoryNumber(recommendation.iqr)}`,
+				recommendation.median_absolute_deviation === null
+					? ''
+					: `MAD ${formatQualityMemoryNumber(recommendation.median_absolute_deviation)}`
+			]
+				.filter(Boolean)
+				.join(' · ') || 'Dispersion not recorded'
+		: '—';
+	const comparison = recommendation
+		? memory.comparison.crf_delta === null
+			? 'Production comparison unavailable'
+			: `${withinOne ? 'Within 1 CRF' : 'Outside 1 CRF'} · Δ ${formatSignedQualityMemoryNumber(memory.comparison.crf_delta)}`
+		: 'No recommendation to compare';
+	return {
+		state,
+		tone,
+		badge,
+		title: recommendation
+			? 'Measured run and shadow recommendation'
+			: 'Measured run; memory held back',
+		source: memory.source_rel_path ? episodeLabel(memory.source_rel_path) : '',
+		measured: [
+			{
+				label: 'Chosen CRF',
+				value: formatQualityMemoryNumber(measured.selected_crf),
+				detail: searchDetail || 'Production selection'
+			},
+			{
+				label: `Measured ${metric}`,
+				value: formatQualityMemoryNumber(measured.quality_score),
+				detail: qualityDetail || 'No quality target details recorded'
+			},
+			{
+				label: 'Final size',
+				value: formatDecimalFileSize(measured.output_bytes),
+				detail: qualityMemorySizeDetail(measured.size_error_percent)
+			}
+		],
+		recommendation: recommendation
+			? {
+					label: 'Shadow first CRF',
+					value: formatQualityMemoryNumber(recommendation.first_crf),
+					detail: evidence
+				}
+			: {
+					label: 'Shadow recommendation',
+					value: 'Held back',
+					detail: 'Production search still ran normally.'
+				},
+		evidence,
+		dispersion,
+		comparison,
+		reason: recommendation
+			? text(memory.reason) || 'The recommendation was recorded for comparison only.'
+			: qualityMemoryFallbackCopy(memory.fallback_reason, memory.reason),
+		policyCopy
+	};
 }
 
 export function calibrationJobTargetContract(

--- a/mediaforce/tuning/quality_observations.py
+++ b/mediaforce/tuning/quality_observations.py
@@ -15,6 +15,7 @@ from mediaforce.core.db_tables import quality_search_observations
 from mediaforce.core.evidence import stable_json_hash
 from mediaforce.core.type_defs import float_value, int_value, object_dict, object_list
 from mediaforce.encoding.quality import QualitySearchResult, parse_quality_search_measurements
+from mediaforce.library.media_scopes import MediaScope, scope_rel_path_filter
 from mediaforce.tuning.quality_memory import (
     QualitySearchContext,
     accepted_quality_outcomes,
@@ -326,6 +327,7 @@ def load_current_quality_search_observations(
         connection: DBClient,
         *,
         recorded_before: str | None = None,
+        scope: MediaScope | None = None,
 ) -> list[Mapping[str, Any]]:
     authority_rank = case(
         (quality_search_observations.c.authority == AUTHORITY_CORRECTION, 30),
@@ -342,10 +344,11 @@ def load_current_quality_search_observations(
     if recorded_before is not None:
         ranked_query = ranked_query.where(quality_search_observations.c.recorded_at < recorded_before)
     ranked = ranked_query.subquery()
+    current_query = select(ranked).where(ranked.c.observation_rank == 1)
+    if scope is not None:
+        current_query = current_query.where(scope_rel_path_filter(ranked.c.source_rel_path, scope))
     return list(
-        connection.execute(
-            select(ranked).where(ranked.c.observation_rank == 1)
-        ).mappings()
+        connection.execute(current_query).mappings()
     )
 
 

--- a/mediaforce/tuning/quality_shadow.py
+++ b/mediaforce/tuning/quality_shadow.py
@@ -505,6 +505,121 @@ def build_quality_shadow_payload(
     return payload
 
 
+def select_latest_quality_shadow_observation(
+        rows: Iterable[Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
+    selected: tuple[datetime, str, Mapping[str, Any]] | None = None
+    for row in _resolve_current_rows(rows):
+        if str(row.get("outcome_kind") or "") != OUTCOME_SELECTED:
+            continue
+        if int_value(row.get("learning_eligible")) != 1:
+            continue
+        shadow = _json_object(row.get("shadow_json"))
+        if (
+            int_value(shadow.get("schema_version")) != QUALITY_SHADOW_SCHEMA_VERSION
+            or str(shadow.get("algorithm_version") or "") != QUALITY_SHADOW_ALGORITHM_VERSION
+        ):
+            continue
+        completed_at = _observation_completion_at(row)
+        if completed_at is None:
+            continue
+        observation_id = str(row.get("observation_id") or "")
+        candidate = (completed_at, observation_id, row)
+        if selected is None or candidate[:2] > selected[:2]:
+            selected = candidate
+    return selected[2] if selected is not None else None
+
+
+def quality_shadow_public_view(observation: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    row = object_dict(observation)
+    shadow = _json_object(row.get("shadow_json"))
+    if (
+        not row
+        or int_value(shadow.get("schema_version")) != QUALITY_SHADOW_SCHEMA_VERSION
+        or str(shadow.get("algorithm_version") or "") != QUALITY_SHADOW_ALGORITHM_VERSION
+    ):
+        return None
+    comparison = object_dict(shadow.get("comparison"))
+    recommendation_payload = object_dict(shadow.get("recommendation"))
+    recommendation = None
+    recommendation_scope = str(recommendation_payload.get("scope") or "")
+    recommendation_confidence = str(recommendation_payload.get("confidence") or "none")
+    recommendation_crf = _strict_number(recommendation_payload.get("first_crf"))
+    if (
+        recommendation_crf is not None
+        and recommendation_scope in {"item", "season", "series"}
+        and recommendation_confidence in {"none", "limited", "moderate", "high"}
+    ):
+        evidence_ids = [
+            str(value)
+            for value in object_list(recommendation_payload.get("evidence_observation_ids"))
+            if str(value).strip()
+        ]
+        recommendation = {
+            "first_crf": recommendation_crf,
+            "scope": recommendation_scope,
+            "confidence": recommendation_confidence,
+            "sample_count": max(int_value(recommendation_payload.get("sample_count")), 0),
+            "evidence_count": len(evidence_ids),
+            "minimum_crf": _strict_number(recommendation_payload.get("minimum_crf")),
+            "maximum_crf": _strict_number(recommendation_payload.get("maximum_crf")),
+            "iqr": _strict_number(recommendation_payload.get("iqr")),
+            "median_absolute_deviation": _strict_number(
+                recommendation_payload.get("median_absolute_deviation")
+            ),
+        }
+    selected_score = _strict_number(row.get("selected_score"))
+    context = _json_object(row.get("context_json"))
+    quality_floor = _strict_number(object_dict(context.get("search")).get("minimum_quality_score"))
+    quality_margin = (
+        round(selected_score - quality_floor, 3)
+        if selected_score is not None and quality_floor is not None
+        else None
+    )
+    selected_crf = _strict_number(comparison.get("selected_crf"))
+    if selected_crf is None:
+        selected_crf = _strict_number(row.get("selected_crf"))
+    candidate_count = int_value(comparison.get("candidate_count"))
+    if "candidate_count" not in comparison:
+        candidate_count = int_value(row.get("candidate_count"))
+    search_duration_seconds = _strict_number(comparison.get("search_duration_seconds"))
+    if search_duration_seconds is None:
+        search_duration_seconds = _strict_number(row.get("search_duration_seconds"))
+    fallback_reason = _optional_text(shadow.get("fallback_reason"))
+    return {
+        "schema_version": QUALITY_SHADOW_SCHEMA_VERSION,
+        "algorithm_version": QUALITY_SHADOW_ALGORITHM_VERSION,
+        "observation_id": _optional_text(row.get("observation_id")),
+        "source_rel_path": _optional_text(row.get("source_rel_path")),
+        "recorded_at": _optional_text(row.get("recorded_at")),
+        "evidence_cutoff_at": _optional_text(shadow.get("evidence_cutoff_at")),
+        "measured": {
+            "selected_crf": selected_crf,
+            "quality_metric": _optional_text(row.get("quality_metric")),
+            "quality_score": selected_score,
+            "quality_target": _strict_number(row.get("selected_target")),
+            "quality_floor": quality_floor,
+            "quality_margin": quality_margin,
+            "output_bytes": int_value(row.get("actual_output_bytes")) or None,
+            "size_error_percent": _strict_number(comparison.get("size_error_percent")),
+            "candidate_count": max(candidate_count, 0),
+            "search_duration_seconds": search_duration_seconds,
+        },
+        "recommendation": recommendation,
+        "comparison": {
+            "crf_delta": _strict_number(comparison.get("crf_delta")),
+            "within_one_crf": (
+                comparison.get("within_one_crf")
+                if isinstance(comparison.get("within_one_crf"), bool)
+                else None
+            ),
+        },
+        "fallback_reason": fallback_reason,
+        "reason": str(shadow.get("reason") or "").strip(),
+        "production_search_changed": False,
+    }
+
+
 def load_quality_shadow_metrics(connection: DBClient) -> QualityShadowMetrics:
     return quality_shadow_metrics(load_current_quality_search_observations(connection))
 

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -34,7 +34,14 @@ from mediaforce.advisor import TuningPolicyResponse
 from mediaforce.advising.routing import advisor_routing_from_config
 from mediaforce.tuning.calibration_jobs import load_active_job, load_job, \
     list_queue_summary, update_job_telemetry
-from mediaforce.tuning.quality_observations import backfill_quality_search_observations
+from mediaforce.tuning.quality_observations import (
+    backfill_quality_search_observations,
+    load_current_quality_search_observations,
+)
+from mediaforce.tuning.quality_shadow import (
+    quality_shadow_public_view,
+    select_latest_quality_shadow_observation,
+)
 from mediaforce.core.config import DEFAULT_CONFIG_PATH, MediaforceConfig, load_config, update_runtime_settings, \
     update_runtime_folder_policy_values, upsert_runtime_folder_policy_override
 from mediaforce.core.binaries import ffmpeg_binary
@@ -1202,6 +1209,11 @@ def create_app(config_path: Path | None = None) -> FastAPI:
             latest_failed_sample_job_payload = object_dict(
                 _load_latest_failed_target_size_job_state(connection, config, normalized_prefix)
             ) or None
+            quality_memory = quality_shadow_public_view(
+                select_latest_quality_shadow_observation(
+                    load_current_quality_search_observations(connection, scope=media_scope)
+                )
+            )
         policy = _folder_display_policy(
             sample_item=sample_item,
             calibration=calibration,
@@ -1296,6 +1308,7 @@ def create_app(config_path: Path | None = None) -> FastAPI:
                 "stream_budget_ledger": stream_budget.to_payload(),
                 "size_goal_options": size_goal_options,
                 "quality_risk": quality_risk_public_view(quality_risk_contract),
+                "quality_memory": quality_memory,
                 "failed_target_size_search": target_size_search_public_view(latest_failed_target_trace),
                 "pending_proposal": pending_proposal,
                 "recent_tuning_sessions": recent_sessions,

--- a/tests/test_quality_observations.py
+++ b/tests/test_quality_observations.py
@@ -18,6 +18,7 @@ from mediaforce.core.db_tables import (
     staged_artifacts,
 )
 from mediaforce.encoding.quality import QualitySearchResult
+from mediaforce.library.media_scopes import media_scope_from_prefix
 from mediaforce.tuning.quality_memory import QualitySearchContext
 from mediaforce.tuning.quality_observations import (
     AUTHORITY_CORRECTION,
@@ -183,6 +184,31 @@ class QualityObservationTests(unittest.TestCase):
         self.assertEqual(current[0]["selected_crf"], 31.0)
         self.assertEqual(current_before_correction[0]["observation_id"], initial.observation_id)
 
+    def test_current_observations_can_be_limited_to_a_folder_scope(self) -> None:
+        in_scope = self._selected_observation(
+            search_run_id="qsr1_in_scope",
+            library_item_id=1,
+            source_rel_path="tv/Example/Season 01/Episode 01.mkv",
+        )
+        out_of_scope = self._selected_observation(
+            search_run_id="qsr1_out_of_scope",
+            library_item_id=2,
+            source_rel_path="tv/Other/Season 01/Episode 01.mkv",
+        )
+        append_quality_search_observation(self.connection, in_scope)
+        append_quality_search_observation(self.connection, out_of_scope)
+
+        current = load_current_quality_search_observations(
+            self.connection,
+            scope=media_scope_from_prefix(
+                "tv/Example/Season 01",
+                match="descendants",
+                library_types={"tv": "tv"},
+            ),
+        )
+
+        self.assertEqual([row["search_run_id"] for row in current], ["qsr1_in_scope"])
+
     def test_database_rejects_update_and_delete(self) -> None:
         observation = self._selected_observation()
         append_quality_search_observation(self.connection, observation)
@@ -284,6 +310,9 @@ class QualityObservationTests(unittest.TestCase):
             self,
             *,
             result: QualitySearchResult | None = None,
+            search_run_id: str = "qsr1_success",
+            library_item_id: int = 1,
+            source_rel_path: str = "tv/Example/Season 01/Episode 01.mkv",
             authority: str = "runtime_native",
             revision: int = 0,
             supersedes_observation_id: str | None = None,
@@ -292,9 +321,9 @@ class QualityObservationTests(unittest.TestCase):
             recorded_at: str = "2026-07-24T17:00:00+00:00",
     ) -> QualitySearchObservation:
         return build_selected_quality_observation(
-            search_run_id="qsr1_success",
-            library_item_id=1,
-            source_rel_path="tv/Example/Season 01/Episode 01.mkv",
+            search_run_id=search_run_id,
+            library_item_id=library_item_id,
+            source_rel_path=source_rel_path,
             source_fingerprint="source-fingerprint",
             context=self._context(),
             policy_hash="policy-hash",

--- a/tests/test_quality_shadow.py
+++ b/tests/test_quality_shadow.py
@@ -7,10 +7,12 @@ from mediaforce.tuning.quality_shadow import (
     MIN_SHADOW_RECOMMENDATIONS,
     QualityShadowRecommendation,
     build_quality_shadow_payload,
+    quality_shadow_public_view,
     quality_result_candidate_count,
     quality_result_target_changed,
     quality_shadow_metrics,
     recommend_quality_search_from_rows,
+    select_latest_quality_shadow_observation,
 )
 
 
@@ -236,6 +238,133 @@ class QualityShadowTests(unittest.TestCase):
         self.assertEqual(comparison["candidate_savings_rate"], -0.2)
         self.assertTrue(comparison["fallback_needed"])
         self.assertTrue(comparison["false_narrow"])
+
+    def test_public_view_separates_measured_run_from_shadow_recommendation(self) -> None:
+        recommendation = self._available_recommendation(first_crf=50.0)
+        shadow = build_quality_shadow_payload(
+            recommendation,
+            selected_crf=51.0,
+            selected_score=86.5,
+            minimum_quality_score=84.0,
+            candidate_count=5,
+            search_duration_seconds=100.0,
+            actual_output_bytes=510_000_000,
+            size_target_bytes=500_000_000,
+        )
+        row = {
+            **self._row(index=1, crf=51.0),
+            "quality_metric": "VMAF",
+            "selected_target": 85.0,
+            "selected_score": 86.5,
+            "actual_output_bytes": 510_000_000,
+            "context_json": json.dumps({"search": {"minimum_quality_score": 84.0}}),
+            "shadow_json": json.dumps(shadow),
+        }
+
+        public = quality_shadow_public_view(row)
+
+        self.assertIsNotNone(public)
+        assert public is not None
+        self.assertEqual(public["source_rel_path"], "tv/Show/Season 01/Episode 01.mkv")
+        self.assertEqual(
+            public["measured"],
+            {
+                "selected_crf": 51.0,
+                "quality_metric": "VMAF",
+                "quality_score": 86.5,
+                "quality_target": 85.0,
+                "quality_floor": 84.0,
+                "quality_margin": 2.5,
+                "output_bytes": 510_000_000,
+                "size_error_percent": 2.0,
+                "candidate_count": 5,
+                "search_duration_seconds": 100.0,
+            },
+        )
+        self.assertEqual(public["recommendation"]["first_crf"], 50.0)
+        self.assertEqual(public["recommendation"]["scope"], "season")
+        self.assertEqual(public["recommendation"]["sample_count"], 6)
+        self.assertEqual(public["recommendation"]["evidence_count"], 1)
+        self.assertEqual(public["comparison"], {"crf_delta": 1.0, "within_one_crf": True})
+        self.assertFalse(public["production_search_changed"])
+
+    def test_public_view_keeps_typed_fallback_without_a_recommendation(self) -> None:
+        recommendation = QualityShadowRecommendation(
+            search_signature_id=self.context.signature_id,
+            evidence_cutoff_at=self.as_of.isoformat(),
+            first_crf=None,
+            scope=None,
+            confidence="none",
+            sample_count=0,
+            cohort_id=None,
+            minimum_crf=None,
+            maximum_crf=None,
+            iqr=None,
+            median_absolute_deviation=None,
+            evidence_observation_ids=(),
+            fallback_reason="sparse_cohort",
+            reason="Compatible observations exist, but the cohort is too small.",
+            exclusions=(),
+        )
+        shadow = build_quality_shadow_payload(
+            recommendation,
+            selected_crf=52.0,
+            selected_score=85.0,
+            minimum_quality_score=84.0,
+            candidate_count=4,
+            search_duration_seconds=80.0,
+            actual_output_bytes=None,
+            size_target_bytes=None,
+        )
+        public = quality_shadow_public_view(
+            {
+                **self._row(index=1, crf=52.0),
+                "quality_metric": "VMAF",
+                "shadow_json": json.dumps(shadow),
+            }
+        )
+
+        self.assertIsNotNone(public)
+        assert public is not None
+        self.assertIsNone(public["recommendation"])
+        self.assertEqual(public["fallback_reason"], "sparse_cohort")
+        self.assertIn("cohort is too small", public["reason"])
+
+    def test_latest_shadow_selection_uses_current_valid_completed_observation(self) -> None:
+        shadow = build_quality_shadow_payload(
+            self._available_recommendation(first_crf=50.0),
+            selected_crf=50.0,
+            selected_score=85.0,
+            minimum_quality_score=84.0,
+            candidate_count=5,
+            search_duration_seconds=100.0,
+            actual_output_bytes=None,
+            size_target_bytes=None,
+        )
+        older = {
+            **self._row(index=2, crf=50.0),
+            "shadow_json": json.dumps(shadow),
+        }
+        newer = {
+            **self._row(index=1, crf=51.0),
+            "shadow_json": json.dumps(shadow),
+        }
+        invalid = {
+            **self._row(
+                index=0,
+                crf=52.0,
+                completed_at=self.as_of + timedelta(minutes=1),
+            ),
+            "shadow_json": json.dumps({"algorithm_version": "old"}),
+        }
+
+        selected = select_latest_quality_shadow_observation([older, invalid, newer])
+
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertEqual(selected["observation_id"], newer["observation_id"])
+        self.assertIsNone(quality_shadow_public_view(None))
+        self.assertIsNone(quality_shadow_public_view(invalid))
 
     def test_metrics_apply_accuracy_savings_and_safety_gates(self) -> None:
         rows = []


### PR DESCRIPTION
## Summary
- add a scoped, typed Folder Studio projection for the latest immutable quality-shadow observation
- separate measured production CRF, quality, and size from the passive shadow recommendation
- render compact empty, sparse, stale, conflicting, unavailable, and high-confidence states in the active TV Studio surface
- state explicitly that quality floors, saved policy, and production search behavior remain unchanged
- document the projection and operator vocabulary

## Validation
- `bash scripts/pre-commit-check.sh` (1,148 backend tests, frontend check/lint/unit/build, desktop+narrow route smoke)
- focused backend and season view-model tests
- real-browser desktop and 390px review of high-confidence and empty states; no horizontal overflow
- PyCharm changed-files inspection: zero problems; verdict inconclusive only because Svelte resolved as plain text
- independent Opus/GPT reviews; fixed the evaluator-error state so it no longer appears as evidence conflict

Closes #260