### PR TITLE
Add AV1 trait reachability preflight

### DIFF
--- a/docs/architecture/av1-cold-start-priors.md
+++ b/docs/architecture/av1-cold-start-priors.md
@@ -81,7 +81,22 @@ remains available.
 
 ## Content and intent
 
-Measured fingerprint traits map into the public multi-label vocabulary:
+Prospective validation uses the `acstp1` AV1 trait projection rather than the
+fingerprint decision's raw finding list. The projection is canonical JSON with
+a hash-bound `projection_id`; it separates stable cell identity from review-only
+advisories before any validation cell is selected.
+
+Stable non-advisory `dark_luma`, `high_motion`, and `high_texture` findings can
+produce darkness, motion, and texture/detail identity at the contract's
+confidence floor. `animation_cues` and `likely_film_grain` are the only
+advisories explicitly promotable into identity, and only at the higher
+promotion floor. Audio complexity, duplicate cadence, banding risk, analog or
+ambiguous noise, and low-confidence animation/grain findings remain review
+advisories. An audio-only or advisory-only decision therefore remains
+`typical`; an unrecognized or low-confidence identity finding becomes
+`unknown` rather than being mislabeled as typical.
+
+The projected public multi-label vocabulary is:
 
 - `animation`
 - `darkness`
@@ -93,12 +108,19 @@ Measured fingerprint traits map into the public multi-label vocabulary:
 - `typical`
 - `unknown`
 
-`mixed` is added when multiple measured risk traits are present. `unknown` is
-an explicit state, not an inferred genre. The current fingerprint contract does
-not invent low-motion dialogue; that label is used only when measured evidence
-provides it. Public cells require an exact match to the complete sorted trait
-set, so a narrow animation-only cell cannot generalize into unvalidated dark,
-grainy, textured, or mixed content.
+`mixed` is added when multiple measured identity traits are present. `unknown`
+is an explicit state, not an inferred genre. The current analyzer has no
+low-motion-dialogue producer, and the current request contract rejects
+unmeasured evidence before it can create an unknown fallback request. The
+feasibility gate therefore marks both paths unavailable instead of accepting an
+unexecutable preregistration cell. Public cells require an exact match to the
+complete sorted trait set, so a narrow animation-only cell cannot generalize
+into unvalidated dark, grainy, textured, or mixed content.
+
+Historical content-intent observations remain append-only. Feasibility can
+join an observation to current retained fingerprint analysis only when the
+content-version binding still matches, then apply `acstp1` in memory without
+rewriting the observation or reopening the media.
 
 Each confirmed compression intent has one exact optimization objective:
 

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -246,6 +246,12 @@ Guidance:
   - deterministic AV1 preregistration manifests, private redacted evidence
     validation, privacy-safe held-out range/candidate-work/safety aggregation,
     and non-mutating publication-review reports
+- `av1_trait_projection.py`
+  - versioned deterministic AV1 cell identity, review-only advisory separation,
+    retained-analysis reclassification, and current producer reachability
+- `av1_trait_feasibility.py`
+  - read-only public-safe aggregate inventory and coherent derivation preflight
+    for proposed AV1 validation cells
 - `quality_memory.py`
   - read-only accepted-outcome cohorts, command-derived search signatures,
     confidence, dispersion, and explainable central CRF hints

--- a/docs/development/av1-cold-start-validation.md
+++ b/docs/development/av1-cold-start-validation.md
@@ -34,6 +34,41 @@ The validator reports `runtime_execution_authorized=false`. A valid manifest is
 permission to prepare a private mapping and candidate locks, not permission to
 run encodes.
 
+## Trait reachability preflight
+
+Before a future preregistration is treated as executable, run the read-only
+trait feasibility report against the proposed manifest and an explicit UTC
+cutoff:
+
+```bash
+uv run mediaforce av1-trait-feasibility \
+  docs/validation/av1-cold-start-preregistration-v1.json \
+  --as-of 2026-07-27T18:00:00Z --json
+```
+
+The `acstp1` projection reclassifies compatible retained fingerprint analysis
+without reading media. The report emits only aggregate item, parent-scope,
+source, series, source-group, coherent compatibility/policy cohort, and bitrate
+range counts. Paths, titles, source IDs, fingerprints, review-media identities,
+compatibility tokens, and policy tokens are never emitted. The report is
+deterministic for the same database snapshot, manifest, and `--as-of` value.
+
+`ready_for_private_mapping` means only that current code can produce the
+requested trait/intent path and aggregate inventory and derivation upper bounds
+meet the preregistered minima. Parent-scope diversity is a conservative public
+preflight; the private mapping must still prove unique titles/series, source
+group concentration, derivation/holdout disjointness, and every other selection
+constraint. Every feasibility report carries `execution_authorized=false` and
+`runtime_integration_required=true`; it cannot start Mediaforce, alter the v1
+request path, or authorize an encode. Issue #285 owns integration of the
+prospective projection into an executable successor protocol.
+
+The current analyzer deliberately reports low-motion dialogue as unreachable,
+and the current request contract reports unknown fallback cases as unreachable.
+Low-confidence animation or grain/noise advisories cannot silently create those
+cell identities. The v1 preregistration remains immutable; these findings guide
+the versioned successor protocol rather than relabeling v1 evidence.
+
 ## Evidence lifecycle
 
 The execution phase has five boundaries:

--- a/mediaforce/cli.py
+++ b/mediaforce/cli.py
@@ -32,6 +32,10 @@ from mediaforce.library.metadata_sync import sync_external_metadata
 from mediaforce.review import generate_compare_clips
 from mediaforce.state_cleanup import purge_transient_artifacts
 from mediaforce.tuning.quality_acceptance import format_quality_acceptance_report, load_quality_acceptance_report
+from mediaforce.tuning.av1_trait_feasibility import (
+    format_av1_trait_feasibility_report,
+    load_av1_trait_feasibility_report_from_path,
+)
 
 
 class TargetSizePreflightBlocked(RuntimeError):
@@ -115,6 +119,27 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         dest="json_output",
         help="Print the stable JSON report",
+    )
+
+    av1_trait_feasibility_parser = subparsers.add_parser(
+        "av1-trait-feasibility",
+        help="Report privacy-safe reachability for AV1 validation cells",
+    )
+    av1_trait_feasibility_parser.add_argument(
+        "manifest",
+        type=Path,
+        help="Path to a canonical AV1 validation preregistration manifest",
+    )
+    av1_trait_feasibility_parser.add_argument(
+        "--as-of",
+        required=True,
+        help="Canonical UTC report cutoff such as 2026-07-27T18:00:00Z",
+    )
+    av1_trait_feasibility_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Print the stable privacy-safe JSON report",
     )
 
     plan_parser = subparsers.add_parser("plan", help="Generate a run manifest from current state")
@@ -225,6 +250,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             print(format_quality_acceptance_report(report))
         return 0
+
+    if args.command == "av1-trait-feasibility":
+        try:
+            with open_readonly_db(config.paths.db_path) as connection:
+                report = load_av1_trait_feasibility_report_from_path(
+                    connection,
+                    manifest_path=args.manifest,
+                    as_of=args.as_of,
+                )
+        except (OSError, TypeError, ValueError) as exc:
+            print(f"AV1 trait feasibility failed: {exc}")
+            return 1
+        if args.json_output:
+            print(json.dumps(report.to_payload(), indent=2, sort_keys=True))
+        else:
+            print(format_av1_trait_feasibility_report(report))
+        return 0 if report.ready else 2
 
     purge_transient_artifacts(config)
     default_review_dir = config.paths.review_dir

--- a/mediaforce/tuning/av1_trait_feasibility.py
+++ b/mediaforce/tuning/av1_trait_feasibility.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from sqlalchemy import func, inspect, select
+
+from mediaforce.core.db import DBClient
+from mediaforce.core.db_tables import (
+    content_intent_boundary_observations,
+    library_item_evidence_state,
+    library_items,
+)
+from mediaforce.core.evidence import canonical_json_bytes, stable_json_hash
+from mediaforce.core.type_defs import int_value, object_dict
+from mediaforce.encoding.fingerprint import MEDIA_FINGERPRINT_EVIDENCE_KIND
+from mediaforce.tuning.av1_cold_start import assert_av1_cold_start_public_payload_safe
+from mediaforce.tuning.av1_cold_start_evaluation import (
+    AV1ColdStartValidationCellPlanV1,
+    AV1ColdStartValidationManifestV1,
+    load_av1_cold_start_validation_manifest,
+)
+from mediaforce.tuning.av1_trait_projection import (
+    AV1_COLD_START_TRAIT_PROJECTION_CONTRACT_VERSION,
+    AV1ColdStartTraitProjectionError,
+    av1_trait_selector_matches,
+    av1_trait_selector_producer_blockers,
+    project_av1_cold_start_fingerprint_summary,
+)
+
+
+AV1_COLD_START_TRAIT_FEASIBILITY_SCHEMA = "mediaforce.av1_cold_start_trait_feasibility"
+AV1_COLD_START_TRAIT_FEASIBILITY_SCHEMA_VERSION = 1
+AV1_COLD_START_TRAIT_FEASIBILITY_CONTRACT_VERSION = "acstf1"
+AV1_COLD_START_TRAIT_FEASIBILITY_MAX_AGE_DAYS = 180
+
+
+class AV1ColdStartTraitFeasibilityError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ColdStartTraitFeasibilityCellV1:
+    cell_plan_id: str
+    name: str
+    mode: str
+    intent_level: str
+    selector_match: str
+    required_traits: tuple[str, ...]
+    registered_case_count: int
+    producer_blockers: tuple[str, ...]
+    matching_item_count: int
+    distinct_parent_scope_count: int
+    eligible_observation_count: int
+    independent_source_count: int
+    independent_series_count: int
+    independent_source_group_count: int
+    coherent_cohort_count: int
+    coherent_bitrate_min_bps: int | None
+    coherent_bitrate_max_bps: int | None
+    content_version_mismatch_count: int
+    aged_out_observation_count: int
+    ineligible_observation_count: int
+    withdrawn_observation_count: int
+    status: str
+
+    def __post_init__(self) -> None:
+        if self.required_traits != tuple(sorted(set(self.required_traits))):
+            raise AV1ColdStartTraitFeasibilityError("AV1 feasibility traits must be unique and sorted")
+        if self.producer_blockers != tuple(sorted(set(self.producer_blockers))):
+            raise AV1ColdStartTraitFeasibilityError("AV1 feasibility blockers must be unique and sorted")
+        counts = (
+            self.registered_case_count,
+            self.matching_item_count,
+            self.distinct_parent_scope_count,
+            self.eligible_observation_count,
+            self.independent_source_count,
+            self.independent_series_count,
+            self.independent_source_group_count,
+            self.coherent_cohort_count,
+            self.content_version_mismatch_count,
+            self.aged_out_observation_count,
+            self.ineligible_observation_count,
+            self.withdrawn_observation_count,
+        )
+        if any(value < 0 for value in counts):
+            raise AV1ColdStartTraitFeasibilityError("AV1 feasibility counts cannot be negative")
+        if self.status not in {
+            "unreachable",
+            "insufficient_inventory",
+            "insufficient_scope_diversity",
+            "insufficient_derivation_evidence",
+            "ready_for_private_mapping",
+        }:
+            raise AV1ColdStartTraitFeasibilityError("AV1 feasibility status is unsupported")
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "cell_plan_id": self.cell_plan_id,
+            "name": self.name,
+            "mode": self.mode,
+            "intent_level": self.intent_level,
+            "trait_selector": {
+                "match": self.selector_match,
+                "traits": list(self.required_traits),
+            },
+            "registered_case_count": self.registered_case_count,
+            "producer_reachable": not self.producer_blockers,
+            "producer_blockers": list(self.producer_blockers),
+            "inventory": {
+                "matching_item_count": self.matching_item_count,
+                "distinct_parent_scope_count": self.distinct_parent_scope_count,
+            },
+            "derivation": {
+                "required": self.mode == "publication_candidate",
+                "eligible_observation_count": self.eligible_observation_count,
+                "independent_source_count": self.independent_source_count,
+                "independent_series_count": self.independent_series_count,
+                "independent_source_group_count": self.independent_source_group_count,
+                "coherent_cohort_count": self.coherent_cohort_count,
+                "coherent_bitrate_min_bps": self.coherent_bitrate_min_bps,
+                "coherent_bitrate_max_bps": self.coherent_bitrate_max_bps,
+                "content_version_mismatch_count": self.content_version_mismatch_count,
+                "aged_out_observation_count": self.aged_out_observation_count,
+                "ineligible_observation_count": self.ineligible_observation_count,
+                "withdrawn_observation_count": self.withdrawn_observation_count,
+            },
+            "status": self.status,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ColdStartTraitFeasibilityReportV1:
+    report_id: str
+    as_of: str
+    manifest_id: str
+    measured_analysis_count: int
+    incompatible_analysis_count: int
+    observation_store_available: bool
+    cells: tuple[AV1ColdStartTraitFeasibilityCellV1, ...]
+
+    def __post_init__(self) -> None:
+        _parse_as_of(self.as_of)
+        if self.measured_analysis_count < 0 or self.incompatible_analysis_count < 0:
+            raise AV1ColdStartTraitFeasibilityError("AV1 feasibility analysis counts cannot be negative")
+        if not self.cells or self.cells != tuple(sorted(self.cells, key=lambda cell: cell.name)):
+            raise AV1ColdStartTraitFeasibilityError("AV1 feasibility cells must be non-empty and sorted")
+        if self.report_id != _report_id(self.semantic_payload()):
+            raise AV1ColdStartTraitFeasibilityError("AV1 feasibility report ID does not match its payload")
+        assert_av1_cold_start_public_payload_safe(self.to_payload())
+
+    @property
+    def ready(self) -> bool:
+        return all(cell.status == "ready_for_private_mapping" for cell in self.cells)
+
+    def semantic_payload(self) -> dict[str, Any]:
+        return {
+            "schema": AV1_COLD_START_TRAIT_FEASIBILITY_SCHEMA,
+            "schema_version": AV1_COLD_START_TRAIT_FEASIBILITY_SCHEMA_VERSION,
+            "contract_version": AV1_COLD_START_TRAIT_FEASIBILITY_CONTRACT_VERSION,
+            "projection_contract_version": AV1_COLD_START_TRAIT_PROJECTION_CONTRACT_VERSION,
+            "as_of": self.as_of,
+            "manifest_id": self.manifest_id,
+            "execution_authorized": False,
+            "private_mapping_required": True,
+            "runtime_integration_required": True,
+            "measured_analysis_count": self.measured_analysis_count,
+            "incompatible_analysis_count": self.incompatible_analysis_count,
+            "observation_store_available": self.observation_store_available,
+            "cells": [cell.to_payload() for cell in self.cells],
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {"report_id": self.report_id, **self.semantic_payload(), "ready": self.ready}
+
+
+def load_av1_trait_feasibility_report(
+        connection: DBClient,
+        *,
+        manifest: AV1ColdStartValidationManifestV1,
+        as_of: str,
+) -> AV1ColdStartTraitFeasibilityReportV1:
+    as_of_time = _parse_as_of(as_of)
+    item_rows = list(connection.execute(
+        select(
+            library_items.c.id,
+            library_items.c.media_root,
+            library_items.c.parent_dir,
+            library_items.c.content_version_fingerprint,
+            library_items.c.media_fingerprint_json,
+        )
+        .join(
+            library_item_evidence_state,
+            library_item_evidence_state.c.library_item_id == library_items.c.id,
+        )
+        .where(
+            library_item_evidence_state.c.evidence_kind == MEDIA_FINGERPRINT_EVIDENCE_KIND,
+            library_item_evidence_state.c.state == "current",
+            library_item_evidence_state.c.decision_status == "measured",
+        )
+    ).mappings())
+
+    projected_items: dict[int, dict[str, Any]] = {}
+    incompatible_analysis_count = 0
+    for row in item_rows:
+        try:
+            summary = object_dict(json.loads(str(row.get("media_fingerprint_json") or "{}")))
+            projection = project_av1_cold_start_fingerprint_summary(summary)
+        except (json.JSONDecodeError, TypeError, AV1ColdStartTraitProjectionError):
+            incompatible_analysis_count += 1
+            continue
+        projected_items[int_value(row.get("id"))] = {
+            "traits": projection.cell_traits,
+            "parent_scope": stable_json_hash({
+                "media_root": str(row.get("media_root") or ""),
+                "parent_dir": str(row.get("parent_dir") or ""),
+            }),
+            "content_version": str(row.get("content_version_fingerprint") or ""),
+        }
+
+    observations, observation_store_available = _current_observations(connection, as_of=as_of)
+    cells = tuple(sorted((
+        _cell_feasibility(
+            plan,
+            projected_items=projected_items,
+            observations=observations,
+            as_of=as_of_time,
+            minimum_derivation_count=manifest.criteria.minimum_derivation_evidence_count,
+            minimum_derivation_sources=manifest.criteria.minimum_derivation_source_count,
+        )
+        for plan in manifest.cell_plans
+    ), key=lambda cell: cell.name))
+    semantic_payload = {
+        "schema": AV1_COLD_START_TRAIT_FEASIBILITY_SCHEMA,
+        "schema_version": AV1_COLD_START_TRAIT_FEASIBILITY_SCHEMA_VERSION,
+        "contract_version": AV1_COLD_START_TRAIT_FEASIBILITY_CONTRACT_VERSION,
+        "projection_contract_version": AV1_COLD_START_TRAIT_PROJECTION_CONTRACT_VERSION,
+        "as_of": as_of,
+        "manifest_id": manifest.manifest_id,
+        "execution_authorized": False,
+        "private_mapping_required": True,
+        "runtime_integration_required": True,
+        "measured_analysis_count": len(projected_items),
+        "incompatible_analysis_count": incompatible_analysis_count,
+        "observation_store_available": observation_store_available,
+        "cells": [cell.to_payload() for cell in cells],
+    }
+    return AV1ColdStartTraitFeasibilityReportV1(
+        report_id=_report_id(semantic_payload),
+        as_of=as_of,
+        manifest_id=manifest.manifest_id,
+        measured_analysis_count=len(projected_items),
+        incompatible_analysis_count=incompatible_analysis_count,
+        observation_store_available=observation_store_available,
+        cells=cells,
+    )
+
+
+def load_av1_trait_feasibility_report_from_path(
+        connection: DBClient,
+        *,
+        manifest_path: Path,
+        as_of: str,
+) -> AV1ColdStartTraitFeasibilityReportV1:
+    return load_av1_trait_feasibility_report(
+        connection,
+        manifest=load_av1_cold_start_validation_manifest(manifest_path),
+        as_of=as_of,
+    )
+
+
+def serialize_av1_trait_feasibility_report(
+        report: AV1ColdStartTraitFeasibilityReportV1,
+) -> bytes:
+    return canonical_json_bytes(report.to_payload())
+
+
+def format_av1_trait_feasibility_report(report: AV1ColdStartTraitFeasibilityReportV1) -> str:
+    lines = [
+        f"AV1 trait feasibility {report.report_id}",
+        f"as_of={report.as_of} ready={str(report.ready).lower()} execution_authorized=false",
+        (
+            f"measured_analysis={report.measured_analysis_count} "
+            f"incompatible_analysis={report.incompatible_analysis_count} "
+            f"observation_store_available={str(report.observation_store_available).lower()}"
+        ),
+    ]
+    for cell in report.cells:
+        blockers = ",".join(cell.producer_blockers) if cell.producer_blockers else "none"
+        lines.append(
+            f"{cell.name}: status={cell.status} items={cell.matching_item_count}/"
+            f"{cell.registered_case_count} derivation={cell.eligible_observation_count} "
+            f"sources={cell.independent_source_count} producer_blockers={blockers}"
+        )
+    return "\n".join(lines)
+
+
+def _cell_feasibility(
+        plan: AV1ColdStartValidationCellPlanV1,
+        *,
+        projected_items: Mapping[int, Mapping[str, Any]],
+        observations: Sequence[Mapping[str, Any]],
+        as_of: datetime,
+        minimum_derivation_count: int,
+        minimum_derivation_sources: int,
+) -> AV1ColdStartTraitFeasibilityCellV1:
+    required_traits = tuple(plan.trait_selector.traits)
+    producer_blockers = av1_trait_selector_producer_blockers(
+        intent_level=plan.intent_level,
+        required_traits=required_traits,
+        match=plan.trait_selector.match,
+        expected_prediction=plan.expected_prediction,
+    )
+    matching_items = {
+        item_id: item
+        for item_id, item in projected_items.items()
+        if av1_trait_selector_matches(item.get("traits", ()), required_traits, plan.trait_selector.match)
+    }
+    distinct_parent_scopes = {str(item.get("parent_scope") or "") for item in matching_items.values()}
+
+    fresh_cutoff = as_of - timedelta(days=AV1_COLD_START_TRAIT_FEASIBILITY_MAX_AGE_DAYS)
+    coherent_groups: dict[tuple[str, str, str], list[Mapping[str, Any]]] = defaultdict(list)
+    content_version_mismatch_count = 0
+    aged_out_observation_count = 0
+    ineligible_observation_count = 0
+    withdrawn_observation_count = 0
+    for observation in observations:
+        if str(observation.get("intent_level") or "") != plan.intent_level:
+            continue
+        item_id = int_value(observation.get("library_item_id"))
+        item = matching_items.get(item_id)
+        if item is None:
+            continue
+        if str(observation.get("disposition") or "") == "withdrawn":
+            withdrawn_observation_count += 1
+            continue
+        if str(observation.get("content_fingerprint") or "") != str(item.get("content_version") or ""):
+            content_version_mismatch_count += 1
+            continue
+        recorded_at = _parse_timestamp(
+            str(observation.get("recorded_at") or ""),
+            "observation timestamp",
+            canonical=False,
+        )
+        if recorded_at < fresh_cutoff:
+            aged_out_observation_count += 1
+            continue
+        if not bool(observation.get("personalization_eligible")):
+            ineligible_observation_count += 1
+            continue
+        cohort_key = (
+            str(observation.get("intent_semantic_id") or ""),
+            str(observation.get("compatibility_key") or ""),
+            str(observation.get("policy_hash") or ""),
+        )
+        coherent_groups[cohort_key].append(observation)
+
+    best_group = max(
+        coherent_groups.values(),
+        key=_cohort_rank,
+        default=[],
+    )
+    source_count = len({str(row.get("source_id") or "") for row in best_group})
+    series_count = len({str(row.get("series_id") or "") for row in best_group})
+    source_group_count = len({str(row.get("boundary_group_id") or "") for row in best_group})
+    bitrates = [int_value(row.get("boundary_bitrate_bps")) for row in best_group if int_value(row.get("boundary_bitrate_bps")) > 0]
+
+    if producer_blockers:
+        status = "unreachable"
+    elif len(matching_items) < plan.registered_case_count:
+        status = "insufficient_inventory"
+    elif len(distinct_parent_scopes) < plan.registered_case_count:
+        status = "insufficient_scope_diversity"
+    elif (
+            plan.mode == "publication_candidate"
+            and (len(best_group) < minimum_derivation_count or source_count < minimum_derivation_sources)
+    ):
+        status = "insufficient_derivation_evidence"
+    else:
+        status = "ready_for_private_mapping"
+
+    return AV1ColdStartTraitFeasibilityCellV1(
+        cell_plan_id=plan.cell_plan_id,
+        name=plan.name,
+        mode=plan.mode,
+        intent_level=plan.intent_level,
+        selector_match=plan.trait_selector.match,
+        required_traits=required_traits,
+        registered_case_count=plan.registered_case_count,
+        producer_blockers=producer_blockers,
+        matching_item_count=len(matching_items),
+        distinct_parent_scope_count=len(distinct_parent_scopes),
+        eligible_observation_count=len(best_group),
+        independent_source_count=source_count,
+        independent_series_count=series_count,
+        independent_source_group_count=source_group_count,
+        coherent_cohort_count=len(coherent_groups),
+        coherent_bitrate_min_bps=min(bitrates) if bitrates and source_count >= minimum_derivation_sources else None,
+        coherent_bitrate_max_bps=max(bitrates) if bitrates and source_count >= minimum_derivation_sources else None,
+        content_version_mismatch_count=content_version_mismatch_count,
+        aged_out_observation_count=aged_out_observation_count,
+        ineligible_observation_count=ineligible_observation_count,
+        withdrawn_observation_count=withdrawn_observation_count,
+        status=status,
+    )
+
+
+def _current_observations(
+        connection: DBClient,
+        *,
+        as_of: str,
+) -> tuple[list[Mapping[str, Any]], bool]:
+    if not inspect(connection).has_table(content_intent_boundary_observations.name):
+        return [], False
+    stored_cutoff = _parse_as_of(as_of).isoformat()
+    ranked_query = select(
+        *content_intent_boundary_observations.c,
+        func.row_number().over(
+            partition_by=content_intent_boundary_observations.c.series_id,
+            order_by=content_intent_boundary_observations.c.revision.desc(),
+        ).label("observation_rank"),
+    ).where(content_intent_boundary_observations.c.recorded_at <= stored_cutoff)
+    ranked = ranked_query.subquery()
+    return list(connection.execute(
+        select(ranked).where(ranked.c.observation_rank == 1)
+    ).mappings()), True
+
+
+def _cohort_rank(rows: Sequence[Mapping[str, Any]]) -> tuple[int, int, int, int, int, int]:
+    bitrates = [int_value(row.get("boundary_bitrate_bps")) for row in rows if int_value(row.get("boundary_bitrate_bps")) > 0]
+    return (
+        len(rows),
+        len({str(row.get("source_id") or "") for row in rows}),
+        len({str(row.get("series_id") or "") for row in rows}),
+        len({str(row.get("boundary_group_id") or "") for row in rows}),
+        -(max(bitrates) - min(bitrates)) if bitrates else 0,
+        -min(bitrates) if bitrates else 0,
+    )
+
+
+def _parse_as_of(value: str) -> datetime:
+    return _parse_timestamp(value, "report timestamp", canonical=True)
+
+
+def _parse_timestamp(value: str, label: str, *, canonical: bool = False) -> datetime:
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise AV1ColdStartTraitFeasibilityError(f"Invalid AV1 feasibility {label}") from exc
+    if parsed.tzinfo is None:
+        raise AV1ColdStartTraitFeasibilityError(f"AV1 feasibility {label} must include UTC")
+    parsed = parsed.astimezone(UTC)
+    if canonical and parsed.isoformat().replace("+00:00", "Z") != value:
+        raise AV1ColdStartTraitFeasibilityError(f"AV1 feasibility {label} must use canonical UTC")
+    return parsed
+
+
+def _report_id(payload: Mapping[str, Any]) -> str:
+    return f"av1tf1_{stable_json_hash(payload)[:32]}"

--- a/mediaforce/tuning/av1_trait_projection.py
+++ b/mediaforce/tuning/av1_trait_projection.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Sequence
+
+from mediaforce.core.evidence import canonical_json_bytes, stable_json_hash
+from mediaforce.core.type_defs import float_value, int_value, object_dict, object_list
+from mediaforce.encoding.fingerprint import (
+    MEDIA_FINGERPRINT_SCHEMA_VERSION,
+    MEDIA_FINGERPRINT_TOOL_NAME,
+    MEDIA_FINGERPRINT_TOOL_VERSION,
+    classify_media_fingerprint,
+    media_fingerprint_policy_snapshot,
+)
+from mediaforce.tuning.av1_cold_start import (
+    AV1_COLD_START_PROBE_SUPPORTED_INTENTS,
+    AV1_COLD_START_TRAITS,
+    AV1ColdStartTrait,
+)
+
+
+AV1_COLD_START_TRAIT_PROJECTION_SCHEMA = "mediaforce.av1_cold_start_trait_projection"
+AV1_COLD_START_TRAIT_PROJECTION_SCHEMA_VERSION = 1
+AV1_COLD_START_TRAIT_PROJECTION_CONTRACT_VERSION = "acstp1"
+AV1_COLD_START_TRAIT_IDENTITY_CONFIDENCE_FLOOR = 0.65
+AV1_COLD_START_TRAIT_PROMOTION_CONFIDENCE_FLOOR = 0.70
+
+AV1ColdStartTraitSelectorMatch = Literal["exact", "contains_all"]
+
+_DIRECT_IDENTITY_FINDINGS: dict[str, AV1ColdStartTrait] = {
+    "dark_luma": "darkness",
+    "high_motion": "motion",
+    "high_texture": "texture_detail",
+}
+_PROMOTED_ADVISORY_FINDINGS: dict[str, AV1ColdStartTrait] = {
+    "animation_cues": "animation",
+    "likely_film_grain": "grain_noise",
+}
+_REVIEW_ONLY_FINDINGS = frozenset({
+    "audio_complexity",
+    "compression_noise_advisory",
+    "dark_gradient_banding_risk",
+    "duplicate_cadence",
+    "likely_analog_noise",
+    "uncertain_noise_mix",
+})
+class AV1ColdStartTraitProjectionError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ColdStartTraitProjectionV1:
+    projection_id: str
+    evidence_status: str
+    cell_traits: tuple[AV1ColdStartTrait, ...]
+    review_advisories: tuple[str, ...]
+    promoted_findings: tuple[str, ...]
+    unrecognized_finding_count: int
+
+    def __post_init__(self) -> None:
+        if self.evidence_status not in {"measured", "unknown"}:
+            raise AV1ColdStartTraitProjectionError("AV1 trait projection evidence status is unsupported")
+        if not self.cell_traits or self.cell_traits != tuple(sorted(set(self.cell_traits))):
+            raise AV1ColdStartTraitProjectionError("AV1 trait projection cell traits must be unique and sorted")
+        if any(trait not in AV1_COLD_START_TRAITS for trait in self.cell_traits):
+            raise AV1ColdStartTraitProjectionError("AV1 trait projection contains an unsupported cell trait")
+        if self.review_advisories != tuple(sorted(set(self.review_advisories))):
+            raise AV1ColdStartTraitProjectionError("AV1 review advisories must be unique and sorted")
+        if self.promoted_findings != tuple(sorted(set(self.promoted_findings))):
+            raise AV1ColdStartTraitProjectionError("AV1 promoted findings must be unique and sorted")
+        if self.unrecognized_finding_count < 0:
+            raise AV1ColdStartTraitProjectionError("AV1 unrecognized-finding count cannot be negative")
+        expected_id = _projection_id(self.semantic_payload())
+        if self.projection_id != expected_id:
+            raise AV1ColdStartTraitProjectionError("AV1 trait projection ID does not match its payload")
+
+    def semantic_payload(self) -> dict[str, Any]:
+        return {
+            "schema": AV1_COLD_START_TRAIT_PROJECTION_SCHEMA,
+            "schema_version": AV1_COLD_START_TRAIT_PROJECTION_SCHEMA_VERSION,
+            "contract_version": AV1_COLD_START_TRAIT_PROJECTION_CONTRACT_VERSION,
+            "identity_confidence_floor": AV1_COLD_START_TRAIT_IDENTITY_CONFIDENCE_FLOOR,
+            "promotion_confidence_floor": AV1_COLD_START_TRAIT_PROMOTION_CONFIDENCE_FLOOR,
+            "evidence_status": self.evidence_status,
+            "cell_traits": list(self.cell_traits),
+            "review_advisories": list(self.review_advisories),
+            "promoted_findings": list(self.promoted_findings),
+            "unrecognized_finding_count": self.unrecognized_finding_count,
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {"projection_id": self.projection_id, **self.semantic_payload()}
+
+
+def project_av1_cold_start_traits(
+        decision: Mapping[str, Any] | None,
+) -> AV1ColdStartTraitProjectionV1:
+    payload = object_dict(decision)
+    if str(payload.get("status") or "") != "measured":
+        return _build_projection(
+            evidence_status="unknown",
+            cell_traits=("unknown",),
+            review_advisories=(),
+            promoted_findings=(),
+            unrecognized_finding_count=0,
+        )
+
+    identity_traits: set[AV1ColdStartTrait] = set()
+    review_advisories: set[str] = set()
+    promoted_findings: set[str] = set()
+    unrecognized_finding_count = 0
+    identity_ambiguous = False
+
+    for finding in (object_dict(value) for value in object_list(payload.get("findings"))):
+        finding_id = str(finding.get("id") or "").strip().casefold()
+        confidence = float_value(finding.get("confidence"))
+        advisory = bool(finding.get("advisory"))
+        direct_trait = _DIRECT_IDENTITY_FINDINGS.get(finding_id)
+        promoted_trait = _PROMOTED_ADVISORY_FINDINGS.get(finding_id)
+
+        if direct_trait is not None and not advisory:
+            if confidence >= AV1_COLD_START_TRAIT_IDENTITY_CONFIDENCE_FLOOR:
+                identity_traits.add(direct_trait)
+            else:
+                review_advisories.add(finding_id)
+                identity_ambiguous = True
+            continue
+        if promoted_trait is not None and advisory:
+            if confidence >= AV1_COLD_START_TRAIT_PROMOTION_CONFIDENCE_FLOOR:
+                identity_traits.add(promoted_trait)
+                promoted_findings.add(finding_id)
+            else:
+                review_advisories.add(finding_id)
+            continue
+        if finding_id in _REVIEW_ONLY_FINDINGS:
+            review_advisories.add(finding_id)
+            continue
+        unrecognized_finding_count += 1
+        identity_ambiguous = True
+
+    if identity_ambiguous:
+        cell_traits: set[AV1ColdStartTrait] = {"unknown"}
+    elif identity_traits:
+        cell_traits = set(identity_traits)
+        if len(identity_traits) > 1:
+            cell_traits.add("mixed")
+    else:
+        cell_traits = {"typical"}
+
+    return _build_projection(
+        evidence_status="measured",
+        cell_traits=tuple(sorted(cell_traits)),
+        review_advisories=tuple(sorted(review_advisories)),
+        promoted_findings=tuple(sorted(promoted_findings)),
+        unrecognized_finding_count=unrecognized_finding_count,
+    )
+
+
+def project_av1_cold_start_fingerprint_summary(
+        summary: Mapping[str, Any] | None,
+) -> AV1ColdStartTraitProjectionV1:
+    payload = object_dict(summary)
+    analysis = object_dict(payload.get("analysis"))
+    tool = object_dict(analysis.get("tool"))
+    if int_value(payload.get("schema_version")) != MEDIA_FINGERPRINT_SCHEMA_VERSION:
+        raise AV1ColdStartTraitProjectionError("Media fingerprint schema is incompatible with AV1 trait projection")
+    if str(tool.get("name") or "") != MEDIA_FINGERPRINT_TOOL_NAME:
+        raise AV1ColdStartTraitProjectionError("Media fingerprint analyzer is incompatible with AV1 trait projection")
+    if str(tool.get("version") or "") != MEDIA_FINGERPRINT_TOOL_VERSION:
+        raise AV1ColdStartTraitProjectionError("Media fingerprint analyzer version is incompatible with AV1 trait projection")
+    return project_av1_cold_start_traits(classify_media_fingerprint(analysis))
+
+
+def serialize_av1_cold_start_trait_projection(
+        projection: AV1ColdStartTraitProjectionV1,
+) -> bytes:
+    return canonical_json_bytes(projection.to_payload())
+
+
+def av1_trait_selector_producer_blockers(
+        *,
+        intent_level: str,
+        required_traits: Sequence[str],
+        match: AV1ColdStartTraitSelectorMatch,
+        expected_prediction: str,
+) -> tuple[str, ...]:
+    normalized_traits = tuple(sorted({str(value).strip().casefold() for value in required_traits if str(value).strip()}))
+    blockers: set[str] = set()
+    if not normalized_traits:
+        blockers.add("trait_selector_empty")
+    if match not in {"exact", "contains_all"}:
+        blockers.add("trait_selector_match_unsupported")
+    if any(trait not in AV1_COLD_START_TRAITS for trait in normalized_traits):
+        blockers.add("trait_unsupported")
+    if expected_prediction not in {"recommended", "no_recommendation"}:
+        blockers.add("expected_prediction_unsupported")
+    if expected_prediction == "recommended" and intent_level not in AV1_COLD_START_PROBE_SUPPORTED_INTENTS:
+        blockers.add("intent_cannot_produce_recommendation")
+    if "low_motion_dialogue" in normalized_traits:
+        blockers.add("low_motion_dialogue_analyzer_unavailable")
+    if "unknown" in normalized_traits:
+        blockers.add("unknown_evidence_rejected_by_request_contract")
+    if "typical" in normalized_traits and len(normalized_traits) > 1:
+        blockers.add("typical_trait_is_exclusive")
+    if "unknown" in normalized_traits and len(normalized_traits) > 1:
+        blockers.add("unknown_trait_is_exclusive")
+    current_producer_traits = _current_producer_traits()
+    unsupported_producer_traits = set(normalized_traits).difference(
+        current_producer_traits,
+        {"unknown", "low_motion_dialogue"},
+    )
+    if unsupported_producer_traits:
+        blockers.add("trait_producer_unavailable")
+
+    base_traits = set(normalized_traits).difference({"mixed", "typical", "unknown"})
+    if match == "exact":
+        if "mixed" in normalized_traits and len(base_traits) < 2:
+            blockers.add("mixed_exact_selector_requires_two_base_traits")
+        if len(base_traits) > 1 and "mixed" not in normalized_traits:
+            blockers.add("multi_trait_exact_selector_requires_mixed")
+
+    return tuple(sorted(blockers))
+
+
+def av1_trait_selector_matches(
+        projected_traits: Sequence[str],
+        required_traits: Sequence[str],
+        match: AV1ColdStartTraitSelectorMatch,
+) -> bool:
+    projected = {str(value).strip().casefold() for value in projected_traits if str(value).strip()}
+    required = {str(value).strip().casefold() for value in required_traits if str(value).strip()}
+    if match == "exact":
+        return projected == required
+    if match == "contains_all":
+        return required.issubset(projected)
+    raise AV1ColdStartTraitProjectionError("AV1 trait selector match is unsupported")
+
+
+def _build_projection(
+        *,
+        evidence_status: str,
+        cell_traits: tuple[AV1ColdStartTrait, ...],
+        review_advisories: tuple[str, ...],
+        promoted_findings: tuple[str, ...],
+        unrecognized_finding_count: int,
+) -> AV1ColdStartTraitProjectionV1:
+    semantic_payload = {
+        "schema": AV1_COLD_START_TRAIT_PROJECTION_SCHEMA,
+        "schema_version": AV1_COLD_START_TRAIT_PROJECTION_SCHEMA_VERSION,
+        "contract_version": AV1_COLD_START_TRAIT_PROJECTION_CONTRACT_VERSION,
+        "identity_confidence_floor": AV1_COLD_START_TRAIT_IDENTITY_CONFIDENCE_FLOOR,
+        "promotion_confidence_floor": AV1_COLD_START_TRAIT_PROMOTION_CONFIDENCE_FLOOR,
+        "evidence_status": evidence_status,
+        "cell_traits": list(cell_traits),
+        "review_advisories": list(review_advisories),
+        "promoted_findings": list(promoted_findings),
+        "unrecognized_finding_count": unrecognized_finding_count,
+    }
+    return AV1ColdStartTraitProjectionV1(
+        projection_id=_projection_id(semantic_payload),
+        evidence_status=evidence_status,
+        cell_traits=cell_traits,
+        review_advisories=review_advisories,
+        promoted_findings=promoted_findings,
+        unrecognized_finding_count=unrecognized_finding_count,
+    )
+
+
+def _projection_id(payload: Mapping[str, Any]) -> str:
+    return f"av1tp1_{stable_json_hash(payload)[:32]}"
+
+
+def _current_producer_traits() -> frozenset[str]:
+    findings = {
+        str(value).strip().casefold()
+        for value in media_fingerprint_policy_snapshot().get("findings", [])
+        if str(value).strip()
+    }
+    producer_traits = {
+        trait
+        for finding_id, trait in {**_DIRECT_IDENTITY_FINDINGS, **_PROMOTED_ADVISORY_FINDINGS}.items()
+        if finding_id in findings
+    }
+    producer_traits.add("typical")
+    if len(producer_traits.difference({"typical"})) >= 2:
+        producer_traits.add("mixed")
+    return frozenset(producer_traits)

--- a/tests/test_av1_trait_feasibility.py
+++ b/tests/test_av1_trait_feasibility.py
@@ -1,0 +1,204 @@
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+import unittest
+
+from sqlalchemy import create_engine, insert, select
+
+from mediaforce.core.db_tables import library_item_evidence_state, library_items, metadata
+from mediaforce.tuning.av1_cold_start_evaluation import load_av1_cold_start_validation_manifest
+from mediaforce.tuning.av1_trait_feasibility import (
+    _cell_feasibility,
+    load_av1_trait_feasibility_report,
+    serialize_av1_trait_feasibility_report,
+)
+
+
+MANIFEST_PATH = Path("docs/validation/av1-cold-start-preregistration-v1.json")
+
+
+class AV1TraitFeasibilityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.engine = create_engine("sqlite+pysqlite:///:memory:")
+        metadata.create_all(self.engine)
+        self.connection = self.engine.connect()
+        self.manifest = load_av1_cold_start_validation_manifest(MANIFEST_PATH)
+        self.as_of = "2026-07-27T18:00:00Z"
+
+    def tearDown(self) -> None:
+        self.connection.close()
+        self.engine.dispose()
+
+    def test_report_is_deterministic_read_only_and_privacy_safe(self) -> None:
+        self._insert_item(1, "/private/media/Secret Show/Episode 01.mkv")
+        before = self.connection.execute(select(library_items.c.id)).all()
+
+        first = load_av1_trait_feasibility_report(
+            self.connection,
+            manifest=self.manifest,
+            as_of=self.as_of,
+        )
+        second = load_av1_trait_feasibility_report(
+            self.connection,
+            manifest=self.manifest,
+            as_of=self.as_of,
+        )
+        after = self.connection.execute(select(library_items.c.id)).all()
+
+        self.assertEqual(first.report_id, second.report_id)
+        self.assertEqual(serialize_av1_trait_feasibility_report(first), serialize_av1_trait_feasibility_report(second))
+        self.assertEqual(before, after)
+        self.assertTrue(first.observation_store_available)
+        payload_text = json.dumps(first.to_payload(), sort_keys=True)
+        for private_value in ("Secret Show", "Episode 01", "/private/media", "source-1", "fingerprint-1"):
+            self.assertNotIn(private_value, payload_text)
+
+    def test_v1_unreachable_cells_are_reported_instead_of_accepted(self) -> None:
+        report = load_av1_trait_feasibility_report(
+            self.connection,
+            manifest=self.manifest,
+            as_of=self.as_of,
+        )
+        cells = {cell.name: cell for cell in report.cells}
+
+        self.assertEqual(cells["low_motion_dialogue_risk_fallback"].status, "unreachable")
+        self.assertIn(
+            "low_motion_dialogue_analyzer_unavailable",
+            cells["low_motion_dialogue_risk_fallback"].producer_blockers,
+        )
+        self.assertEqual(cells["unknown_risk_fallback"].status, "unreachable")
+        self.assertIn(
+            "unknown_evidence_rejected_by_request_contract",
+            cells["unknown_risk_fallback"].producer_blockers,
+        )
+        self.assertFalse(report.ready)
+        self.assertFalse(report.to_payload()["execution_authorized"])
+        self.assertTrue(report.to_payload()["runtime_integration_required"])
+
+    def test_missing_observation_store_is_reported_without_mutation(self) -> None:
+        self.connection.exec_driver_sql("DROP TABLE content_intent_boundary_observations")
+
+        report = load_av1_trait_feasibility_report(
+            self.connection,
+            manifest=self.manifest,
+            as_of=self.as_of,
+        )
+
+        self.assertFalse(report.observation_store_available)
+        self.assertFalse(report.ready)
+        publication_cells = [cell for cell in report.cells if cell.mode == "publication_candidate"]
+        self.assertTrue(publication_cells)
+        self.assertTrue(all(cell.status == "insufficient_inventory" for cell in publication_cells))
+
+    def test_publication_cell_requires_coherent_fresh_derivation_evidence(self) -> None:
+        plan = next(cell for cell in self.manifest.cell_plans if cell.name == "typical_live_action_balanced_candidate")
+        projected_items = {
+            item_id: {
+                "traits": ("typical",),
+                "parent_scope": f"parent-{item_id}",
+                "content_version": f"content-{item_id}",
+            }
+            for item_id in range(1, 17)
+        }
+        observations = [
+            {
+                "library_item_id": item_id,
+                "content_fingerprint": f"content-{item_id}",
+                "intent_level": "balanced",
+                "intent_semantic_id": "cis1_balanced",
+                "compatibility_key": "compatibility-a",
+                "policy_hash": "policy-a",
+                "disposition": "active",
+                "personalization_eligible": 1,
+                "recorded_at": "2026-07-01T12:00:00+00:00",
+                "source_id": f"source-{(item_id - 1) % 6}",
+                "series_id": f"series-{item_id}",
+                "boundary_group_id": f"group-{(item_id - 1) % 6}",
+                "boundary_bitrate_bps": 1_500_000 + item_id,
+            }
+            for item_id in range(1, 13)
+        ]
+
+        cell = _cell_feasibility(
+            plan,
+            projected_items=projected_items,
+            observations=observations,
+            as_of=datetime(2026, 7, 27, 18, 0, tzinfo=UTC),
+            minimum_derivation_count=self.manifest.criteria.minimum_derivation_evidence_count,
+            minimum_derivation_sources=self.manifest.criteria.minimum_derivation_source_count,
+        )
+
+        self.assertEqual(cell.status, "ready_for_private_mapping")
+        self.assertEqual(cell.eligible_observation_count, 12)
+        self.assertEqual(cell.independent_source_count, 6)
+        self.assertEqual(cell.independent_series_count, 12)
+        self.assertEqual(cell.independent_source_group_count, 6)
+
+    def _insert_item(self, item_id: int, source_path: str) -> None:
+        timestamp = "2026-07-27T17:00:00Z"
+        summary = {
+            "schema_version": 1,
+            "analysis": {
+                "sampled_frames": 120,
+                "coverage": 1.0,
+                "aggregate": {
+                    "dark_frame_fraction": 0.05,
+                    "gradient_frame_fraction": 0.02,
+                    "banding_risk_score": 0.02,
+                    "high_motion_frame_fraction": 0.04,
+                    "ydif_p90": 3.0,
+                    "high_texture_frame_fraction": 0.04,
+                    "edge_density_p90": 0.035,
+                    "duplicate_like_frame_fraction": 0.05,
+                    "temporal_noise_proxy": 0.5,
+                    "chroma_instability": 0.2,
+                    "smooth_temporal_noise_fraction": 0.02,
+                    "audio_loudness_range_lu_max": 0.0,
+                },
+                "audio_probe": {"track_count": 0, "max_channels": 0},
+                "ranges": [],
+                "tool": {
+                    "name": "mediaforce.media_fingerprint",
+                    "version": "1",
+                    "ffmpeg_version": "ffmpeg test",
+                },
+            },
+        }
+        self.connection.execute(insert(library_items).values(
+            id=item_id,
+            source_path=source_path,
+            rel_path="tv/private/episode.mkv",
+            media_root="tv",
+            parent_dir="private",
+            file_name="episode.mkv",
+            container="matroska",
+            size_bytes=1_000_000,
+            mtime_ns=1,
+            fingerprint=f"fingerprint-{item_id}",
+            audio_track_count=1,
+            subtitle_track_count=0,
+            english_audio_count=1,
+            english_subtitle_count=0,
+            audio_summary_json="[]",
+            subtitle_summary_json="[]",
+            media_fingerprint_json=json.dumps(summary),
+            content_version_fingerprint=f"content-{item_id}",
+            status="discovered",
+            priority_score=0,
+            last_scan_id="scan-1",
+            discovered_at=timestamp,
+            last_seen_at=timestamp,
+            updated_at=timestamp,
+        ))
+        self.connection.execute(insert(library_item_evidence_state).values(
+            library_item_id=item_id,
+            evidence_kind="media_fingerprint",
+            state="current",
+            policy_hash="policy-test",
+            decision_status="measured",
+            updated_at=timestamp,
+        ))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_av1_trait_projection.py
+++ b/tests/test_av1_trait_projection.py
@@ -1,0 +1,178 @@
+import json
+import unittest
+
+from mediaforce.tuning.av1_trait_projection import (
+    av1_trait_selector_producer_blockers,
+    project_av1_cold_start_fingerprint_summary,
+    project_av1_cold_start_traits,
+    serialize_av1_cold_start_trait_projection,
+)
+
+
+class AV1TraitProjectionTests(unittest.TestCase):
+    def test_typical_identity_ignores_audio_only_review_advisory(self) -> None:
+        projection = project_av1_cold_start_traits({
+            "status": "measured",
+            "findings": [self._finding("audio_complexity", confidence=0.85, advisory=True)],
+        })
+
+        self.assertEqual(projection.cell_traits, ("typical",))
+        self.assertEqual(projection.review_advisories, ("audio_complexity",))
+
+    def test_low_confidence_animation_remains_review_only(self) -> None:
+        projection = project_av1_cold_start_traits({
+            "status": "measured",
+            "findings": [self._finding("animation_cues", confidence=0.69, advisory=True)],
+        })
+
+        self.assertEqual(projection.cell_traits, ("typical",))
+        self.assertEqual(projection.review_advisories, ("animation_cues",))
+        self.assertEqual(projection.promoted_findings, ())
+
+    def test_high_confidence_animation_is_explicitly_promoted(self) -> None:
+        projection = project_av1_cold_start_traits({
+            "status": "measured",
+            "findings": [self._finding("animation_cues", confidence=0.70, advisory=True)],
+        })
+
+        self.assertEqual(projection.cell_traits, ("animation",))
+        self.assertEqual(projection.promoted_findings, ("animation_cues",))
+
+    def test_film_grain_promotion_respects_confidence_boundary(self) -> None:
+        low = project_av1_cold_start_traits({
+            "status": "measured",
+            "findings": [self._finding("likely_film_grain", confidence=0.69, advisory=True)],
+        })
+        high = project_av1_cold_start_traits({
+            "status": "measured",
+            "findings": [self._finding("likely_film_grain", confidence=0.70, advisory=True)],
+        })
+
+        self.assertEqual(low.cell_traits, ("typical",))
+        self.assertEqual(low.review_advisories, ("likely_film_grain",))
+        self.assertEqual(high.cell_traits, ("grain_noise",))
+        self.assertEqual(high.promoted_findings, ("likely_film_grain",))
+
+    def test_low_confidence_direct_finding_keeps_advisories_from_becoming_typical(self) -> None:
+        projection = project_av1_cold_start_traits({
+            "status": "measured",
+            "findings": [
+                self._finding("dark_luma", confidence=0.64),
+                self._finding("animation_cues", confidence=0.69, advisory=True),
+            ],
+        })
+
+        self.assertEqual(projection.cell_traits, ("unknown",))
+        self.assertEqual(projection.review_advisories, ("animation_cues", "dark_luma"))
+
+    def test_multiple_stable_findings_add_mixed_identity(self) -> None:
+        projection = project_av1_cold_start_traits({
+            "status": "measured",
+            "findings": [
+                self._finding("dark_luma", confidence=0.75),
+                self._finding("high_motion", confidence=0.80),
+            ],
+        })
+
+        self.assertEqual(projection.cell_traits, ("darkness", "mixed", "motion"))
+
+    def test_unknown_evidence_has_unknown_identity(self) -> None:
+        projection = project_av1_cold_start_traits({"status": "unknown", "findings": []})
+
+        self.assertEqual(projection.evidence_status, "unknown")
+        self.assertEqual(projection.cell_traits, ("unknown",))
+
+    def test_unrecognized_finding_does_not_become_typical(self) -> None:
+        projection = project_av1_cold_start_traits({
+            "status": "measured",
+            "findings": [self._finding("future_video_trait", confidence=0.95)],
+        })
+
+        self.assertEqual(projection.cell_traits, ("unknown",))
+        self.assertEqual(projection.unrecognized_finding_count, 1)
+
+    def test_low_motion_dialogue_and_unknown_are_not_currently_reachable(self) -> None:
+        low_motion = av1_trait_selector_producer_blockers(
+            intent_level="balanced",
+            required_traits=("low_motion_dialogue",),
+            match="contains_all",
+            expected_prediction="no_recommendation",
+        )
+        unknown = av1_trait_selector_producer_blockers(
+            intent_level="balanced",
+            required_traits=("unknown",),
+            match="contains_all",
+            expected_prediction="no_recommendation",
+        )
+
+        self.assertIn("low_motion_dialogue_analyzer_unavailable", low_motion)
+        self.assertIn("unknown_evidence_rejected_by_request_contract", unknown)
+
+    def test_projection_serialization_and_hash_are_deterministic(self) -> None:
+        decision = {
+            "status": "measured",
+            "findings": [
+                self._finding("high_texture", confidence=0.80),
+                self._finding("audio_complexity", confidence=0.75, advisory=True),
+            ],
+        }
+
+        first = project_av1_cold_start_traits(decision)
+        second = project_av1_cold_start_traits(decision)
+
+        self.assertEqual(first.projection_id, second.projection_id)
+        self.assertEqual(serialize_av1_cold_start_trait_projection(first), serialize_av1_cold_start_trait_projection(second))
+        self.assertEqual(json.loads(serialize_av1_cold_start_trait_projection(first)), first.to_payload())
+
+    def test_retained_analysis_reclassifies_without_media_access(self) -> None:
+        projection = project_av1_cold_start_fingerprint_summary({
+            "schema_version": 1,
+            "analysis": self._analysis(duplicate_like_frame_fraction=0.80, edge_density_p90=0.10),
+        })
+
+        self.assertEqual(projection.cell_traits, ("animation", "mixed", "texture_detail"))
+        self.assertIn("animation_cues", projection.promoted_findings)
+
+    @staticmethod
+    def _finding(finding_id: str, *, confidence: float, advisory: bool = False) -> dict[str, object]:
+        return {
+            "id": finding_id,
+            "confidence": confidence,
+            "coverage": 1.0,
+            "advisory": advisory,
+            "rationale": "test",
+        }
+
+    @staticmethod
+    def _analysis(**metrics: float) -> dict[str, object]:
+        aggregate = {
+            "dark_frame_fraction": 0.05,
+            "gradient_frame_fraction": 0.02,
+            "banding_risk_score": 0.02,
+            "high_motion_frame_fraction": 0.04,
+            "ydif_p90": 3.0,
+            "high_texture_frame_fraction": 0.04,
+            "edge_density_p90": 0.035,
+            "duplicate_like_frame_fraction": 0.05,
+            "temporal_noise_proxy": 0.5,
+            "chroma_instability": 0.2,
+            "smooth_temporal_noise_fraction": 0.02,
+            "audio_loudness_range_lu_max": 0.0,
+        }
+        aggregate.update(metrics)
+        return {
+            "sampled_frames": 120,
+            "coverage": 1.0,
+            "aggregate": aggregate,
+            "audio_probe": {"track_count": 0, "max_channels": 0},
+            "ranges": [],
+            "tool": {
+                "name": "mediaforce.media_fingerprint",
+                "version": "1",
+                "ffmpeg_version": "ffmpeg test",
+            },
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the versioned `acstp1` AV1 trait projection separating stable cell identity from review-only advisories
- add a deterministic, read-only, privacy-safe feasibility report and `mediaforce av1-trait-feasibility` CLI
- preserve the immutable v1 runtime request path, public bundle, and append-only content-intent observations
- document the prospective projection boundary and the required #285 runtime integration

## Safe local evidence

A read-only run against the configured database at an explicit UTC cutoff produced a no-go report without starting Mediaforce or reading media:

- 9,820 compatible retained analyses; 0 incompatible
- exact animation candidate: 0 items
- exact typical candidate: 14 items across 11 parent scopes
- low-motion-dialogue: analyzer unavailable
- unknown fallback: rejected by the current request contract
- content-intent observation store unavailable in the current database snapshot
- `execution_authorized=false`, `runtime_integration_required=true`, `ready=false`

The aggregate output contains no paths, titles, source IDs, fingerprints, review-media identities, compatibility tokens, or policy tokens.

## Validation

- `bash scripts/pre-commit-check.sh` — 1,335 backend tests plus frontend checks/build and browser smoke passed
- `uv build` — wheel and sdist built from source
- `uv run python scripts/verify_package_contents.py ...` — package contents verified
- scoped PyCharm `changed_files` inspection — clean
- independent architecture, statistical/model-contract, privacy/security, experimental-design, and adversarial reviews completed; the stored timestamp-format finding was fixed and regression-tested

Refs #283
