### PR TITLE
Add AV1 v2 private source partition tooling

### DIFF
--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -258,6 +258,12 @@ Guidance:
 - `av1_validation_v2.py`
   - immutable v2 preregistration, digest-bound aggregate eligibility,
     explicit excluded-cell records, and fail-closed derivation-only authority
+- `av1_validation_partition.py`
+  - pure private v2 partition schema, domain-separated HMAC selection/tokens,
+    canonical selection-lock digests, and fail-closed identity constraints
+- `av1_validation_partition_inventory.py`
+  - read-only current fingerprint/config projection into private partition
+    candidates without runtime, observation, authorization, or encode authority
 - `quality_memory.py`
   - read-only accepted-outcome cohorts, command-derived search signatures,
     confidence, dispersion, and explainable central CRF hints

--- a/docs/development/av1-cold-start-validation.md
+++ b/docs/development/av1-cold-start-validation.md
@@ -77,6 +77,87 @@ holdout case execution, and public bundle activation. A different, later
 authorization must bind the reviewed candidate locks before any v2 holdout can
 run. The verifier therefore refuses the v2 `report` action at this phase.
 
+## Private v2 source partition
+
+Issue `#286` uses the `av1vsp1` partition contract to freeze all fifty holdout
+slots and two twelve-source derivation reservations while Mediaforce remains
+paused. The pure contract lives in
+`mediaforce/tuning/av1_validation_partition.py`; the separate read-only
+inventory adapter lives in
+`mediaforce/tuning/av1_validation_partition_inventory.py`. Neither module
+starts runtime work, probes media, creates observations, builds a candidate
+lock, or creates either execution authorization.
+
+Create a dedicated owner-only directory outside the repository, then create its
+HMAC key once:
+
+```bash
+uv run python scripts/verify_av1_cold_start_preregistration.py \
+  create-partition-key /private/owner-only/av1-v2/partition.key --json
+```
+
+The command emits an opaque `token_key_id`. Record that ID on issue `#286`
+before reading the private inventory. The later build requires the same ID, so
+replacing or rerolling the HMAC key after its durable commitment fails closed.
+
+Build the immutable private partition from the checked-in manifest, pinned
+machine-local eligibility attestation, current measured fingerprint inventory,
+and an explicit canonical UTC timestamp:
+
+```bash
+uv run python scripts/verify_av1_cold_start_preregistration.py \
+  build-partition docs/validation/av1-cold-start-preregistration-v2.json \
+  /private/owner-only/eligibility-attestation-v1.json \
+  --key /private/owner-only/av1-v2/partition.key \
+  --expected-token-key-id av1vkey1_<committed-id> \
+  --output /private/owner-only/av1-v2/source-partition-v1.json \
+  --selected-at 2026-07-27T23:00:00Z --json
+```
+
+Validate both the embedded immutable private inventory snapshot and the current
+read-only database/config projection. A narrowed inventory, selected-source
+change, taxonomy change, policy change, or compatibility change fails the
+current-input gate:
+
+```bash
+uv run python scripts/verify_av1_cold_start_preregistration.py \
+  validate-partition docs/validation/av1-cold-start-preregistration-v2.json \
+  /private/owner-only/eligibility-attestation-v1.json \
+  /private/owner-only/av1-v2/source-partition-v1.json \
+  --key /private/owner-only/av1-v2/partition.key --json
+```
+
+The partition requires owner-only directory and file permissions, rejects any
+private artifact path inside the repository, and never prints the output path,
+local item IDs, identity tokens, fingerprints, titles, series, or source-group
+values. Its public-safe output is limited to the manifest ID, the selection-lock
+and derivation-partition digests, preregistered counts, and false execution
+authority flags.
+
+Selection uses domain-separated HMAC-SHA256 ranking and identity tokens. It
+enforces exact trait selectors for publication candidates, the registered
+`contains_all` selectors for fallback cells, and global uniqueness across all
+seventy-four reservations by content version, logical title, and series.
+Publication holdout and derivation cohorts separately enforce the six-group
+minimum and one-third concentration maximum, and no derivation source group may
+overlap any holdout source group. Ambiguous duplicate content versions are
+excluded before the immutable inventory snapshot is frozen. Within a plan,
+holdout slots receive selection priority over derivation reservations so the
+holdout cohort cannot be shaped by later derivation needs.
+
+The lock also binds one coherent pre-execution compatibility signature,
+plan-specific policy signatures, target-video-bitrate ranges, and the configured
+numeric quality floor before any derivation observation exists. Revalidate the
+partition before creating the later derivation authorization. Any config,
+policy, toolchain, or selected-source drift is a stop condition, not a reason to
+rewrite the frozen snapshot or mapping.
+
+The private partition and key are machine-local audit artifacts. Only the
+reviewed `selection_lock_sha256` and `derivation_partition_sha256` may leave
+owner-only storage. The lock carries `runtime_execution_authorized=false`,
+`derivation_execution_authorized=false`, and
+`holdout_execution_authorized=false`; creating it does not create `acsvda1`.
+
 Validate the pinned machine-local aggregate attestation without printing its
 counts:
 
@@ -163,8 +244,9 @@ The v2 evidence lifecycle has six boundaries:
 1. Validate the checked-in v2 manifest against its digest-bound aggregate
    eligibility attestation. This does not authorize runtime execution.
 2. Map the protocol's case slots and separate derivation pools to eligible media
-   in a private local file.
-   Commit only its SHA-256 selection lock to the redacted evidence set.
+   in the canonical owner-only `av1vsp1` private partition. Independently review
+   the exact partition, and commit only its SHA-256 selection lock and
+   derivation-partition digest to later redacted evidence.
 3. Create the separate derivation-only authorization, then build a candidate
    lock from current-contract observations collected through unchanged measured
    full search. Each
@@ -191,9 +273,10 @@ digest, and is the only publication-safe output. Rebuilding a different
 self-consistent manifest is insufficient: reporting requires exact equality
 with the checked-in issue #277 preregistration.
 
-No database migration is required. The protocol and report builder are pure
-Python and do not import database, scheduler, web-runtime, subprocess, or media
-probing code.
+No database migration is required. The protocol, partition contract, and report
+builder are pure Python and do not import database, scheduler, web-runtime,
+subprocess, or media probing code. The partition inventory adapter is a separate
+read-only database/config boundary and does not open a writable connection.
 
 ## Paired holdout contract
 

--- a/mediaforce/tuning/av1_validation_partition.py
+++ b/mediaforce/tuning/av1_validation_partition.py
@@ -1,0 +1,1935 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import hashlib
+import hmac
+import json
+import math
+import os
+from pathlib import Path
+import re
+import secrets
+import stat
+from typing import Any, Literal, Mapping, Sequence
+
+from mediaforce.core.evidence import canonical_json_bytes, stable_json_hash
+from mediaforce.core.type_defs import float_value, int_value, object_dict, object_list
+from mediaforce.tuning.av1_cold_start import assert_av1_cold_start_public_payload_safe
+from mediaforce.tuning.av1_validation_v2 import (
+    AV1ValidationManifestV2,
+    AV1ValidationV2CellPlan,
+    assert_preregistered_av1_validation_manifest_v2,
+)
+
+
+AV1_VALIDATION_PARTITION_SCHEMA = "mediaforce.av1_cold_start_private_source_partition"
+AV1_VALIDATION_PARTITION_SCHEMA_VERSION = 1
+AV1_VALIDATION_SELECTION_LOCK_SCHEMA = "mediaforce.av1_cold_start_source_selection_lock"
+AV1_VALIDATION_SELECTION_LOCK_SCHEMA_VERSION = 1
+AV1_VALIDATION_PARTITION_SUMMARY_SCHEMA = (
+    "mediaforce.av1_cold_start_source_partition_summary"
+)
+AV1_VALIDATION_PARTITION_CONTRACT_VERSION = "av1vsp1"
+AV1_VALIDATION_PARTITION_TOKEN_VERSION = "av1vtok1"
+AV1_VALIDATION_PARTITION_ALGORITHM = "hmac_rank_backtracking_v1"
+AV1_VALIDATION_DERIVATION_RESERVATION_COUNT = 12
+AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT = 6
+AV1_VALIDATION_MAXIMUM_SOURCE_GROUP_FRACTION = 1 / 3
+
+AV1ValidationPartitionRole = Literal["holdout", "derivation"]
+
+_SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{7,191}\Z")
+_QUALITY_METRIC_RE = re.compile(r"[a-z0-9][a-z0-9_.-]{1,31}\Z")
+_MAXIMUM_SEARCH_NODES = 1_000_000
+
+
+class AV1ValidationPartitionError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationPartitionExpectations:
+    compatibility_signature: str
+    base_policy_signature: str
+    quality_metric: str
+    quality_target: float
+    minimum_quality_score: float
+
+    def __post_init__(self) -> None:
+        for value, label in (
+            (self.compatibility_signature, "compatibility signature"),
+            (self.base_policy_signature, "base policy signature"),
+        ):
+            if not _TOKEN_RE.fullmatch(value):
+                raise AV1ValidationPartitionError(f"AV1 partition {label} is invalid")
+        if not _QUALITY_METRIC_RE.fullmatch(self.quality_metric):
+            raise AV1ValidationPartitionError("AV1 partition quality metric is invalid")
+        if not all(
+            math.isfinite(value) and value >= 0
+            for value in (
+                self.quality_target,
+                self.minimum_quality_score,
+            )
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition quality expectations are invalid"
+            )
+        if self.minimum_quality_score > self.quality_target:
+            raise AV1ValidationPartitionError(
+                "AV1 partition quality floor exceeds its target"
+            )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "compatibility_signature": self.compatibility_signature,
+            "base_policy_signature": self.base_policy_signature,
+            "quality_metric": self.quality_metric,
+            "quality_target": self.quality_target,
+            "minimum_quality_score": self.minimum_quality_score,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationPartitionSource:
+    local_item_id: int
+    source_identity: str
+    title_identity: str
+    series_identity: str
+    source_group_identity: str
+    traits: tuple[str, ...]
+    compatibility_signature: str
+    base_policy_signature: str
+    target_video_bitrate_bps: int
+    quality_metric: str
+    quality_target: float
+    minimum_quality_score: float
+    evidence_summary_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.local_item_id <= 0:
+            raise AV1ValidationPartitionError("AV1 partition source item ID is invalid")
+        if any(
+            not value
+            for value in (
+                self.source_identity,
+                self.title_identity,
+                self.series_identity,
+                self.source_group_identity,
+            )
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition source identity is incomplete"
+            )
+        if self.traits != tuple(sorted(set(self.traits))) or not self.traits:
+            raise AV1ValidationPartitionError("AV1 partition source traits are invalid")
+        for value, label in (
+            (self.compatibility_signature, "compatibility signature"),
+            (self.base_policy_signature, "base policy signature"),
+        ):
+            if not _TOKEN_RE.fullmatch(value):
+                raise AV1ValidationPartitionError(
+                    f"AV1 partition source {label} is invalid"
+                )
+        if not _QUALITY_METRIC_RE.fullmatch(self.quality_metric):
+            raise AV1ValidationPartitionError(
+                "AV1 partition source quality metric is invalid"
+            )
+        if self.target_video_bitrate_bps <= 0:
+            raise AV1ValidationPartitionError(
+                "AV1 partition source target bitrate is invalid"
+            )
+        if not all(
+            math.isfinite(value) and value >= 0
+            for value in (
+                self.quality_target,
+                self.minimum_quality_score,
+            )
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition source quality contract is invalid"
+            )
+        if self.minimum_quality_score > self.quality_target:
+            raise AV1ValidationPartitionError(
+                "AV1 partition source quality floor exceeds its target"
+            )
+        _require_sha256(self.evidence_summary_sha256, "source evidence digest")
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "local_item_id": self.local_item_id,
+            "source_identity": self.source_identity,
+            "title_identity": self.title_identity,
+            "series_identity": self.series_identity,
+            "source_group_identity": self.source_group_identity,
+            "traits": list(self.traits),
+            "compatibility_signature": self.compatibility_signature,
+            "base_policy_signature": self.base_policy_signature,
+            "target_video_bitrate_bps": self.target_video_bitrate_bps,
+            "quality_metric": self.quality_metric,
+            "quality_target": self.quality_target,
+            "minimum_quality_score": self.minimum_quality_score,
+            "evidence_summary_sha256": self.evidence_summary_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationPartitionAssignment:
+    assignment_id: str
+    role: AV1ValidationPartitionRole
+    cell_plan_id: str
+    ordinal: int
+    local_item_id: int
+    traits: tuple[str, ...]
+    intent_level: str
+    source_token: str
+    title_token: str
+    series_token: str
+    source_group_token: str
+    compatibility_signature: str
+    policy_signature: str
+    target_video_bitrate_bps: int
+    quality_metric: str
+    quality_target: float
+    minimum_quality_score: float
+    evidence_summary_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.role not in {"holdout", "derivation"}:
+            raise AV1ValidationPartitionError(
+                "AV1 partition assignment role is invalid"
+            )
+        if self.ordinal <= 0 or self.local_item_id <= 0:
+            raise AV1ValidationPartitionError(
+                "AV1 partition assignment ordinal or item ID is invalid"
+            )
+        if self.traits != tuple(sorted(set(self.traits))) or not self.traits:
+            raise AV1ValidationPartitionError(
+                "AV1 partition assignment traits are invalid"
+            )
+        for value, label in (
+            (self.assignment_id, "assignment ID"),
+            (self.cell_plan_id, "cell-plan ID"),
+            (self.intent_level, "intent"),
+            (self.source_token, "source token"),
+            (self.title_token, "title token"),
+            (self.series_token, "series token"),
+            (self.source_group_token, "source-group token"),
+            (self.compatibility_signature, "compatibility signature"),
+            (self.policy_signature, "policy signature"),
+        ):
+            if not _TOKEN_RE.fullmatch(value):
+                raise AV1ValidationPartitionError(
+                    f"AV1 partition assignment {label} is invalid"
+                )
+        if not _QUALITY_METRIC_RE.fullmatch(self.quality_metric):
+            raise AV1ValidationPartitionError(
+                "AV1 partition assignment quality metric is invalid"
+            )
+        if self.target_video_bitrate_bps <= 0:
+            raise AV1ValidationPartitionError(
+                "AV1 partition assignment target bitrate is invalid"
+            )
+        if not all(
+            math.isfinite(value) and value >= 0
+            for value in (
+                self.quality_target,
+                self.minimum_quality_score,
+            )
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition assignment quality contract is invalid"
+            )
+        if self.minimum_quality_score > self.quality_target:
+            raise AV1ValidationPartitionError(
+                "AV1 partition assignment quality floor exceeds target"
+            )
+        _require_sha256(self.evidence_summary_sha256, "assignment evidence digest")
+
+    def token_payload(self) -> dict[str, Any]:
+        return {
+            "assignment_id": self.assignment_id,
+            "role": self.role,
+            "cell_plan_id": self.cell_plan_id,
+            "ordinal": self.ordinal,
+            "traits": list(self.traits),
+            "intent_level": self.intent_level,
+            "source_token": self.source_token,
+            "title_token": self.title_token,
+            "series_token": self.series_token,
+            "source_group_token": self.source_group_token,
+            "compatibility_signature": self.compatibility_signature,
+            "policy_signature": self.policy_signature,
+            "target_video_bitrate_bps": self.target_video_bitrate_bps,
+            "quality_metric": self.quality_metric,
+            "quality_target": self.quality_target,
+            "minimum_quality_score": self.minimum_quality_score,
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            **self.token_payload(),
+            "local_item_id": self.local_item_id,
+            "evidence_summary_sha256": self.evidence_summary_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationPartitionPlanBinding:
+    cell_plan_id: str
+    intent_level: str
+    compatibility_signature: str
+    policy_signature: str
+    target_video_bitrate_min_bps: int
+    target_video_bitrate_max_bps: int
+    quality_metric: str
+    quality_target: float
+    minimum_quality_score: float
+    holdout_count: int
+    derivation_reservation_count: int
+
+    def __post_init__(self) -> None:
+        for value, label in (
+            (self.cell_plan_id, "cell-plan ID"),
+            (self.intent_level, "intent"),
+            (self.compatibility_signature, "compatibility signature"),
+            (self.policy_signature, "policy signature"),
+        ):
+            if not _TOKEN_RE.fullmatch(value):
+                raise AV1ValidationPartitionError(
+                    f"AV1 partition plan {label} is invalid"
+                )
+        if not _QUALITY_METRIC_RE.fullmatch(self.quality_metric):
+            raise AV1ValidationPartitionError(
+                "AV1 partition plan quality metric is invalid"
+            )
+        if (
+            not 0
+            < self.target_video_bitrate_min_bps
+            <= self.target_video_bitrate_max_bps
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition plan bitrate range is invalid"
+            )
+        if self.holdout_count <= 0 or self.derivation_reservation_count < 0:
+            raise AV1ValidationPartitionError("AV1 partition plan counts are invalid")
+        if not all(
+            math.isfinite(value) and value >= 0
+            for value in (
+                self.quality_target,
+                self.minimum_quality_score,
+            )
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition plan quality contract is invalid"
+            )
+        if self.minimum_quality_score > self.quality_target:
+            raise AV1ValidationPartitionError(
+                "AV1 partition plan quality floor exceeds target"
+            )
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "cell_plan_id": self.cell_plan_id,
+            "intent_level": self.intent_level,
+            "compatibility_signature": self.compatibility_signature,
+            "policy_signature": self.policy_signature,
+            "target_video_bitrate_min_bps": self.target_video_bitrate_min_bps,
+            "target_video_bitrate_max_bps": self.target_video_bitrate_max_bps,
+            "quality_metric": self.quality_metric,
+            "quality_target": self.quality_target,
+            "minimum_quality_score": self.minimum_quality_score,
+            "holdout_count": self.holdout_count,
+            "derivation_reservation_count": self.derivation_reservation_count,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationPrivatePartition:
+    partition_id: str
+    manifest_id: str
+    manifest_payload_sha256: str
+    eligibility_attestation_id: str
+    eligibility_payload_sha256: str
+    selected_at: str
+    token_key_id: str
+    inventory_snapshot_sha256: str
+    expectations: AV1ValidationPartitionExpectations
+    inventory_sources: tuple[AV1ValidationPartitionSource, ...]
+    plan_bindings: tuple[AV1ValidationPartitionPlanBinding, ...]
+    assignments: tuple[AV1ValidationPartitionAssignment, ...]
+    derivation_partition_sha256: str
+    selection_lock_sha256: str
+    payload_sha256: str
+
+    def __post_init__(self) -> None:
+        if not self.partition_id.startswith("av1vpartition1_"):
+            raise AV1ValidationPartitionError("AV1 partition ID is invalid")
+        if not self.manifest_id.startswith("av1vmanifest2_"):
+            raise AV1ValidationPartitionError(
+                "AV1 partition manifest reference is invalid"
+            )
+        if not self.eligibility_attestation_id.startswith("av1vfeasibility2_"):
+            raise AV1ValidationPartitionError(
+                "AV1 partition eligibility reference is invalid"
+            )
+        if not self.token_key_id.startswith("av1vkey1_"):
+            raise AV1ValidationPartitionError("AV1 partition token-key ID is invalid")
+        for value, label in (
+            (self.manifest_payload_sha256, "manifest digest"),
+            (self.eligibility_payload_sha256, "eligibility digest"),
+            (self.inventory_snapshot_sha256, "inventory snapshot digest"),
+            (self.derivation_partition_sha256, "derivation partition digest"),
+            (self.selection_lock_sha256, "selection lock digest"),
+            (self.payload_sha256, "payload digest"),
+        ):
+            _require_sha256(value, label)
+        _parse_timestamp(self.selected_at, "selection timestamp")
+        if self.plan_bindings != tuple(
+            sorted(self.plan_bindings, key=lambda item: item.cell_plan_id)
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition plan bindings are not canonical"
+            )
+        if self.inventory_sources != tuple(
+            sorted(self.inventory_sources, key=lambda source: source.local_item_id)
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition inventory snapshot is not canonical"
+            )
+        _validate_source_set(self.inventory_sources)
+        if self.assignments != tuple(
+            sorted(self.assignments, key=_assignment_sort_key)
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition assignments are not canonical"
+            )
+        if self.derivation_partition_sha256 != _derivation_partition_sha256(
+            manifest_id=self.manifest_id,
+            assignments=self.assignments,
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 derivation partition digest does not match assignments"
+            )
+        if self.selection_lock_sha256 != _payload_sha256(self.selection_lock_payload()):
+            raise AV1ValidationPartitionError(
+                "AV1 selection lock digest does not match its payload"
+            )
+        semantic_payload = self.semantic_payload()
+        if self.partition_id != _partition_id("partition", semantic_payload):
+            raise AV1ValidationPartitionError(
+                "AV1 partition ID does not match its payload"
+            )
+        if self.payload_sha256 != _payload_sha256(
+            {
+                "partition_id": self.partition_id,
+                **semantic_payload,
+            }
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition payload digest does not match its payload"
+            )
+
+    @property
+    def holdout_count(self) -> int:
+        return sum(assignment.role == "holdout" for assignment in self.assignments)
+
+    @property
+    def derivation_reservation_count(self) -> int:
+        return sum(assignment.role == "derivation" for assignment in self.assignments)
+
+    def selection_lock_payload(self) -> dict[str, Any]:
+        return _selection_lock_payload(
+            manifest_id=self.manifest_id,
+            manifest_payload_sha256=self.manifest_payload_sha256,
+            eligibility_attestation_id=self.eligibility_attestation_id,
+            eligibility_payload_sha256=self.eligibility_payload_sha256,
+            selected_at=self.selected_at,
+            token_key_id=self.token_key_id,
+            inventory_snapshot_sha256=self.inventory_snapshot_sha256,
+            expectations=self.expectations,
+            plan_bindings=self.plan_bindings,
+            assignments=self.assignments,
+            derivation_partition_sha256=self.derivation_partition_sha256,
+        )
+
+    def semantic_payload(self) -> dict[str, Any]:
+        return {
+            "schema": AV1_VALIDATION_PARTITION_SCHEMA,
+            "schema_version": AV1_VALIDATION_PARTITION_SCHEMA_VERSION,
+            "contract_version": AV1_VALIDATION_PARTITION_CONTRACT_VERSION,
+            "selection_lock": self.selection_lock_payload(),
+            "inventory_sources": [
+                source.to_payload() for source in self.inventory_sources
+            ],
+            "assignments": [assignment.to_payload() for assignment in self.assignments],
+            "selection_lock_sha256": self.selection_lock_sha256,
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "partition_id": self.partition_id,
+            **self.semantic_payload(),
+            "payload_sha256": self.payload_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class _PartitionSlot:
+    assignment_id: str
+    role: AV1ValidationPartitionRole
+    plan: AV1ValidationV2CellPlan
+    ordinal: int
+
+
+def build_av1_validation_private_partition(
+    *,
+    manifest: AV1ValidationManifestV2,
+    eligibility_attestation_id: str,
+    eligibility_payload_sha256: str,
+    sources: Sequence[AV1ValidationPartitionSource],
+    expectations: AV1ValidationPartitionExpectations,
+    token_key: bytes,
+    expected_token_key_id: str,
+    selected_at: str,
+) -> AV1ValidationPrivatePartition:
+    assert_preregistered_av1_validation_manifest_v2(manifest)
+    _assert_partition_criteria(manifest)
+    _parse_timestamp(selected_at, "selection timestamp")
+    _validate_key(token_key)
+    token_key_id = _token_key_id(token_key)
+    if expected_token_key_id != token_key_id:
+        raise AV1ValidationPartitionError(
+            "AV1 partition key does not match its precommitted token-key ID"
+        )
+    if eligibility_attestation_id != manifest.eligibility_attestation_id:
+        raise AV1ValidationPartitionError(
+            "AV1 partition eligibility ID does not match manifest"
+        )
+    if eligibility_payload_sha256 != manifest.eligibility_payload_sha256:
+        raise AV1ValidationPartitionError(
+            "AV1 partition eligibility digest does not match manifest"
+        )
+    _validate_source_set(sources)
+
+    eligible_sources = tuple(
+        source
+        for source in sources
+        if _source_matches_expectations(
+            source,
+            expectations=expectations,
+        )
+    )
+    if not eligible_sources:
+        raise AV1ValidationPartitionError(
+            "AV1 partition has no compatible eligible sources"
+        )
+    slots = _partition_slots(manifest)
+    candidates_by_plan = {
+        plan.cell_plan_id: tuple(
+            source
+            for source in eligible_sources
+            if plan.trait_selector.matches(source.traits)
+        )
+        for plan in manifest.cell_plans
+    }
+    for plan in manifest.cell_plans:
+        required = plan.registered_case_count + (
+            AV1_VALIDATION_DERIVATION_RESERVATION_COUNT
+            if plan.mode == "publication_candidate"
+            else 0
+        )
+        candidates = candidates_by_plan[plan.cell_plan_id]
+        if len({source.series_identity for source in candidates}) < required:
+            raise AV1ValidationPartitionError(
+                f"AV1 partition cell {plan.cell_plan_id} lacks distinct eligible series"
+            )
+        if plan.mode == "publication_candidate":
+            _validate_candidate_group_capacity(plan, candidates)
+    mapped_sources = tuple(
+        source
+        for source in eligible_sources
+        if any(
+            plan.trait_selector.matches(source.traits) for plan in manifest.cell_plans
+        )
+    )
+    for attribute in ("source_identity", "title_identity", "series_identity"):
+        if len({getattr(source, attribute) for source in mapped_sources}) < len(slots):
+            raise AV1ValidationPartitionError(
+                f"AV1 partition lacks globally distinct {attribute.replace('_', ' ')} values"
+            )
+
+    ordered_holdout_slots = _ordered_partition_slots(
+        slots,
+        candidates_by_plan=candidates_by_plan,
+        role="holdout",
+    )
+    holdout_selected = _select_sources(
+        slots=ordered_holdout_slots,
+        candidates_by_plan=candidates_by_plan,
+        manifest_id=manifest.manifest_id,
+        token_key=token_key,
+    )
+    ordered_derivation_slots = _ordered_partition_slots(
+        slots,
+        candidates_by_plan=candidates_by_plan,
+        role="derivation",
+    )
+    fixed_holdouts = tuple(
+        (slot, holdout_selected[slot.assignment_id]) for slot in ordered_holdout_slots
+    )
+    selected = _select_sources(
+        slots=ordered_derivation_slots,
+        candidates_by_plan=candidates_by_plan,
+        manifest_id=manifest.manifest_id,
+        token_key=token_key,
+        fixed=fixed_holdouts,
+    )
+    assignments = tuple(
+        sorted(
+            (
+                _assignment_for_source(
+                    slot, selected[slot.assignment_id], token_key=token_key
+                )
+                for slot in slots
+            ),
+            key=_assignment_sort_key,
+        )
+    )
+    _validate_assignment_contract(manifest, assignments)
+
+    plan_bindings = _plan_bindings(manifest, assignments)
+    inventory_sources = tuple(
+        sorted(eligible_sources, key=lambda source: source.local_item_id)
+    )
+    inventory_snapshot_sha256 = _inventory_snapshot_sha256(
+        manifest=manifest,
+        sources=inventory_sources,
+        token_key=token_key,
+    )
+    derivation_partition_sha256 = _derivation_partition_sha256(
+        manifest_id=manifest.manifest_id,
+        assignments=assignments,
+    )
+    selection_lock_payload = _selection_lock_payload(
+        manifest_id=manifest.manifest_id,
+        manifest_payload_sha256=manifest.payload_sha256,
+        eligibility_attestation_id=eligibility_attestation_id,
+        eligibility_payload_sha256=eligibility_payload_sha256,
+        selected_at=selected_at,
+        token_key_id=token_key_id,
+        inventory_snapshot_sha256=inventory_snapshot_sha256,
+        expectations=expectations,
+        plan_bindings=plan_bindings,
+        assignments=assignments,
+        derivation_partition_sha256=derivation_partition_sha256,
+    )
+    selection_lock_sha256 = _payload_sha256(selection_lock_payload)
+    semantic_payload = {
+        "schema": AV1_VALIDATION_PARTITION_SCHEMA,
+        "schema_version": AV1_VALIDATION_PARTITION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_PARTITION_CONTRACT_VERSION,
+        "selection_lock": selection_lock_payload,
+        "inventory_sources": [source.to_payload() for source in inventory_sources],
+        "assignments": [assignment.to_payload() for assignment in assignments],
+        "selection_lock_sha256": selection_lock_sha256,
+    }
+    partition_id = _partition_id("partition", semantic_payload)
+    return AV1ValidationPrivatePartition(
+        partition_id=partition_id,
+        manifest_id=manifest.manifest_id,
+        manifest_payload_sha256=manifest.payload_sha256,
+        eligibility_attestation_id=eligibility_attestation_id,
+        eligibility_payload_sha256=eligibility_payload_sha256,
+        selected_at=selected_at,
+        token_key_id=token_key_id,
+        inventory_snapshot_sha256=inventory_snapshot_sha256,
+        expectations=expectations,
+        inventory_sources=inventory_sources,
+        plan_bindings=plan_bindings,
+        assignments=assignments,
+        derivation_partition_sha256=derivation_partition_sha256,
+        selection_lock_sha256=selection_lock_sha256,
+        payload_sha256=_payload_sha256(
+            {"partition_id": partition_id, **semantic_payload}
+        ),
+    )
+
+
+def validate_av1_validation_private_partition(
+    partition: AV1ValidationPrivatePartition,
+    *,
+    manifest: AV1ValidationManifestV2,
+    token_key: bytes,
+) -> None:
+    rebuilt = build_av1_validation_private_partition(
+        manifest=manifest,
+        eligibility_attestation_id=partition.eligibility_attestation_id,
+        eligibility_payload_sha256=partition.eligibility_payload_sha256,
+        sources=partition.inventory_sources,
+        expectations=partition.expectations,
+        token_key=token_key,
+        expected_token_key_id=partition.token_key_id,
+        selected_at=partition.selected_at,
+    )
+    if rebuilt != partition:
+        raise AV1ValidationPartitionError(
+            "AV1 private partition does not match current locked inputs"
+        )
+
+
+def validate_av1_validation_partition_current_inputs(
+    partition: AV1ValidationPrivatePartition,
+    *,
+    manifest: AV1ValidationManifestV2,
+    sources: Sequence[AV1ValidationPartitionSource],
+    expectations: AV1ValidationPartitionExpectations,
+    token_key: bytes,
+) -> None:
+    rebuilt = build_av1_validation_private_partition(
+        manifest=manifest,
+        eligibility_attestation_id=partition.eligibility_attestation_id,
+        eligibility_payload_sha256=partition.eligibility_payload_sha256,
+        sources=sources,
+        expectations=expectations,
+        token_key=token_key,
+        expected_token_key_id=partition.token_key_id,
+        selected_at=partition.selected_at,
+    )
+    if rebuilt != partition:
+        raise AV1ValidationPartitionError(
+            "AV1 private partition does not match current inventory or policy inputs"
+        )
+
+
+def serialize_av1_validation_private_partition(
+    partition: AV1ValidationPrivatePartition,
+) -> bytes:
+    return canonical_json_bytes(partition.to_payload())
+
+
+def load_av1_validation_private_partition(path: Path) -> AV1ValidationPrivatePartition:
+    _assert_owner_only_regular_file(path, label="private partition")
+    raw = path.read_bytes()
+    try:
+        payload = object_dict(json.loads(raw.decode("utf-8")))
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError) as exc:
+        raise AV1ValidationPartitionError(
+            "AV1 private partition is not valid JSON"
+        ) from exc
+    partition = av1_validation_private_partition_from_payload(payload)
+    if raw != serialize_av1_validation_private_partition(partition):
+        raise AV1ValidationPartitionError("AV1 private partition JSON is not canonical")
+    return partition
+
+
+def av1_validation_private_partition_from_payload(
+    payload: Mapping[str, Any],
+) -> AV1ValidationPrivatePartition:
+    data = object_dict(payload)
+    _require_exact_keys(
+        data,
+        {
+            "partition_id",
+            "schema",
+            "schema_version",
+            "contract_version",
+            "selection_lock",
+            "inventory_sources",
+            "assignments",
+            "selection_lock_sha256",
+            "payload_sha256",
+        },
+        "private partition",
+    )
+    if data.get("schema") != AV1_VALIDATION_PARTITION_SCHEMA:
+        raise AV1ValidationPartitionError("AV1 private partition schema is invalid")
+    if int_value(data.get("schema_version")) != AV1_VALIDATION_PARTITION_SCHEMA_VERSION:
+        raise AV1ValidationPartitionError(
+            "AV1 private partition schema version is invalid"
+        )
+    if data.get("contract_version") != AV1_VALIDATION_PARTITION_CONTRACT_VERSION:
+        raise AV1ValidationPartitionError(
+            "AV1 private partition contract version is invalid"
+        )
+    selection_lock = object_dict(data.get("selection_lock"))
+    _require_exact_keys(
+        selection_lock,
+        {
+            "schema",
+            "schema_version",
+            "contract_version",
+            "authority",
+            "runtime_execution_authorized",
+            "derivation_execution_authorized",
+            "holdout_execution_authorized",
+            "manifest_id",
+            "manifest_payload_sha256",
+            "eligibility_attestation_id",
+            "eligibility_payload_sha256",
+            "selected_at",
+            "assignment_algorithm",
+            "token_version",
+            "token_key_id",
+            "identity_policy",
+            "inventory_snapshot_sha256",
+            "expectations",
+            "plan_bindings",
+            "assignments",
+            "derivation_partition_sha256",
+        },
+        "selection lock",
+    )
+    if selection_lock.get("schema") != AV1_VALIDATION_SELECTION_LOCK_SCHEMA:
+        raise AV1ValidationPartitionError("AV1 selection lock schema is invalid")
+    if (
+        int_value(selection_lock.get("schema_version"))
+        != AV1_VALIDATION_SELECTION_LOCK_SCHEMA_VERSION
+    ):
+        raise AV1ValidationPartitionError(
+            "AV1 selection lock schema version is invalid"
+        )
+    if (
+        selection_lock.get("contract_version")
+        != AV1_VALIDATION_PARTITION_CONTRACT_VERSION
+    ):
+        raise AV1ValidationPartitionError(
+            "AV1 selection lock contract version is invalid"
+        )
+    if (
+        selection_lock.get("assignment_algorithm") != AV1_VALIDATION_PARTITION_ALGORITHM
+        or selection_lock.get("token_version") != AV1_VALIDATION_PARTITION_TOKEN_VERSION
+    ):
+        raise AV1ValidationPartitionError(
+            "AV1 selection lock algorithm or token version is invalid"
+        )
+    if (
+        selection_lock.get("authority") != "selection_lock_only"
+        or selection_lock.get("runtime_execution_authorized") is not False
+        or selection_lock.get("derivation_execution_authorized") is not False
+        or selection_lock.get("holdout_execution_authorized") is not False
+    ):
+        raise AV1ValidationPartitionError(
+            "AV1 selection lock carries unauthorized execution authority"
+        )
+    identity_policy = object_dict(selection_lock.get("identity_policy"))
+    if identity_policy != {
+        "global_source_unique": True,
+        "global_title_unique": True,
+        "global_series_unique": True,
+        "derivation_holdout_disjoint": ["source", "series", "source_group"],
+        "candidate_source_group_minimum": AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT,
+        "candidate_source_group_maximum_numerator": 1,
+        "candidate_source_group_maximum_denominator": 3,
+    }:
+        raise AV1ValidationPartitionError(
+            "AV1 selection lock identity policy is invalid"
+        )
+    expectations = _expectations_from_payload(
+        object_dict(selection_lock.get("expectations"))
+    )
+    plan_bindings = tuple(
+        _plan_binding_from_payload(object_dict(item))
+        for item in object_list(selection_lock.get("plan_bindings"))
+    )
+    private_assignments = tuple(
+        _assignment_from_payload(object_dict(item))
+        for item in object_list(data.get("assignments"))
+    )
+    inventory_sources = tuple(
+        _source_from_payload(object_dict(item))
+        for item in object_list(data.get("inventory_sources"))
+    )
+    if [
+        assignment.token_payload() for assignment in private_assignments
+    ] != object_list(selection_lock.get("assignments")):
+        raise AV1ValidationPartitionError(
+            "AV1 private assignments do not match the selection lock"
+        )
+    return AV1ValidationPrivatePartition(
+        partition_id=_required_text(data.get("partition_id"), "partition ID"),
+        manifest_id=_required_text(selection_lock.get("manifest_id"), "manifest ID"),
+        manifest_payload_sha256=_required_text(
+            selection_lock.get("manifest_payload_sha256"),
+            "manifest digest",
+        ),
+        eligibility_attestation_id=_required_text(
+            selection_lock.get("eligibility_attestation_id"),
+            "eligibility ID",
+        ),
+        eligibility_payload_sha256=_required_text(
+            selection_lock.get("eligibility_payload_sha256"),
+            "eligibility digest",
+        ),
+        selected_at=_required_text(
+            selection_lock.get("selected_at"), "selection timestamp"
+        ),
+        token_key_id=_required_text(selection_lock.get("token_key_id"), "token-key ID"),
+        inventory_snapshot_sha256=_required_text(
+            selection_lock.get("inventory_snapshot_sha256"),
+            "inventory snapshot digest",
+        ),
+        expectations=expectations,
+        inventory_sources=inventory_sources,
+        plan_bindings=plan_bindings,
+        assignments=private_assignments,
+        derivation_partition_sha256=_required_text(
+            selection_lock.get("derivation_partition_sha256"),
+            "derivation partition digest",
+        ),
+        selection_lock_sha256=_required_text(
+            data.get("selection_lock_sha256"), "selection lock digest"
+        ),
+        payload_sha256=_required_text(data.get("payload_sha256"), "payload digest"),
+    )
+
+
+def create_av1_validation_partition_key(path: Path) -> str:
+    if path.exists():
+        raise AV1ValidationPartitionError("AV1 partition key already exists")
+    key = secrets.token_bytes(32)
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    _assert_owner_only_directory(path.parent)
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(key)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+    return _token_key_id(key)
+
+
+def load_av1_validation_partition_key(path: Path) -> bytes:
+    _assert_owner_only_regular_file(path, label="partition key")
+    key = path.read_bytes()
+    _validate_key(key)
+    return key
+
+
+def av1_validation_partition_key_id(token_key: bytes) -> str:
+    _validate_key(token_key)
+    return _token_key_id(token_key)
+
+
+def write_av1_validation_private_partition(
+    path: Path,
+    partition: AV1ValidationPrivatePartition,
+) -> None:
+    if path.exists():
+        raise AV1ValidationPartitionError("AV1 private partition already exists")
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    _assert_owner_only_directory(path.parent)
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(serialize_av1_validation_private_partition(partition))
+            handle.flush()
+            os.fsync(handle.fileno())
+    except BaseException:
+        path.unlink(missing_ok=True)
+        raise
+
+
+def av1_validation_partition_public_summary(
+    partition: AV1ValidationPrivatePartition,
+) -> dict[str, Any]:
+    payload = {
+        "schema": AV1_VALIDATION_PARTITION_SUMMARY_SCHEMA,
+        "schema_version": 1,
+        "contract_version": AV1_VALIDATION_PARTITION_CONTRACT_VERSION,
+        "manifest_id": partition.manifest_id,
+        "selection_lock_sha256": partition.selection_lock_sha256,
+        "derivation_partition_sha256": partition.derivation_partition_sha256,
+        "holdout_count": partition.holdout_count,
+        "derivation_reservation_count": partition.derivation_reservation_count,
+        "runtime_execution_authorized": False,
+        "derivation_execution_authorized": False,
+        "holdout_execution_authorized": False,
+    }
+    assert_av1_cold_start_public_payload_safe(payload)
+    return payload
+
+
+def assert_private_artifact_path(path: Path, *, repository_root: Path) -> None:
+    resolved_path = path.expanduser().resolve()
+    resolved_root = repository_root.expanduser().resolve()
+    if resolved_path == resolved_root or resolved_root in resolved_path.parents:
+        raise AV1ValidationPartitionError(
+            "AV1 private artifacts must remain outside the repository"
+        )
+
+
+def _partition_slots(manifest: AV1ValidationManifestV2) -> tuple[_PartitionSlot, ...]:
+    plans = {plan.cell_plan_id: plan for plan in manifest.cell_plans}
+    slots = [
+        _PartitionSlot(
+            assignment_id=case.case_id,
+            role="holdout",
+            plan=plans[case.cell_plan_id],
+            ordinal=case.ordinal,
+        )
+        for case in manifest.cases
+    ]
+    for plan in manifest.cell_plans:
+        if plan.mode != "publication_candidate":
+            continue
+        slots.extend(
+            _PartitionSlot(
+                assignment_id=_partition_id(
+                    "derivation_slot",
+                    {
+                        "manifest_id": manifest.manifest_id,
+                        "cell_plan_id": plan.cell_plan_id,
+                        "ordinal": ordinal,
+                    },
+                ),
+                role="derivation",
+                plan=plan,
+                ordinal=ordinal,
+            )
+            for ordinal in range(1, AV1_VALIDATION_DERIVATION_RESERVATION_COUNT + 1)
+        )
+    return tuple(slots)
+
+
+def _ordered_partition_slots(
+    slots: Sequence[_PartitionSlot],
+    *,
+    candidates_by_plan: Mapping[str, Sequence[AV1ValidationPartitionSource]],
+    role: AV1ValidationPartitionRole,
+) -> tuple[_PartitionSlot, ...]:
+    return tuple(
+        sorted(
+            (slot for slot in slots if slot.role == role),
+            key=lambda slot: (
+                len(
+                    {
+                        source.series_identity
+                        for source in candidates_by_plan[slot.plan.cell_plan_id]
+                    }
+                ),
+                slot.plan.name,
+                slot.ordinal,
+                slot.assignment_id,
+            ),
+        )
+    )
+
+
+def _select_sources(
+    *,
+    slots: Sequence[_PartitionSlot],
+    candidates_by_plan: Mapping[str, Sequence[AV1ValidationPartitionSource]],
+    manifest_id: str,
+    token_key: bytes,
+    fixed: Sequence[tuple[_PartitionSlot, AV1ValidationPartitionSource]] = (),
+) -> dict[str, AV1ValidationPartitionSource]:
+    ranked_candidates = {
+        slot.assignment_id: tuple(
+            sorted(
+                candidates_by_plan[slot.plan.cell_plan_id],
+                key=lambda source: (
+                    _rank_source(
+                        source,
+                        manifest_id=manifest_id,
+                        assignment_id=slot.assignment_id,
+                        token_key=token_key,
+                    ),
+                    source.local_item_id,
+                ),
+            )
+        )
+        for slot in slots
+    }
+    selected = {slot.assignment_id: source for slot, source in fixed}
+    used: dict[str, set[str]] = {
+        "source": set(),
+        "title": set(),
+        "series": set(),
+    }
+    groups_by_role: dict[AV1ValidationPartitionRole, Counter[str]] = {
+        "holdout": Counter(),
+        "derivation": Counter(),
+    }
+    groups_by_plan_role: dict[tuple[str, AV1ValidationPartitionRole], Counter[str]] = {}
+    for slot, source in fixed:
+        identities = {
+            "source": source.source_identity,
+            "title": source.title_identity,
+            "series": source.series_identity,
+        }
+        if any(value in used[kind] for kind, value in identities.items()):
+            raise AV1ValidationPartitionError(
+                "AV1 partition fixed selection repeats an identity"
+            )
+        for kind, value in identities.items():
+            used[kind].add(value)
+        group = source.source_group_identity
+        groups_by_role[slot.role][group] += 1
+        groups_by_plan_role.setdefault((slot.plan.cell_plan_id, slot.role), Counter())[
+            group
+        ] += 1
+    search_nodes = 0
+    validation_slots = tuple(slot for slot, _ in fixed) + tuple(slots)
+
+    def _search(index: int) -> bool:
+        nonlocal search_nodes
+        if index == len(slots):
+            return _source_group_selection_valid(validation_slots, selected)
+        slot = slots[index]
+        for source in ranked_candidates[slot.assignment_id]:
+            search_nodes += 1
+            if search_nodes > _MAXIMUM_SEARCH_NODES:
+                raise AV1ValidationPartitionError(
+                    "AV1 partition assignment search exceeded its bound"
+                )
+            identities = {
+                "source": source.source_identity,
+                "title": source.title_identity,
+                "series": source.series_identity,
+            }
+            if any(value in used[kind] for kind, value in identities.items()):
+                continue
+            opposite_role: AV1ValidationPartitionRole = (
+                "derivation" if slot.role == "holdout" else "holdout"
+            )
+            group = source.source_group_identity
+            if groups_by_role[opposite_role][group] > 0:
+                continue
+            plan_group_key = (slot.plan.cell_plan_id, slot.role)
+            plan_groups = groups_by_plan_role.setdefault(plan_group_key, Counter())
+            if slot.plan.mode == "publication_candidate":
+                cohort_size = (
+                    slot.plan.registered_case_count
+                    if slot.role == "holdout"
+                    else AV1_VALIDATION_DERIVATION_RESERVATION_COUNT
+                )
+                maximum = math.floor(
+                    cohort_size * AV1_VALIDATION_MAXIMUM_SOURCE_GROUP_FRACTION
+                )
+                if plan_groups[group] >= maximum:
+                    continue
+            for kind, value in identities.items():
+                used[kind].add(value)
+            groups_by_role[slot.role][group] += 1
+            plan_groups[group] += 1
+            selected[slot.assignment_id] = source
+            if _search(index + 1):
+                return True
+            selected.pop(slot.assignment_id)
+            groups_by_role[slot.role][group] -= 1
+            if groups_by_role[slot.role][group] == 0:
+                del groups_by_role[slot.role][group]
+            plan_groups[group] -= 1
+            if plan_groups[group] == 0:
+                del plan_groups[group]
+            for kind, value in identities.items():
+                used[kind].remove(value)
+        return False
+
+    if not _search(0):
+        raise AV1ValidationPartitionError(
+            "AV1 partition cannot satisfy the preregistered identity constraints"
+        )
+    return selected
+
+
+def _assignment_for_source(
+    slot: _PartitionSlot,
+    source: AV1ValidationPartitionSource,
+    *,
+    token_key: bytes,
+) -> AV1ValidationPartitionAssignment:
+    return AV1ValidationPartitionAssignment(
+        assignment_id=slot.assignment_id,
+        role=slot.role,
+        cell_plan_id=slot.plan.cell_plan_id,
+        ordinal=slot.ordinal,
+        local_item_id=source.local_item_id,
+        traits=source.traits,
+        intent_level=slot.plan.intent_level,
+        source_token=_identity_token(
+            "source", source.source_identity, token_key=token_key
+        ),
+        title_token=_identity_token(
+            "title", source.title_identity, token_key=token_key
+        ),
+        series_token=_identity_token(
+            "series", source.series_identity, token_key=token_key
+        ),
+        source_group_token=_identity_token(
+            "group", source.source_group_identity, token_key=token_key
+        ),
+        compatibility_signature=source.compatibility_signature,
+        policy_signature=_plan_policy_signature(
+            source.base_policy_signature, slot.plan
+        ),
+        target_video_bitrate_bps=source.target_video_bitrate_bps,
+        quality_metric=source.quality_metric,
+        quality_target=source.quality_target,
+        minimum_quality_score=source.minimum_quality_score,
+        evidence_summary_sha256=source.evidence_summary_sha256,
+    )
+
+
+def _validate_assignment_contract(
+    manifest: AV1ValidationManifestV2,
+    assignments: Sequence[AV1ValidationPartitionAssignment],
+) -> None:
+    expected_slots = {slot.assignment_id: slot for slot in _partition_slots(manifest)}
+    actual_ids = [assignment.assignment_id for assignment in assignments]
+    if len(actual_ids) != len(set(actual_ids)) or set(actual_ids) != set(
+        expected_slots
+    ):
+        raise AV1ValidationPartitionError(
+            "AV1 partition does not cover the exact registered slots"
+        )
+    for attribute in (
+        "local_item_id",
+        "source_token",
+        "title_token",
+        "series_token",
+    ):
+        values = [getattr(assignment, attribute) for assignment in assignments]
+        if len(values) != len(set(values)):
+            raise AV1ValidationPartitionError(
+                f"AV1 partition repeats {attribute.replace('_', ' ')}"
+            )
+    for assignment in assignments:
+        slot = expected_slots[assignment.assignment_id]
+        if (
+            assignment.role != slot.role
+            or assignment.cell_plan_id != slot.plan.cell_plan_id
+            or assignment.ordinal != slot.ordinal
+            or assignment.intent_level != slot.plan.intent_level
+            or not slot.plan.trait_selector.matches(assignment.traits)
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition assignment violates its registered slot"
+            )
+    by_plan = {
+        plan.cell_plan_id: [
+            assignment
+            for assignment in assignments
+            if assignment.cell_plan_id == plan.cell_plan_id
+        ]
+        for plan in manifest.cell_plans
+    }
+    for plan in manifest.cell_plans:
+        plan_assignments = by_plan[plan.cell_plan_id]
+        holdouts = [
+            assignment
+            for assignment in plan_assignments
+            if assignment.role == "holdout"
+        ]
+        derivation = [
+            assignment
+            for assignment in plan_assignments
+            if assignment.role == "derivation"
+        ]
+        if len(holdouts) != plan.registered_case_count:
+            raise AV1ValidationPartitionError(
+                "AV1 partition holdout count does not match manifest"
+            )
+        expected_derivation = (
+            AV1_VALIDATION_DERIVATION_RESERVATION_COUNT
+            if plan.mode == "publication_candidate"
+            else 0
+        )
+        if len(derivation) != expected_derivation:
+            raise AV1ValidationPartitionError(
+                "AV1 partition derivation count does not match protocol"
+            )
+        if plan.mode != "publication_candidate":
+            continue
+        _validate_source_group_distribution(holdouts)
+        _validate_source_group_distribution(derivation)
+        for attribute in ("source_token", "series_token"):
+            if {getattr(assignment, attribute) for assignment in holdouts} & {
+                getattr(assignment, attribute) for assignment in derivation
+            }:
+                raise AV1ValidationPartitionError(
+                    "AV1 partition derivation overlaps its holdout"
+                )
+    holdout_groups = {
+        assignment.source_group_token
+        for assignment in assignments
+        if assignment.role == "holdout"
+    }
+    derivation_groups = {
+        assignment.source_group_token
+        for assignment in assignments
+        if assignment.role == "derivation"
+    }
+    if holdout_groups & derivation_groups:
+        raise AV1ValidationPartitionError(
+            "AV1 partition derivation source groups overlap holdouts"
+        )
+
+
+def _validate_source_group_distribution(
+    assignments: Sequence[AV1ValidationPartitionAssignment],
+) -> None:
+    groups = Counter(assignment.source_group_token for assignment in assignments)
+    if len(groups) < AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT:
+        raise AV1ValidationPartitionError(
+            "AV1 partition lacks required source-group diversity"
+        )
+    maximum = math.floor(
+        len(assignments) * AV1_VALIDATION_MAXIMUM_SOURCE_GROUP_FRACTION
+    )
+    if max(groups.values(), default=0) > maximum:
+        raise AV1ValidationPartitionError(
+            "AV1 partition exceeds source-group concentration limit"
+        )
+
+
+def _validate_candidate_group_capacity(
+    plan: AV1ValidationV2CellPlan,
+    candidates: Sequence[AV1ValidationPartitionSource],
+) -> None:
+    groups = Counter(source.source_group_identity for source in candidates)
+    minimum_distinct_groups = 2 * AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT
+    if len(groups) < minimum_distinct_groups:
+        raise AV1ValidationPartitionError(
+            f"AV1 partition cell {plan.cell_plan_id} lacks disjoint candidate source-group diversity"
+        )
+    if not _candidate_group_capacity_available(plan, groups):
+        raise AV1ValidationPartitionError(
+            f"AV1 partition cell {plan.cell_plan_id} lacks source-group concentration capacity"
+        )
+
+
+def _candidate_group_capacity_available(
+    plan: AV1ValidationV2CellPlan,
+    groups: Mapping[str, int],
+) -> bool:
+    holdout_target = plan.registered_case_count
+    derivation_target = AV1_VALIDATION_DERIVATION_RESERVATION_COUNT
+    holdout_maximum = math.floor(
+        holdout_target * AV1_VALIDATION_MAXIMUM_SOURCE_GROUP_FRACTION
+    )
+    derivation_maximum = math.floor(
+        derivation_target * AV1_VALIDATION_MAXIMUM_SOURCE_GROUP_FRACTION
+    )
+    minimum_groups = AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT
+    states = {(0, 0, 0, 0)}
+    for count in groups.values():
+        holdout_capacity = min(count, holdout_maximum)
+        derivation_capacity = min(count, derivation_maximum)
+        updated = set(states)
+        for (
+            holdout_count,
+            derivation_count,
+            holdout_groups,
+            derivation_groups,
+        ) in states:
+            updated.add(
+                (
+                    min(holdout_target, holdout_count + holdout_capacity),
+                    derivation_count,
+                    min(minimum_groups, holdout_groups + 1),
+                    derivation_groups,
+                )
+            )
+            updated.add(
+                (
+                    holdout_count,
+                    min(derivation_target, derivation_count + derivation_capacity),
+                    holdout_groups,
+                    min(minimum_groups, derivation_groups + 1),
+                )
+            )
+        states = updated
+    return (
+        holdout_target,
+        derivation_target,
+        minimum_groups,
+        minimum_groups,
+    ) in states
+
+
+def _source_group_selection_valid(
+    slots: Sequence[_PartitionSlot],
+    selected: Mapping[str, AV1ValidationPartitionSource],
+) -> bool:
+    for role in ("holdout", "derivation"):
+        for plan_id in {
+            slot.plan.cell_plan_id
+            for slot in slots
+            if slot.plan.mode == "publication_candidate" and slot.role == role
+        }:
+            groups = Counter(
+                selected[slot.assignment_id].source_group_identity
+                for slot in slots
+                if slot.plan.cell_plan_id == plan_id and slot.role == role
+            )
+            if len(groups) < AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT:
+                return False
+    return True
+
+
+def _plan_bindings(
+    manifest: AV1ValidationManifestV2,
+    assignments: Sequence[AV1ValidationPartitionAssignment],
+) -> tuple[AV1ValidationPartitionPlanBinding, ...]:
+    bindings = []
+    for plan in manifest.cell_plans:
+        selected = [
+            assignment
+            for assignment in assignments
+            if assignment.cell_plan_id == plan.cell_plan_id
+        ]
+        compatibility = {assignment.compatibility_signature for assignment in selected}
+        policies = {assignment.policy_signature for assignment in selected}
+        metrics = {assignment.quality_metric for assignment in selected}
+        targets = {assignment.quality_target for assignment in selected}
+        floors = {assignment.minimum_quality_score for assignment in selected}
+        if any(
+            len(values) != 1
+            for values in (compatibility, policies, metrics, targets, floors)
+        ):
+            raise AV1ValidationPartitionError(
+                "AV1 partition plan execution contract is incoherent"
+            )
+        bitrates = [assignment.target_video_bitrate_bps for assignment in selected]
+        bindings.append(
+            AV1ValidationPartitionPlanBinding(
+                cell_plan_id=plan.cell_plan_id,
+                intent_level=plan.intent_level,
+                compatibility_signature=next(iter(compatibility)),
+                policy_signature=next(iter(policies)),
+                target_video_bitrate_min_bps=min(bitrates),
+                target_video_bitrate_max_bps=max(bitrates),
+                quality_metric=next(iter(metrics)),
+                quality_target=next(iter(targets)),
+                minimum_quality_score=next(iter(floors)),
+                holdout_count=sum(
+                    assignment.role == "holdout" for assignment in selected
+                ),
+                derivation_reservation_count=sum(
+                    assignment.role == "derivation" for assignment in selected
+                ),
+            )
+        )
+    return tuple(sorted(bindings, key=lambda binding: binding.cell_plan_id))
+
+
+def _inventory_snapshot_sha256(
+    *,
+    manifest: AV1ValidationManifestV2,
+    sources: Sequence[AV1ValidationPartitionSource],
+    token_key: bytes,
+) -> str:
+    rows = []
+    for source in sources:
+        eligible_plan_ids = sorted(
+            plan.cell_plan_id
+            for plan in manifest.cell_plans
+            if plan.trait_selector.matches(source.traits)
+        )
+        if not eligible_plan_ids:
+            continue
+        rows.append(
+            {
+                "source_token": _identity_token(
+                    "source", source.source_identity, token_key=token_key
+                ),
+                "title_token": _identity_token(
+                    "title", source.title_identity, token_key=token_key
+                ),
+                "series_token": _identity_token(
+                    "series", source.series_identity, token_key=token_key
+                ),
+                "source_group_token": _identity_token(
+                    "group", source.source_group_identity, token_key=token_key
+                ),
+                "traits": list(source.traits),
+                "eligible_cell_plan_ids": eligible_plan_ids,
+                "compatibility_signature": source.compatibility_signature,
+                "base_policy_signature": source.base_policy_signature,
+                "target_video_bitrate_bps": source.target_video_bitrate_bps,
+                "quality_metric": source.quality_metric,
+                "quality_target": source.quality_target,
+                "minimum_quality_score": source.minimum_quality_score,
+                "evidence_summary_sha256": source.evidence_summary_sha256,
+            }
+        )
+    return _payload_sha256(
+        sorted(
+            rows,
+            key=lambda row: (
+                str(row["source_token"]),
+                str(row["series_token"]),
+            ),
+        )
+    )
+
+
+def _derivation_partition_sha256(
+    *,
+    manifest_id: str,
+    assignments: Sequence[AV1ValidationPartitionAssignment],
+) -> str:
+    return _payload_sha256(
+        {
+            "schema": "mediaforce.av1_cold_start_derivation_partition",
+            "schema_version": 1,
+            "contract_version": AV1_VALIDATION_PARTITION_CONTRACT_VERSION,
+            "manifest_id": manifest_id,
+            "assignments": [
+                assignment.token_payload()
+                for assignment in assignments
+                if assignment.role == "derivation"
+            ],
+        }
+    )
+
+
+def _selection_lock_payload(
+    *,
+    manifest_id: str,
+    manifest_payload_sha256: str,
+    eligibility_attestation_id: str,
+    eligibility_payload_sha256: str,
+    selected_at: str,
+    token_key_id: str,
+    inventory_snapshot_sha256: str,
+    expectations: AV1ValidationPartitionExpectations,
+    plan_bindings: Sequence[AV1ValidationPartitionPlanBinding],
+    assignments: Sequence[AV1ValidationPartitionAssignment],
+    derivation_partition_sha256: str,
+) -> dict[str, Any]:
+    return {
+        "schema": AV1_VALIDATION_SELECTION_LOCK_SCHEMA,
+        "schema_version": AV1_VALIDATION_SELECTION_LOCK_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_PARTITION_CONTRACT_VERSION,
+        "authority": "selection_lock_only",
+        "runtime_execution_authorized": False,
+        "derivation_execution_authorized": False,
+        "holdout_execution_authorized": False,
+        "manifest_id": manifest_id,
+        "manifest_payload_sha256": manifest_payload_sha256,
+        "eligibility_attestation_id": eligibility_attestation_id,
+        "eligibility_payload_sha256": eligibility_payload_sha256,
+        "selected_at": selected_at,
+        "assignment_algorithm": AV1_VALIDATION_PARTITION_ALGORITHM,
+        "token_version": AV1_VALIDATION_PARTITION_TOKEN_VERSION,
+        "token_key_id": token_key_id,
+        "identity_policy": {
+            "global_source_unique": True,
+            "global_title_unique": True,
+            "global_series_unique": True,
+            "derivation_holdout_disjoint": ["source", "series", "source_group"],
+            "candidate_source_group_minimum": AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT,
+            "candidate_source_group_maximum_numerator": 1,
+            "candidate_source_group_maximum_denominator": 3,
+        },
+        "inventory_snapshot_sha256": inventory_snapshot_sha256,
+        "expectations": expectations.to_payload(),
+        "plan_bindings": [binding.to_payload() for binding in plan_bindings],
+        "assignments": [assignment.token_payload() for assignment in assignments],
+        "derivation_partition_sha256": derivation_partition_sha256,
+    }
+
+
+def _source_matches_expectations(
+    source: AV1ValidationPartitionSource,
+    *,
+    expectations: AV1ValidationPartitionExpectations,
+) -> bool:
+    return (
+        source.compatibility_signature == expectations.compatibility_signature
+        and source.base_policy_signature == expectations.base_policy_signature
+        and source.quality_metric == expectations.quality_metric
+        and source.quality_target == expectations.quality_target
+        and source.minimum_quality_score == expectations.minimum_quality_score
+    )
+
+
+def _validate_source_set(sources: Sequence[AV1ValidationPartitionSource]) -> None:
+    for attribute, label in (
+        ("local_item_id", "local item IDs"),
+        ("source_identity", "source identities"),
+    ):
+        values = [getattr(source, attribute) for source in sources]
+        if len(values) != len(set(values)):
+            raise AV1ValidationPartitionError(
+                f"AV1 partition inventory repeats {label}"
+            )
+
+
+def _assert_partition_criteria(manifest: AV1ValidationManifestV2) -> None:
+    criteria = manifest.criteria
+    if (
+        criteria.minimum_derivation_evidence_count
+        != AV1_VALIDATION_DERIVATION_RESERVATION_COUNT
+        or criteria.minimum_derivation_source_count
+        != AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT
+        or criteria.minimum_holdout_source_count
+        != AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT
+    ):
+        raise AV1ValidationPartitionError(
+            "AV1 partition policy does not match the preregistered criteria"
+        )
+
+
+def _rank_source(
+    source: AV1ValidationPartitionSource,
+    *,
+    manifest_id: str,
+    assignment_id: str,
+    token_key: bytes,
+) -> str:
+    return hmac.new(
+        _derived_key(token_key, "selection-rank"),
+        canonical_json_bytes(
+            {
+                "manifest_id": manifest_id,
+                "assignment_id": assignment_id,
+                "source_identity": source.source_identity,
+                "title_identity": source.title_identity,
+                "series_identity": source.series_identity,
+                "source_group_identity": source.source_group_identity,
+            }
+        ),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _identity_token(kind: str, identity: str, *, token_key: bytes) -> str:
+    prefixes = {
+        "source": "av1src1",
+        "title": "av1title1",
+        "series": "av1series1",
+        "group": "av1group1",
+    }
+    prefix = prefixes.get(kind)
+    if prefix is None:
+        raise AV1ValidationPartitionError("AV1 partition token kind is invalid")
+    digest = hmac.new(
+        _derived_key(token_key, f"identity:{kind}"),
+        canonical_json_bytes({"identity": identity}),
+        hashlib.sha256,
+    ).hexdigest()
+    return f"{prefix}_{digest[:32]}"
+
+
+def _plan_policy_signature(
+    base_policy_signature: str, plan: AV1ValidationV2CellPlan
+) -> str:
+    return f"av1vpolicy1_{
+        stable_json_hash(
+            {
+                'base_policy_signature': base_policy_signature,
+                'intent_level': plan.intent_level,
+                'optimization_objective': plan.optimization_objective,
+            }
+        )[:32]
+    }"
+
+
+def _derived_key(token_key: bytes, domain: str) -> bytes:
+    return hmac.new(
+        token_key,
+        f"{AV1_VALIDATION_PARTITION_TOKEN_VERSION}:{domain}".encode(),
+        hashlib.sha256,
+    ).digest()
+
+
+def _token_key_id(token_key: bytes) -> str:
+    return f"av1vkey1_{
+        hmac.new(
+            _derived_key(token_key, 'key-id'),
+            b'mediaforce-av1-validation-partition',
+            hashlib.sha256,
+        ).hexdigest()[:32]
+    }"
+
+
+def _validate_key(token_key: bytes) -> None:
+    if len(token_key) < 32:
+        raise AV1ValidationPartitionError(
+            "AV1 partition token key must contain at least 32 bytes"
+        )
+
+
+def _assignment_sort_key(
+    assignment: AV1ValidationPartitionAssignment,
+) -> tuple[str, str, int, str]:
+    return (
+        assignment.role,
+        assignment.cell_plan_id,
+        assignment.ordinal,
+        assignment.assignment_id,
+    )
+
+
+def _partition_id(kind: str, payload: object) -> str:
+    prefixes = {
+        "partition": "av1vpartition1",
+        "derivation_slot": "av1vderive1",
+    }
+    prefix = prefixes.get(kind)
+    if prefix is None:
+        raise AV1ValidationPartitionError("AV1 partition ID kind is invalid")
+    return f"{prefix}_{stable_json_hash(payload)[:32]}"
+
+
+def _payload_sha256(payload: object) -> str:
+    return f"sha256:{stable_json_hash(payload)}"
+
+
+def _require_sha256(value: str, label: str) -> None:
+    if not _SHA256_RE.fullmatch(value):
+        raise AV1ValidationPartitionError(f"AV1 partition {label} is invalid")
+
+
+def _parse_timestamp(value: str, label: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise AV1ValidationPartitionError(f"AV1 partition {label} is invalid") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise AV1ValidationPartitionError(
+            f"AV1 partition {label} must be timezone-aware"
+        )
+    normalized = (
+        parsed.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+    if value != normalized:
+        raise AV1ValidationPartitionError(
+            f"AV1 partition {label} must be canonical UTC"
+        )
+    return parsed
+
+
+def _required_text(value: object, label: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise AV1ValidationPartitionError(f"AV1 partition {label} is required")
+    return text
+
+
+def _assert_owner_only_directory(path: Path) -> None:
+    if os.name != "posix":
+        return
+    directory_stat = path.stat()
+    if not stat.S_ISDIR(directory_stat.st_mode):
+        raise AV1ValidationPartitionError(
+            "AV1 private artifact parent is not a directory"
+        )
+    if directory_stat.st_uid != os.getuid() or directory_stat.st_mode & 0o077:
+        raise AV1ValidationPartitionError(
+            "AV1 private artifact directory must be owner-only"
+        )
+
+
+def _assert_owner_only_regular_file(path: Path, *, label: str) -> None:
+    file_stat = path.stat()
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise AV1ValidationPartitionError(f"AV1 {label} is not a regular file")
+    if os.name == "posix" and (
+        file_stat.st_uid != os.getuid() or file_stat.st_mode & 0o077
+    ):
+        raise AV1ValidationPartitionError(f"AV1 {label} permissions must be owner-only")
+
+
+def _expectations_from_payload(
+    payload: Mapping[str, Any],
+) -> AV1ValidationPartitionExpectations:
+    data = object_dict(payload)
+    _require_exact_keys(
+        data,
+        {
+            "compatibility_signature",
+            "base_policy_signature",
+            "quality_metric",
+            "quality_target",
+            "minimum_quality_score",
+        },
+        "expectations",
+    )
+    return AV1ValidationPartitionExpectations(
+        compatibility_signature=_required_text(
+            data.get("compatibility_signature"), "compatibility signature"
+        ),
+        base_policy_signature=_required_text(
+            data.get("base_policy_signature"), "base policy signature"
+        ),
+        quality_metric=_required_text(data.get("quality_metric"), "quality metric"),
+        quality_target=float_value(data.get("quality_target")),
+        minimum_quality_score=float_value(data.get("minimum_quality_score")),
+    )
+
+
+def _source_from_payload(
+    payload: Mapping[str, Any],
+) -> AV1ValidationPartitionSource:
+    data = object_dict(payload)
+    _require_exact_keys(
+        data,
+        {
+            "local_item_id",
+            "source_identity",
+            "title_identity",
+            "series_identity",
+            "source_group_identity",
+            "traits",
+            "compatibility_signature",
+            "base_policy_signature",
+            "target_video_bitrate_bps",
+            "quality_metric",
+            "quality_target",
+            "minimum_quality_score",
+            "evidence_summary_sha256",
+        },
+        "inventory source",
+    )
+    return AV1ValidationPartitionSource(
+        local_item_id=int_value(data.get("local_item_id")),
+        source_identity=_required_text(data.get("source_identity"), "source identity"),
+        title_identity=_required_text(data.get("title_identity"), "title identity"),
+        series_identity=_required_text(data.get("series_identity"), "series identity"),
+        source_group_identity=_required_text(
+            data.get("source_group_identity"), "source-group identity"
+        ),
+        traits=tuple(str(item) for item in object_list(data.get("traits"))),
+        compatibility_signature=_required_text(
+            data.get("compatibility_signature"), "compatibility signature"
+        ),
+        base_policy_signature=_required_text(
+            data.get("base_policy_signature"), "base policy signature"
+        ),
+        target_video_bitrate_bps=int_value(data.get("target_video_bitrate_bps")),
+        quality_metric=_required_text(data.get("quality_metric"), "quality metric"),
+        quality_target=float_value(data.get("quality_target")),
+        minimum_quality_score=float_value(data.get("minimum_quality_score")),
+        evidence_summary_sha256=_required_text(
+            data.get("evidence_summary_sha256"), "evidence digest"
+        ),
+    )
+
+
+def _plan_binding_from_payload(
+    payload: Mapping[str, Any],
+) -> AV1ValidationPartitionPlanBinding:
+    data = object_dict(payload)
+    _require_exact_keys(
+        data,
+        {
+            "cell_plan_id",
+            "intent_level",
+            "compatibility_signature",
+            "policy_signature",
+            "target_video_bitrate_min_bps",
+            "target_video_bitrate_max_bps",
+            "quality_metric",
+            "quality_target",
+            "minimum_quality_score",
+            "holdout_count",
+            "derivation_reservation_count",
+        },
+        "plan binding",
+    )
+    return AV1ValidationPartitionPlanBinding(
+        cell_plan_id=_required_text(data.get("cell_plan_id"), "cell-plan ID"),
+        intent_level=_required_text(data.get("intent_level"), "intent"),
+        compatibility_signature=_required_text(
+            data.get("compatibility_signature"),
+            "compatibility signature",
+        ),
+        policy_signature=_required_text(
+            data.get("policy_signature"), "policy signature"
+        ),
+        target_video_bitrate_min_bps=int_value(
+            data.get("target_video_bitrate_min_bps")
+        ),
+        target_video_bitrate_max_bps=int_value(
+            data.get("target_video_bitrate_max_bps")
+        ),
+        quality_metric=_required_text(data.get("quality_metric"), "quality metric"),
+        quality_target=float_value(data.get("quality_target")),
+        minimum_quality_score=float_value(data.get("minimum_quality_score")),
+        holdout_count=int_value(data.get("holdout_count")),
+        derivation_reservation_count=int_value(
+            data.get("derivation_reservation_count")
+        ),
+    )
+
+
+def _assignment_from_payload(
+    payload: Mapping[str, Any],
+) -> AV1ValidationPartitionAssignment:
+    data = object_dict(payload)
+    _require_exact_keys(
+        data,
+        {
+            "assignment_id",
+            "role",
+            "cell_plan_id",
+            "ordinal",
+            "traits",
+            "intent_level",
+            "source_token",
+            "title_token",
+            "series_token",
+            "source_group_token",
+            "compatibility_signature",
+            "policy_signature",
+            "target_video_bitrate_bps",
+            "quality_metric",
+            "quality_target",
+            "minimum_quality_score",
+            "local_item_id",
+            "evidence_summary_sha256",
+        },
+        "assignment",
+    )
+    role = _required_text(data.get("role"), "assignment role")
+    if role not in {"holdout", "derivation"}:
+        raise AV1ValidationPartitionError("AV1 partition assignment role is invalid")
+    return AV1ValidationPartitionAssignment(
+        assignment_id=_required_text(data.get("assignment_id"), "assignment ID"),
+        role=role,
+        cell_plan_id=_required_text(data.get("cell_plan_id"), "cell-plan ID"),
+        ordinal=int_value(data.get("ordinal")),
+        local_item_id=int_value(data.get("local_item_id")),
+        traits=tuple(str(item) for item in object_list(data.get("traits"))),
+        intent_level=_required_text(data.get("intent_level"), "intent"),
+        source_token=_required_text(data.get("source_token"), "source token"),
+        title_token=_required_text(data.get("title_token"), "title token"),
+        series_token=_required_text(data.get("series_token"), "series token"),
+        source_group_token=_required_text(
+            data.get("source_group_token"), "source-group token"
+        ),
+        compatibility_signature=_required_text(
+            data.get("compatibility_signature"),
+            "compatibility signature",
+        ),
+        policy_signature=_required_text(
+            data.get("policy_signature"), "policy signature"
+        ),
+        target_video_bitrate_bps=int_value(data.get("target_video_bitrate_bps")),
+        quality_metric=_required_text(data.get("quality_metric"), "quality metric"),
+        quality_target=float_value(data.get("quality_target")),
+        minimum_quality_score=float_value(data.get("minimum_quality_score")),
+        evidence_summary_sha256=_required_text(
+            data.get("evidence_summary_sha256"),
+            "evidence digest",
+        ),
+    )
+
+
+def _require_exact_keys(
+    payload: Mapping[str, Any],
+    expected: set[str],
+    label: str,
+) -> None:
+    if set(payload) != expected:
+        raise AV1ValidationPartitionError(f"AV1 partition {label} keys are invalid")

--- a/mediaforce/tuning/av1_validation_partition_inventory.py
+++ b/mediaforce/tuning/av1_validation_partition_inventory.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+import json
+import math
+import unicodedata
+from typing import Any, Mapping
+
+from sqlalchemy import select
+
+from mediaforce.core.config import MediaforceConfig
+from mediaforce.core.db import DBClient
+from mediaforce.core.db_tables import library_item_evidence_state, library_items
+from mediaforce.core.evidence import stable_json_hash
+from mediaforce.core.type_defs import object_dict
+from mediaforce.encoding.fingerprint import MEDIA_FINGERPRINT_EVIDENCE_KIND
+from mediaforce.library.media_scopes import (
+    media_group_scope_for_rel_path,
+    normalize_scope_prefix,
+    tv_series_scope_for_rel_path,
+)
+from mediaforce.tuning.av1_trait_projection import (
+    AV1_COLD_START_TRAIT_PROJECTION_CONTRACT_VERSION,
+    AV1ColdStartTraitProjectionError,
+    project_av1_cold_start_fingerprint_summary,
+)
+from mediaforce.tuning.av1_validation_partition import (
+    AV1_VALIDATION_PARTITION_CONTRACT_VERSION,
+    AV1ValidationPartitionExpectations,
+    AV1ValidationPartitionSource,
+)
+from mediaforce.tuning.stream_budget import (
+    resolve_stream_budget_ledger,
+    stream_budget_projection_blocker,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationPartitionInventory:
+    expectations: AV1ValidationPartitionExpectations
+    sources: tuple[AV1ValidationPartitionSource, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _EvidenceCompatibility:
+    summary_schema_version: int
+    analyzer_name: str
+    analyzer_version: str
+    analyzer_runtime_version: str
+    analyzer_policy_digest: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "summary_schema_version": self.summary_schema_version,
+            "analyzer_name": self.analyzer_name,
+            "analyzer_version": self.analyzer_version,
+            "analyzer_runtime_version": self.analyzer_runtime_version,
+            "analyzer_policy_digest": self.analyzer_policy_digest,
+        }
+
+
+def load_av1_validation_partition_inventory(
+    connection: DBClient,
+    *,
+    config: MediaforceConfig,
+) -> AV1ValidationPartitionInventory:
+    rows = list(
+        connection.execute(
+            select(
+                library_items.c.id,
+                library_items.c.rel_path,
+                library_items.c.fingerprint,
+                library_items.c.content_version_fingerprint,
+                library_items.c.size_bytes,
+                library_items.c.video_bitrate,
+                library_items.c.duration_seconds,
+                library_items.c.container,
+                library_items.c.audio_summary_json,
+                library_items.c.subtitle_summary_json,
+                library_items.c.attachment_summary_json,
+                library_items.c.media_fingerprint_json,
+                library_item_evidence_state.c.summary_sha256,
+                library_item_evidence_state.c.summary_schema_version,
+                library_item_evidence_state.c.analyzer_name,
+                library_item_evidence_state.c.analyzer_version,
+                library_item_evidence_state.c.analyzer_runtime_version,
+                library_item_evidence_state.c.policy_hash,
+            )
+            .join(
+                library_item_evidence_state,
+                library_item_evidence_state.c.library_item_id == library_items.c.id,
+            )
+            .where(
+                library_items.c.status != "missing",
+                library_item_evidence_state.c.evidence_kind
+                == MEDIA_FINGERPRINT_EVIDENCE_KIND,
+                library_item_evidence_state.c.state == "current",
+                library_item_evidence_state.c.decision_status == "measured",
+            )
+        ).mappings()
+    )
+    compatible_evidence = [
+        evidence
+        for row in rows
+        if (evidence := _evidence_compatibility(row)) is not None
+    ]
+    evidence_cohorts = Counter(compatible_evidence)
+    if not evidence_cohorts:
+        raise ValueError(
+            "AV1 partition inventory has no compatible measured fingerprint evidence"
+        )
+    expected_evidence = min(
+        evidence_cohorts,
+        key=lambda cohort: (-evidence_cohorts[cohort], _compatibility_sort_key(cohort)),
+    )
+    default_policy = _partition_policy(
+        {
+            "video": config.video,
+            "audio": config.audio,
+            "subtitle": config.subtitle,
+        }
+    )
+    expectations = _expectations(
+        config=config,
+        policy=default_policy,
+        evidence=expected_evidence,
+    )
+
+    sources = []
+    for row in rows:
+        evidence = _evidence_compatibility(row)
+        if evidence is None:
+            continue
+        source = _source_from_row(
+            row,
+            config=config,
+            evidence=evidence,
+        )
+        if source is not None:
+            sources.append(source)
+    source_counts = Counter(source.source_identity for source in sources)
+    unambiguous_sources = [
+        source for source in sources if source_counts[source.source_identity] == 1
+    ]
+    return AV1ValidationPartitionInventory(
+        expectations=expectations,
+        sources=tuple(
+            sorted(unambiguous_sources, key=lambda source: source.local_item_id)
+        ),
+    )
+
+
+def _source_from_row(
+    row: Mapping[str, Any],
+    *,
+    config: MediaforceConfig,
+    evidence: _EvidenceCompatibility,
+) -> AV1ValidationPartitionSource | None:
+    rel_path = normalize_scope_prefix(str(row.get("rel_path") or ""))
+    content_version = str(row.get("content_version_fingerprint") or "").strip()
+    summary_digest = str(row.get("summary_sha256") or "").strip()
+    if not rel_path or not content_version or not summary_digest:
+        return None
+    group_scope = media_group_scope_for_rel_path(
+        rel_path,
+        library_types=config.library_type_map,
+    )
+    if group_scope is None or not group_scope.prefix:
+        return None
+    series_scope = tv_series_scope_for_rel_path(
+        rel_path,
+        library_types=config.library_type_map,
+    )
+    series_prefix = (
+        series_scope.prefix if series_scope is not None else group_scope.prefix
+    )
+    try:
+        fingerprint_summary = object_dict(
+            json.loads(str(row.get("media_fingerprint_json") or "{}"))
+        )
+        projection = project_av1_cold_start_fingerprint_summary(fingerprint_summary)
+        audio_summary = json.loads(str(row.get("audio_summary_json") or "[]"))
+        subtitle_summary = json.loads(str(row.get("subtitle_summary_json") or "[]"))
+        attachment_raw = row.get("attachment_summary_json")
+        attachment_summary = json.loads(str(attachment_raw)) if attachment_raw else None
+    except (
+        AV1ColdStartTraitProjectionError,
+        json.JSONDecodeError,
+        TypeError,
+        ValueError,
+    ):
+        return None
+
+    resolved_policy = config.resolve_policy(rel_path)
+    normalized_policy = _partition_policy(resolved_policy)
+    quality_contract = _quality_contract(normalized_policy)
+    if quality_contract is None:
+        return None
+    quality_metric, quality_target, minimum_quality_score = quality_contract
+    item = {
+        "library_item_id": int(row["id"]),
+        "rel_path": rel_path,
+        "source_fingerprint": str(row.get("fingerprint") or "") or None,
+        "source_size_bytes": int(row.get("size_bytes") or 0),
+        "video_bitrate": row.get("video_bitrate"),
+        "duration_seconds": row.get("duration_seconds"),
+        "container": str(row.get("container") or ""),
+        "output_container": config.output_container,
+        "resolved_policy": resolved_policy,
+        "audio_summary": audio_summary,
+        "subtitle_summary": subtitle_summary,
+        "attachment_summary": attachment_summary,
+    }
+    try:
+        ledger = resolve_stream_budget_ledger(
+            item,
+            default_video_policy=config.video,
+            output_container=config.output_container,
+            prefer_persisted=False,
+        )
+    except (TypeError, ValueError):
+        return None
+    target_video_bitrate_bps = ledger.remaining_video_bitrate_bps
+    if (
+        ledger.feasibility_status != "feasible"
+        or target_video_bitrate_bps is None
+        or target_video_bitrate_bps <= 0
+        or stream_budget_projection_blocker(ledger) is not None
+    ):
+        return None
+    return AV1ValidationPartitionSource(
+        local_item_id=int(row["id"]),
+        source_identity=content_version,
+        title_identity=_normalized_identity(rel_path),
+        series_identity=_normalized_identity(series_prefix),
+        source_group_identity=_normalized_identity(group_scope.prefix),
+        traits=projection.cell_traits,
+        compatibility_signature=_compatibility_signature(
+            config=config,
+            evidence=evidence,
+        ),
+        base_policy_signature=_base_policy_signature(normalized_policy),
+        target_video_bitrate_bps=target_video_bitrate_bps,
+        quality_metric=quality_metric,
+        quality_target=quality_target,
+        minimum_quality_score=minimum_quality_score,
+        evidence_summary_sha256=summary_digest,
+    )
+
+
+def _expectations(
+    *,
+    config: MediaforceConfig,
+    policy: Mapping[str, Any],
+    evidence: _EvidenceCompatibility,
+) -> AV1ValidationPartitionExpectations:
+    quality_contract = _quality_contract(policy)
+    if quality_contract is None:
+        raise ValueError("AV1 partition default quality contract is incomplete")
+    quality_metric, quality_target, minimum_quality_score = quality_contract
+    return AV1ValidationPartitionExpectations(
+        compatibility_signature=_compatibility_signature(
+            config=config,
+            evidence=evidence,
+        ),
+        base_policy_signature=_base_policy_signature(policy),
+        quality_metric=quality_metric,
+        quality_target=quality_target,
+        minimum_quality_score=minimum_quality_score,
+    )
+
+
+def _partition_policy(policy: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = {
+        "video": dict(object_dict(policy.get("video"))),
+        "audio": dict(object_dict(policy.get("audio"))),
+        "subtitle": dict(object_dict(policy.get("subtitle"))),
+    }
+    for key in (
+        "compression_intent",
+        "compression_intent_source",
+        "compression_intent_confirmed",
+    ):
+        normalized["video"].pop(key, None)
+    return normalized
+
+
+def _base_policy_signature(policy: Mapping[str, Any]) -> str:
+    return f"av1vbasepolicy1_{
+        stable_json_hash(
+            {
+                'contract_version': AV1_VALIDATION_PARTITION_CONTRACT_VERSION,
+                'policy': policy,
+            }
+        )[:32]
+    }"
+
+
+def _compatibility_signature(
+    *,
+    config: MediaforceConfig,
+    evidence: _EvidenceCompatibility,
+) -> str:
+    video = config.video
+    payload = {
+        "contract_version": AV1_VALIDATION_PARTITION_CONTRACT_VERSION,
+        "trait_projection_contract_version": AV1_COLD_START_TRAIT_PROJECTION_CONTRACT_VERSION,
+        "output_container": config.output_container,
+        "video": {
+            key: video.get(key)
+            for key in (
+                "encoder",
+                "pixel_format",
+                "preset",
+                "quality_engine",
+                "quality_metric",
+                "max_height",
+                "resolution_intent_mode",
+                "downsample_algorithm",
+                "black_bar_handling",
+                "crop",
+            )
+        },
+        "fingerprint_evidence": evidence.to_payload(),
+    }
+    return f"av1vcompat1_{stable_json_hash(payload)[:32]}"
+
+
+def _quality_contract(policy: Mapping[str, Any]) -> tuple[str, float, float] | None:
+    video = object_dict(policy.get("video"))
+    metric = str(video.get("quality_metric") or "").strip().lower()
+    if metric == "vmaf":
+        target = _finite_number(video.get("target_vmaf"))
+        minimum = _finite_number(video.get("min_target_vmaf"))
+    elif metric == "xpsnr":
+        target = _finite_number(video.get("target_xpsnr"))
+        minimum = _finite_number(video.get("min_target_xpsnr"))
+    else:
+        return None
+    if target is None or minimum is None or minimum > target:
+        return None
+    return metric, target, minimum
+
+
+def _evidence_compatibility(row: Mapping[str, Any]) -> _EvidenceCompatibility | None:
+    summary_schema_version = int(row.get("summary_schema_version") or 0)
+    analyzer_name = str(row.get("analyzer_name") or "").strip()
+    analyzer_version = str(row.get("analyzer_version") or "").strip()
+    analyzer_runtime_version = str(row.get("analyzer_runtime_version") or "").strip()
+    analyzer_policy_digest = str(row.get("policy_hash") or "").strip()
+    if (
+        summary_schema_version <= 0
+        or not analyzer_name
+        or not analyzer_version
+        or not analyzer_runtime_version
+        or not analyzer_policy_digest
+    ):
+        return None
+    return _EvidenceCompatibility(
+        summary_schema_version=summary_schema_version,
+        analyzer_name=analyzer_name,
+        analyzer_version=analyzer_version,
+        analyzer_runtime_version=analyzer_runtime_version,
+        analyzer_policy_digest=analyzer_policy_digest,
+    )
+
+
+def _compatibility_sort_key(cohort: _EvidenceCompatibility) -> tuple[object, ...]:
+    return (
+        cohort.summary_schema_version,
+        cohort.analyzer_name,
+        cohort.analyzer_version,
+        cohort.analyzer_runtime_version,
+        cohort.analyzer_policy_digest,
+    )
+
+
+def _normalized_identity(value: str) -> str:
+    return unicodedata.normalize("NFC", normalize_scope_prefix(value)).casefold()
+
+
+def _finite_number(value: object) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed) or parsed < 0:
+        return None
+    return parsed

--- a/scripts/verify_av1_cold_start_preregistration.py
+++ b/scripts/verify_av1_cold_start_preregistration.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import sys
 from typing import Sequence, TypeAlias
 
+from mediaforce.core.config import DEFAULT_CONFIG_PATH, load_config
+from mediaforce.core.db import open_readonly_db
 from mediaforce.tuning.av1_cold_start_evaluation import (
     AV1ColdStartValidationError,
     AV1ColdStartValidationManifestV1,
@@ -21,9 +23,28 @@ from mediaforce.tuning.av1_validation_v2 import (
     load_av1_validation_manifest_v2,
     load_av1_validation_v2_eligibility,
 )
+from mediaforce.tuning.av1_validation_partition import (
+    AV1ValidationPartitionError,
+    assert_private_artifact_path,
+    av1_validation_partition_key_id,
+    av1_validation_partition_public_summary,
+    build_av1_validation_private_partition,
+    create_av1_validation_partition_key,
+    load_av1_validation_partition_key,
+    load_av1_validation_private_partition,
+    validate_av1_validation_partition_current_inputs,
+    validate_av1_validation_private_partition,
+    write_av1_validation_private_partition,
+)
+from mediaforce.tuning.av1_validation_partition_inventory import (
+    load_av1_validation_partition_inventory,
+)
 
 
-ValidationManifest: TypeAlias = AV1ColdStartValidationManifestV1 | AV1ValidationManifestV2
+ValidationManifest: TypeAlias = (
+    AV1ColdStartValidationManifestV1 | AV1ValidationManifestV2
+)
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -32,7 +53,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     actions = parser.add_subparsers(dest="action", required=True)
 
-    validate = actions.add_parser("validate", help="Validate one canonical preregistration manifest")
+    validate = actions.add_parser(
+        "validate", help="Validate one canonical preregistration manifest"
+    )
     validate.add_argument("manifest", type=Path)
     validate.add_argument("--json", action="store_true", dest="json_output")
 
@@ -43,11 +66,46 @@ def build_parser() -> argparse.ArgumentParser:
     eligibility.add_argument("attestation", type=Path)
     eligibility.add_argument("--json", action="store_true", dest="json_output")
 
-    report = actions.add_parser("report", help="Build a deterministic aggregate acceptance report")
+    create_key = actions.add_parser(
+        "create-partition-key",
+        help="Create one owner-only machine-local key for the private v2 source partition",
+    )
+    create_key.add_argument("key", type=Path)
+    create_key.add_argument("--json", action="store_true", dest="json_output")
+
+    build_partition = actions.add_parser(
+        "build-partition",
+        help="Build the private v2 source partition without authorizing execution",
+    )
+    build_partition.add_argument("manifest", type=Path)
+    build_partition.add_argument("eligibility", type=Path)
+    build_partition.add_argument("--key", type=Path, required=True)
+    build_partition.add_argument("--expected-token-key-id", required=True)
+    build_partition.add_argument("--output", type=Path, required=True)
+    build_partition.add_argument("--selected-at", required=True)
+    build_partition.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    build_partition.add_argument("--json", action="store_true", dest="json_output")
+
+    validate_partition = actions.add_parser(
+        "validate-partition",
+        help="Validate the exact private v2 source partition against current locked inputs",
+    )
+    validate_partition.add_argument("manifest", type=Path)
+    validate_partition.add_argument("eligibility", type=Path)
+    validate_partition.add_argument("partition", type=Path)
+    validate_partition.add_argument("--key", type=Path, required=True)
+    validate_partition.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    validate_partition.add_argument("--json", action="store_true", dest="json_output")
+
+    report = actions.add_parser(
+        "report", help="Build a deterministic aggregate acceptance report"
+    )
     report.add_argument("manifest", type=Path)
     report.add_argument("evidence", type=Path)
     report.add_argument("--as-of", required=True)
-    report.add_argument("--runtime-state", choices=("paused", "available"), default="paused")
+    report.add_argument(
+        "--runtime-state", choices=("paused", "available"), default="paused"
+    )
     report.add_argument("--json", action="store_true", dest="json_output")
     return parser
 
@@ -55,14 +113,38 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
+        if args.action == "create-partition-key":
+            assert_private_artifact_path(args.key, repository_root=REPOSITORY_ROOT)
+            token_key_id = create_av1_validation_partition_key(args.key)
+            payload = {
+                "created": True,
+                "token_key_id": token_key_id,
+                "runtime_execution_authorized": False,
+                "derivation_execution_authorized": False,
+                "holdout_execution_authorized": False,
+            }
+            _print_partition_payload(payload, json_output=args.json_output)
+            return 0
+
+        if args.action in {"build-partition", "validate-partition"}:
+            return _run_partition_action(args)
+
         if args.action == "validate-eligibility":
+            assert_private_artifact_path(
+                args.attestation,
+                repository_root=REPOSITORY_ROOT,
+            )
             eligibility = load_av1_validation_v2_eligibility(args.attestation)
             assert_preregistered_av1_validation_v2_eligibility(eligibility)
             payload = {
                 "attestation_id": eligibility.attestation_id,
                 "as_of": eligibility.as_of,
-                "eligible_cell_count": sum(cell.state == "eligible" for cell in eligibility.cells),
-                "excluded_cell_count": sum(cell.state == "excluded" for cell in eligibility.cells),
+                "eligible_cell_count": sum(
+                    cell.state == "eligible" for cell in eligibility.cells
+                ),
+                "excluded_cell_count": sum(
+                    cell.state == "excluded" for cell in eligibility.cells
+                ),
                 "runtime_execution_authorized": False,
                 "holdout_execution_authorized": False,
             }
@@ -110,21 +192,108 @@ def main(argv: Sequence[str] | None = None) -> int:
         else:
             print(format_av1_cold_start_validation_report(report))
         return 0 if report.supports_publication_review else 2
-    except (AV1ColdStartValidationError, AV1ValidationV2Error, OSError, json.JSONDecodeError) as exc:
+    except OSError:
+        print(
+            "AV1 cold-start validation failed: private or repository input is unreadable",
+            file=sys.stderr,
+        )
+        return 1
+    except (
+        AV1ColdStartValidationError,
+        AV1ValidationPartitionError,
+        AV1ValidationV2Error,
+        json.JSONDecodeError,
+        TypeError,
+        ValueError,
+    ) as exc:
         print(f"AV1 cold-start validation failed: {exc}", file=sys.stderr)
         return 1
+
+
+def _run_partition_action(args: argparse.Namespace) -> int:
+    manifest = load_av1_validation_manifest_v2(args.manifest)
+    assert_preregistered_av1_validation_manifest_v2(manifest)
+    assert_private_artifact_path(args.eligibility, repository_root=REPOSITORY_ROOT)
+    assert_private_artifact_path(args.key, repository_root=REPOSITORY_ROOT)
+    eligibility = load_av1_validation_v2_eligibility(args.eligibility)
+    assert_preregistered_av1_validation_v2_eligibility(eligibility)
+    token_key = load_av1_validation_partition_key(args.key)
+    if args.action == "build-partition":
+        assert_private_artifact_path(args.output, repository_root=REPOSITORY_ROOT)
+        config = load_config(args.config)
+        with open_readonly_db(config.paths.db_path) as connection:
+            inventory = load_av1_validation_partition_inventory(
+                connection,
+                config=config,
+            )
+        partition = build_av1_validation_private_partition(
+            manifest=manifest,
+            eligibility_attestation_id=eligibility.attestation_id,
+            eligibility_payload_sha256=eligibility.payload_sha256,
+            sources=inventory.sources,
+            expectations=inventory.expectations,
+            token_key=token_key,
+            expected_token_key_id=args.expected_token_key_id,
+            selected_at=args.selected_at,
+        )
+        write_av1_validation_private_partition(args.output, partition)
+    else:
+        assert_private_artifact_path(args.partition, repository_root=REPOSITORY_ROOT)
+        partition = load_av1_validation_private_partition(args.partition)
+        if av1_validation_partition_key_id(token_key) != partition.token_key_id:
+            raise AV1ValidationPartitionError(
+                "AV1 partition key does not match the frozen token-key ID"
+            )
+        validate_av1_validation_private_partition(
+            partition,
+            manifest=manifest,
+            token_key=token_key,
+        )
+        config = load_config(args.config)
+        with open_readonly_db(config.paths.db_path) as connection:
+            inventory = load_av1_validation_partition_inventory(
+                connection,
+                config=config,
+            )
+        validate_av1_validation_partition_current_inputs(
+            partition,
+            manifest=manifest,
+            sources=inventory.sources,
+            expectations=inventory.expectations,
+            token_key=token_key,
+        )
+    _print_partition_payload(
+        av1_validation_partition_public_summary(partition),
+        json_output=args.json_output,
+    )
+    return 0
+
+
+def _print_partition_payload(payload: dict[str, object], *, json_output: bool) -> None:
+    if json_output:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    fields = [
+        f"{key}={str(value).lower() if isinstance(value, bool) else value}"
+        for key, value in payload.items()
+    ]
+    print(" ".join(fields))
 
 
 def _load_manifest(path: Path) -> ValidationManifest:
     payload = json.loads(path.read_bytes())
     if not isinstance(payload, dict):
-        raise AV1ColdStartValidationError("AV1 validation manifest must be a JSON object")
+        raise AV1ColdStartValidationError(
+            "AV1 validation manifest must be a JSON object"
+        )
     schema_version = payload.get("schema_version")
     if schema_version == 1:
         return load_av1_cold_start_validation_manifest(path)
     if schema_version == 2:
         return load_av1_validation_manifest_v2(path)
-    raise AV1ColdStartValidationError("AV1 validation manifest schema version is unsupported")
+    raise AV1ColdStartValidationError(
+        "AV1 validation manifest schema version is unsupported"
+    )
 
 
 def _validation_payload(manifest: ValidationManifest) -> dict[str, object]:
@@ -135,8 +304,12 @@ def _validation_payload(manifest: ValidationManifest) -> dict[str, object]:
             "state": "preregistered_derivation_only",
             "authority": "derivation_only",
             "cell_plan_count": len(manifest.cell_plans),
-            "candidate_cell_count": sum(plan.mode == "publication_candidate" for plan in manifest.cell_plans),
-            "fallback_cell_count": sum(plan.mode == "fallback_conformance" for plan in manifest.cell_plans),
+            "candidate_cell_count": sum(
+                plan.mode == "publication_candidate" for plan in manifest.cell_plans
+            ),
+            "fallback_cell_count": sum(
+                plan.mode == "fallback_conformance" for plan in manifest.cell_plans
+            ),
             "excluded_cell_count": len(manifest.excluded_cells),
             "registered_case_count": len(manifest.cases),
             "runtime_execution_authorized": False,

--- a/tests/test_av1_validation_partition.py
+++ b/tests/test_av1_validation_partition.py
@@ -1,0 +1,431 @@
+import copy
+from dataclasses import replace
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+from mediaforce.tuning.av1_validation_partition import (
+    AV1ValidationPartitionError,
+    AV1ValidationPartitionExpectations,
+    AV1ValidationPartitionSource,
+    AV1ValidationPrivatePartition,
+    _ordered_partition_slots,
+    _partition_slots,
+    _select_sources,
+    av1_validation_partition_key_id,
+    av1_validation_private_partition_from_payload,
+    assert_private_artifact_path,
+    av1_validation_partition_public_summary,
+    build_av1_validation_private_partition,
+    create_av1_validation_partition_key,
+    load_av1_validation_partition_key,
+    load_av1_validation_private_partition,
+    validate_av1_validation_partition_current_inputs,
+    validate_av1_validation_private_partition,
+    write_av1_validation_private_partition,
+)
+from mediaforce.tuning.av1_validation_v2 import load_av1_validation_manifest_v2
+
+
+V2_MANIFEST_PATH = Path("docs/validation/av1-cold-start-preregistration-v2.json")
+SELECTED_AT = "2026-07-27T22:50:00Z"
+
+
+class AV1ValidationPartitionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manifest = load_av1_validation_manifest_v2(V2_MANIFEST_PATH)
+        self.expectations = AV1ValidationPartitionExpectations(
+            compatibility_signature="av1vcompat1_test_contract",
+            base_policy_signature="av1vbasepolicy1_test_contract",
+            quality_metric="vmaf",
+            quality_target=85.0,
+            minimum_quality_score=80.0,
+        )
+        self.sources = _partition_sources(self.expectations)
+        self.token_key = b"k" * 32
+        self.token_key_id = av1_validation_partition_key_id(self.token_key)
+
+    def test_partition_covers_exact_slots_and_has_no_execution_authority(self) -> None:
+        partition = self._build()
+        self.assertEqual(partition.holdout_count, 50)
+        self.assertEqual(partition.derivation_reservation_count, 24)
+        self.assertEqual(len(partition.assignments), 74)
+        self.assertEqual(
+            len({assignment.source_token for assignment in partition.assignments}),
+            74,
+        )
+        self.assertEqual(
+            len({assignment.title_token for assignment in partition.assignments}),
+            74,
+        )
+        self.assertEqual(
+            len({assignment.series_token for assignment in partition.assignments}),
+            74,
+        )
+        self.assertEqual(
+            len(
+                {assignment.source_group_token for assignment in partition.assignments}
+            ),
+            74,
+        )
+        summary = av1_validation_partition_public_summary(partition)
+        self.assertFalse(summary["runtime_execution_authorized"])
+        self.assertFalse(summary["derivation_execution_authorized"])
+        self.assertFalse(summary["holdout_execution_authorized"])
+        self.assertNotIn("local_item_id", json.dumps(summary))
+        self.assertNotIn("source_token", json.dumps(summary))
+
+    def test_partition_is_deterministic_for_shuffled_inventory(self) -> None:
+        expected = self._build()
+        actual = build_av1_validation_private_partition(
+            manifest=self.manifest,
+            eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+            eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+            sources=tuple(reversed(self.sources)),
+            expectations=self.expectations,
+            token_key=self.token_key,
+            expected_token_key_id=self.token_key_id,
+            selected_at=SELECTED_AT,
+        )
+        self.assertEqual(actual, expected)
+        validate_av1_validation_private_partition(
+            actual,
+            manifest=self.manifest,
+            token_key=self.token_key,
+        )
+        validate_av1_validation_partition_current_inputs(
+            actual,
+            manifest=self.manifest,
+            sources=self.sources,
+            expectations=self.expectations,
+            token_key=self.token_key,
+        )
+
+    def test_derivation_selection_cannot_remap_frozen_holdouts(self) -> None:
+        candidates_by_plan = {
+            plan.cell_plan_id: tuple(
+                source
+                for source in self.sources
+                if plan.trait_selector.matches(source.traits)
+            )
+            for plan in self.manifest.cell_plans
+        }
+        holdout_slots = _ordered_partition_slots(
+            _partition_slots(self.manifest),
+            candidates_by_plan=candidates_by_plan,
+            role="holdout",
+        )
+        holdout_selection = _select_sources(
+            slots=holdout_slots,
+            candidates_by_plan=candidates_by_plan,
+            manifest_id=self.manifest.manifest_id,
+            token_key=self.token_key,
+        )
+        partition_holdouts = {
+            assignment.assignment_id: assignment.local_item_id
+            for assignment in self._build().assignments
+            if assignment.role == "holdout"
+        }
+        self.assertEqual(
+            partition_holdouts,
+            {
+                assignment_id: source.local_item_id
+                for assignment_id, source in holdout_selection.items()
+            },
+        )
+
+    def test_partition_rejects_a_key_that_does_not_match_the_precommitment(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError,
+            "precommitted token-key ID",
+        ):
+            build_av1_validation_private_partition(
+                manifest=self.manifest,
+                eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+                eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+                sources=self.sources,
+                expectations=self.expectations,
+                token_key=self.token_key,
+                expected_token_key_id="av1vkey1_not_the_committed_key",
+                selected_at=SELECTED_AT,
+            )
+
+    def test_current_input_validation_rejects_a_narrowed_inventory(self) -> None:
+        partition = self._build()
+        selected_ids = {
+            assignment.local_item_id for assignment in partition.assignments
+        }
+        narrowed = tuple(
+            source for source in self.sources if source.local_item_id in selected_ids
+        )
+        narrowed_partition = build_av1_validation_private_partition(
+            manifest=self.manifest,
+            eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+            eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+            sources=narrowed,
+            expectations=self.expectations,
+            token_key=self.token_key,
+            expected_token_key_id=self.token_key_id,
+            selected_at=SELECTED_AT,
+        )
+        validate_av1_validation_private_partition(
+            narrowed_partition,
+            manifest=self.manifest,
+            token_key=self.token_key,
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError,
+            "does not match current inventory or policy inputs",
+        ):
+            validate_av1_validation_partition_current_inputs(
+                narrowed_partition,
+                manifest=self.manifest,
+                sources=self.sources,
+                expectations=self.expectations,
+                token_key=self.token_key,
+            )
+
+    def test_exact_candidate_selector_rejects_trait_supersets(self) -> None:
+        widened = tuple(
+            replace(source, traits=("darkness", "motion"))
+            if source.traits == ("motion",)
+            else source
+            for source in self.sources
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError, "lacks distinct eligible series"
+        ):
+            build_av1_validation_private_partition(
+                manifest=self.manifest,
+                eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+                eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+                sources=widened,
+                expectations=self.expectations,
+                token_key=self.token_key,
+                expected_token_key_id=self.token_key_id,
+                selected_at=SELECTED_AT,
+            )
+
+    def test_partition_fails_closed_when_global_series_disjointness_is_impossible(
+        self,
+    ) -> None:
+        repeated_series = tuple(
+            replace(source, series_identity="darkness-shared-series")
+            if source.traits == ("darkness",)
+            else source
+            for source in self.sources
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError, "lacks distinct eligible series"
+        ):
+            build_av1_validation_private_partition(
+                manifest=self.manifest,
+                eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+                eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+                sources=repeated_series,
+                expectations=self.expectations,
+                token_key=self.token_key,
+                expected_token_key_id=self.token_key_id,
+                selected_at=SELECTED_AT,
+            )
+
+    def test_partition_rejects_candidate_source_group_concentration(self) -> None:
+        darkness_index = 0
+        concentrated = []
+        for source in self.sources:
+            if source.traits != ("darkness",):
+                concentrated.append(source)
+                continue
+            darkness_index += 1
+            group = (
+                f"darkness-minority-{darkness_index}"
+                if darkness_index <= 11
+                else "darkness-dominant"
+            )
+            concentrated.append(replace(source, source_group_identity=group))
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError,
+            "lacks source-group concentration capacity",
+        ):
+            build_av1_validation_private_partition(
+                manifest=self.manifest,
+                eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+                eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+                sources=tuple(concentrated),
+                expectations=self.expectations,
+                token_key=self.token_key,
+                expected_token_key_id=self.token_key_id,
+                selected_at=SELECTED_AT,
+            )
+
+    def test_partition_rejects_fewer_than_six_candidate_source_groups(self) -> None:
+        grouped = tuple(
+            replace(
+                source,
+                source_group_identity=f"darkness-group-{source.local_item_id % 5}",
+            )
+            if source.traits == ("darkness",)
+            else source
+            for source in self.sources
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError,
+            "lacks disjoint candidate source-group diversity",
+        ):
+            build_av1_validation_private_partition(
+                manifest=self.manifest,
+                eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+                eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+                sources=grouped,
+                expectations=self.expectations,
+                token_key=self.token_key,
+                expected_token_key_id=self.token_key_id,
+                selected_at=SELECTED_AT,
+            )
+
+    def test_partition_rejects_duplicate_content_versions(self) -> None:
+        duplicate = replace(
+            self.sources[-1],
+            source_identity=self.sources[0].source_identity,
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError,
+            "repeats source identities",
+        ):
+            build_av1_validation_private_partition(
+                manifest=self.manifest,
+                eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+                eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+                sources=(*self.sources[:-1], duplicate),
+                expectations=self.expectations,
+                token_key=self.token_key,
+                expected_token_key_id=self.token_key_id,
+                selected_at=SELECTED_AT,
+            )
+
+    def test_partition_filters_policy_incompatible_sources(self) -> None:
+        incompatible = tuple(
+            replace(source, base_policy_signature="av1vbasepolicy1_incompatible")
+            if source.traits == ("motion",)
+            else source
+            for source in self.sources
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError, "lacks distinct eligible series"
+        ):
+            build_av1_validation_private_partition(
+                manifest=self.manifest,
+                eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+                eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+                sources=incompatible,
+                expectations=self.expectations,
+                token_key=self.token_key,
+                expected_token_key_id=self.token_key_id,
+                selected_at=SELECTED_AT,
+            )
+
+    def test_private_key_and_partition_are_owner_only_and_canonical(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            private_dir = Path(directory) / "private"
+            private_dir.mkdir(mode=0o700)
+            key_path = private_dir / "partition.key"
+            partition_path = private_dir / "partition.json"
+            create_av1_validation_partition_key(key_path)
+            key = load_av1_validation_partition_key(key_path)
+            partition = build_av1_validation_private_partition(
+                manifest=self.manifest,
+                eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+                eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+                sources=self.sources,
+                expectations=self.expectations,
+                token_key=key,
+                expected_token_key_id=av1_validation_partition_key_id(key),
+                selected_at=SELECTED_AT,
+            )
+            write_av1_validation_private_partition(partition_path, partition)
+            self.assertEqual(os.stat(key_path).st_mode & 0o777, 0o600)
+            self.assertEqual(os.stat(partition_path).st_mode & 0o777, 0o600)
+            self.assertEqual(
+                load_av1_validation_private_partition(partition_path), partition
+            )
+
+    def test_private_artifact_path_rejects_repository_contents(self) -> None:
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError, "outside the repository"
+        ):
+            assert_private_artifact_path(
+                Path("docs/validation/private-partition.json"),
+                repository_root=Path.cwd(),
+            )
+
+    def test_private_partition_parser_rejects_unknown_keys_and_algorithm_drift(
+        self,
+    ) -> None:
+        payload = copy.deepcopy(self._build().to_payload())
+        payload["unexpected"] = True
+        with self.assertRaisesRegex(AV1ValidationPartitionError, "keys are invalid"):
+            av1_validation_private_partition_from_payload(payload)
+
+        payload = copy.deepcopy(self._build().to_payload())
+        payload["selection_lock"]["assignment_algorithm"] = "unreviewed_algorithm"
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError,
+            "algorithm or token version is invalid",
+        ):
+            av1_validation_private_partition_from_payload(payload)
+
+    def _build(self) -> AV1ValidationPrivatePartition:
+        return build_av1_validation_private_partition(
+            manifest=self.manifest,
+            eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+            eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+            sources=self.sources,
+            expectations=self.expectations,
+            token_key=self.token_key,
+            expected_token_key_id=self.token_key_id,
+            selected_at=SELECTED_AT,
+        )
+
+
+def _partition_sources(
+    expectations: AV1ValidationPartitionExpectations,
+) -> tuple[AV1ValidationPartitionSource, ...]:
+    sources = []
+    local_item_id = 1
+    for label, traits, count in (
+        ("darkness", ("darkness",), 32),
+        ("motion", ("motion",), 32),
+        ("grain", ("grain_noise",), 6),
+        ("mixed", ("mixed",), 6),
+        ("texture", ("texture_detail",), 6),
+        ("typical", ("typical",), 12),
+    ):
+        for ordinal in range(1, count + 1):
+            identity = f"{label}-{ordinal:03d}"
+            sources.append(
+                AV1ValidationPartitionSource(
+                    local_item_id=local_item_id,
+                    source_identity=f"source-{identity}",
+                    title_identity=f"title-{identity}",
+                    series_identity=f"series-{identity}",
+                    source_group_identity=f"group-{identity}",
+                    traits=traits,
+                    compatibility_signature=expectations.compatibility_signature,
+                    base_policy_signature=expectations.base_policy_signature,
+                    target_video_bitrate_bps=500_000 + local_item_id,
+                    quality_metric=expectations.quality_metric,
+                    quality_target=expectations.quality_target,
+                    minimum_quality_score=expectations.minimum_quality_score,
+                    evidence_summary_sha256=f"sha256:{local_item_id:064x}",
+                )
+            )
+            local_item_id += 1
+    return tuple(sources)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the snapshot-backed `av1vsp1` private source partition and selection-lock contract
- add read-only inventory projection, HMAC key precommit, current-input drift checks, and holdout-first selection
- extend the verifier CLI and AV1 validation docs

## Validation
- `bash scripts/pre-commit-check.sh`
- `uv build`
- `uv run python scripts/verify_package_contents.py dist/mediaforce-0.1.0-py3-none-any.whl dist/mediaforce-0.1.0.tar.gz`
- scoped PyCharm inspection: clean
- independent architecture, model-contract, privacy/security, experimental-design, and adversarial reviews: approved

Implements the repository tooling required by #286. The issue remains open until the exact machine-local partition is built, independently reviewed, and frozen.
