### PR TITLE
Enforce AV1 partition chronology and privacy

### DIFF
--- a/docs/development/av1-cold-start-validation.md
+++ b/docs/development/av1-cold-start-validation.md
@@ -114,6 +114,10 @@ uv run python scripts/verify_av1_cold_start_preregistration.py \
   --selected-at 2026-07-27T23:00:00Z --json
 ```
 
+The selection timestamp must be at or after the manifest registration and
+strictly before its expiration. Both the initial build and every embedded or
+current-input replay reject an out-of-window timestamp.
+
 Validate both the embedded immutable private inventory snapshot and the current
 read-only database/config projection. A narrowed inventory, selected-source
 change, taxonomy change, policy change, or compatibility change fails the
@@ -165,6 +169,10 @@ counts:
 uv run python scripts/verify_av1_cold_start_preregistration.py \
   validate-eligibility /path/to/eligibility-attestation-v1.json --json
 ```
+
+Successful validation emits only `eligibility_valid=true` and false execution
+authority flags. It does not emit the attestation ID, cutoff timestamp, or any
+aggregate counts.
 
 ## Trait reachability preflight
 

--- a/mediaforce/tuning/av1_validation_partition.py
+++ b/mediaforce/tuning/av1_validation_partition.py
@@ -497,7 +497,23 @@ def build_av1_validation_private_partition(
 ) -> AV1ValidationPrivatePartition:
     assert_preregistered_av1_validation_manifest_v2(manifest)
     _assert_partition_criteria(manifest)
-    _parse_timestamp(selected_at, "selection timestamp")
+    selection_timestamp = _parse_timestamp(selected_at, "selection timestamp")
+    manifest_registered_at = _parse_timestamp(
+        manifest.registered_at,
+        "manifest registration",
+    )
+    manifest_valid_until = _parse_timestamp(
+        manifest.valid_until,
+        "manifest expiration",
+    )
+    if selection_timestamp < manifest_registered_at:
+        raise AV1ValidationPartitionError(
+            "AV1 partition selection timestamp predates manifest registration"
+        )
+    if selection_timestamp >= manifest_valid_until:
+        raise AV1ValidationPartitionError(
+            "AV1 partition selection timestamp must precede manifest expiration"
+        )
     _validate_key(token_key)
     token_key_id = _token_key_id(token_key)
     if expected_token_key_id != token_key_id:

--- a/scripts/verify_av1_cold_start_preregistration.py
+++ b/scripts/verify_av1_cold_start_preregistration.py
@@ -137,25 +137,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             eligibility = load_av1_validation_v2_eligibility(args.attestation)
             assert_preregistered_av1_validation_v2_eligibility(eligibility)
             payload = {
-                "attestation_id": eligibility.attestation_id,
-                "as_of": eligibility.as_of,
-                "eligible_cell_count": sum(
-                    cell.state == "eligible" for cell in eligibility.cells
-                ),
-                "excluded_cell_count": sum(
-                    cell.state == "excluded" for cell in eligibility.cells
-                ),
+                "eligibility_valid": True,
                 "runtime_execution_authorized": False,
+                "derivation_execution_authorized": False,
                 "holdout_execution_authorized": False,
             }
-            if args.json_output:
-                print(json.dumps(payload, indent=2, sort_keys=True))
-            else:
-                print(
-                    f"attestation={eligibility.attestation_id} as_of={eligibility.as_of} "
-                    f"eligible={payload['eligible_cell_count']} excluded={payload['excluded_cell_count']} "
-                    "runtime_execution_authorized=false holdout_execution_authorized=false"
-                )
+            _print_partition_payload(payload, json_output=args.json_output)
             return 0
 
         manifest = _load_manifest(args.manifest)

--- a/tests/test_av1_validation_partition.py
+++ b/tests/test_av1_validation_partition.py
@@ -1,10 +1,14 @@
 import copy
+from contextlib import redirect_stdout
 from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+import io
 import json
 import os
 from pathlib import Path
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from mediaforce.tuning.av1_validation_partition import (
     AV1ValidationPartitionError,
@@ -27,6 +31,7 @@ from mediaforce.tuning.av1_validation_partition import (
     write_av1_validation_private_partition,
 )
 from mediaforce.tuning.av1_validation_v2 import load_av1_validation_manifest_v2
+from scripts import verify_av1_cold_start_preregistration
 
 
 V2_MANIFEST_PATH = Path("docs/validation/av1-cold-start-preregistration-v2.json")
@@ -102,6 +107,59 @@ class AV1ValidationPartitionTests(unittest.TestCase):
             expectations=self.expectations,
             token_key=self.token_key,
         )
+
+    def test_partition_rejects_selection_outside_manifest_window(self) -> None:
+        registered_at = datetime.fromisoformat(
+            self.manifest.registered_at.replace("Z", "+00:00")
+        )
+        valid_until = datetime.fromisoformat(
+            self.manifest.valid_until.replace("Z", "+00:00")
+        )
+        partition = build_av1_validation_private_partition(
+            manifest=self.manifest,
+            eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+            eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+            sources=self.sources,
+            expectations=self.expectations,
+            token_key=self.token_key,
+            expected_token_key_id=self.token_key_id,
+            selected_at=self.manifest.registered_at,
+        )
+        self.assertEqual(partition.selected_at, self.manifest.registered_at)
+
+        invalid_timestamps = (
+            (
+                registered_at - timedelta(seconds=1),
+                "predates manifest registration",
+            ),
+            (valid_until, "must precede manifest expiration"),
+            (
+                valid_until + timedelta(seconds=1),
+                "must precede manifest expiration",
+            ),
+        )
+        for timestamp, message in invalid_timestamps:
+            selected_at = (
+                timestamp.astimezone(UTC)
+                .isoformat(timespec="seconds")
+                .replace("+00:00", "Z")
+            )
+            with self.subTest(selected_at=selected_at):
+                with self.assertRaisesRegex(AV1ValidationPartitionError, message):
+                    build_av1_validation_private_partition(
+                        manifest=self.manifest,
+                        eligibility_attestation_id=(
+                            self.manifest.eligibility_attestation_id
+                        ),
+                        eligibility_payload_sha256=(
+                            self.manifest.eligibility_payload_sha256
+                        ),
+                        sources=self.sources,
+                        expectations=self.expectations,
+                        token_key=self.token_key,
+                        expected_token_key_id=self.token_key_id,
+                        selected_at=selected_at,
+                    )
 
     def test_derivation_selection_cannot_remap_frozen_holdouts(self) -> None:
         candidates_by_plan = {
@@ -389,6 +447,49 @@ class AV1ValidationPartitionTests(unittest.TestCase):
             expected_token_key_id=self.token_key_id,
             selected_at=SELECTED_AT,
         )
+
+
+class AV1ValidationPartitionCliTests(unittest.TestCase):
+    def test_validate_eligibility_output_is_count_free(self) -> None:
+        expected = {
+            "eligibility_valid": True,
+            "runtime_execution_authorized": False,
+            "derivation_execution_authorized": False,
+            "holdout_execution_authorized": False,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            attestation_path = Path(directory) / "eligibility.json"
+            for json_output in (False, True):
+                output = io.StringIO()
+                argv = ["validate-eligibility", str(attestation_path)]
+                if json_output:
+                    argv.append("--json")
+                with (
+                    self.subTest(json_output=json_output),
+                    patch.object(
+                        verify_av1_cold_start_preregistration,
+                        "load_av1_validation_v2_eligibility",
+                        return_value=object(),
+                    ),
+                    patch.object(
+                        verify_av1_cold_start_preregistration,
+                        "assert_preregistered_av1_validation_v2_eligibility",
+                    ),
+                    redirect_stdout(output),
+                ):
+                    exit_code = verify_av1_cold_start_preregistration.main(argv)
+
+                self.assertEqual(exit_code, 0)
+                if json_output:
+                    self.assertEqual(json.loads(output.getvalue()), expected)
+                else:
+                    self.assertEqual(
+                        output.getvalue().strip(),
+                        "eligibility_valid=true "
+                        "runtime_execution_authorized=false "
+                        "derivation_execution_authorized=false "
+                        "holdout_execution_authorized=false",
+                    )
 
 
 def _partition_sources(


### PR DESCRIPTION
## Summary
- reject AV1 v2 partition selection timestamps before manifest registration or at/after expiration
- make standalone eligibility validation proof-only and count-free in JSON and text output
- add boundary, replay-contract, and output-regression coverage plus operator documentation

## Validation
- `bash scripts/pre-commit-check.sh`
- `uv build`
- `uv run python scripts/verify_package_contents.py dist/mediaforce-0.1.0-py3-none-any.whl dist/mediaforce-0.1.0.tar.gz`
- explicit PyCharm inspection of the three changed Python files: clean
- independent architecture, privacy/security, and adversarial reviews: approved
- real machine-local eligibility and current-input partition validation: passed with all execution authority false

Part of #286. This PR repairs preregistration gates only; it does not close the private partition issue or authorize runtime, derivation, holdouts, observations, or encodes.
