### PR TITLE
Add bounded AV1 v2 derivation workflow

### DIFF
--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -72,9 +72,11 @@ Guidance:
   - `job_runtime.py`
   - `calibration_runtime.py`
   - `av1_validation_derivation.py`
-    - isolated, derivation-only execution adapter over sampled calibration
+    - isolated derivation-only execution adapter over sampled calibration
+    - shared-lock verdict/finalization transactions and current-input rechecks
   - `runtime_lock.py`
     - shared process exclusivity for web and bounded operator runtimes
+    - stable parent-directory guard against lock-file unlink/recreate splits
   - `encode_runtime.py`
   - `folder_state.py`
   - `folder_actions.py`
@@ -262,6 +264,11 @@ Guidance:
 - `av1_validation_v2.py`
   - immutable v2 preregistration, digest-bound aggregate eligibility,
     explicit excluded-cell records, and fail-closed derivation-only authority
+- `av1_validation_derivation.py`
+  - immutable partition-global plan, attempt, terminal, proposal, review-claim,
+    review-evidence, and candidate-lock contracts
+  - preregistered candidate statistics, affected-cell stop semantics, and
+    authorization-bound Every Code runner identity
 - `av1_validation_partition.py`
   - pure private v2 partition schema, domain-separated HMAC selection/tokens,
     canonical selection-lock digests, and fail-closed identity constraints

--- a/docs/architecture/module-boundaries.md
+++ b/docs/architecture/module-boundaries.md
@@ -71,6 +71,10 @@ Guidance:
   - `queue_actions.py`
   - `job_runtime.py`
   - `calibration_runtime.py`
+  - `av1_validation_derivation.py`
+    - isolated, derivation-only execution adapter over sampled calibration
+  - `runtime_lock.py`
+    - shared process exclusivity for web and bounded operator runtimes
   - `encode_runtime.py`
   - `folder_state.py`
   - `folder_actions.py`

--- a/docs/development/av1-cold-start-validation.md
+++ b/docs/development/av1-cold-start-validation.md
@@ -216,6 +216,10 @@ directory carries an immutable binding to one plan or proposal, so artifacts
 cannot be mixed across authorization windows or review sets. Newly created
 claim files and newly created parent directories are fsynced before work can
 continue, so a power loss cannot silently erase assignment or review ownership.
+On the next runtime-lock-held invocation, an orphaned assignment claim is
+terminalized as an unfavorable `interrupted_claim` without rerunning media, and
+a persisted non-review attempt missing its terminal record is idempotently
+terminalized before any later reservation can run.
 
 Run one assignment at a time. The command revalidates the partition and current
 inventory before touching media, uses the exact assigned library item, forces
@@ -344,11 +348,14 @@ that claim; a crash leaves an unresolved terminal claim, and a rejected review
 remains terminal. The exact PATH-selected runner must match the authorization
 before launch and again after completion. The already-verified authorized bytes
 must be a native Mach-O executable, so a shebang wrapper cannot delegate to an
-unbound interpreter. Those bytes are executed from an owner-only ephemeral copy
+unbound interpreter. Its canonical path must also match the active ancestor Code
+process that is conducting the operator session, so a different PATH-selected
+native binary cannot establish its own trust root. Those bytes are executed from
+an owner-only ephemeral copy
 rather than reopening the mutable PATH-selected source. The review process uses
-a fixed system `PATH`, strips loader, interpreter, proxy, certificate, and model
-endpoint overrides, and gives agent shell commands an explicit minimal
-environment with no caller-environment inheritance. On the macOS execution host,
+a fixed system `PATH` and a strict allowlisted process environment containing no
+caller secrets; agent shell commands use the same explicit minimal environment
+with no caller-environment inheritance. On the macOS execution host,
 a held no-follow descriptor and kqueue vnode guard reject any write, delete,
 rename, link, or revoke event on that copy before its output can become evidence;
 unavailable secure monitoring fails closed. Each attestation binds the claim plus

--- a/docs/development/av1-cold-start-validation.md
+++ b/docs/development/av1-cold-start-validation.md
@@ -219,10 +219,17 @@ continue, so a power loss cannot silently erase assignment or review ownership.
 On the next runtime-lock-held invocation, an orphaned assignment claim is
 terminalized as an unfavorable `interrupted_claim` without rerunning media, and
 a persisted non-review attempt missing its terminal record is idempotently
-terminalized before any later reservation can run.
+terminalized before any later reservation can run. Recovery first confirms the
+same canonical state root and its frozen plan/partition bindings, then runs
+before full runtime-context, execution-environment, statistics-contract, live
+inventory, or source compatibility checks. Later database, review-directory,
+toolchain, policy-code, or source drift therefore cannot strand an existing
+claim. Because the state root also owns the global runtime lock, a moved
+`web_state_dir` must be restored before recovery rather than silently using a
+different lock domain.
 
-Run one assignment at a time. The command revalidates the partition and current
-inventory before touching media, uses the exact assigned library item, forces
+Run one fresh assignment at a time. The command revalidates the partition and
+current inventory before touching media, uses the exact assigned library item, forces
 the existing sampled calibration path to leave the cold-start planner absent,
 and preserves an owner-only attempt artifact plus review media. Derivation
 review clips are redirected beneath the partition-global private artifact root;
@@ -239,8 +246,12 @@ bounded derivation case. Machine or toolchain drift before the claim or after
 measurement is a safety stop rather than a newly compatible cohort.
 The shared lock uses a stable parent-directory guard in addition to the metadata
 file, so unlinking and recreating `mediaforce-web.lock` cannot create a second
-lock inode for another compliant runtime. `scripts/mediaforce-dev.sh` leaves
-that persistent lock path in place when stopping the backend.
+lock inode for another compliant runtime. The lock path resolves
+`web_state_dir` symlinks before choosing that parent, so aliases cannot create a
+second lock domain. Fresh execution samples its authorization timestamp only
+after all preflight checks and immediately before the immutable claim.
+`scripts/mediaforce-dev.sh` leaves that persistent lock path in place when
+stopping the backend.
 
 ```bash
 uv run python scripts/verify_av1_cold_start_preregistration.py \
@@ -365,6 +376,10 @@ transcript are written together as one immutable atomic lane envelope. Duplicate
 run IDs or transcript digests are rejected. The completed process must emit a
 matching quiescent agent message whose final non-empty line is the exact
 proposal-, lane-, claim-, and run-bound `MEDIAFORCE_AV1_REVIEW_V2` JSON marker;
+the JSONL parser requires one ordered config record and one ordered prompt,
+rejects duplicate JSON keys, reserved-field mixing, malformed or repeated
+completion, and any event after quiescence, and treats only LF/CRLF as record
+boundaries so Unicode line separators remain inside their JSON strings.
 the decision is extracted rather than supplied by the operator. Public summaries
 expose only that the runner identity is bound, never the canonical private path.
 Review, verdict, proposal, and lock timestamps come from the runtime clock.

--- a/docs/development/av1-cold-start-validation.md
+++ b/docs/development/av1-cold-start-validation.md
@@ -257,14 +257,17 @@ ineligible for local personalization, so later planning and holdout execution
 cannot consume them as warm-start evidence. The complete derivation terminal is
 preceded by an immutable verdict intent that freezes the first human input and
 runtime timestamp. The terminal is then validated and written as an immutable
-terminal intent before the observation is appended. The quarantined database
-row is committed before the immutable terminal record is completed; an
-interrupted retry reuses the frozen verdict timestamp, idempotently confirms the
-same observation, and finishes the missing terminal without replacing or
-duplicating evidence. Review-media identity is freshly recomputed immediately
-before the verdict and must still match the frozen attempt. The complete media
-recheck, immutable verdict intent, immediate database transaction, observation
-append, and terminal-intent/terminal-record path holds the shared runtime lock.
+terminal intent before the observation is appended. After a successful append,
+the immutable terminal record is written before the database transaction can
+commit. An append conflict therefore cannot create a false terminal, while a
+terminal-record write failure rolls back the database append. If the database
+commit fails after the immutable record exists, an interrupted retry reuses the
+frozen verdict timestamp and idempotently completes the same observation without
+replacing or duplicating evidence. Review-media identity is freshly recomputed
+immediately before the verdict and must still match the frozen attempt. The
+complete media recheck, immutable verdict intent, immediate database transaction,
+observation append, and terminal-intent/terminal-record path holds the shared
+runtime lock.
 Inside that lock it reloads the canonical plan and attempt, revalidates the
 current partition inputs and execution contract, and fails closed before any
 verdict or terminal mutation on drift.
@@ -322,10 +325,12 @@ the exact applied dispersion and confidence contract from immutable evidence.
 The full-search proof validates the native target-size trace contract, including
 the first `target_seed`, any later `compression_floor`, `expanded_bound`, or
 `refine` measurements, the native curve/retry policy, and exact selected CRF,
-quality, and bitrate projection values. A one-point `target_seed` trace remains
-valid when the unchanged search naturally selects its first measured candidate;
-the workflow does not force exploratory probes that production search would not
-perform.
+quality, and bitrate projection values. The persisted sample stream-budget
+ledger must also retain the exact frozen assignment
+`target_video_bitrate_bps`; a changed or missing remaining-video-bitrate value
+invalidates the attempt. A one-point `target_seed` trace remains valid when the
+unchanged search naturally selects its first measured candidate; the workflow
+does not force exploratory probes that production search would not perform.
 
 The resulting proposal is explicitly non-authoritative. Finalization requires
 five proposal-bound approvals from distinct completed Every Code agent runs:
@@ -337,17 +342,21 @@ binds the run nonce, authorization, proposal, lane, canonical runner-path
 digest, and runner-binary digest. A concurrent or repeated lane cannot replace
 that claim; a crash leaves an unresolved terminal claim, and a rejected review
 remains terminal. The exact PATH-selected runner must match the authorization
-before launch and again after completion, so PATH substitution or an in-place
-binary change fails closed. Each attestation binds the claim plus the SHA-256
-digest of the canonical immutable owner-only completion transcript, and the
-loader recomputes that digest before trusting it. The attestation and transcript
-are written together as one immutable atomic lane envelope. Duplicate run IDs
-or transcript digests are rejected. The completed process must emit a matching
-quiescent agent message whose final non-empty line is the exact proposal-,
-lane-, claim-, and run-bound `MEDIAFORCE_AV1_REVIEW_V2` JSON marker; the decision
-is extracted rather than supplied by the operator. Public summaries expose only
-that the runner identity is bound, never the canonical private path. Review,
-verdict, proposal, and lock timestamps come from the runtime clock.
+before launch and again after completion. The already-verified authorized bytes
+are executed from an owner-only ephemeral copy rather than reopening the mutable
+PATH-selected source. On the macOS execution host, a held no-follow descriptor
+and kqueue vnode guard reject any write, delete, rename, link, or revoke event on
+that copy before its output can become evidence; unavailable secure monitoring
+fails closed. Each attestation binds the claim plus the SHA-256 digest of the
+canonical immutable owner-only completion transcript, and the loader recomputes
+that digest before trusting it. The attestation and transcript are written
+together as one immutable atomic lane envelope. Duplicate run IDs or transcript
+digests are rejected. The completed process must emit a matching quiescent agent
+message whose final non-empty line is the exact proposal-, lane-, claim-, and
+run-bound `MEDIAFORCE_AV1_REVIEW_V2` JSON marker; the decision is extracted rather
+than supplied by the operator. Public summaries expose only that the runner
+identity is bound, never the canonical private path. Review, verdict, proposal,
+and lock timestamps come from the runtime clock.
 Finalization requires exactly five resolved claims and five matching approvals;
 any unresolved claim or rejection blocks it permanently.
 Finalization loads configuration once, opens an immediate database write

--- a/docs/development/av1-cold-start-validation.md
+++ b/docs/development/av1-cold-start-validation.md
@@ -343,20 +343,24 @@ digest, and runner-binary digest. A concurrent or repeated lane cannot replace
 that claim; a crash leaves an unresolved terminal claim, and a rejected review
 remains terminal. The exact PATH-selected runner must match the authorization
 before launch and again after completion. The already-verified authorized bytes
-are executed from an owner-only ephemeral copy rather than reopening the mutable
-PATH-selected source. On the macOS execution host, a held no-follow descriptor
-and kqueue vnode guard reject any write, delete, rename, link, or revoke event on
-that copy before its output can become evidence; unavailable secure monitoring
-fails closed. Each attestation binds the claim plus the SHA-256 digest of the
-canonical immutable owner-only completion transcript, and the loader recomputes
-that digest before trusting it. The attestation and transcript are written
-together as one immutable atomic lane envelope. Duplicate run IDs or transcript
-digests are rejected. The completed process must emit a matching quiescent agent
-message whose final non-empty line is the exact proposal-, lane-, claim-, and
-run-bound `MEDIAFORCE_AV1_REVIEW_V2` JSON marker; the decision is extracted rather
-than supplied by the operator. Public summaries expose only that the runner
-identity is bound, never the canonical private path. Review, verdict, proposal,
-and lock timestamps come from the runtime clock.
+must be a native Mach-O executable, so a shebang wrapper cannot delegate to an
+unbound interpreter. Those bytes are executed from an owner-only ephemeral copy
+rather than reopening the mutable PATH-selected source. The review process uses
+a fixed system `PATH`, strips loader, interpreter, proxy, certificate, and model
+endpoint overrides, and gives agent shell commands an explicit minimal
+environment with no caller-environment inheritance. On the macOS execution host,
+a held no-follow descriptor and kqueue vnode guard reject any write, delete,
+rename, link, or revoke event on that copy before its output can become evidence;
+unavailable secure monitoring fails closed. Each attestation binds the claim plus
+the SHA-256 digest of the canonical immutable owner-only completion transcript,
+and the loader recomputes that digest before trusting it. The attestation and
+transcript are written together as one immutable atomic lane envelope. Duplicate
+run IDs or transcript digests are rejected. The completed process must emit a
+matching quiescent agent message whose final non-empty line is the exact
+proposal-, lane-, claim-, and run-bound `MEDIAFORCE_AV1_REVIEW_V2` JSON marker;
+the decision is extracted rather than supplied by the operator. Public summaries
+expose only that the runner identity is bound, never the canonical private path.
+Review, verdict, proposal, and lock timestamps come from the runtime clock.
 Finalization requires exactly five resolved claims and five matching approvals;
 any unresolved claim or rejection blocks it permanently.
 Finalization loads configuration once, opens an immediate database write

--- a/docs/development/av1-cold-start-validation.md
+++ b/docs/development/av1-cold-start-validation.md
@@ -236,10 +236,42 @@ review clips are redirected beneath the partition-global private artifact root;
 their directory is `0700`, files are `0600`, and verdict-time identity checks
 use no-follow file descriptors:
 
+Private partition creation first performs logical selection without hashing the
+broader eligible library. It then handles only the selected holdout and
+derivation sources: each selected file is opened with no-follow semantics,
+guarded together with its canonical pathname ancestors, fully SHA-256 hashed,
+and re-analyzed with the current media-fingerprint toolchain. The fresh
+canonical fingerprint summary must exactly reproduce the immutable evidence
+digest used for selection. A changed unsampled byte therefore cannot preserve
+stale traits while acquiring a new frozen digest. The selected source SHA-256
+is private assignment data and contributes to the inventory lock, derivation
+partition, authorization, and plan digests; public summaries never expose it.
+Older private partitions without this binding fail closed.
+
+After the immutable assignment claim and before crop, search, encode, or review
+work, the runtime opens the assigned source with no-follow semantics, verifies
+its inode, size, sampled identity, and frozen full SHA-256, and copies the
+complete file into a private owner-only snapshot under the canonical artifact
+root. It records the snapshot's full SHA-256 and size in the immutable
+calibration payload, closes the writable descriptor, reopens the snapshot
+read-only, and routes every source read through that canonical snapshot path
+rather than the mutable library path. A macOS kqueue guard watches the snapshot
+vnode and every canonical pathname ancestor throughout media work; write,
+extend, attribute, hardlink, delete, rename, or revoke activity is latched even
+if bytes or names are later restored. The snapshot must keep one link, the
+source and snapshot identities are rechecked, and final guard validation runs
+even when media work raises. Creating the snapshot requires free space for the
+complete source plus the existing five-gibibyte safety floor. Snapshots are
+removed after the attempt; crash leftovers are purged under the runtime lock
+when interruption recovery terminalizes the owned assignment.
+
 The authorization binds the resolved database, review, and state roots together
-with the current machine, AV1 encoder/metric toolchain, and merged statistical
-contract. It also binds SHA-256 digests of the canonical Every Code executable
-path and binary without persisting or printing the private path. Assignment
+with the current machine, Python executable, relevant Mediaforce implementation
+files, AV1 encoder/metric toolchain, source-integrity guard contract, and merged
+statistical contract. It also binds SHA-256 digests of the canonical Every Code
+executable path and binary without persisting or printing the private path. A
+real same-filesystem kqueue mutation probe must pass before the immutable
+assignment claim is written. Assignment
 execution holds the same exclusive runtime lock as
 `mediaforce-web`, so web, staging, database, and cleanup work cannot overlap the
 bounded derivation case. Machine or toolchain drift before the claim or after

--- a/docs/development/av1-cold-start-validation.md
+++ b/docs/development/av1-cold-start-validation.md
@@ -176,7 +176,7 @@ aggregate counts.
 
 ## Bounded v2 derivation workflow
 
-Issue `#287` uses `av1vdw1` to turn the reviewed partition into one immutable,
+Issue `#287` uses `av1vdw2` to turn the reviewed partition into one immutable,
 owner-only derivation plan. Plan creation revalidates the exact partition
 against the current read-only inventory before it embeds the separate
 `acsvda1` authorization and exactly twenty-four derivation assignments:
@@ -192,8 +192,11 @@ uv run python scripts/verify_av1_cold_start_preregistration.py \
 ```
 
 The plan authorizes only its twelve motion and twelve darkness reservations.
-The command writes `plan.json` only beneath the plan-global canonical private
-state root derived from `web_state_dir`; there is no caller-selected plan path.
+The command writes `plan.json` only beneath the partition-global canonical
+private state root derived from `web_state_dir`; there is no caller-selected
+plan path. The root is keyed by the frozen private partition and immutably bound
+to the first authorization and plan, so a second authorization cannot rerun the
+same reservations under another plan ID.
 Its authorization timestamp comes from the runtime clock. The plan binds a
 privacy-safe digest of the resolved database, review, and web-state locations;
 every later command must use that same machine-local runtime context. Every
@@ -205,33 +208,42 @@ source, use a holdout, invoke the validation harness, inject a cold-start or
 guided probe, consume local personalization, backfill a historical row, or
 activate the public bundle. A claim file is created before media work begins so
 an interrupted process cannot silently rerun the same reservation. Attempt,
-terminal-intent, terminal-record, proposal, review, and candidate-lock artifacts
-live under the plan-global canonical private state root derived from
-`web_state_dir`; callers cannot select alternate artifact directories. Each
+terminal-intent, terminal-record, proposal, review-claim, review, and
+candidate-lock artifacts live under the partition-global canonical private
+state root derived from `web_state_dir`; callers cannot select alternate
+artifact directories. Each
 directory carries an immutable binding to one plan or proposal, so artifacts
-cannot be mixed across authorization windows or review sets.
+cannot be mixed across authorization windows or review sets. Newly created
+claim files and newly created parent directories are fsynced before work can
+continue, so a power loss cannot silently erase assignment or review ownership.
 
 Run one assignment at a time. The command revalidates the partition and current
 inventory before touching media, uses the exact assigned library item, forces
 the existing sampled calibration path to leave the cold-start planner absent,
 and preserves an owner-only attempt artifact plus review media. Derivation
-review clips are redirected beneath the plan-global private artifact root;
+review clips are redirected beneath the partition-global private artifact root;
 their directory is `0700`, files are `0600`, and verdict-time identity checks
 use no-follow file descriptors:
 
 The authorization binds the resolved database, review, and state roots together
 with the current machine, AV1 encoder/metric toolchain, and merged statistical
-contract. Assignment execution holds the same exclusive runtime lock as
+contract. It also binds SHA-256 digests of the canonical Every Code executable
+path and binary without persisting or printing the private path. Assignment
+execution holds the same exclusive runtime lock as
 `mediaforce-web`, so web, staging, database, and cleanup work cannot overlap the
 bounded derivation case. Machine or toolchain drift before the claim or after
 measurement is a safety stop rather than a newly compatible cohort.
+The shared lock uses a stable parent-directory guard in addition to the metadata
+file, so unlinking and recreating `mediaforce-web.lock` cannot create a second
+lock inode for another compliant runtime. `scripts/mediaforce-dev.sh` leaves
+that persistent lock path in place when stopping the backend.
 
 ```bash
 uv run python scripts/verify_av1_cold_start_preregistration.py \
   run-derivation-assignment \
   docs/validation/av1-cold-start-preregistration-v2.json \
   /private/owner-only/av1-v2/source-partition-v1.json \
-  '<web_state_dir>/av1-validation-derivation/<plan_id>/plan.json' \
+  '<web_state_dir>/av1-validation-derivation/<partition_id>/plan.json' \
   av1vderive1_<opaque-slot> \
   --key /private/owner-only/av1-v2/partition.key \
   --config /private/owner-only/mediaforce.toml --json
@@ -250,13 +262,36 @@ row is committed before the immutable terminal record is completed; an
 interrupted retry reuses the frozen verdict timestamp, idempotently confirms the
 same observation, and finishes the missing terminal without replacing or
 duplicating evidence. Review-media identity is freshly recomputed immediately
-before the verdict and must still match the frozen attempt.
+before the verdict and must still match the frozen attempt. The complete media
+recheck, immutable verdict intent, immediate database transaction, observation
+append, and terminal-intent/terminal-record path holds the shared runtime lock.
+Inside that lock it reloads the canonical plan and attempt, revalidates the
+current partition inputs and execution contract, and fails closed before any
+verdict or terminal mutation on drift.
+
+```bash
+uv run python scripts/verify_av1_cold_start_preregistration.py \
+  record-derivation-verdict \
+  docs/validation/av1-cold-start-preregistration-v2.json \
+  /private/owner-only/av1-v2/source-partition-v1.json \
+  '<web_state_dir>/av1-validation-derivation/<partition_id>/plan.json' \
+  av1vderive1_<opaque-slot> \
+  --key /private/owner-only/av1-v2/partition.key \
+  --verdict approved \
+  --config /private/owner-only/mediaforce.toml --json
+```
+
 Rejected, excluded, failed, stopped, and missing outcomes remain visible and
 cannot be replaced. The next reservation cannot run until every prior technical
-attempt has its human terminal. Any terminal unsuccessful attempt or unfavorable
-reviewed record stops later assignments. Because each candidate has exactly
-twelve reservations and requires twelve eligible observations, any unfavorable
-or incomplete reservation is an exact candidate no-go.
+attempt has its human terminal. In accordance with the preregistered
+`safety_stop_scope=affected_cell`, a terminal unsuccessful attempt or
+unfavorable reviewed record permanently stops only that candidate cell. The
+global immutable assignment order remains authoritative: later assignments in
+the stopped cell are never allowed, while the next assignment in another cell
+may proceed only at its original canonical position. Because each candidate has
+exactly twelve reservations and requires twelve eligible observations, the
+affected candidate is an exact no-go without stopping collection for the other
+candidate.
 
 Candidate derivation uses every retained terminal record. The proposal and final
 candidate lock retain opaque source, logical-title, series, and source-group
@@ -269,12 +304,18 @@ enters those artifacts. For an eligible cell, the CRF bounds are the full
 observed minimum and maximum with the median center;
 no trimming is allowed. CRF MAD must be at most `2.0`, the full span must be at
 most `6`, and the range must contain an executable integer CRF. The bitrate
-range is the full observed minimum and maximum. The quality floor remains the
-numeric value frozen in the partition. Confidence reuses the existing bitrate
-relative-MAD categories and records `round(1 - relative_mad, 3)` after the hard
-evidence and independent-source minima; limited confidence or a score below
-`0.7` is a no-go. The proposal records the measured CRF MAD, bitrate relative
-MAD, derived conflict count, and pre-run statistical-contract digest. A
+applicability range is the minimum and maximum frozen assignment
+`target_video_bitrate_bps`, not the measured visual boundary bitrate. Measured
+boundary bitrates remain the dispersion and confidence input. The quality floor
+remains the numeric value frozen in the partition. Confidence reuses the
+existing bitrate relative-MAD categories and records
+`round(1 - relative_mad, 3)` after the hard evidence and preregistered
+independent-source minima; limited confidence or a score below `0.7` is a no-go.
+Proposal and lock types independently enforce exactly one series token per
+observation, the preregistered source minimum, a CRF span no wider than `6`, and
+freshness at proposal and lock time. The proposal records the measured CRF MAD,
+bitrate relative MAD, derived conflict count, and pre-run statistical-contract
+digest. A
 proposal exists only when the conflict count is zero, so reviewers can verify
 the exact applied dispersion and confidence contract from immutable evidence.
 
@@ -291,29 +332,40 @@ five proposal-bound approvals from distinct completed Every Code agent runs:
 architecture, statistical/model-contract, privacy/security,
 experimental-design, and adversarial. `record-derivation-review` launches a new
 read-only `code exec --json` process itself; it accepts no caller-supplied result
-path. Each attestation binds a fresh run nonce and SHA-256 digest of the
-immutable owner-only completion transcript. The attestation and transcript are
-written together as one immutable atomic lane envelope, preventing a crash from
-leaving a trusted half-review. Duplicate run IDs or transcript digests are
-rejected. The completed process must emit a matching quiescent
-agent message whose final non-empty line is the exact proposal-, lane-, and
-run-bound `MEDIAFORCE_AV1_REVIEW_V2` JSON marker; the decision is extracted
-rather than supplied by the operator. Review, verdict, proposal, and lock
-timestamps come from the runtime clock. A rejection blocks finalization.
+path. Before launch it atomically creates one immutable proposal/lane claim that
+binds the run nonce, authorization, proposal, lane, canonical runner-path
+digest, and runner-binary digest. A concurrent or repeated lane cannot replace
+that claim; a crash leaves an unresolved terminal claim, and a rejected review
+remains terminal. The exact PATH-selected runner must match the authorization
+before launch and again after completion, so PATH substitution or an in-place
+binary change fails closed. Each attestation binds the claim plus the SHA-256
+digest of the canonical immutable owner-only completion transcript, and the
+loader recomputes that digest before trusting it. The attestation and transcript
+are written together as one immutable atomic lane envelope. Duplicate run IDs
+or transcript digests are rejected. The completed process must emit a matching
+quiescent agent message whose final non-empty line is the exact proposal-,
+lane-, claim-, and run-bound `MEDIAFORCE_AV1_REVIEW_V2` JSON marker; the decision
+is extracted rather than supplied by the operator. Public summaries expose only
+that the runner identity is bound, never the canonical private path. Review,
+verdict, proposal, and lock timestamps come from the runtime clock.
+Finalization requires exactly five resolved claims and five matching approvals;
+any unresolved claim or rejection blocks it permanently.
 Finalization loads configuration once, opens an immediate database write
 transaction, revalidates the frozen partition against inventory in that same
 transaction, rereads current observations, and computes and writes the lock
 through one runtime-owned finalization API. That API derives the canonical root
 from config and the immutable plan path, loads the attempts, terminals,
-proposal, and review envelopes itself, and exposes no write-capable caller path
-that accepts a precomputed evaluation. A finalized candidate lock still does
-not authorize holdout execution or mutate the shipped public bundle.
+proposal, review claims, and review envelopes itself, and exposes no
+write-capable caller path that accepts a precomputed evaluation. A finalized
+candidate lock still does not authorize holdout execution or mutate the shipped
+public bundle.
 
 The candidate-lock file is a provenance envelope, not a standalone lock. It
-commits to the plan and derivation authorization, proposal, five atomic review
-envelopes, canonical artifact-root binding, candidate lock, and terminal
-snapshot. #288 must load it through the verified derivation-chain loader and
-must reject a raw or synthetic candidate lock. That loader also derives the
+commits to the plan and derivation authorization, proposal, five immutable
+review claims, five atomic review envelopes, canonical artifact-root binding,
+candidate lock, and terminal snapshot. #288 must load it through the verified
+derivation-chain loader and must reject a raw or synthetic candidate lock. That
+loader also derives the
 root from config, reloads the full chain, and rechecks current database evidence
 inside an immediate transaction. These owner-local hashes detect
 stale, copied, mixed, and partially replaced artifacts; they do not claim to

--- a/docs/development/av1-cold-start-validation.md
+++ b/docs/development/av1-cold-start-validation.md
@@ -174,6 +174,152 @@ Successful validation emits only `eligibility_valid=true` and false execution
 authority flags. It does not emit the attestation ID, cutoff timestamp, or any
 aggregate counts.
 
+## Bounded v2 derivation workflow
+
+Issue `#287` uses `av1vdw1` to turn the reviewed partition into one immutable,
+owner-only derivation plan. Plan creation revalidates the exact partition
+against the current read-only inventory before it embeds the separate
+`acsvda1` authorization and exactly twenty-four derivation assignments:
+
+```bash
+uv run python scripts/verify_av1_cold_start_preregistration.py \
+  create-derivation-plan \
+  docs/validation/av1-cold-start-preregistration-v2.json \
+  /private/owner-only/eligibility-attestation-v1.json \
+  /private/owner-only/av1-v2/source-partition-v1.json \
+  --key /private/owner-only/av1-v2/partition.key \
+  --valid-until YYYY-MM-DDTHH:MM:SSZ --json
+```
+
+The plan authorizes only its twelve motion and twelve darkness reservations.
+The command writes `plan.json` only beneath the plan-global canonical private
+state root derived from `web_state_dir`; there is no caller-selected plan path.
+Its authorization timestamp comes from the runtime clock. The plan binds a
+privacy-safe digest of the resolved database, review, and web-state locations;
+every later command must use that same machine-local runtime context. Every
+execution, proposal, and finalization also re-compares the plan's complete
+twenty-four-assignment payload with the frozen partition rather than trusting
+top-level digests alone.
+Each assignment has one attempt. Execution cannot select a replacement, retry a
+source, use a holdout, invoke the validation harness, inject a cold-start or
+guided probe, consume local personalization, backfill a historical row, or
+activate the public bundle. A claim file is created before media work begins so
+an interrupted process cannot silently rerun the same reservation. Attempt,
+terminal-intent, terminal-record, proposal, review, and candidate-lock artifacts
+live under the plan-global canonical private state root derived from
+`web_state_dir`; callers cannot select alternate artifact directories. Each
+directory carries an immutable binding to one plan or proposal, so artifacts
+cannot be mixed across authorization windows or review sets.
+
+Run one assignment at a time. The command revalidates the partition and current
+inventory before touching media, uses the exact assigned library item, forces
+the existing sampled calibration path to leave the cold-start planner absent,
+and preserves an owner-only attempt artifact plus review media. Derivation
+review clips are redirected beneath the plan-global private artifact root;
+their directory is `0700`, files are `0600`, and verdict-time identity checks
+use no-follow file descriptors:
+
+The authorization binds the resolved database, review, and state roots together
+with the current machine, AV1 encoder/metric toolchain, and merged statistical
+contract. Assignment execution holds the same exclusive runtime lock as
+`mediaforce-web`, so web, staging, database, and cleanup work cannot overlap the
+bounded derivation case. Machine or toolchain drift before the claim or after
+measurement is a safety stop rather than a newly compatible cohort.
+
+```bash
+uv run python scripts/verify_av1_cold_start_preregistration.py \
+  run-derivation-assignment \
+  docs/validation/av1-cold-start-preregistration-v2.json \
+  /private/owner-only/av1-v2/source-partition-v1.json \
+  '<web_state_dir>/av1-validation-derivation/<plan_id>/plan.json' \
+  av1vderive1_<opaque-slot> \
+  --key /private/owner-only/av1-v2/partition.key \
+  --config /private/owner-only/mediaforce.toml --json
+```
+
+Successful technical attempts remain `review_pending` until a human records an
+explicit visual verdict. The verdict path appends the existing current-contract
+`ContentIntentBoundaryObservation`; it never infers a verdict. Derivation rows
+are active evidence for the bound candidate snapshot but are explicitly marked
+ineligible for local personalization, so later planning and holdout execution
+cannot consume them as warm-start evidence. The complete derivation terminal is
+preceded by an immutable verdict intent that freezes the first human input and
+runtime timestamp. The terminal is then validated and written as an immutable
+terminal intent before the observation is appended. The quarantined database
+row is committed before the immutable terminal record is completed; an
+interrupted retry reuses the frozen verdict timestamp, idempotently confirms the
+same observation, and finishes the missing terminal without replacing or
+duplicating evidence. Review-media identity is freshly recomputed immediately
+before the verdict and must still match the frozen attempt.
+Rejected, excluded, failed, stopped, and missing outcomes remain visible and
+cannot be replaced. The next reservation cannot run until every prior technical
+attempt has its human terminal. Any terminal unsuccessful attempt or unfavorable
+reviewed record stops later assignments. Because each candidate has exactly
+twelve reservations and requires twelve eligible observations, any unfavorable
+or incomplete reservation is an exact candidate no-go.
+
+Candidate derivation uses every retained terminal record. The proposal and final
+candidate lock retain opaque source, logical-title, series, and source-group
+token sets plus the sorted source-group token for every derivation observation.
+That multiplicity-preserving projection makes the six-group minimum and
+one-third concentration maximum independently verifiable after serialization,
+while later holdout evidence can recheck within-holdout title uniqueness and
+every derivation/holdout overlap dimension. No raw title or source identity
+enters those artifacts. For an eligible cell, the CRF bounds are the full
+observed minimum and maximum with the median center;
+no trimming is allowed. CRF MAD must be at most `2.0`, the full span must be at
+most `6`, and the range must contain an executable integer CRF. The bitrate
+range is the full observed minimum and maximum. The quality floor remains the
+numeric value frozen in the partition. Confidence reuses the existing bitrate
+relative-MAD categories and records `round(1 - relative_mad, 3)` after the hard
+evidence and independent-source minima; limited confidence or a score below
+`0.7` is a no-go. The proposal records the measured CRF MAD, bitrate relative
+MAD, derived conflict count, and pre-run statistical-contract digest. A
+proposal exists only when the conflict count is zero, so reviewers can verify
+the exact applied dispersion and confidence contract from immutable evidence.
+
+The full-search proof validates the native target-size trace contract, including
+the first `target_seed`, any later `compression_floor`, `expanded_bound`, or
+`refine` measurements, the native curve/retry policy, and exact selected CRF,
+quality, and bitrate projection values. A one-point `target_seed` trace remains
+valid when the unchanged search naturally selects its first measured candidate;
+the workflow does not force exploratory probes that production search would not
+perform.
+
+The resulting proposal is explicitly non-authoritative. Finalization requires
+five proposal-bound approvals from distinct completed Every Code agent runs:
+architecture, statistical/model-contract, privacy/security,
+experimental-design, and adversarial. `record-derivation-review` launches a new
+read-only `code exec --json` process itself; it accepts no caller-supplied result
+path. Each attestation binds a fresh run nonce and SHA-256 digest of the
+immutable owner-only completion transcript. The attestation and transcript are
+written together as one immutable atomic lane envelope, preventing a crash from
+leaving a trusted half-review. Duplicate run IDs or transcript digests are
+rejected. The completed process must emit a matching quiescent
+agent message whose final non-empty line is the exact proposal-, lane-, and
+run-bound `MEDIAFORCE_AV1_REVIEW_V2` JSON marker; the decision is extracted
+rather than supplied by the operator. Review, verdict, proposal, and lock
+timestamps come from the runtime clock. A rejection blocks finalization.
+Finalization loads configuration once, opens an immediate database write
+transaction, revalidates the frozen partition against inventory in that same
+transaction, rereads current observations, and computes and writes the lock
+through one runtime-owned finalization API. That API derives the canonical root
+from config and the immutable plan path, loads the attempts, terminals,
+proposal, and review envelopes itself, and exposes no write-capable caller path
+that accepts a precomputed evaluation. A finalized candidate lock still does
+not authorize holdout execution or mutate the shipped public bundle.
+
+The candidate-lock file is a provenance envelope, not a standalone lock. It
+commits to the plan and derivation authorization, proposal, five atomic review
+envelopes, canonical artifact-root binding, candidate lock, and terminal
+snapshot. #288 must load it through the verified derivation-chain loader and
+must reject a raw or synthetic candidate lock. That loader also derives the
+root from config, reloads the full chain, and rechecks current database evidence
+inside an immediate transaction. These owner-local hashes detect
+stale, copied, mixed, and partially replaced artifacts; they do not claim to
+authenticate against a malicious machine owner who changes code and rebuilds a
+fully self-consistent private evidence tree.
+
 ## Trait reachability preflight
 
 Before a future preregistration is treated as executable, run the read-only

--- a/mediaforce/core/file_integrity.py
+++ b/mediaforce/core/file_integrity.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import platform
+import select as select_module
+import shutil
+import stat
+import tempfile
+from typing import Any
+
+
+MACOS_FILE_INTEGRITY_CONTRACT_VERSION = "macos-kqueue-path-chain-v1"
+
+_REQUIRED_KQUEUE_NAMES = (
+    "kqueue",
+    "kevent",
+    "KQ_FILTER_VNODE",
+    "KQ_EV_ADD",
+    "KQ_EV_CLEAR",
+    "KQ_NOTE_WRITE",
+    "KQ_NOTE_DELETE",
+    "KQ_NOTE_RENAME",
+    "KQ_NOTE_LINK",
+    "KQ_NOTE_REVOKE",
+    "KQ_NOTE_ATTRIB",
+    "KQ_NOTE_EXTEND",
+)
+
+
+class FileIntegrityError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class _PathBinding:
+    path: Path
+    descriptor: int
+    device: int
+    inode: int
+
+
+class MacOSFileIntegrityGuard:
+    def __init__(
+            self,
+            *,
+            path: Path,
+            descriptor: int,
+            require_single_link: bool,
+    ) -> None:
+        assert_macos_file_integrity_capability()
+        self._path = path.expanduser().resolve(strict=True)
+        self._descriptor = descriptor
+        self._require_single_link = require_single_link
+        self._directory_bindings: list[_PathBinding] = []
+        self._watcher: Any | None = None
+        self._violated = False
+        try:
+            self._open_directory_bindings()
+            self._watcher = select_module.kqueue()
+            self._register_watchers()
+            self.assert_quiet()
+        except BaseException:
+            self.close()
+            raise
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def assert_quiet(self, *, timeout_seconds: float = 0.0) -> None:
+        watcher = self._watcher
+        if watcher is None:
+            self._violated = True
+        else:
+            try:
+                if watcher.control(None, 32, timeout_seconds):
+                    self._violated = True
+            except OSError:
+                self._violated = True
+        if not self._current_bindings_match():
+            self._violated = True
+        if self._violated:
+            raise FileIntegrityError("guarded file or path changed")
+
+    def close(self) -> None:
+        if self._watcher is not None:
+            self._watcher.close()
+            self._watcher = None
+        for binding in reversed(self._directory_bindings):
+            os.close(binding.descriptor)
+        self._directory_bindings.clear()
+
+    def _open_directory_bindings(self) -> None:
+        directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        for directory in self._path.parents:
+            descriptor = os.open(directory, directory_flags)
+            descriptor_info = os.fstat(descriptor)
+            try:
+                path_info = directory.lstat()
+            except BaseException:
+                os.close(descriptor)
+                raise
+            if (
+                not stat.S_ISDIR(descriptor_info.st_mode)
+                or not stat.S_ISDIR(path_info.st_mode)
+                or (descriptor_info.st_dev, descriptor_info.st_ino)
+                != (path_info.st_dev, path_info.st_ino)
+            ):
+                os.close(descriptor)
+                raise FileIntegrityError("guarded path contains an unstable directory")
+            self._directory_bindings.append(_PathBinding(
+                path=directory,
+                descriptor=descriptor,
+                device=int(descriptor_info.st_dev),
+                inode=int(descriptor_info.st_ino),
+            ))
+
+    def _register_watchers(self) -> None:
+        watcher = self._watcher
+        if watcher is None:
+            raise FileIntegrityError("guarded file watcher is unavailable")
+        file_flags = (
+            select_module.KQ_NOTE_WRITE
+            | select_module.KQ_NOTE_DELETE
+            | select_module.KQ_NOTE_RENAME
+            | select_module.KQ_NOTE_LINK
+            | select_module.KQ_NOTE_REVOKE
+            | select_module.KQ_NOTE_ATTRIB
+            | select_module.KQ_NOTE_EXTEND
+        )
+        directory_flags = (
+            select_module.KQ_NOTE_DELETE
+            | select_module.KQ_NOTE_RENAME
+            | select_module.KQ_NOTE_REVOKE
+            | select_module.KQ_NOTE_ATTRIB
+        )
+        events = [
+            select_module.kevent(
+                self._descriptor,
+                filter=select_module.KQ_FILTER_VNODE,
+                flags=select_module.KQ_EV_ADD | select_module.KQ_EV_CLEAR,
+                fflags=file_flags,
+            )
+        ]
+        events.extend(
+            select_module.kevent(
+                binding.descriptor,
+                filter=select_module.KQ_FILTER_VNODE,
+                flags=select_module.KQ_EV_ADD | select_module.KQ_EV_CLEAR,
+                fflags=directory_flags,
+            )
+            for binding in self._directory_bindings
+        )
+        watcher.control(events, 0, 0)
+
+    def _current_bindings_match(self) -> bool:
+        try:
+            descriptor_info = os.fstat(self._descriptor)
+            path_info = self._path.lstat()
+        except OSError:
+            return False
+        if (
+            not stat.S_ISREG(descriptor_info.st_mode)
+            or not stat.S_ISREG(path_info.st_mode)
+            or (descriptor_info.st_dev, descriptor_info.st_ino)
+            != (path_info.st_dev, path_info.st_ino)
+            or (
+                self._require_single_link
+                and (descriptor_info.st_nlink != 1 or path_info.st_nlink != 1)
+            )
+        ):
+            return False
+        for binding in self._directory_bindings:
+            try:
+                descriptor_info = os.fstat(binding.descriptor)
+                path_info = binding.path.lstat()
+            except OSError:
+                return False
+            if (
+                not stat.S_ISDIR(descriptor_info.st_mode)
+                or not stat.S_ISDIR(path_info.st_mode)
+                or (descriptor_info.st_dev, descriptor_info.st_ino)
+                != (binding.device, binding.inode)
+                or (path_info.st_dev, path_info.st_ino)
+                != (binding.device, binding.inode)
+            ):
+                return False
+        return True
+
+
+def assert_macos_file_integrity_capability() -> None:
+    if (
+        platform.system() != "Darwin"
+        or not hasattr(os, "O_NOFOLLOW")
+        or not hasattr(os, "O_DIRECTORY")
+        or any(not hasattr(select_module, name) for name in _REQUIRED_KQUEUE_NAMES)
+    ):
+        raise FileIntegrityError("macOS file-integrity monitoring is unavailable")
+
+
+def probe_macos_file_integrity(root: Path) -> None:
+    assert_macos_file_integrity_capability()
+    probe_directory = Path(tempfile.mkdtemp(prefix=".mediaforce-integrity-", dir=root))
+    probe_path = probe_directory / "probe"
+    descriptor = -1
+    guard: MacOSFileIntegrityGuard | None = None
+    try:
+        write_descriptor = os.open(
+            probe_path,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+            0o600,
+        )
+        try:
+            os.write(write_descriptor, b"clean")
+            os.fsync(write_descriptor)
+        finally:
+            os.close(write_descriptor)
+        descriptor = os.open(probe_path, os.O_RDONLY | os.O_NOFOLLOW)
+        guard = MacOSFileIntegrityGuard(
+            path=probe_path,
+            descriptor=descriptor,
+            require_single_link=True,
+        )
+        guard.assert_quiet()
+        mutation_descriptor = os.open(probe_path, os.O_WRONLY | os.O_NOFOLLOW)
+        try:
+            os.pwrite(mutation_descriptor, b"X", 0)
+            os.fsync(mutation_descriptor)
+        finally:
+            os.close(mutation_descriptor)
+        try:
+            guard.assert_quiet(timeout_seconds=0.1)
+        except FileIntegrityError:
+            return
+        raise FileIntegrityError("macOS file-integrity probe missed a mutation")
+    finally:
+        if guard is not None:
+            guard.close()
+        if descriptor >= 0:
+            os.close(descriptor)
+        shutil.rmtree(probe_directory, ignore_errors=True)

--- a/mediaforce/core/utils.py
+++ b/mediaforce/core/utils.py
@@ -3,8 +3,10 @@ import os
 import unicodedata
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Callable
 
 CONTENT_VERSION_SAMPLE_BYTES = 64 * 1024
+FILE_DIGEST_CHUNK_BYTES = 4 * 1024 * 1024
 
 
 def filesystem_collision_key(path: Path) -> str:
@@ -28,7 +30,19 @@ def file_fingerprint(file_path: Path, stat_result: os.stat_result, duration_seco
 
 
 def content_version_fingerprint(file_path: Path, stat_result: os.stat_result) -> str:
-    size = max(0, int(stat_result.st_size))
+    with file_path.open("rb") as handle:
+        return descriptor_content_version_fingerprint(
+            handle.fileno(),
+            size_bytes=stat_result.st_size,
+        )
+
+
+def descriptor_content_version_fingerprint(
+        descriptor: int,
+        *,
+        size_bytes: int,
+) -> str:
+    size = max(0, int(size_bytes))
     chunk_size = min(CONTENT_VERSION_SAMPLE_BYTES, size)
     positions = {0}
     if size > chunk_size:
@@ -36,9 +50,36 @@ def content_version_fingerprint(file_path: Path, stat_result: os.stat_result) ->
         positions.add(max(0, size - chunk_size))
     digest = hashlib.sha1(usedforsecurity=False)
     digest.update(str(size).encode())
-    with file_path.open("rb") as handle:
-        for position in sorted(positions):
-            handle.seek(position)
-            digest.update(position.to_bytes(8, "big", signed=False))
-            digest.update(handle.read(chunk_size))
+    for position in sorted(positions):
+        digest.update(position.to_bytes(8, "big", signed=False))
+        digest.update(os.pread(descriptor, chunk_size, position))
     return digest.hexdigest()
+
+
+def descriptor_sha256(
+        descriptor: int,
+        *,
+        check_cancelled: Callable[[], None] | None = None,
+) -> str:
+    digest = hashlib.sha256()
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    while True:
+        if check_cancelled is not None:
+            check_cancelled()
+        chunk = os.read(descriptor, FILE_DIGEST_CHUNK_BYTES)
+        if not chunk:
+            break
+        digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def file_stat_signature(
+        file_stat: os.stat_result,
+) -> tuple[int, int, int, int, int]:
+    return (
+        int(file_stat.st_dev),
+        int(file_stat.st_ino),
+        int(file_stat.st_size),
+        int(file_stat.st_mtime_ns),
+        int(file_stat.st_ctime_ns),
+    )

--- a/mediaforce/reviewing/artifact_identity.py
+++ b/mediaforce/reviewing/artifact_identity.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import hashlib
+import os
 from pathlib import Path
+import stat
 from typing import Sequence
 
 from mediaforce.core.evidence import stable_json_hash
@@ -13,14 +15,23 @@ def reviewed_artifact_fingerprint(
 ) -> str | None:
     clip_payloads: list[dict[str, object]] = []
     for role, path, timestamp_seconds, duration_seconds in clips:
+        descriptor = -1
         try:
-            initial_stat = path.stat()
-            content_sha256 = _file_sha256(path)
-            final_stat = path.stat()
+            descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+            initial_stat = os.fstat(descriptor)
+            if not stat.S_ISREG(initial_stat.st_mode):
+                return None
+            content_sha256 = _file_sha256(descriptor)
+            final_stat = os.fstat(descriptor)
         except OSError:
             return None
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
         if (
-                initial_stat.st_size != final_stat.st_size
+                initial_stat.st_dev != final_stat.st_dev
+                or initial_stat.st_ino != final_stat.st_ino
+                or initial_stat.st_size != final_stat.st_size
                 or initial_stat.st_mtime_ns != final_stat.st_mtime_ns
         ):
             return None
@@ -46,9 +57,9 @@ def reviewed_artifact_fingerprint(
     return f"cira1_{stable_json_hash({'schema_version': 1, 'clips': clip_payloads})[:32]}"
 
 
-def _file_sha256(path: Path) -> str:
+def _file_sha256(descriptor: int) -> str:
     digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    for chunk in iter(lambda: os.read(descriptor, 1024 * 1024), b""):
+        digest.update(chunk)
     return digest.hexdigest()

--- a/mediaforce/tuning/av1_cold_start_evaluation.py
+++ b/mediaforce/tuning/av1_cold_start_evaluation.py
@@ -30,6 +30,9 @@ AV1_COLD_START_VALIDATION_PREDICTOR_CONTRACT_VERSION = "acsp1"
 AV1_COLD_START_VALIDATION_REGISTERED_AT = "2026-07-27T00:00:00Z"
 AV1_COLD_START_VALIDATION_VALID_UNTIL = "2027-01-27T00:00:00Z"
 AV1_COLD_START_VALIDATION_REQUIRED_DERIVATION_EVIDENCE_COUNT = 12
+AV1_COLD_START_VALIDATION_MINIMUM_DERIVATION_SOURCE_COUNT = 6
+AV1_COLD_START_VALIDATION_MAXIMUM_DERIVATION_AGE_DAYS = 180
+AV1_COLD_START_VALIDATION_MAXIMUM_CANDIDATE_CRF_SPAN = 6.0
 AV1_COLD_START_VALIDATION_MINIMUM_DERIVATION_SOURCE_GROUP_COUNT = 6
 AV1_COLD_START_VALIDATION_MAXIMUM_DERIVATION_SOURCE_GROUP_COUNT = (
     AV1_COLD_START_VALIDATION_REQUIRED_DERIVATION_EVIDENCE_COUNT // 3
@@ -173,13 +176,21 @@ class AV1ColdStartValidationCriteriaV1:
             raise AV1ColdStartValidationError(
                 "AV1 validation requires exactly twelve derivation observations"
             )
-        if not 6 <= self.minimum_derivation_source_count <= self.minimum_derivation_evidence_count:
+        if not (
+            AV1_COLD_START_VALIDATION_MINIMUM_DERIVATION_SOURCE_COUNT
+            <= self.minimum_derivation_source_count
+            <= self.minimum_derivation_evidence_count
+        ):
             raise AV1ColdStartValidationError("AV1 validation derivation-source minimum is invalid")
         if self.minimum_holdout_count < 16:
             raise AV1ColdStartValidationError("AV1 validation requires at least sixteen held-out cases")
         if not 6 <= self.minimum_holdout_source_count <= self.minimum_holdout_count:
             raise AV1ColdStartValidationError("AV1 validation held-out source minimum is invalid")
-        if not 1 <= self.maximum_derivation_age_days <= 180:
+        if not (
+            1
+            <= self.maximum_derivation_age_days
+            <= AV1_COLD_START_VALIDATION_MAXIMUM_DERIVATION_AGE_DAYS
+        ):
             raise AV1ColdStartValidationError("AV1 validation derivation evidence age is too permissive")
         rates = (
             self.range_hit_null_rate,
@@ -194,7 +205,12 @@ class AV1ColdStartValidationCriteriaV1:
             raise AV1ColdStartValidationError("AV1 validation range-hit null rate must remain one half")
         if self.maximum_one_sided_p_value > 0.025:
             raise AV1ColdStartValidationError("AV1 validation significance threshold is too permissive")
-        if not math.isfinite(self.maximum_candidate_crf_span) or not 0 < self.maximum_candidate_crf_span <= 6:
+        if (
+            not math.isfinite(self.maximum_candidate_crf_span)
+            or not 0
+            < self.maximum_candidate_crf_span
+            <= AV1_COLD_START_VALIDATION_MAXIMUM_CANDIDATE_CRF_SPAN
+        ):
             raise AV1ColdStartValidationError("AV1 validation candidate range exceeds the safe span")
         if self.maximum_safety_regression_count != 0:
             raise AV1ColdStartValidationError("AV1 validation safety regressions must remain zero")
@@ -521,6 +537,11 @@ class AV1ColdStartValidationCandidateLockV1:
             raise AV1ColdStartValidationError("AV1 validation candidate CRFs must be finite")
         if not 0 <= self.crf_lower <= self.crf_center <= self.crf_upper <= 63:
             raise AV1ColdStartValidationError("AV1 validation candidate CRF range is invalid")
+        if (
+            self.crf_upper - self.crf_lower
+            > AV1_COLD_START_VALIDATION_MAXIMUM_CANDIDATE_CRF_SPAN
+        ):
+            raise AV1ColdStartValidationError("AV1 validation candidate CRF span is too wide")
         for signature in (self.compatibility_signature, self.policy_signature):
             if not _SAFE_TOKEN_RE.fullmatch(signature):
                 raise AV1ColdStartValidationError("AV1 validation candidate signature is invalid")
@@ -534,8 +555,13 @@ class AV1ColdStartValidationCandidateLockV1:
             raise AV1ColdStartValidationError("AV1 validation candidate confidence score is invalid")
         if self.derivation_evidence_count != AV1_COLD_START_VALIDATION_REQUIRED_DERIVATION_EVIDENCE_COUNT:
             raise AV1ColdStartValidationError("AV1 validation candidate lock requires exactly 12 derivation observations")
-        if self.derivation_source_count < 0:
-            raise AV1ColdStartValidationError("AV1 validation derivation counts must be non-negative")
+        if (
+            self.derivation_source_count
+            < AV1_COLD_START_VALIDATION_MINIMUM_DERIVATION_SOURCE_COUNT
+        ):
+            raise AV1ColdStartValidationError(
+                "AV1 validation derivation source count is below the preregistered minimum"
+            )
         if self.derivation_source_count > self.derivation_evidence_count:
             raise AV1ColdStartValidationError("AV1 validation derivation sources exceed evidence")
         if self.derivation_conflict_count < 0:
@@ -583,11 +609,10 @@ class AV1ColdStartValidationCandidateLockV1:
             raise AV1ColdStartValidationError("AV1 validation derivation source tokens are incomplete")
         if len(self.derivation_title_tokens) != self.derivation_evidence_count:
             raise AV1ColdStartValidationError("AV1 validation derivation title tokens are incomplete")
-        if len(self.derivation_series_tokens) < self.derivation_source_count:
+        if len(self.derivation_series_tokens) != self.derivation_evidence_count:
             raise AV1ColdStartValidationError("AV1 validation derivation series tokens are incomplete")
         if (
-            len(self.derivation_series_tokens) > self.derivation_evidence_count
-            or len(self.derivation_source_group_tokens) > self.derivation_source_count
+            len(self.derivation_source_group_tokens) > self.derivation_source_count
         ):
             raise AV1ColdStartValidationError("AV1 validation derivation grouping tokens exceed evidence")
         for digest in (self.derivation_snapshot_sha256, self.selection_lock_sha256, self.payload_sha256):
@@ -605,6 +630,10 @@ class AV1ColdStartValidationCandidateLockV1:
         )
         if not oldest_recorded_at <= newest_recorded_at <= locked_at:
             raise AV1ColdStartValidationError("AV1 validation derivation chronology is invalid")
+        if oldest_recorded_at < locked_at - timedelta(
+            days=AV1_COLD_START_VALIDATION_MAXIMUM_DERIVATION_AGE_DAYS
+        ):
+            raise AV1ColdStartValidationError("AV1 validation derivation evidence is stale")
         if reviewed_at < locked_at or self.review_state != "approved_for_holdout":
             raise AV1ColdStartValidationError("AV1 validation candidate review state is invalid")
         semantic_payload = self.semantic_payload()

--- a/mediaforce/tuning/av1_cold_start_evaluation.py
+++ b/mediaforce/tuning/av1_cold_start_evaluation.py
@@ -29,6 +29,11 @@ AV1_COLD_START_VALIDATION_CONTRACT_VERSION = "acsv1"
 AV1_COLD_START_VALIDATION_PREDICTOR_CONTRACT_VERSION = "acsp1"
 AV1_COLD_START_VALIDATION_REGISTERED_AT = "2026-07-27T00:00:00Z"
 AV1_COLD_START_VALIDATION_VALID_UNTIL = "2027-01-27T00:00:00Z"
+AV1_COLD_START_VALIDATION_REQUIRED_DERIVATION_EVIDENCE_COUNT = 12
+AV1_COLD_START_VALIDATION_MINIMUM_DERIVATION_SOURCE_GROUP_COUNT = 6
+AV1_COLD_START_VALIDATION_MAXIMUM_DERIVATION_SOURCE_GROUP_COUNT = (
+    AV1_COLD_START_VALIDATION_REQUIRED_DERIVATION_EVIDENCE_COUNT // 3
+)
 
 AV1ColdStartValidationMode = Literal["publication_candidate", "fallback_conformance"]
 AV1ColdStartValidationTraitMatch = Literal["exact", "contains_all"]
@@ -161,8 +166,13 @@ class AV1ColdStartValidationCriteriaV1:
     confidence_score: float
 
     def __post_init__(self) -> None:
-        if self.minimum_derivation_evidence_count < 12:
-            raise AV1ColdStartValidationError("AV1 validation requires at least twelve derivation observations")
+        if (
+            self.minimum_derivation_evidence_count
+            != AV1_COLD_START_VALIDATION_REQUIRED_DERIVATION_EVIDENCE_COUNT
+        ):
+            raise AV1ColdStartValidationError(
+                "AV1 validation requires exactly twelve derivation observations"
+            )
         if not 6 <= self.minimum_derivation_source_count <= self.minimum_derivation_evidence_count:
             raise AV1ColdStartValidationError("AV1 validation derivation-source minimum is invalid")
         if self.minimum_holdout_count < 16:
@@ -482,8 +492,10 @@ class AV1ColdStartValidationCandidateLockV1:
     derivation_evidence_count: int
     derivation_source_count: int
     derivation_source_tokens: tuple[str, ...]
+    derivation_title_tokens: tuple[str, ...]
     derivation_series_tokens: tuple[str, ...]
     derivation_source_group_tokens: tuple[str, ...]
+    derivation_source_group_observation_tokens: tuple[str, ...]
     derivation_oldest_recorded_at: str
     derivation_newest_recorded_at: str
     derivation_conflict_count: int
@@ -514,13 +526,15 @@ class AV1ColdStartValidationCandidateLockV1:
                 raise AV1ColdStartValidationError("AV1 validation candidate signature is invalid")
         if not 0 < self.target_video_bitrate_min_bps <= self.target_video_bitrate_max_bps:
             raise AV1ColdStartValidationError("AV1 validation candidate bitrate range is invalid")
-        if not math.isfinite(self.minimum_quality_score) or self.minimum_quality_score < 0:
+        if not math.isfinite(self.minimum_quality_score) or self.minimum_quality_score <= 0:
             raise AV1ColdStartValidationError("AV1 validation candidate quality floor is invalid")
         if self.confidence_level not in {"none", "limited", "moderate", "high"}:
             raise AV1ColdStartValidationError("AV1 validation candidate confidence is unsupported")
         if not math.isfinite(self.confidence_score) or not 0 <= self.confidence_score <= 1:
             raise AV1ColdStartValidationError("AV1 validation candidate confidence score is invalid")
-        if self.derivation_evidence_count < 0 or self.derivation_source_count < 0:
+        if self.derivation_evidence_count != AV1_COLD_START_VALIDATION_REQUIRED_DERIVATION_EVIDENCE_COUNT:
+            raise AV1ColdStartValidationError("AV1 validation candidate lock requires exactly 12 derivation observations")
+        if self.derivation_source_count < 0:
             raise AV1ColdStartValidationError("AV1 validation derivation counts must be non-negative")
         if self.derivation_source_count > self.derivation_evidence_count:
             raise AV1ColdStartValidationError("AV1 validation derivation sources exceed evidence")
@@ -528,13 +542,54 @@ class AV1ColdStartValidationCandidateLockV1:
             raise AV1ColdStartValidationError("AV1 validation derivation conflict count is invalid")
         for tokens in (
             self.derivation_source_tokens,
+            self.derivation_title_tokens,
             self.derivation_series_tokens,
             self.derivation_source_group_tokens,
         ):
-            if tokens != tuple(sorted(set(tokens))) or len(tokens) < self.derivation_source_count:
+            if tokens != tuple(sorted(set(tokens))) or not tokens:
                 raise AV1ColdStartValidationError("AV1 validation derivation tokens are incomplete")
             if any(not _SAFE_TOKEN_RE.fullmatch(token) for token in tokens):
                 raise AV1ColdStartValidationError("AV1 validation derivation token is invalid")
+        if (
+            self.derivation_source_group_observation_tokens
+            != tuple(sorted(self.derivation_source_group_observation_tokens))
+            or len(self.derivation_source_group_observation_tokens)
+            != self.derivation_evidence_count
+            or any(
+                not _SAFE_TOKEN_RE.fullmatch(token)
+                for token in self.derivation_source_group_observation_tokens
+            )
+        ):
+            raise AV1ColdStartValidationError(
+                "AV1 validation derivation source-group observations are invalid"
+            )
+        source_group_counts = Counter(self.derivation_source_group_observation_tokens)
+        if tuple(sorted(source_group_counts)) != self.derivation_source_group_tokens:
+            raise AV1ColdStartValidationError(
+                "AV1 validation derivation source-group observations are incomplete"
+            )
+        if len(source_group_counts) < AV1_COLD_START_VALIDATION_MINIMUM_DERIVATION_SOURCE_GROUP_COUNT:
+            raise AV1ColdStartValidationError(
+                "AV1 validation derivation requires at least six source groups"
+            )
+        if any(
+            count > AV1_COLD_START_VALIDATION_MAXIMUM_DERIVATION_SOURCE_GROUP_COUNT
+            for count in source_group_counts.values()
+        ):
+            raise AV1ColdStartValidationError(
+                "AV1 validation derivation source-group concentration is too high"
+            )
+        if len(self.derivation_source_tokens) != self.derivation_source_count:
+            raise AV1ColdStartValidationError("AV1 validation derivation source tokens are incomplete")
+        if len(self.derivation_title_tokens) != self.derivation_evidence_count:
+            raise AV1ColdStartValidationError("AV1 validation derivation title tokens are incomplete")
+        if len(self.derivation_series_tokens) < self.derivation_source_count:
+            raise AV1ColdStartValidationError("AV1 validation derivation series tokens are incomplete")
+        if (
+            len(self.derivation_series_tokens) > self.derivation_evidence_count
+            or len(self.derivation_source_group_tokens) > self.derivation_source_count
+        ):
+            raise AV1ColdStartValidationError("AV1 validation derivation grouping tokens exceed evidence")
         for digest in (self.derivation_snapshot_sha256, self.selection_lock_sha256, self.payload_sha256):
             if not _SHA256_RE.fullmatch(digest):
                 raise AV1ColdStartValidationError("AV1 validation candidate digest is invalid")
@@ -579,8 +634,12 @@ class AV1ColdStartValidationCandidateLockV1:
             "derivation_evidence_count": self.derivation_evidence_count,
             "derivation_source_count": self.derivation_source_count,
             "derivation_source_tokens": list(self.derivation_source_tokens),
+            "derivation_title_tokens": list(self.derivation_title_tokens),
             "derivation_series_tokens": list(self.derivation_series_tokens),
             "derivation_source_group_tokens": list(self.derivation_source_group_tokens),
+            "derivation_source_group_observation_tokens": list(
+                self.derivation_source_group_observation_tokens
+            ),
             "derivation_oldest_recorded_at": self.derivation_oldest_recorded_at,
             "derivation_newest_recorded_at": self.derivation_newest_recorded_at,
             "derivation_conflict_count": self.derivation_conflict_count,
@@ -716,6 +775,7 @@ class AV1ColdStartValidationResultV1:
     completed_at: str
     status: AV1ColdStartValidationStatus
     source_token: str
+    title_token: str
     series_token: str
     source_group_token: str
     content_traits: tuple[str, ...]
@@ -756,6 +816,7 @@ class AV1ColdStartValidationResultV1:
             raise AV1ColdStartValidationError("AV1 validation result status is unsupported")
         for token in (
             self.source_token,
+            self.title_token,
             self.series_token,
             self.source_group_token,
             self.compatibility_signature,
@@ -814,6 +875,7 @@ class AV1ColdStartValidationResultV1:
             "completed_at": self.completed_at,
             "status": self.status,
             "source_token": self.source_token,
+            "title_token": self.title_token,
             "series_token": self.series_token,
             "source_group_token": self.source_group_token,
             "content_traits": list(self.content_traits),
@@ -1360,8 +1422,10 @@ def build_av1_cold_start_validation_candidate_lock(
         derivation_evidence_count: int,
         derivation_source_count: int,
         derivation_source_tokens: Sequence[str],
+        derivation_title_tokens: Sequence[str],
         derivation_series_tokens: Sequence[str],
         derivation_source_group_tokens: Sequence[str],
+        derivation_source_group_observation_tokens: Sequence[str],
         derivation_oldest_recorded_at: str,
         derivation_newest_recorded_at: str,
         derivation_conflict_count: int,
@@ -1387,8 +1451,12 @@ def build_av1_cold_start_validation_candidate_lock(
         "derivation_evidence_count": derivation_evidence_count,
         "derivation_source_count": derivation_source_count,
         "derivation_source_tokens": sorted(set(derivation_source_tokens)),
+        "derivation_title_tokens": sorted(set(derivation_title_tokens)),
         "derivation_series_tokens": sorted(set(derivation_series_tokens)),
         "derivation_source_group_tokens": sorted(set(derivation_source_group_tokens)),
+        "derivation_source_group_observation_tokens": sorted(
+            derivation_source_group_observation_tokens
+        ),
         "derivation_oldest_recorded_at": derivation_oldest_recorded_at,
         "derivation_newest_recorded_at": derivation_newest_recorded_at,
         "derivation_conflict_count": derivation_conflict_count,
@@ -1417,8 +1485,12 @@ def build_av1_cold_start_validation_candidate_lock(
         derivation_evidence_count=derivation_evidence_count,
         derivation_source_count=derivation_source_count,
         derivation_source_tokens=tuple(semantic_payload["derivation_source_tokens"]),
+        derivation_title_tokens=tuple(semantic_payload["derivation_title_tokens"]),
         derivation_series_tokens=tuple(semantic_payload["derivation_series_tokens"]),
         derivation_source_group_tokens=tuple(semantic_payload["derivation_source_group_tokens"]),
+        derivation_source_group_observation_tokens=tuple(
+            semantic_payload["derivation_source_group_observation_tokens"]
+        ),
         derivation_oldest_recorded_at=derivation_oldest_recorded_at,
         derivation_newest_recorded_at=derivation_newest_recorded_at,
         derivation_conflict_count=derivation_conflict_count,
@@ -1472,6 +1544,7 @@ def build_av1_cold_start_validation_result(
         completed_at: str,
         status: AV1ColdStartValidationStatus,
         source_token: str,
+        title_token: str,
         series_token: str,
         source_group_token: str,
         content_traits: Sequence[str],
@@ -1499,6 +1572,7 @@ def build_av1_cold_start_validation_result(
         "completed_at": completed_at,
         "status": status,
         "source_token": source_token,
+        "title_token": title_token,
         "series_token": series_token,
         "source_group_token": source_group_token,
         "content_traits": sorted(set(str(trait) for trait in content_traits)),
@@ -1528,6 +1602,7 @@ def build_av1_cold_start_validation_result(
         completed_at=completed_at,
         status=status,
         source_token=source_token,
+        title_token=title_token,
         series_token=series_token,
         source_group_token=source_group_token,
         content_traits=tuple(semantic_payload["content_traits"]),
@@ -1994,10 +2069,13 @@ def _build_publication_candidate_report(
             compatible_results.append(result)
 
     source_tokens = {result.source_token for result in compatible_results}
+    title_counts = Counter(result.title_token for result in compatible_results)
     series_counts = Counter(result.series_token for result in compatible_results)
     source_group_counts = Counter(result.source_group_token for result in compatible_results)
     if len(source_tokens) < criteria.minimum_holdout_count:
         blockers.append("held_out_source_tokens_not_unique")
+    if any(count > 1 for count in title_counts.values()):
+        blockers.append("held_out_titles_reused")
     if any(count > 1 for count in series_counts.values()):
         blockers.append("held_out_series_reused")
     maximum_source_group_count = math.floor(len(compatible_results) / 3)
@@ -2008,6 +2086,8 @@ def _build_publication_candidate_report(
     if candidate_lock is not None:
         if source_tokens.intersection(candidate_lock.derivation_source_tokens):
             blockers.append("derivation_holdout_source_overlap")
+        if set(title_counts).intersection(candidate_lock.derivation_title_tokens):
+            blockers.append("derivation_holdout_title_overlap")
         if set(series_counts).intersection(candidate_lock.derivation_series_tokens):
             blockers.append("derivation_holdout_series_overlap")
         if set(source_group_counts).intersection(candidate_lock.derivation_source_group_tokens):
@@ -2350,8 +2430,10 @@ def _candidate_lock_from_payload(
         "derivation_evidence_count",
         "derivation_source_count",
         "derivation_source_tokens",
+        "derivation_title_tokens",
         "derivation_series_tokens",
         "derivation_source_group_tokens",
+        "derivation_source_group_observation_tokens",
         "derivation_oldest_recorded_at",
         "derivation_newest_recorded_at",
         "derivation_conflict_count",
@@ -2401,6 +2483,13 @@ def _candidate_lock_from_payload(
             _text(value, "derivation source token")
             for value in _sequence(payload["derivation_source_tokens"], "derivation source tokens")
         ),
+        derivation_title_tokens=tuple(
+            _text(value, "derivation title token")
+            for value in _sequence(
+                payload["derivation_title_tokens"],
+                "derivation title tokens",
+            )
+        ),
         derivation_series_tokens=tuple(
             _text(value, "derivation series token")
             for value in _sequence(payload["derivation_series_tokens"], "derivation series tokens")
@@ -2410,6 +2499,13 @@ def _candidate_lock_from_payload(
             for value in _sequence(
                 payload["derivation_source_group_tokens"],
                 "derivation source-group tokens",
+            )
+        ),
+        derivation_source_group_observation_tokens=tuple(
+            _text(value, "derivation source-group observation token")
+            for value in _sequence(
+                payload["derivation_source_group_observation_tokens"],
+                "derivation source-group observation tokens",
             )
         ),
         derivation_oldest_recorded_at=_text(
@@ -2515,6 +2611,7 @@ def _result_from_payload(payload: Mapping[str, Any]) -> AV1ColdStartValidationRe
         "completed_at",
         "status",
         "source_token",
+        "title_token",
         "series_token",
         "source_group_token",
         "content_traits",
@@ -2548,6 +2645,7 @@ def _result_from_payload(payload: Mapping[str, Any]) -> AV1ColdStartValidationRe
         completed_at=_text(payload["completed_at"], "result completion"),
         status=cast(AV1ColdStartValidationStatus, _text(payload["status"], "result status")),
         source_token=_text(payload["source_token"], "source token"),
+        title_token=_text(payload["title_token"], "title token"),
         series_token=_text(payload["series_token"], "series token"),
         source_group_token=_text(payload["source_group_token"], "source-group token"),
         content_traits=tuple(

--- a/mediaforce/tuning/av1_validation_derivation.py
+++ b/mediaforce/tuning/av1_validation_derivation.py
@@ -108,6 +108,7 @@ AV1_VALIDATION_DERIVATION_REASON_CODES = frozenset({
     "authorization_expired",
     "compatibility_drift",
     "content_intent_observation_excluded",
+    "interrupted_claim",
     "media_unavailable",
     "metrics_incomplete",
     "operator_stop",
@@ -2414,6 +2415,7 @@ def write_av1_validation_derivation_assignment_claim(
         assignment_id: str,
         plan_id: str,
         authorization_id: str,
+        claimed_at: str,
 ) -> Path:
     bind_av1_validation_derivation_attempt_directory(
         directory,
@@ -2428,8 +2430,52 @@ def write_av1_validation_derivation_assignment_claim(
         "plan_id": plan_id,
         "authorization_id": authorization_id,
         "assignment_id": assignment_id,
+        "claimed_at": claimed_at,
     }))
     return path
+
+
+def load_av1_validation_derivation_assignment_claims(
+        directory: Path,
+) -> tuple[dict[str, Any], ...]:
+    if not directory.exists():
+        return ()
+    claims: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.claim")):
+        payload, raw = _load_owner_only_json(path, "derivation assignment claim")
+        _require_exact_keys(payload, {
+            "schema", "schema_version", "contract_version", "plan_id",
+            "authorization_id", "assignment_id", "claimed_at",
+        }, "derivation assignment claim")
+        claim = {
+            "schema": "mediaforce.av1_cold_start_derivation_assignment_claim",
+            "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+            "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+            "plan_id": _required_text(payload.get("plan_id"), "plan ID"),
+            "authorization_id": _required_text(
+                payload.get("authorization_id"), "authorization ID"
+            ),
+            "assignment_id": _required_text(
+                payload.get("assignment_id"), "assignment ID"
+            ),
+            "claimed_at": _required_text(
+                payload.get("claimed_at"), "claim timestamp"
+            ),
+        }
+        if (
+            payload.get("schema") != claim["schema"]
+            or int_value(payload.get("schema_version"))
+            != AV1_VALIDATION_DERIVATION_SCHEMA_VERSION
+            or payload.get("contract_version")
+            != AV1_VALIDATION_DERIVATION_CONTRACT_VERSION
+            or raw != canonical_json_bytes(claim)
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation assignment claim is invalid"
+            )
+        _parse_timestamp(str(claim["claimed_at"]), "claim timestamp")
+        claims.append(claim)
+    return tuple(claims)
 
 
 def load_av1_validation_derivation_terminal_records(
@@ -3800,6 +3846,7 @@ def _validate_calibration_payload(
     _validate_calibration_execution(calibration)
     sample_item = object_dict(calibration.get("sample_item"))
     stream_budget_ledger = object_dict(sample_item.get("stream_budget_ledger"))
+    stream_budget_totals = object_dict(stream_budget_ledger.get("totals"))
     sample_result = object_dict(calibration.get("sample_result"))
     target_trace = object_dict(sample_result.get("target_size_trace"))
     quality_floor = object_dict(target_trace.get("quality_floor"))
@@ -3815,7 +3862,7 @@ def _validate_calibration_payload(
         int_value(sample_item.get("library_item_id")) != assignment.local_item_id
         or str(sample_item.get("content_version_fingerprint") or "")
         != source_identity
-        or int_value(stream_budget_ledger.get("remaining_video_bitrate_bps"))
+        or int_value(stream_budget_totals.get("remaining_video_bitrate_bps"))
         != assignment.target_video_bitrate_bps
         or str(sample_result.get("quality_metric") or "").casefold()
         != assignment.quality_metric.casefold()

--- a/mediaforce/tuning/av1_validation_derivation.py
+++ b/mediaforce/tuning/av1_validation_derivation.py
@@ -18,6 +18,9 @@ from mediaforce.core.evidence import canonical_json_bytes
 from mediaforce.core.type_defs import float_value, int_value, object_dict, object_list
 from mediaforce.tuning.av1_cold_start import assert_av1_cold_start_public_payload_safe
 from mediaforce.tuning.av1_cold_start_evaluation import (
+    AV1_COLD_START_VALIDATION_MAXIMUM_CANDIDATE_CRF_SPAN,
+    AV1_COLD_START_VALIDATION_MAXIMUM_DERIVATION_AGE_DAYS,
+    AV1_COLD_START_VALIDATION_MINIMUM_DERIVATION_SOURCE_COUNT,
     AV1_COLD_START_VALIDATION_REQUIRED_DERIVATION_EVIDENCE_COUNT,
     AV1ColdStartValidationCandidateLockV1,
     _candidate_lock_from_payload,
@@ -54,14 +57,17 @@ AV1_VALIDATION_DERIVATION_REVIEW_SCHEMA = "mediaforce.av1_cold_start_derivation_
 AV1_VALIDATION_DERIVATION_REVIEW_ENVELOPE_SCHEMA = (
     "mediaforce.av1_cold_start_derivation_review_envelope"
 )
+AV1_VALIDATION_DERIVATION_REVIEW_CLAIM_SCHEMA = (
+    "mediaforce.av1_cold_start_derivation_review_claim"
+)
 AV1_VALIDATION_DERIVATION_LOCK_ENVELOPE_SCHEMA = (
     "mediaforce.av1_cold_start_derivation_candidate_lock_envelope"
 )
 AV1_VALIDATION_DERIVATION_DIRECTORY_BINDING_SCHEMA = (
     "mediaforce.av1_cold_start_derivation_directory_binding"
 )
-AV1_VALIDATION_DERIVATION_SCHEMA_VERSION = 1
-AV1_VALIDATION_DERIVATION_CONTRACT_VERSION = "av1vdw1"
+AV1_VALIDATION_DERIVATION_SCHEMA_VERSION = 2
+AV1_VALIDATION_DERIVATION_CONTRACT_VERSION = "av1vdw2"
 AV1_VALIDATION_DERIVATION_EXECUTION_SCOPE = "reserved_derivation_sources_only"
 AV1_VALIDATION_DERIVATION_SEARCH_MODE = "unchanged_measured_full_search"
 AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY = "av1-validation-derivation"
@@ -511,6 +517,9 @@ class AV1ValidationDerivationCandidateProposal:
     crf_mad: float
     bitrate_relative_mad: float
     statistics_contract_sha256: str
+    minimum_derivation_source_count: int
+    maximum_derivation_age_days: int
+    maximum_candidate_crf_span: float
     compatibility_signature: str
     policy_signature: str
     target_video_bitrate_min_bps: int
@@ -549,6 +558,17 @@ class AV1ValidationDerivationCandidateProposal:
             raise AV1ValidationDerivationError("AV1 derivation proposal CRF range is invalid")
         if math.ceil(self.crf_lower) > math.floor(self.crf_upper):
             raise AV1ValidationDerivationError("AV1 derivation proposal has no executable CRF")
+        if not (
+            math.isfinite(self.maximum_candidate_crf_span)
+            and 0
+            < self.maximum_candidate_crf_span
+            <= AV1_COLD_START_VALIDATION_MAXIMUM_CANDIDATE_CRF_SPAN
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation proposal CRF-span contract is invalid"
+            )
+        if self.crf_upper - self.crf_lower > self.maximum_candidate_crf_span:
+            raise AV1ValidationDerivationError("AV1 derivation proposal CRF span is too wide")
         if (
             not math.isfinite(self.crf_mad)
             or self.crf_mad < 0
@@ -572,9 +592,25 @@ class AV1ValidationDerivationCandidateProposal:
             raise AV1ValidationDerivationError("AV1 derivation proposal quality floor is invalid")
         if self.derivation_evidence_count != AV1_VALIDATION_DERIVATION_RESERVATION_COUNT:
             raise AV1ValidationDerivationError("AV1 derivation proposal evidence count is invalid")
+        if not (
+            AV1_COLD_START_VALIDATION_MINIMUM_DERIVATION_SOURCE_COUNT
+            <= self.minimum_derivation_source_count
+            <= self.derivation_evidence_count
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation proposal source-count contract is invalid"
+            )
+        if not (
+            1
+            <= self.maximum_derivation_age_days
+            <= AV1_COLD_START_VALIDATION_MAXIMUM_DERIVATION_AGE_DAYS
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation proposal freshness contract is invalid"
+            )
         if self.derivation_conflict_count != 0:
             raise AV1ValidationDerivationError("AV1 derivation proposal evidence is conflicting")
-        if self.derivation_source_count < AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT:
+        if self.derivation_source_count < self.minimum_derivation_source_count:
             raise AV1ValidationDerivationError("AV1 derivation proposal source count is invalid")
         if self.confidence_level not in {"moderate", "high"} or self.confidence_score < 0.7:
             raise AV1ValidationDerivationError("AV1 derivation proposal confidence is insufficient")
@@ -643,6 +679,8 @@ class AV1ValidationDerivationCandidateProposal:
         proposed = _parse_timestamp(self.proposed_at, "proposal timestamp")
         if not oldest <= newest <= proposed:
             raise AV1ValidationDerivationError("AV1 derivation proposal chronology is invalid")
+        if oldest < proposed - timedelta(days=self.maximum_derivation_age_days):
+            raise AV1ValidationDerivationError("AV1 derivation proposal evidence is stale")
         semantic_payload = self.semantic_payload()
         if self.proposal_id != _derivation_id("proposal", semantic_payload):
             raise AV1ValidationDerivationError("AV1 derivation proposal ID does not match its payload")
@@ -664,6 +702,9 @@ class AV1ValidationDerivationCandidateProposal:
             "crf_mad": self.crf_mad,
             "bitrate_relative_mad": self.bitrate_relative_mad,
             "statistics_contract_sha256": self.statistics_contract_sha256,
+            "minimum_derivation_source_count": self.minimum_derivation_source_count,
+            "maximum_derivation_age_days": self.maximum_derivation_age_days,
+            "maximum_candidate_crf_span": self.maximum_candidate_crf_span,
             "compatibility_signature": self.compatibility_signature,
             "policy_signature": self.policy_signature,
             "target_video_bitrate_min_bps": self.target_video_bitrate_min_bps,
@@ -700,12 +741,102 @@ class AV1ValidationDerivationCandidateProposal:
 
 
 @dataclass(frozen=True, slots=True)
+class AV1ValidationDerivationReviewClaim:
+    claim_id: str
+    plan_id: str
+    authorization_id: str
+    proposal_id: str
+    proposal_payload_sha256: str
+    lane: AV1ValidationDerivationReviewLane
+    review_run_id: str
+    reviewer_token: str
+    review_runner_canonical_path_sha256: str
+    review_runner_binary_sha256: str
+    claimed_at: str
+    payload_sha256: str
+
+    def __post_init__(self) -> None:
+        if not self.plan_id.startswith("av1vdplan1_"):
+            raise AV1ValidationDerivationError("AV1 derivation review claim plan is invalid")
+        if not self.authorization_id.startswith("av1vderivation1_"):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review claim authorization is invalid"
+            )
+        if not self.proposal_id.startswith("av1vdproposal1_"):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review claim proposal is invalid"
+            )
+        if self.lane not in AV1_VALIDATION_DERIVATION_REVIEW_LANES:
+            raise AV1ValidationDerivationError("AV1 derivation review claim lane is invalid")
+        if (
+            not _AGENT_REVIEWER_RE.fullmatch(self.reviewer_token)
+            or self.reviewer_token != f"agent:{self.review_run_id}"
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review claim must identify one Every Code agent run"
+            )
+        for digest, label in (
+            (self.proposal_payload_sha256, "proposal digest"),
+            (
+                self.review_runner_canonical_path_sha256,
+                "review-runner canonical-path digest",
+            ),
+            (self.review_runner_binary_sha256, "review-runner binary digest"),
+            (self.payload_sha256, "review-claim digest"),
+        ):
+            _require_sha256(digest, label)
+        _parse_timestamp(self.claimed_at, "review-claim timestamp")
+        semantic_payload = self.semantic_payload()
+        if self.claim_id != _derivation_id("review_claim", semantic_payload):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review claim ID does not match its payload"
+            )
+        if self.payload_sha256 != _payload_sha256({
+            "claim_id": self.claim_id,
+            **semantic_payload,
+        }):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review claim digest does not match its payload"
+            )
+
+    def semantic_payload(self) -> dict[str, Any]:
+        return {
+            "schema": AV1_VALIDATION_DERIVATION_REVIEW_CLAIM_SCHEMA,
+            "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+            "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+            "plan_id": self.plan_id,
+            "authorization_id": self.authorization_id,
+            "proposal_id": self.proposal_id,
+            "proposal_payload_sha256": self.proposal_payload_sha256,
+            "lane": self.lane,
+            "review_run_id": self.review_run_id,
+            "reviewer_token": self.reviewer_token,
+            "review_runner_canonical_path_sha256": (
+                self.review_runner_canonical_path_sha256
+            ),
+            "review_runner_binary_sha256": self.review_runner_binary_sha256,
+            "claimed_at": self.claimed_at,
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "claim_id": self.claim_id,
+            **self.semantic_payload(),
+            "payload_sha256": self.payload_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class AV1ValidationDerivationReviewAttestation:
     attestation_id: str
     proposal_id: str
     proposal_payload_sha256: str
+    review_claim_id: str
+    review_claim_payload_sha256: str
     lane: AV1ValidationDerivationReviewLane
     reviewer_token: str
+    review_runner_canonical_path_sha256: str
+    review_runner_binary_sha256: str
     review_evidence_sha256: str
     decision: AV1ValidationDerivationReviewDecision
     reviewed_at: str
@@ -718,7 +849,20 @@ class AV1ValidationDerivationReviewAttestation:
             raise AV1ValidationDerivationError(
                 "AV1 derivation reviewer token must identify one Every Code agent run"
             )
-        _require_sha256(self.review_evidence_sha256, "review evidence digest")
+        if not self.review_claim_id.startswith("av1vdreviewclaim1_"):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review claim reference is invalid"
+            )
+        for digest, label in (
+            (self.review_claim_payload_sha256, "review-claim digest"),
+            (
+                self.review_runner_canonical_path_sha256,
+                "review-runner canonical-path digest",
+            ),
+            (self.review_runner_binary_sha256, "review-runner binary digest"),
+            (self.review_evidence_sha256, "review evidence digest"),
+        ):
+            _require_sha256(digest, label)
         if self.decision not in {"approved", "rejected"}:
             raise AV1ValidationDerivationError("AV1 derivation review decision is invalid")
         _require_sha256(self.proposal_payload_sha256, "proposal digest")
@@ -737,8 +881,14 @@ class AV1ValidationDerivationReviewAttestation:
             "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
             "proposal_id": self.proposal_id,
             "proposal_payload_sha256": self.proposal_payload_sha256,
+            "review_claim_id": self.review_claim_id,
+            "review_claim_payload_sha256": self.review_claim_payload_sha256,
             "lane": self.lane,
             "reviewer_token": self.reviewer_token,
+            "review_runner_canonical_path_sha256": (
+                self.review_runner_canonical_path_sha256
+            ),
+            "review_runner_binary_sha256": self.review_runner_binary_sha256,
             "review_evidence_sha256": self.review_evidence_sha256,
             "decision": self.decision,
             "reviewed_at": self.reviewed_at,
@@ -1384,6 +1534,10 @@ def evaluate_av1_validation_derivation_candidate(
             blockers=tuple(sorted(set(blockers))),
             proposal=None,
         )
+    target_bitrates = sorted(
+        assignment.target_video_bitrate_bps
+        for assignment in expected
+    )
     proposed_payload = _proposal_semantic_payload(
         plan=plan,
         cell_plan_id=cell_plan_id,
@@ -1394,8 +1548,13 @@ def evaluate_av1_validation_derivation_candidate(
         crf_mad=crf_mad,
         bitrate_relative_mad=relative_mad,
         statistics_contract_sha256=plan.authorization.statistics_contract_sha256,
-        bitrate_min=bitrates[0],
-        bitrate_max=bitrates[-1],
+        minimum_derivation_source_count=(
+            manifest.criteria.minimum_derivation_source_count
+        ),
+        maximum_derivation_age_days=manifest.criteria.maximum_derivation_age_days,
+        maximum_candidate_crf_span=manifest.criteria.maximum_candidate_crf_span,
+        target_video_bitrate_min_bps=target_bitrates[0],
+        target_video_bitrate_max_bps=target_bitrates[-1],
         confidence_level=cast(Literal["moderate", "high"], confidence_level),
         confidence_score=confidence_score,
         derivation_conflict_count=derivation_conflict_count,
@@ -1415,10 +1574,15 @@ def evaluate_av1_validation_derivation_candidate(
         crf_mad=crf_mad,
         bitrate_relative_mad=relative_mad,
         statistics_contract_sha256=plan.authorization.statistics_contract_sha256,
+        minimum_derivation_source_count=(
+            manifest.criteria.minimum_derivation_source_count
+        ),
+        maximum_derivation_age_days=manifest.criteria.maximum_derivation_age_days,
+        maximum_candidate_crf_span=manifest.criteria.maximum_candidate_crf_span,
         compatibility_signature=observations[0].compatibility_signature,
         policy_signature=observations[0].policy_signature,
-        target_video_bitrate_min_bps=bitrates[0],
-        target_video_bitrate_max_bps=bitrates[-1],
+        target_video_bitrate_min_bps=target_bitrates[0],
+        target_video_bitrate_max_bps=target_bitrates[-1],
         minimum_quality_score=observations[0].minimum_quality_score,
         confidence_level=cast(Literal["moderate", "high"], confidence_level),
         confidence_score=confidence_score,
@@ -1446,20 +1610,106 @@ def evaluate_av1_validation_derivation_candidate(
     )
 
 
+def build_av1_validation_derivation_review_claim(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        lane: AV1ValidationDerivationReviewLane,
+        review_run_id: str,
+        review_runner_canonical_path_sha256: str,
+        review_runner_binary_sha256: str,
+        claimed_at: str,
+) -> AV1ValidationDerivationReviewClaim:
+    claimed = _parse_timestamp(claimed_at, "review-claim timestamp")
+    if (
+        proposal.plan_id != plan.plan_id
+        or proposal.manifest_id != plan.manifest_id
+        or proposal.selection_lock_sha256 != plan.selection_lock_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review claim is bound to another plan"
+        )
+    if (
+        review_runner_canonical_path_sha256
+        != plan.authorization.review_runner_canonical_path_sha256
+        or review_runner_binary_sha256
+        != plan.authorization.review_runner_binary_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review runner does not match the authorization"
+        )
+    if not (
+        _parse_timestamp(proposal.proposed_at, "proposal timestamp")
+        <= claimed
+        < _parse_timestamp(
+            plan.authorization.valid_until,
+            "derivation authorization expiration",
+        )
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review claim is outside its authorization window"
+        )
+    reviewer_token = f"agent:{review_run_id}"
+    semantic_payload = {
+        "schema": AV1_VALIDATION_DERIVATION_REVIEW_CLAIM_SCHEMA,
+        "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "plan_id": plan.plan_id,
+        "authorization_id": plan.authorization.authorization_id,
+        "proposal_id": proposal.proposal_id,
+        "proposal_payload_sha256": proposal.payload_sha256,
+        "lane": lane,
+        "review_run_id": review_run_id,
+        "reviewer_token": reviewer_token,
+        "review_runner_canonical_path_sha256": (
+            review_runner_canonical_path_sha256
+        ),
+        "review_runner_binary_sha256": review_runner_binary_sha256,
+        "claimed_at": _utc_timestamp(claimed),
+    }
+    claim_id = _derivation_id("review_claim", semantic_payload)
+    return AV1ValidationDerivationReviewClaim(
+        claim_id=claim_id,
+        plan_id=plan.plan_id,
+        authorization_id=plan.authorization.authorization_id,
+        proposal_id=proposal.proposal_id,
+        proposal_payload_sha256=proposal.payload_sha256,
+        lane=lane,
+        review_run_id=review_run_id,
+        reviewer_token=reviewer_token,
+        review_runner_canonical_path_sha256=(
+            review_runner_canonical_path_sha256
+        ),
+        review_runner_binary_sha256=review_runner_binary_sha256,
+        claimed_at=_utc_timestamp(claimed),
+        payload_sha256=_payload_sha256({
+            "claim_id": claim_id,
+            **semantic_payload,
+        }),
+    )
+
+
 def build_av1_validation_derivation_review_attestation(
         *,
         proposal: AV1ValidationDerivationCandidateProposal,
-        lane: AV1ValidationDerivationReviewLane,
-        reviewer_token: str,
+        claim: AV1ValidationDerivationReviewClaim,
         review_evidence_sha256: str,
         decision: AV1ValidationDerivationReviewDecision,
         reviewed_at: str,
 ) -> AV1ValidationDerivationReviewAttestation:
     reviewed = _parse_timestamp(reviewed_at, "review timestamp")
-    if reviewed < _parse_timestamp(
-        proposal.proposed_at, "proposal timestamp"
+    if (
+        claim.proposal_id != proposal.proposal_id
+        or claim.proposal_payload_sha256 != proposal.payload_sha256
+        or claim.plan_id != proposal.plan_id
     ):
-        raise AV1ValidationDerivationError("AV1 derivation review predates its proposal")
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review claim is bound to another proposal"
+        )
+    if reviewed < _parse_timestamp(claim.claimed_at, "review-claim timestamp"):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review predates its immutable claim"
+        )
     normalized_reviewed_at = _utc_timestamp(reviewed)
     semantic_payload = {
         "schema": AV1_VALIDATION_DERIVATION_REVIEW_SCHEMA,
@@ -1467,8 +1717,14 @@ def build_av1_validation_derivation_review_attestation(
         "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
         "proposal_id": proposal.proposal_id,
         "proposal_payload_sha256": proposal.payload_sha256,
-        "lane": lane,
-        "reviewer_token": reviewer_token,
+        "review_claim_id": claim.claim_id,
+        "review_claim_payload_sha256": claim.payload_sha256,
+        "lane": claim.lane,
+        "reviewer_token": claim.reviewer_token,
+        "review_runner_canonical_path_sha256": (
+            claim.review_runner_canonical_path_sha256
+        ),
+        "review_runner_binary_sha256": claim.review_runner_binary_sha256,
         "review_evidence_sha256": review_evidence_sha256,
         "decision": decision,
         "reviewed_at": normalized_reviewed_at,
@@ -1478,8 +1734,14 @@ def build_av1_validation_derivation_review_attestation(
         attestation_id=attestation_id,
         proposal_id=proposal.proposal_id,
         proposal_payload_sha256=proposal.payload_sha256,
-        lane=lane,
-        reviewer_token=reviewer_token,
+        review_claim_id=claim.claim_id,
+        review_claim_payload_sha256=claim.payload_sha256,
+        lane=claim.lane,
+        reviewer_token=claim.reviewer_token,
+        review_runner_canonical_path_sha256=(
+            claim.review_runner_canonical_path_sha256
+        ),
+        review_runner_binary_sha256=claim.review_runner_binary_sha256,
         review_evidence_sha256=review_evidence_sha256,
         decision=decision,
         reviewed_at=normalized_reviewed_at,
@@ -1522,11 +1784,16 @@ def build_av1_validation_derivation_review_envelope(
 
 
 def _av1_validation_derivation_review_set_sha256(
+        claims: Sequence[AV1ValidationDerivationReviewClaim],
         envelopes: Sequence[AV1ValidationDerivationReviewEnvelope],
 ) -> str:
     reviews = tuple(envelope.review for envelope in envelopes)
+    claims_by_lane = {claim.lane: claim for claim in claims}
     if (
-        len(envelopes) != len(AV1_VALIDATION_DERIVATION_REVIEW_LANES)
+        len(claims) != len(AV1_VALIDATION_DERIVATION_REVIEW_LANES)
+        or set(claims_by_lane) != set(AV1_VALIDATION_DERIVATION_REVIEW_LANES)
+        or len({claim.review_run_id for claim in claims}) != len(claims)
+        or len(envelopes) != len(AV1_VALIDATION_DERIVATION_REVIEW_LANES)
         or {review.lane for review in reviews}
         != set(AV1_VALIDATION_DERIVATION_REVIEW_LANES)
         or len({review.reviewer_token for review in reviews}) != len(reviews)
@@ -1535,11 +1802,25 @@ def _av1_validation_derivation_review_set_sha256(
         raise AV1ValidationDerivationError(
             "AV1 derivation review set is incomplete or not independent"
         )
+    if any(
+        not _av1_validation_derivation_review_matches_claim(
+            review,
+            claims_by_lane[review.lane],
+        )
+        for review in reviews
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review set does not resolve its immutable claims"
+        )
     return _payload_sha256({
         "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
         "reviews": [
             {
                 "lane": envelope.review.lane,
+                "claim_id": claims_by_lane[envelope.review.lane].claim_id,
+                "claim_payload_sha256": (
+                    claims_by_lane[envelope.review.lane].payload_sha256
+                ),
                 "envelope_id": envelope.envelope_id,
                 "envelope_payload_sha256": envelope.payload_sha256,
             }
@@ -1548,9 +1829,30 @@ def _av1_validation_derivation_review_set_sha256(
     })
 
 
+def _av1_validation_derivation_review_matches_claim(
+        review: AV1ValidationDerivationReviewAttestation,
+        claim: AV1ValidationDerivationReviewClaim,
+) -> bool:
+    return (
+        review.review_claim_id == claim.claim_id
+        and review.review_claim_payload_sha256 == claim.payload_sha256
+        and review.proposal_id == claim.proposal_id
+        and review.proposal_payload_sha256 == claim.proposal_payload_sha256
+        and review.lane == claim.lane
+        and review.reviewer_token == claim.reviewer_token
+        and review.review_runner_canonical_path_sha256
+        == claim.review_runner_canonical_path_sha256
+        and review.review_runner_binary_sha256
+        == claim.review_runner_binary_sha256
+        and _parse_timestamp(review.reviewed_at, "review timestamp")
+        >= _parse_timestamp(claim.claimed_at, "review-claim timestamp")
+    )
+
+
 def finalize_av1_validation_derivation_candidate_lock(
         *,
         proposal: AV1ValidationDerivationCandidateProposal,
+        review_claims: Sequence[AV1ValidationDerivationReviewClaim],
         reviews: Sequence[AV1ValidationDerivationReviewAttestation],
         current_evaluation: AV1ValidationDerivationCandidateEvaluation,
         locked_at: str,
@@ -1573,6 +1875,21 @@ def finalize_av1_validation_derivation_candidate_lock(
         raise AV1ValidationDerivationError(
             "AV1 derivation candidate is no longer current at lock time"
         )
+    if _parse_timestamp(
+        current_proposal.derivation_oldest_recorded_at,
+        "oldest current observation",
+    ) < locked - timedelta(days=current_proposal.maximum_derivation_age_days):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation candidate evidence is stale at lock time"
+        )
+    claims_by_lane = {claim.lane: claim for claim in review_claims}
+    if (
+        len(review_claims) != len(AV1_VALIDATION_DERIVATION_REVIEW_LANES)
+        or set(claims_by_lane) != set(AV1_VALIDATION_DERIVATION_REVIEW_LANES)
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation candidate requires all five immutable review claims"
+        )
     if {review.lane for review in reviews} != set(AV1_VALIDATION_DERIVATION_REVIEW_LANES):
         raise AV1ValidationDerivationError("AV1 derivation candidate requires all five review lanes")
     if len(reviews) != len(AV1_VALIDATION_DERIVATION_REVIEW_LANES):
@@ -1585,8 +1902,13 @@ def finalize_av1_validation_derivation_candidate_lock(
         )
     for review in reviews:
         reviewed = _parse_timestamp(review.reviewed_at, "review timestamp")
+        claim = claims_by_lane[review.lane]
         if (
-            review.proposal_id != proposal.proposal_id
+            claim.plan_id != proposal.plan_id
+            or claim.proposal_id != proposal.proposal_id
+            or claim.proposal_payload_sha256 != proposal.payload_sha256
+            or not _av1_validation_derivation_review_matches_claim(review, claim)
+            or review.proposal_id != proposal.proposal_id
             or review.proposal_payload_sha256 != proposal.payload_sha256
             or review.decision != "approved"
             or reviewed < _parse_timestamp(
@@ -1635,6 +1957,7 @@ def _finalize_and_write_av1_validation_derivation_candidate_lock(
         *,
         plan: AV1ValidationDerivationPlan,
         proposal: AV1ValidationDerivationCandidateProposal,
+        review_claims: Sequence[AV1ValidationDerivationReviewClaim],
         review_envelopes: Sequence[AV1ValidationDerivationReviewEnvelope],
         current_evaluation: AV1ValidationDerivationCandidateEvaluation,
         locked_at: str,
@@ -1642,6 +1965,7 @@ def _finalize_and_write_av1_validation_derivation_candidate_lock(
     reviews = tuple(envelope.review for envelope in review_envelopes)
     candidate_lock = finalize_av1_validation_derivation_candidate_lock(
         proposal=proposal,
+        review_claims=review_claims,
         reviews=reviews,
         current_evaluation=current_evaluation,
         locked_at=locked_at,
@@ -1653,6 +1977,15 @@ def _finalize_and_write_av1_validation_derivation_candidate_lock(
         or candidate_lock.cell_plan_id not in {
             assignment.cell_plan_id for assignment in plan.assignments
         }
+        or any(
+            claim.plan_id != plan.plan_id
+            or claim.authorization_id != plan.authorization.authorization_id
+            or claim.review_runner_canonical_path_sha256
+            != plan.authorization.review_runner_canonical_path_sha256
+            or claim.review_runner_binary_sha256
+            != plan.authorization.review_runner_binary_sha256
+            for claim in review_claims
+        )
     ):
         raise AV1ValidationDerivationError(
             "AV1 derivation candidate lock is bound to another plan"
@@ -1679,6 +2012,7 @@ def _finalize_and_write_av1_validation_derivation_candidate_lock(
         "proposal_id": proposal.proposal_id,
         "proposal_payload_sha256": proposal.payload_sha256,
         "review_set_sha256": _av1_validation_derivation_review_set_sha256(
+            review_claims,
             review_envelopes
         ),
         "artifact_root_binding_sha256": (
@@ -1754,6 +2088,7 @@ def _load_verified_av1_validation_derivation_candidate_lock(
         *,
         plan: AV1ValidationDerivationPlan,
         proposal: AV1ValidationDerivationCandidateProposal,
+        review_claims: Sequence[AV1ValidationDerivationReviewClaim],
         review_envelopes: Sequence[AV1ValidationDerivationReviewEnvelope],
         current_evaluation: AV1ValidationDerivationCandidateEvaluation,
         cell_plan_id: str,
@@ -1770,6 +2105,7 @@ def _load_verified_av1_validation_derivation_candidate_lock(
     reviews = tuple(item.review for item in review_envelopes)
     expected_lock = finalize_av1_validation_derivation_candidate_lock(
         proposal=proposal,
+        review_claims=review_claims,
         reviews=reviews,
         current_evaluation=current_evaluation,
         locked_at=envelope.candidate_lock.locked_at,
@@ -1786,6 +2122,7 @@ def _load_verified_av1_validation_derivation_candidate_lock(
         "proposal_id": proposal.proposal_id,
         "proposal_payload_sha256": proposal.payload_sha256,
         "review_set_sha256": _av1_validation_derivation_review_set_sha256(
+            review_claims,
             review_envelopes
         ),
         "artifact_root_binding_sha256": (
@@ -1808,11 +2145,11 @@ def _av1_validation_derivation_artifact_root_path(
 ) -> Path:
     root = artifact_root.expanduser().resolve()
     if (
-        root.name != plan.plan_id
+        root.name != plan.partition_id
         or root.parent.name != AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
     ):
         raise AV1ValidationDerivationError(
-            "AV1 derivation artifacts must use the plan-global canonical root"
+            "AV1 derivation artifacts must use the partition-global canonical root"
         )
     return root
 
@@ -2198,11 +2535,110 @@ def load_av1_validation_derivation_candidate_proposal(
     return proposal
 
 
+def write_av1_validation_derivation_review_claim(
+        artifact_root: Path,
+        *,
+        plan: AV1ValidationDerivationPlan,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        claim: AV1ValidationDerivationReviewClaim,
+) -> Path:
+    root = _bind_av1_validation_derivation_artifact_root(artifact_root, plan)
+    if (
+        proposal.plan_id != plan.plan_id
+        or proposal.manifest_id != plan.manifest_id
+        or claim.plan_id != plan.plan_id
+        or claim.authorization_id != plan.authorization.authorization_id
+        or claim.proposal_id != proposal.proposal_id
+        or claim.proposal_payload_sha256 != proposal.payload_sha256
+        or claim.review_runner_canonical_path_sha256
+        != plan.authorization.review_runner_canonical_path_sha256
+        or claim.review_runner_binary_sha256
+        != plan.authorization.review_runner_binary_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review claim is bound to another run or proposal"
+        )
+    directory = root / "review-claims" / proposal.proposal_id
+    _bind_owner_only_directory(
+        directory,
+        kind="review_claims",
+        binding_id=proposal.proposal_id,
+        binding_digest=proposal.payload_sha256,
+    )
+    path = directory / f"{claim.lane}.json"
+    _write_owner_only(path, canonical_json_bytes(claim.to_payload()))
+    return path
+
+
+def load_av1_validation_derivation_review_claims(
+        artifact_root: Path,
+        *,
+        plan: AV1ValidationDerivationPlan,
+        proposal: AV1ValidationDerivationCandidateProposal,
+) -> tuple[AV1ValidationDerivationReviewClaim, ...]:
+    root = _assert_av1_validation_derivation_artifact_root_binding(
+        artifact_root,
+        plan,
+    )
+    if proposal.plan_id != plan.plan_id or proposal.manifest_id != plan.manifest_id:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation proposal is bound to another plan"
+        )
+    directory = root / "review-claims" / proposal.proposal_id
+    binding = _load_owner_only_directory_binding(
+        directory,
+        expected_kind="review_claims",
+    )
+    if (
+        binding["binding_id"] != proposal.proposal_id
+        or binding["binding_digest"] != proposal.payload_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review-claim directory binding drifted"
+        )
+    claims: list[AV1ValidationDerivationReviewClaim] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.stem not in AV1_VALIDATION_DERIVATION_REVIEW_LANES:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review-claim directory contains an invalid lane"
+            )
+        payload, raw = _load_owner_only_json(
+            path,
+            "derivation review claim",
+        )
+        claim = av1_validation_derivation_review_claim_from_payload(
+            payload,
+            raw=raw,
+        )
+        if (
+            claim.plan_id != plan.plan_id
+            or claim.authorization_id != plan.authorization.authorization_id
+            or claim.proposal_id != proposal.proposal_id
+            or claim.proposal_payload_sha256 != proposal.payload_sha256
+            or claim.lane != path.stem
+            or claim.review_runner_canonical_path_sha256
+            != plan.authorization.review_runner_canonical_path_sha256
+            or claim.review_runner_binary_sha256
+            != plan.authorization.review_runner_binary_sha256
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review claim is bound to another run or proposal"
+            )
+        claims.append(claim)
+    lanes = [claim.lane for claim in claims]
+    if len(lanes) != len(set(lanes)):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review-claim directory repeats a lane"
+        )
+    return tuple(sorted(claims, key=lambda item: item.lane))
+
+
 def write_av1_validation_derivation_review_envelope(
         artifact_root: Path,
         *,
         plan: AV1ValidationDerivationPlan,
         proposal: AV1ValidationDerivationCandidateProposal,
+        claim: AV1ValidationDerivationReviewClaim,
         envelope: AV1ValidationDerivationReviewEnvelope,
 ) -> Path:
     review = envelope.review
@@ -2212,6 +2648,7 @@ def write_av1_validation_derivation_review_envelope(
         or proposal.manifest_id != plan.manifest_id
         or review.proposal_id != proposal.proposal_id
         or review.proposal_payload_sha256 != proposal.payload_sha256
+        or not _av1_validation_derivation_review_matches_claim(review, claim)
     ):
         raise AV1ValidationDerivationError(
             "AV1 derivation review envelope is bound to another run or proposal"
@@ -2233,6 +2670,7 @@ def load_av1_validation_derivation_review_envelopes(
         *,
         plan: AV1ValidationDerivationPlan,
         proposal: AV1ValidationDerivationCandidateProposal,
+        claims: Sequence[AV1ValidationDerivationReviewClaim],
 ) -> tuple[AV1ValidationDerivationReviewEnvelope, ...]:
     root = _assert_av1_validation_derivation_artifact_root_binding(
         artifact_root,
@@ -2266,16 +2704,22 @@ def load_av1_validation_derivation_review_envelopes(
         )
     envelopes = tuple(envelopes_list)
     reviews = tuple(envelope.review for envelope in envelopes)
+    claims_by_lane = {claim.lane: claim for claim in claims}
     lanes = [review.lane for review in reviews]
     if len(lanes) != len(set(lanes)):
         raise AV1ValidationDerivationError("AV1 derivation review directory repeats a lane")
     if any(
         review.proposal_id != binding["binding_id"]
         or review.proposal_payload_sha256 != binding["binding_digest"]
+        or review.lane not in claims_by_lane
+        or not _av1_validation_derivation_review_matches_claim(
+            review,
+            claims_by_lane[review.lane],
+        )
         for review in reviews
     ):
         raise AV1ValidationDerivationError("AV1 derivation review directory binding drifted")
-    _av1_validation_derivation_review_set_sha256(envelopes)
+    _av1_validation_derivation_review_set_sha256(claims, envelopes)
     return envelopes
 
 
@@ -2292,8 +2736,10 @@ def validate_av1_validation_derivation_review_run_evidence(
         ) from exc
     _require_exact_keys(payload, {
         "schema", "schema_version", "review_run_id", "reviewer_token",
-        "proposal_id", "proposal_payload_sha256", "lane", "decision",
-        "code_binary_sha256", "prompt_sha256", "stdout", "stderr", "returncode",
+        "proposal_id", "proposal_payload_sha256", "review_claim_id",
+        "review_claim_payload_sha256", "lane", "decision",
+        "review_runner_canonical_path_sha256", "review_runner_binary_sha256",
+        "prompt_sha256", "stdout", "stderr", "returncode",
     }, "derivation review run evidence")
     review_run_id = _required_text(payload.get("review_run_id"), "review run ID")
     stdout = payload.get("stdout")
@@ -2306,8 +2752,15 @@ def validate_av1_validation_derivation_review_run_evidence(
         or review.reviewer_token != f"agent:{review_run_id}"
         or payload.get("proposal_id") != review.proposal_id
         or payload.get("proposal_payload_sha256") != review.proposal_payload_sha256
+        or payload.get("review_claim_id") != review.review_claim_id
+        or payload.get("review_claim_payload_sha256")
+        != review.review_claim_payload_sha256
         or payload.get("lane") != review.lane
         or payload.get("decision") != review.decision
+        or payload.get("review_runner_canonical_path_sha256")
+        != review.review_runner_canonical_path_sha256
+        or payload.get("review_runner_binary_sha256")
+        != review.review_runner_binary_sha256
         or type(returncode) is not int
         or returncode != 0
         or not isinstance(stdout, str)
@@ -2318,9 +2771,26 @@ def validate_av1_validation_derivation_review_run_evidence(
             "AV1 derivation review run evidence does not match its attestation"
         )
     _require_sha256(
-        _required_text(payload.get("code_binary_sha256"), "Code binary digest"),
-        "Code binary digest",
+        _required_text(
+            payload.get("review_runner_canonical_path_sha256"),
+            "review-runner canonical-path digest",
+        ),
+        "review-runner canonical-path digest",
     )
+    _require_sha256(
+        _required_text(
+            payload.get("review_runner_binary_sha256"),
+            "review-runner binary digest",
+        ),
+        "review-runner binary digest",
+    )
+    canonical_evidence = canonical_json_bytes(payload)
+    if review.review_evidence_sha256 != (
+        f"sha256:{hashlib.sha256(canonical_evidence).hexdigest()}"
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review evidence digest does not match its canonical evidence"
+        )
     prompt_sha256 = _required_text(payload.get("prompt_sha256"), "review prompt digest")
     _require_sha256(prompt_sha256, "review prompt digest")
     final_message, prompt = _completed_code_review_message(stdout)
@@ -2332,6 +2802,8 @@ def validate_av1_validation_derivation_review_run_evidence(
         review_run_id,
         review.proposal_id,
         review.proposal_payload_sha256,
+        review.review_claim_id,
+        review.review_claim_payload_sha256,
         review.lane,
     ):
         if bound_value not in prompt:
@@ -2344,6 +2816,8 @@ def validate_av1_validation_derivation_review_run_evidence(
         "lane": review.lane,
         "proposal_id": review.proposal_id,
         "proposal_payload_sha256": review.proposal_payload_sha256,
+        "review_claim_id": review.review_claim_id,
+        "review_claim_payload_sha256": review.review_claim_payload_sha256,
         "review_run_id": review_run_id,
     }:
         raise AV1ValidationDerivationError(
@@ -2422,7 +2896,8 @@ def _code_review_marker(message: str) -> dict[str, Any]:
             "AV1 derivation review completion marker is invalid"
         ) from exc
     _require_exact_keys(marker, {
-        "decision", "lane", "proposal_id", "proposal_payload_sha256", "review_run_id",
+        "decision", "lane", "proposal_id", "proposal_payload_sha256",
+        "review_claim_id", "review_claim_payload_sha256", "review_run_id",
     }, "derivation review completion marker")
     return marker
 
@@ -2439,6 +2914,7 @@ def av1_validation_derivation_plan_public_summary(
         "selection_lock_sha256": plan.selection_lock_sha256,
         "derivation_partition_sha256": plan.derivation_partition_sha256,
         "runtime_context_bound": True,
+        "review_runner_identity_bound": True,
         "authorization_id": plan.authorization.authorization_id,
         "derivation_assignment_count": len(plan.assignments),
         "candidate_count": len({assignment.cell_plan_id for assignment in plan.assignments}),
@@ -2634,7 +3110,9 @@ def av1_validation_derivation_candidate_proposal_from_payload(
         "proposal_id", "schema", "schema_version", "contract_version", "plan_id",
         "manifest_id", "cell_plan_id", "exact_traits", "crf_lower", "crf_center",
         "crf_upper", "crf_mad", "bitrate_relative_mad",
-        "statistics_contract_sha256", "compatibility_signature", "policy_signature",
+        "statistics_contract_sha256", "minimum_derivation_source_count",
+        "maximum_derivation_age_days", "maximum_candidate_crf_span",
+        "compatibility_signature", "policy_signature",
         "target_video_bitrate_min_bps", "target_video_bitrate_max_bps",
         "minimum_quality_score", "confidence_level", "confidence_score",
         "derivation_evidence_count", "derivation_source_count", "derivation_source_tokens",
@@ -2671,6 +3149,15 @@ def av1_validation_derivation_candidate_proposal_from_payload(
             value.get("statistics_contract_sha256"),
             "statistics contract digest",
         ),
+        minimum_derivation_source_count=int_value(
+            value.get("minimum_derivation_source_count")
+        ),
+        maximum_derivation_age_days=int_value(
+            value.get("maximum_derivation_age_days")
+        ),
+        maximum_candidate_crf_span=float_value(
+            value.get("maximum_candidate_crf_span")
+        ),
         compatibility_signature=_required_text(value.get("compatibility_signature"), "compatibility signature"),
         policy_signature=_required_text(value.get("policy_signature"), "policy signature"),
         target_video_bitrate_min_bps=int_value(value.get("target_video_bitrate_min_bps")),
@@ -2704,6 +3191,68 @@ def av1_validation_derivation_candidate_proposal_from_payload(
     return proposal
 
 
+def av1_validation_derivation_review_claim_from_payload(
+        payload: Mapping[str, Any],
+        *,
+        raw: bytes | None = None,
+) -> AV1ValidationDerivationReviewClaim:
+    value = object_dict(payload)
+    _require_exact_keys(value, {
+        "claim_id", "schema", "schema_version", "contract_version", "plan_id",
+        "authorization_id", "proposal_id", "proposal_payload_sha256", "lane",
+        "review_run_id", "reviewer_token",
+        "review_runner_canonical_path_sha256", "review_runner_binary_sha256",
+        "claimed_at", "payload_sha256",
+    }, "derivation review claim")
+    if (
+        value.get("schema") != AV1_VALIDATION_DERIVATION_REVIEW_CLAIM_SCHEMA
+        or int_value(value.get("schema_version"))
+        != AV1_VALIDATION_DERIVATION_SCHEMA_VERSION
+        or value.get("contract_version")
+        != AV1_VALIDATION_DERIVATION_CONTRACT_VERSION
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review-claim contract is invalid"
+        )
+    claim = AV1ValidationDerivationReviewClaim(
+        claim_id=_required_text(value.get("claim_id"), "review-claim ID"),
+        plan_id=_required_text(value.get("plan_id"), "plan ID"),
+        authorization_id=_required_text(
+            value.get("authorization_id"),
+            "authorization ID",
+        ),
+        proposal_id=_required_text(value.get("proposal_id"), "proposal ID"),
+        proposal_payload_sha256=_required_text(
+            value.get("proposal_payload_sha256"),
+            "proposal digest",
+        ),
+        lane=cast(
+            AV1ValidationDerivationReviewLane,
+            _required_text(value.get("lane"), "review lane"),
+        ),
+        review_run_id=_required_text(value.get("review_run_id"), "review run ID"),
+        reviewer_token=_required_text(value.get("reviewer_token"), "reviewer token"),
+        review_runner_canonical_path_sha256=_required_text(
+            value.get("review_runner_canonical_path_sha256"),
+            "review-runner canonical-path digest",
+        ),
+        review_runner_binary_sha256=_required_text(
+            value.get("review_runner_binary_sha256"),
+            "review-runner binary digest",
+        ),
+        claimed_at=_required_text(value.get("claimed_at"), "review-claim timestamp"),
+        payload_sha256=_required_text(
+            value.get("payload_sha256"),
+            "review-claim digest",
+        ),
+    )
+    if raw is not None and raw != canonical_json_bytes(claim.to_payload()):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review-claim JSON is not canonical"
+        )
+    return claim
+
+
 def av1_validation_derivation_review_attestation_from_payload(
         payload: Mapping[str, Any],
         *,
@@ -2712,7 +3261,9 @@ def av1_validation_derivation_review_attestation_from_payload(
     value = object_dict(payload)
     _require_exact_keys(value, {
         "attestation_id", "schema", "schema_version", "contract_version", "proposal_id",
-        "proposal_payload_sha256", "lane", "reviewer_token", "review_evidence_sha256",
+        "proposal_payload_sha256", "review_claim_id", "review_claim_payload_sha256",
+        "lane", "reviewer_token", "review_runner_canonical_path_sha256",
+        "review_runner_binary_sha256", "review_evidence_sha256",
         "decision", "reviewed_at", "payload_sha256",
     }, "derivation review attestation")
     if (
@@ -2725,8 +3276,24 @@ def av1_validation_derivation_review_attestation_from_payload(
         attestation_id=_required_text(value.get("attestation_id"), "attestation ID"),
         proposal_id=_required_text(value.get("proposal_id"), "proposal ID"),
         proposal_payload_sha256=_required_text(value.get("proposal_payload_sha256"), "proposal digest"),
+        review_claim_id=_required_text(
+            value.get("review_claim_id"),
+            "review-claim ID",
+        ),
+        review_claim_payload_sha256=_required_text(
+            value.get("review_claim_payload_sha256"),
+            "review-claim digest",
+        ),
         lane=cast(AV1ValidationDerivationReviewLane, _required_text(value.get("lane"), "review lane")),
         reviewer_token=_required_text(value.get("reviewer_token"), "reviewer token"),
+        review_runner_canonical_path_sha256=_required_text(
+            value.get("review_runner_canonical_path_sha256"),
+            "review-runner canonical-path digest",
+        ),
+        review_runner_binary_sha256=_required_text(
+            value.get("review_runner_binary_sha256"),
+            "review-runner binary digest",
+        ),
         review_evidence_sha256=_required_text(
             value.get("review_evidence_sha256"),
             "review evidence digest",
@@ -2962,8 +3529,11 @@ def _proposal_semantic_payload(
         crf_mad: float,
         bitrate_relative_mad: float,
         statistics_contract_sha256: str,
-        bitrate_min: int,
-        bitrate_max: int,
+        minimum_derivation_source_count: int,
+        maximum_derivation_age_days: int,
+        maximum_candidate_crf_span: float,
+        target_video_bitrate_min_bps: int,
+        target_video_bitrate_max_bps: int,
         confidence_level: Literal["moderate", "high"],
         confidence_score: float,
         derivation_conflict_count: int,
@@ -2986,10 +3556,13 @@ def _proposal_semantic_payload(
         "crf_mad": crf_mad,
         "bitrate_relative_mad": bitrate_relative_mad,
         "statistics_contract_sha256": statistics_contract_sha256,
+        "minimum_derivation_source_count": minimum_derivation_source_count,
+        "maximum_derivation_age_days": maximum_derivation_age_days,
+        "maximum_candidate_crf_span": maximum_candidate_crf_span,
         "compatibility_signature": observations[0].compatibility_signature,
         "policy_signature": observations[0].policy_signature,
-        "target_video_bitrate_min_bps": bitrate_min,
-        "target_video_bitrate_max_bps": bitrate_max,
+        "target_video_bitrate_min_bps": target_video_bitrate_min_bps,
+        "target_video_bitrate_max_bps": target_video_bitrate_max_bps,
         "minimum_quality_score": observations[0].minimum_quality_score,
         "confidence_level": confidence_level,
         "confidence_score": confidence_score,
@@ -3028,6 +3601,11 @@ def _proposal_lock_inputs(
         "crf_mad": proposal.crf_mad,
         "bitrate_relative_mad": proposal.bitrate_relative_mad,
         "statistics_contract_sha256": proposal.statistics_contract_sha256,
+        "minimum_derivation_source_count": (
+            proposal.minimum_derivation_source_count
+        ),
+        "maximum_derivation_age_days": proposal.maximum_derivation_age_days,
+        "maximum_candidate_crf_span": proposal.maximum_candidate_crf_span,
         "compatibility_signature": proposal.compatibility_signature,
         "policy_signature": proposal.policy_signature,
         "target_video_bitrate_min_bps": proposal.target_video_bitrate_min_bps,
@@ -3532,7 +4110,38 @@ def _write_owner_only(path: Path, data: bytes) -> None:
 
 
 def _ensure_owner_only_directory(path: Path) -> None:
-    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    missing: list[Path] = []
+    current = path
+    while True:
+        try:
+            current.lstat()
+            break
+        except FileNotFoundError:
+            missing.append(current)
+            parent = current.parent
+            if parent == current:
+                raise AV1ValidationDerivationError(
+                    "AV1 private derivation directory is unavailable"
+                )
+            current = parent
+        except OSError as exc:
+            raise AV1ValidationDerivationError(
+                "AV1 private derivation directory is unavailable"
+            ) from exc
+    for directory in reversed(missing):
+        created = False
+        try:
+            os.mkdir(directory, mode=0o700)
+            created = True
+        except FileExistsError:
+            pass
+        except OSError as exc:
+            raise AV1ValidationDerivationError(
+                "AV1 private derivation directory could not be created"
+            ) from exc
+        _assert_owner_only_directory(directory)
+        if created:
+            _fsync_directory(directory.parent)
     _assert_owner_only_directory(path)
 
 
@@ -3687,6 +4296,7 @@ def _derivation_id(kind: str, payload: Mapping[str, Any]) -> str:
         "attempt": "av1vdattempt1",
         "terminal": "av1vdterminal1",
         "proposal": "av1vdproposal1",
+        "review_claim": "av1vdreviewclaim1",
         "review": "av1vdreview1",
         "review_envelope": "av1vdreviewenv1",
         "lock_envelope": "av1vdlockenv1",

--- a/mediaforce/tuning/av1_validation_derivation.py
+++ b/mediaforce/tuning/av1_validation_derivation.py
@@ -3973,6 +3973,15 @@ def _validate_calibration_payload(
     quality_score = float_value(sample_result.get("quality_score"))
     chosen_crf = float_value(sample_result.get("chosen_crf"))
     duration_seconds = float_value(sample_item.get("duration_seconds"))
+    source_size_bytes = int_value(sample_item.get("source_size_bytes"))
+    source_snapshot_size_bytes = int_value(
+        sample_item.get("source_snapshot_size_bytes")
+    )
+    source_snapshot_sha256 = _required_text(
+        sample_item.get("source_snapshot_sha256"),
+        "source snapshot digest",
+    )
+    _require_sha256(source_snapshot_sha256, "source snapshot digest")
     predicted_video_size_bytes = int_value(
         sample_result.get("predicted_video_size_bytes")
     )
@@ -3980,6 +3989,12 @@ def _validate_calibration_payload(
         int_value(sample_item.get("library_item_id")) != assignment.local_item_id
         or str(sample_item.get("content_version_fingerprint") or "")
         != source_identity
+        or str(
+            sample_item.get("source_snapshot_content_version_fingerprint") or ""
+        ) != source_identity
+        or source_snapshot_sha256 != assignment.source_sha256
+        or source_size_bytes <= 0
+        or source_snapshot_size_bytes != source_size_bytes
         or int_value(stream_budget_totals.get("remaining_video_bitrate_bps"))
         != assignment.target_video_bitrate_bps
         or str(sample_result.get("quality_metric") or "").casefold()
@@ -4177,7 +4192,7 @@ def _assignment_from_payload(payload: Mapping[str, Any]) -> AV1ValidationPartiti
     _require_exact_keys(payload, {
         "assignment_id", "role", "cell_plan_id", "ordinal", "local_item_id", "traits",
         "intent_level", "source_token", "title_token", "series_token", "source_group_token",
-        "compatibility_signature", "policy_signature", "target_video_bitrate_bps",
+        "compatibility_signature", "policy_signature", "source_sha256", "target_video_bitrate_bps",
         "quality_metric", "quality_target", "minimum_quality_score", "evidence_summary_sha256",
     }, "derivation assignment")
     return AV1ValidationPartitionAssignment(
@@ -4194,6 +4209,7 @@ def _assignment_from_payload(payload: Mapping[str, Any]) -> AV1ValidationPartiti
         source_group_token=_required_text(payload.get("source_group_token"), "source-group token"),
         compatibility_signature=_required_text(payload.get("compatibility_signature"), "compatibility signature"),
         policy_signature=_required_text(payload.get("policy_signature"), "policy signature"),
+        source_sha256=_required_text(payload.get("source_sha256"), "source digest"),
         target_video_bitrate_bps=int_value(payload.get("target_video_bitrate_bps")),
         quality_metric=_required_text(payload.get("quality_metric"), "quality metric"),
         quality_target=float_value(payload.get("quality_target")),

--- a/mediaforce/tuning/av1_validation_derivation.py
+++ b/mediaforce/tuning/av1_validation_derivation.py
@@ -3799,6 +3799,7 @@ def _validate_calibration_payload(
 ) -> None:
     _validate_calibration_execution(calibration)
     sample_item = object_dict(calibration.get("sample_item"))
+    stream_budget_ledger = object_dict(sample_item.get("stream_budget_ledger"))
     sample_result = object_dict(calibration.get("sample_result"))
     target_trace = object_dict(sample_result.get("target_size_trace"))
     quality_floor = object_dict(target_trace.get("quality_floor"))
@@ -3814,6 +3815,8 @@ def _validate_calibration_payload(
         int_value(sample_item.get("library_item_id")) != assignment.local_item_id
         or str(sample_item.get("content_version_fingerprint") or "")
         != source_identity
+        or int_value(stream_budget_ledger.get("remaining_video_bitrate_bps"))
+        != assignment.target_video_bitrate_bps
         or str(sample_result.get("quality_metric") or "").casefold()
         != assignment.quality_metric.casefold()
         or not math.isclose(quality_target, assignment.quality_target, rel_tol=0.0, abs_tol=0.001)

--- a/mediaforce/tuning/av1_validation_derivation.py
+++ b/mediaforce/tuning/av1_validation_derivation.py
@@ -1,0 +1,3733 @@
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import secrets
+import stat
+from statistics import median
+from typing import Any, Literal, Mapping, Sequence, cast
+
+from mediaforce.core.evidence import canonical_json_bytes
+from mediaforce.core.type_defs import float_value, int_value, object_dict, object_list
+from mediaforce.tuning.av1_cold_start import assert_av1_cold_start_public_payload_safe
+from mediaforce.tuning.av1_cold_start_evaluation import (
+    AV1_COLD_START_VALIDATION_REQUIRED_DERIVATION_EVIDENCE_COUNT,
+    AV1ColdStartValidationCandidateLockV1,
+    _candidate_lock_from_payload,
+    build_av1_cold_start_validation_candidate_lock,
+)
+from mediaforce.tuning.av1_validation_partition import (
+    AV1_VALIDATION_DERIVATION_RESERVATION_COUNT,
+    AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT,
+    AV1ValidationPartitionAssignment,
+    AV1ValidationPrivatePartition,
+)
+from mediaforce.tuning.av1_validation_v2 import (
+    AV1ValidationManifestV2,
+    AV1ValidationV2DerivationAuthorization,
+    assert_preregistered_av1_validation_manifest_v2,
+)
+from mediaforce.tuning.content_intent_observations import (
+    AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON,
+    BOUNDARY_ASSESSMENT_CONTRACT,
+    ContentIntentBoundaryObservation,
+    content_intent_boundary_compatibility_from_payload,
+    content_intent_boundary_observation_integrity_valid,
+)
+
+
+AV1_VALIDATION_DERIVATION_PLAN_SCHEMA = "mediaforce.av1_cold_start_derivation_plan"
+AV1_VALIDATION_DERIVATION_ATTEMPT_SCHEMA = "mediaforce.av1_cold_start_derivation_attempt"
+AV1_VALIDATION_DERIVATION_TERMINAL_SCHEMA = "mediaforce.av1_cold_start_derivation_terminal_record"
+AV1_VALIDATION_DERIVATION_VERDICT_INTENT_SCHEMA = (
+    "mediaforce.av1_cold_start_derivation_verdict_intent"
+)
+AV1_VALIDATION_DERIVATION_PROPOSAL_SCHEMA = "mediaforce.av1_cold_start_derivation_candidate_proposal"
+AV1_VALIDATION_DERIVATION_REVIEW_SCHEMA = "mediaforce.av1_cold_start_derivation_candidate_review"
+AV1_VALIDATION_DERIVATION_REVIEW_ENVELOPE_SCHEMA = (
+    "mediaforce.av1_cold_start_derivation_review_envelope"
+)
+AV1_VALIDATION_DERIVATION_LOCK_ENVELOPE_SCHEMA = (
+    "mediaforce.av1_cold_start_derivation_candidate_lock_envelope"
+)
+AV1_VALIDATION_DERIVATION_DIRECTORY_BINDING_SCHEMA = (
+    "mediaforce.av1_cold_start_derivation_directory_binding"
+)
+AV1_VALIDATION_DERIVATION_SCHEMA_VERSION = 1
+AV1_VALIDATION_DERIVATION_CONTRACT_VERSION = "av1vdw1"
+AV1_VALIDATION_DERIVATION_EXECUTION_SCOPE = "reserved_derivation_sources_only"
+AV1_VALIDATION_DERIVATION_SEARCH_MODE = "unchanged_measured_full_search"
+AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY = "av1-validation-derivation"
+AV1_VALIDATION_DERIVATION_MAXIMUM_CRF_MAD = 2.0
+AV1_VALIDATION_DERIVATION_HIGH_CONFIDENCE_RELATIVE_MAD = 0.10
+AV1_VALIDATION_DERIVATION_MODERATE_CONFIDENCE_RELATIVE_MAD = 0.25
+AV1_VALIDATION_DERIVATION_AGENT_REVIEW_MARKER = "MEDIAFORCE_AV1_REVIEW_V2 "
+
+AV1ValidationDerivationTerminalStatus = Literal[
+    "observed",
+    "failed",
+    "excluded",
+    "stopped",
+]
+AV1ValidationDerivationAttemptStatus = Literal[
+    "review_pending",
+    "failed",
+    "excluded",
+    "stopped",
+]
+AV1ValidationDerivationReviewLane = Literal[
+    "architecture",
+    "statistical_model_contract",
+    "privacy_security",
+    "experimental_design",
+    "adversarial",
+]
+AV1ValidationDerivationReviewDecision = Literal["approved", "rejected"]
+
+AV1_VALIDATION_DERIVATION_REVIEW_LANES: tuple[AV1ValidationDerivationReviewLane, ...] = (
+    "architecture",
+    "statistical_model_contract",
+    "privacy_security",
+    "experimental_design",
+    "adversarial",
+)
+AV1_VALIDATION_DERIVATION_REASON_CODES = frozenset({
+    "authorization_expired",
+    "compatibility_drift",
+    "content_intent_observation_excluded",
+    "media_unavailable",
+    "metrics_incomplete",
+    "operator_stop",
+    "quality_floor_miss",
+    "runtime_failure",
+    "safety_stop",
+    "storage_stop",
+    "timeout",
+    "toolchain_drift",
+})
+
+_SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+_SAFE_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{7,191}\Z")
+_AGENT_REVIEWER_RE = re.compile(
+    r"agent:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\Z"
+)
+
+if (
+    AV1_VALIDATION_DERIVATION_RESERVATION_COUNT
+    != AV1_COLD_START_VALIDATION_REQUIRED_DERIVATION_EVIDENCE_COUNT
+):
+    raise RuntimeError("AV1 derivation contract requires exactly 12 reservations per candidate")
+
+
+class AV1ValidationDerivationError(ValueError):
+    pass
+
+
+def av1_validation_derivation_statistics_contract_sha256(
+        manifest: AV1ValidationManifestV2,
+) -> str:
+    return _payload_sha256({
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "maximum_crf_mad": AV1_VALIDATION_DERIVATION_MAXIMUM_CRF_MAD,
+        "maximum_candidate_crf_span": manifest.criteria.maximum_candidate_crf_span,
+        "high_confidence_relative_mad_maximum": (
+            AV1_VALIDATION_DERIVATION_HIGH_CONFIDENCE_RELATIVE_MAD
+        ),
+        "moderate_confidence_relative_mad_maximum": (
+            AV1_VALIDATION_DERIVATION_MODERATE_CONFIDENCE_RELATIVE_MAD
+        ),
+        "minimum_confidence_level": manifest.criteria.confidence_level,
+        "minimum_confidence_score": manifest.criteria.confidence_score,
+        "maximum_derivation_age_days": manifest.criteria.maximum_derivation_age_days,
+    })
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationDerivationPlan:
+    plan_id: str
+    manifest_id: str
+    manifest_payload_sha256: str
+    partition_id: str
+    partition_payload_sha256: str
+    selection_lock_sha256: str
+    derivation_partition_sha256: str
+    runtime_context_sha256: str
+    authorization: AV1ValidationV2DerivationAuthorization
+    assignments: tuple[AV1ValidationPartitionAssignment, ...]
+    payload_sha256: str
+
+    def __post_init__(self) -> None:
+        for value, label in (
+            (self.manifest_payload_sha256, "manifest digest"),
+            (self.partition_payload_sha256, "partition digest"),
+            (self.selection_lock_sha256, "selection-lock digest"),
+            (self.derivation_partition_sha256, "derivation-partition digest"),
+            (self.runtime_context_sha256, "runtime-context digest"),
+            (self.payload_sha256, "plan digest"),
+        ):
+            _require_sha256(value, label)
+        if not self.manifest_id.startswith("av1vmanifest2_"):
+            raise AV1ValidationDerivationError("AV1 derivation plan manifest is invalid")
+        if not self.partition_id.startswith("av1vpartition1_"):
+            raise AV1ValidationDerivationError("AV1 derivation plan partition is invalid")
+        if self.authorization.manifest_id != self.manifest_id:
+            raise AV1ValidationDerivationError("AV1 derivation authorization manifest drifted")
+        if self.authorization.manifest_payload_sha256 != self.manifest_payload_sha256:
+            raise AV1ValidationDerivationError("AV1 derivation authorization manifest digest drifted")
+        if self.authorization.selection_lock_sha256 != self.selection_lock_sha256:
+            raise AV1ValidationDerivationError("AV1 derivation authorization selection lock drifted")
+        if self.authorization.derivation_partition_sha256 != self.derivation_partition_sha256:
+            raise AV1ValidationDerivationError("AV1 derivation authorization partition drifted")
+        if self.authorization.runtime_context_sha256 != self.runtime_context_sha256:
+            raise AV1ValidationDerivationError("AV1 derivation authorization runtime context drifted")
+        if len(self.assignments) != 2 * AV1_VALIDATION_DERIVATION_RESERVATION_COUNT:
+            raise AV1ValidationDerivationError("AV1 derivation plan must contain exactly 24 assignments")
+        if any(assignment.role != "derivation" for assignment in self.assignments):
+            raise AV1ValidationDerivationError("AV1 derivation plan contains a non-derivation assignment")
+        assignment_ids = [assignment.assignment_id for assignment in self.assignments]
+        if len(assignment_ids) != len(set(assignment_ids)):
+            raise AV1ValidationDerivationError("AV1 derivation plan repeats an assignment")
+        counts = Counter(assignment.cell_plan_id for assignment in self.assignments)
+        if len(counts) != 2 or set(counts.values()) != {AV1_VALIDATION_DERIVATION_RESERVATION_COUNT}:
+            raise AV1ValidationDerivationError("AV1 derivation plan candidate reservations are invalid")
+        if self.assignments != tuple(sorted(self.assignments, key=_assignment_sort_key)):
+            raise AV1ValidationDerivationError("AV1 derivation plan assignments are not canonical")
+        semantic_payload = self.semantic_payload()
+        if self.plan_id != _derivation_id("plan", semantic_payload):
+            raise AV1ValidationDerivationError("AV1 derivation plan ID does not match its payload")
+        if self.payload_sha256 != _payload_sha256({"plan_id": self.plan_id, **semantic_payload}):
+            raise AV1ValidationDerivationError("AV1 derivation plan digest does not match its payload")
+
+    def semantic_payload(self) -> dict[str, Any]:
+        return {
+            "schema": AV1_VALIDATION_DERIVATION_PLAN_SCHEMA,
+            "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+            "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+            "manifest_id": self.manifest_id,
+            "manifest_payload_sha256": self.manifest_payload_sha256,
+            "partition_id": self.partition_id,
+            "partition_payload_sha256": self.partition_payload_sha256,
+            "selection_lock_sha256": self.selection_lock_sha256,
+            "derivation_partition_sha256": self.derivation_partition_sha256,
+            "runtime_context_sha256": self.runtime_context_sha256,
+            "authorization": self.authorization.to_payload(),
+            "execution_scope": AV1_VALIDATION_DERIVATION_EXECUTION_SCOPE,
+            "search_mode": AV1_VALIDATION_DERIVATION_SEARCH_MODE,
+            "derivation_execution_authorized": True,
+            "cold_start_warm_start_allowed": False,
+            "validation_harness_allowed": False,
+            "guided_probe_allowed": False,
+            "holdout_execution_authorized": False,
+            "retry_substitution_backfill_allowed": False,
+            "public_bundle_activation_allowed": False,
+            "assignments": [assignment.to_payload() for assignment in self.assignments],
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "plan_id": self.plan_id,
+            **self.semantic_payload(),
+            "payload_sha256": self.payload_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationDerivationObservationProjection:
+    observation_id: str
+    observation_payload_sha256: str
+    local_item_id: int
+    source_token: str
+    title_token: str
+    series_token: str
+    source_group_token: str
+    traits: tuple[str, ...]
+    intent_level: str
+    compatibility_signature: str
+    policy_signature: str
+    observation_compatibility_key: str
+    observation_policy_hash: str
+    verdict: Literal["acceptable", "unacceptable"]
+    chosen_crf: float
+    boundary_bitrate_bps: int
+    quality_metric: str
+    quality_target: float
+    minimum_quality_score: float
+    measured_quality_score: float
+    quality_floor_met: bool
+    recorded_at: str
+
+    def __post_init__(self) -> None:
+        if not self.observation_id.startswith("cibo1_"):
+            raise AV1ValidationDerivationError("AV1 derivation observation ID is invalid")
+        _require_sha256(self.observation_payload_sha256, "observation digest")
+        if self.local_item_id <= 0:
+            raise AV1ValidationDerivationError("AV1 derivation observation item is invalid")
+        for token in (
+            self.source_token,
+            self.title_token,
+            self.series_token,
+            self.source_group_token,
+            self.compatibility_signature,
+            self.policy_signature,
+            self.observation_compatibility_key,
+            self.observation_policy_hash,
+        ):
+            if not _SAFE_TOKEN_RE.fullmatch(token):
+                raise AV1ValidationDerivationError("AV1 derivation observation token is invalid")
+        if self.traits != tuple(sorted(set(self.traits))) or not self.traits:
+            raise AV1ValidationDerivationError("AV1 derivation observation traits are invalid")
+        if self.verdict not in {"acceptable", "unacceptable"}:
+            raise AV1ValidationDerivationError("AV1 derivation observation verdict is invalid")
+        if not math.isfinite(self.chosen_crf) or not 0 <= self.chosen_crf <= 63:
+            raise AV1ValidationDerivationError("AV1 derivation observation CRF is invalid")
+        if self.boundary_bitrate_bps <= 0:
+            raise AV1ValidationDerivationError("AV1 derivation observation bitrate is invalid")
+        if not all(
+            math.isfinite(value) and value >= 0
+            for value in (
+                self.quality_target,
+                self.minimum_quality_score,
+                self.measured_quality_score,
+            )
+        ):
+            raise AV1ValidationDerivationError("AV1 derivation observation quality values are invalid")
+        if self.minimum_quality_score > self.quality_target:
+            raise AV1ValidationDerivationError("AV1 derivation observation quality floor is invalid")
+        if self.quality_floor_met != (
+            self.measured_quality_score >= self.minimum_quality_score
+        ):
+            raise AV1ValidationDerivationError("AV1 derivation observation quality flag is inconsistent")
+        _parse_timestamp(self.recorded_at, "observation timestamp")
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "observation_id": self.observation_id,
+            "observation_payload_sha256": self.observation_payload_sha256,
+            "local_item_id": self.local_item_id,
+            "source_token": self.source_token,
+            "title_token": self.title_token,
+            "series_token": self.series_token,
+            "source_group_token": self.source_group_token,
+            "traits": list(self.traits),
+            "intent_level": self.intent_level,
+            "compatibility_signature": self.compatibility_signature,
+            "policy_signature": self.policy_signature,
+            "observation_compatibility_key": self.observation_compatibility_key,
+            "observation_policy_hash": self.observation_policy_hash,
+            "verdict": self.verdict,
+            "chosen_crf": self.chosen_crf,
+            "boundary_bitrate_bps": self.boundary_bitrate_bps,
+            "quality_metric": self.quality_metric,
+            "quality_target": self.quality_target,
+            "minimum_quality_score": self.minimum_quality_score,
+            "measured_quality_score": self.measured_quality_score,
+            "quality_floor_met": self.quality_floor_met,
+            "recorded_at": self.recorded_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationDerivationAttempt:
+    attempt_id: str
+    plan_id: str
+    authorization_id: str
+    assignment_id: str
+    cell_plan_id: str
+    ordinal: int
+    started_at: str
+    completed_at: str
+    status: AV1ValidationDerivationAttemptStatus
+    reason_code: str | None
+    calibration_payload_json: str | None
+    calibration_payload_sha256: str | None
+    payload_sha256: str
+
+    def __post_init__(self) -> None:
+        if not self.plan_id.startswith("av1vdplan1_"):
+            raise AV1ValidationDerivationError("AV1 derivation attempt plan is invalid")
+        if not self.authorization_id.startswith("av1vderivation1_"):
+            raise AV1ValidationDerivationError("AV1 derivation attempt authorization is invalid")
+        if not _SAFE_TOKEN_RE.fullmatch(self.assignment_id):
+            raise AV1ValidationDerivationError("AV1 derivation attempt assignment is invalid")
+        if not _SAFE_TOKEN_RE.fullmatch(self.cell_plan_id) or self.ordinal <= 0:
+            raise AV1ValidationDerivationError("AV1 derivation attempt slot is invalid")
+        started = _parse_timestamp(self.started_at, "attempt start")
+        completed = _parse_timestamp(self.completed_at, "attempt completion")
+        if completed < started:
+            raise AV1ValidationDerivationError("AV1 derivation attempt chronology is invalid")
+        if self.status == "review_pending":
+            if (
+                self.reason_code is not None
+                or self.calibration_payload_json is None
+                or self.calibration_payload_sha256 is None
+            ):
+                raise AV1ValidationDerivationError("AV1 review-pending attempt is incomplete")
+            calibration_payload = self.calibration_payload()
+            _validate_calibration_execution(calibration_payload)
+            if self.calibration_payload_json != canonical_json_bytes(calibration_payload).decode("utf-8"):
+                raise AV1ValidationDerivationError("AV1 derivation calibration payload is not canonical")
+            if self.calibration_payload_sha256 != _payload_sha256(calibration_payload):
+                raise AV1ValidationDerivationError("AV1 derivation calibration digest is invalid")
+        elif (
+            self.status not in {"failed", "excluded", "stopped"}
+            or self.reason_code not in AV1_VALIDATION_DERIVATION_REASON_CODES
+            or self.calibration_payload_json is not None
+            or self.calibration_payload_sha256 is not None
+        ):
+            raise AV1ValidationDerivationError("AV1 non-review attempt is invalid")
+        _require_sha256(self.payload_sha256, "attempt digest")
+        semantic_payload = self.semantic_payload()
+        if self.attempt_id != _derivation_id("attempt", semantic_payload):
+            raise AV1ValidationDerivationError("AV1 derivation attempt ID does not match its payload")
+        if self.payload_sha256 != _payload_sha256({"attempt_id": self.attempt_id, **semantic_payload}):
+            raise AV1ValidationDerivationError("AV1 derivation attempt digest does not match its payload")
+
+    def calibration_payload(self) -> dict[str, Any]:
+        if self.calibration_payload_json is None:
+            return {}
+        try:
+            return object_dict(json.loads(self.calibration_payload_json))
+        except (TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise AV1ValidationDerivationError("AV1 derivation calibration payload is invalid") from exc
+
+    def semantic_payload(self) -> dict[str, Any]:
+        return {
+            "schema": AV1_VALIDATION_DERIVATION_ATTEMPT_SCHEMA,
+            "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+            "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+            "plan_id": self.plan_id,
+            "authorization_id": self.authorization_id,
+            "assignment_id": self.assignment_id,
+            "cell_plan_id": self.cell_plan_id,
+            "ordinal": self.ordinal,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "status": self.status,
+            "reason_code": self.reason_code,
+            "calibration_payload": self.calibration_payload() if self.calibration_payload_json is not None else None,
+            "calibration_payload_sha256": self.calibration_payload_sha256,
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "attempt_id": self.attempt_id,
+            **self.semantic_payload(),
+            "payload_sha256": self.payload_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationDerivationTerminalRecord:
+    record_id: str
+    plan_id: str
+    authorization_id: str
+    attempt_id: str
+    attempt_payload_sha256: str
+    assignment_id: str
+    cell_plan_id: str
+    ordinal: int
+    started_at: str
+    completed_at: str
+    status: AV1ValidationDerivationTerminalStatus
+    reason_code: str | None
+    observation: AV1ValidationDerivationObservationProjection | None
+    payload_sha256: str
+
+    def __post_init__(self) -> None:
+        if not self.plan_id.startswith("av1vdplan1_"):
+            raise AV1ValidationDerivationError("AV1 derivation terminal plan is invalid")
+        if not self.authorization_id.startswith("av1vderivation1_"):
+            raise AV1ValidationDerivationError("AV1 derivation terminal authorization is invalid")
+        if not self.attempt_id.startswith("av1vdattempt1_"):
+            raise AV1ValidationDerivationError("AV1 derivation terminal attempt is invalid")
+        _require_sha256(self.attempt_payload_sha256, "attempt digest")
+        if not _SAFE_TOKEN_RE.fullmatch(self.assignment_id):
+            raise AV1ValidationDerivationError("AV1 derivation terminal assignment is invalid")
+        if not _SAFE_TOKEN_RE.fullmatch(self.cell_plan_id) or self.ordinal <= 0:
+            raise AV1ValidationDerivationError("AV1 derivation terminal slot is invalid")
+        started = _parse_timestamp(self.started_at, "attempt start")
+        completed = _parse_timestamp(self.completed_at, "attempt completion")
+        if completed < started:
+            raise AV1ValidationDerivationError("AV1 derivation terminal chronology is invalid")
+        if self.status == "observed":
+            if self.reason_code is not None or self.observation is None:
+                raise AV1ValidationDerivationError("AV1 observed terminal record is incomplete")
+        elif (
+            self.status not in {"failed", "excluded", "stopped"}
+            or self.reason_code not in AV1_VALIDATION_DERIVATION_REASON_CODES
+            or self.observation is not None
+        ):
+            raise AV1ValidationDerivationError("AV1 non-observed terminal record is invalid")
+        semantic_payload = self.semantic_payload()
+        if self.record_id != _derivation_id("terminal", semantic_payload):
+            raise AV1ValidationDerivationError("AV1 derivation terminal ID does not match its payload")
+        if self.payload_sha256 != _payload_sha256({"record_id": self.record_id, **semantic_payload}):
+            raise AV1ValidationDerivationError("AV1 derivation terminal digest does not match its payload")
+
+    def semantic_payload(self) -> dict[str, Any]:
+        return {
+            "schema": AV1_VALIDATION_DERIVATION_TERMINAL_SCHEMA,
+            "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+            "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+            "plan_id": self.plan_id,
+            "authorization_id": self.authorization_id,
+            "attempt_id": self.attempt_id,
+            "attempt_payload_sha256": self.attempt_payload_sha256,
+            "assignment_id": self.assignment_id,
+            "cell_plan_id": self.cell_plan_id,
+            "ordinal": self.ordinal,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "status": self.status,
+            "reason_code": self.reason_code,
+            "observation": self.observation.to_payload() if self.observation is not None else None,
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "record_id": self.record_id,
+            **self.semantic_payload(),
+            "payload_sha256": self.payload_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationDerivationCandidateProposal:
+    proposal_id: str
+    plan_id: str
+    manifest_id: str
+    cell_plan_id: str
+    exact_traits: tuple[str, ...]
+    crf_lower: float
+    crf_center: float
+    crf_upper: float
+    crf_mad: float
+    bitrate_relative_mad: float
+    statistics_contract_sha256: str
+    compatibility_signature: str
+    policy_signature: str
+    target_video_bitrate_min_bps: int
+    target_video_bitrate_max_bps: int
+    minimum_quality_score: float
+    confidence_level: Literal["moderate", "high"]
+    confidence_score: float
+    derivation_evidence_count: int
+    derivation_source_count: int
+    derivation_source_tokens: tuple[str, ...]
+    derivation_title_tokens: tuple[str, ...]
+    derivation_series_tokens: tuple[str, ...]
+    derivation_source_group_tokens: tuple[str, ...]
+    derivation_source_group_observation_tokens: tuple[str, ...]
+    derivation_oldest_recorded_at: str
+    derivation_newest_recorded_at: str
+    derivation_conflict_count: int
+    derivation_snapshot_sha256: str
+    selection_lock_sha256: str
+    proposed_at: str
+    payload_sha256: str
+
+    def __post_init__(self) -> None:
+        if not self.plan_id.startswith("av1vdplan1_"):
+            raise AV1ValidationDerivationError("AV1 derivation proposal plan is invalid")
+        if not self.manifest_id.startswith("av1vmanifest2_"):
+            raise AV1ValidationDerivationError("AV1 derivation proposal manifest is invalid")
+        if not _SAFE_TOKEN_RE.fullmatch(self.cell_plan_id):
+            raise AV1ValidationDerivationError("AV1 derivation proposal cell plan is invalid")
+        if self.exact_traits != tuple(sorted(set(self.exact_traits))) or not self.exact_traits:
+            raise AV1ValidationDerivationError("AV1 derivation proposal traits are invalid")
+        if not all(
+            math.isfinite(value)
+            for value in (self.crf_lower, self.crf_center, self.crf_upper)
+        ) or not 0 <= self.crf_lower <= self.crf_center <= self.crf_upper <= 63:
+            raise AV1ValidationDerivationError("AV1 derivation proposal CRF range is invalid")
+        if math.ceil(self.crf_lower) > math.floor(self.crf_upper):
+            raise AV1ValidationDerivationError("AV1 derivation proposal has no executable CRF")
+        if (
+            not math.isfinite(self.crf_mad)
+            or self.crf_mad < 0
+            or self.crf_mad > AV1_VALIDATION_DERIVATION_MAXIMUM_CRF_MAD
+        ):
+            raise AV1ValidationDerivationError("AV1 derivation proposal CRF dispersion is invalid")
+        if (
+            not math.isfinite(self.bitrate_relative_mad)
+            or not 0 <= self.bitrate_relative_mad
+            <= AV1_VALIDATION_DERIVATION_MODERATE_CONFIDENCE_RELATIVE_MAD
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation proposal bitrate dispersion is invalid"
+            )
+        for token in (self.compatibility_signature, self.policy_signature):
+            if not _SAFE_TOKEN_RE.fullmatch(token):
+                raise AV1ValidationDerivationError("AV1 derivation proposal signature is invalid")
+        if not 0 < self.target_video_bitrate_min_bps <= self.target_video_bitrate_max_bps:
+            raise AV1ValidationDerivationError("AV1 derivation proposal bitrate range is invalid")
+        if not math.isfinite(self.minimum_quality_score) or self.minimum_quality_score <= 0:
+            raise AV1ValidationDerivationError("AV1 derivation proposal quality floor is invalid")
+        if self.derivation_evidence_count != AV1_VALIDATION_DERIVATION_RESERVATION_COUNT:
+            raise AV1ValidationDerivationError("AV1 derivation proposal evidence count is invalid")
+        if self.derivation_conflict_count != 0:
+            raise AV1ValidationDerivationError("AV1 derivation proposal evidence is conflicting")
+        if self.derivation_source_count < AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT:
+            raise AV1ValidationDerivationError("AV1 derivation proposal source count is invalid")
+        if self.confidence_level not in {"moderate", "high"} or self.confidence_score < 0.7:
+            raise AV1ValidationDerivationError("AV1 derivation proposal confidence is insufficient")
+        for digest in (
+            self.derivation_snapshot_sha256,
+            self.selection_lock_sha256,
+            self.statistics_contract_sha256,
+            self.payload_sha256,
+        ):
+            _require_sha256(digest, "proposal digest")
+        for tokens, label in (
+            (self.derivation_source_tokens, "source"),
+            (self.derivation_title_tokens, "title"),
+            (self.derivation_series_tokens, "series"),
+            (self.derivation_source_group_tokens, "source-group"),
+        ):
+            if tokens != tuple(sorted(set(tokens))) or not tokens:
+                raise AV1ValidationDerivationError(
+                    f"AV1 derivation proposal {label} tokens are invalid"
+                )
+            if any(not _SAFE_TOKEN_RE.fullmatch(token) for token in tokens):
+                raise AV1ValidationDerivationError(
+                    f"AV1 derivation proposal {label} token is invalid"
+                )
+        if (
+            self.derivation_source_group_observation_tokens
+            != tuple(sorted(self.derivation_source_group_observation_tokens))
+            or len(self.derivation_source_group_observation_tokens)
+            != self.derivation_evidence_count
+            or any(
+                not _SAFE_TOKEN_RE.fullmatch(token)
+                for token in self.derivation_source_group_observation_tokens
+            )
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation proposal source-group observations are invalid"
+            )
+        source_group_counts = Counter(self.derivation_source_group_observation_tokens)
+        if tuple(sorted(source_group_counts)) != self.derivation_source_group_tokens:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation proposal source-group observations are incomplete"
+            )
+        if len(source_group_counts) < AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation proposal has insufficient source groups"
+            )
+        if any(
+            count > AV1_VALIDATION_DERIVATION_RESERVATION_COUNT // 3
+            for count in source_group_counts.values()
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation proposal source-group concentration is too high"
+            )
+        if len(self.derivation_source_tokens) != self.derivation_source_count:
+            raise AV1ValidationDerivationError("AV1 derivation proposal source tokens are incomplete")
+        if (
+            self.derivation_source_count != self.derivation_evidence_count
+            or len(self.derivation_title_tokens) != self.derivation_evidence_count
+            or len(self.derivation_series_tokens) != self.derivation_evidence_count
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation proposal does not preserve unique source, title, and series reservations"
+            )
+        oldest = _parse_timestamp(self.derivation_oldest_recorded_at, "oldest observation")
+        newest = _parse_timestamp(self.derivation_newest_recorded_at, "newest observation")
+        proposed = _parse_timestamp(self.proposed_at, "proposal timestamp")
+        if not oldest <= newest <= proposed:
+            raise AV1ValidationDerivationError("AV1 derivation proposal chronology is invalid")
+        semantic_payload = self.semantic_payload()
+        if self.proposal_id != _derivation_id("proposal", semantic_payload):
+            raise AV1ValidationDerivationError("AV1 derivation proposal ID does not match its payload")
+        if self.payload_sha256 != _payload_sha256({"proposal_id": self.proposal_id, **semantic_payload}):
+            raise AV1ValidationDerivationError("AV1 derivation proposal digest does not match its payload")
+
+    def semantic_payload(self) -> dict[str, Any]:
+        return {
+            "schema": AV1_VALIDATION_DERIVATION_PROPOSAL_SCHEMA,
+            "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+            "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+            "plan_id": self.plan_id,
+            "manifest_id": self.manifest_id,
+            "cell_plan_id": self.cell_plan_id,
+            "exact_traits": list(self.exact_traits),
+            "crf_lower": self.crf_lower,
+            "crf_center": self.crf_center,
+            "crf_upper": self.crf_upper,
+            "crf_mad": self.crf_mad,
+            "bitrate_relative_mad": self.bitrate_relative_mad,
+            "statistics_contract_sha256": self.statistics_contract_sha256,
+            "compatibility_signature": self.compatibility_signature,
+            "policy_signature": self.policy_signature,
+            "target_video_bitrate_min_bps": self.target_video_bitrate_min_bps,
+            "target_video_bitrate_max_bps": self.target_video_bitrate_max_bps,
+            "minimum_quality_score": self.minimum_quality_score,
+            "confidence_level": self.confidence_level,
+            "confidence_score": self.confidence_score,
+            "derivation_evidence_count": self.derivation_evidence_count,
+            "derivation_source_count": self.derivation_source_count,
+            "derivation_source_tokens": list(self.derivation_source_tokens),
+            "derivation_title_tokens": list(self.derivation_title_tokens),
+            "derivation_series_tokens": list(self.derivation_series_tokens),
+            "derivation_source_group_tokens": list(self.derivation_source_group_tokens),
+            "derivation_source_group_observation_tokens": list(
+                self.derivation_source_group_observation_tokens
+            ),
+            "derivation_oldest_recorded_at": self.derivation_oldest_recorded_at,
+            "derivation_newest_recorded_at": self.derivation_newest_recorded_at,
+            "derivation_conflict_count": self.derivation_conflict_count,
+            "derivation_snapshot_sha256": self.derivation_snapshot_sha256,
+            "selection_lock_sha256": self.selection_lock_sha256,
+            "proposed_at": self.proposed_at,
+            "review_state": "pending_independent_review",
+            "holdout_execution_authorized": False,
+            "public_bundle_activation_allowed": False,
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "proposal_id": self.proposal_id,
+            **self.semantic_payload(),
+            "payload_sha256": self.payload_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationDerivationReviewAttestation:
+    attestation_id: str
+    proposal_id: str
+    proposal_payload_sha256: str
+    lane: AV1ValidationDerivationReviewLane
+    reviewer_token: str
+    review_evidence_sha256: str
+    decision: AV1ValidationDerivationReviewDecision
+    reviewed_at: str
+    payload_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.lane not in AV1_VALIDATION_DERIVATION_REVIEW_LANES:
+            raise AV1ValidationDerivationError("AV1 derivation review lane is invalid")
+        if not _AGENT_REVIEWER_RE.fullmatch(self.reviewer_token):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation reviewer token must identify one Every Code agent run"
+            )
+        _require_sha256(self.review_evidence_sha256, "review evidence digest")
+        if self.decision not in {"approved", "rejected"}:
+            raise AV1ValidationDerivationError("AV1 derivation review decision is invalid")
+        _require_sha256(self.proposal_payload_sha256, "proposal digest")
+        _require_sha256(self.payload_sha256, "review digest")
+        _parse_timestamp(self.reviewed_at, "review timestamp")
+        semantic_payload = self.semantic_payload()
+        if self.attestation_id != _derivation_id("review", semantic_payload):
+            raise AV1ValidationDerivationError("AV1 derivation review ID does not match its payload")
+        if self.payload_sha256 != _payload_sha256({"attestation_id": self.attestation_id, **semantic_payload}):
+            raise AV1ValidationDerivationError("AV1 derivation review digest does not match its payload")
+
+    def semantic_payload(self) -> dict[str, Any]:
+        return {
+            "schema": AV1_VALIDATION_DERIVATION_REVIEW_SCHEMA,
+            "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+            "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+            "proposal_id": self.proposal_id,
+            "proposal_payload_sha256": self.proposal_payload_sha256,
+            "lane": self.lane,
+            "reviewer_token": self.reviewer_token,
+            "review_evidence_sha256": self.review_evidence_sha256,
+            "decision": self.decision,
+            "reviewed_at": self.reviewed_at,
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "attestation_id": self.attestation_id,
+            **self.semantic_payload(),
+            "payload_sha256": self.payload_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationDerivationReviewEnvelope:
+    envelope_id: str
+    review: AV1ValidationDerivationReviewAttestation
+    review_run_payload_json: str
+    payload_sha256: str
+
+    def __post_init__(self) -> None:
+        try:
+            evidence_payload = object_dict(json.loads(self.review_run_payload_json))
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review envelope evidence is invalid"
+            ) from exc
+        evidence = canonical_json_bytes(evidence_payload)
+        if evidence.decode("utf-8") != self.review_run_payload_json:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review envelope evidence is not canonical"
+            )
+        validate_av1_validation_derivation_review_run_evidence(
+            evidence,
+            review=self.review,
+        )
+        semantic_payload = self.semantic_payload()
+        if self.envelope_id != _derivation_id("review_envelope", semantic_payload):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review envelope ID does not match its payload"
+            )
+        if self.payload_sha256 != _payload_sha256({
+            "envelope_id": self.envelope_id,
+            **semantic_payload,
+        }):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review envelope digest does not match its payload"
+            )
+
+    def semantic_payload(self) -> dict[str, Any]:
+        return {
+            "schema": AV1_VALIDATION_DERIVATION_REVIEW_ENVELOPE_SCHEMA,
+            "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+            "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+            "review": self.review.to_payload(),
+            "review_run_evidence": object_dict(json.loads(self.review_run_payload_json)),
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "envelope_id": self.envelope_id,
+            **self.semantic_payload(),
+            "payload_sha256": self.payload_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationDerivationCandidateLockEnvelope:
+    envelope_id: str
+    plan_id: str
+    plan_payload_sha256: str
+    authorization_id: str
+    authorization_payload_sha256: str
+    proposal_id: str
+    proposal_payload_sha256: str
+    review_set_sha256: str
+    artifact_root_binding_sha256: str
+    candidate_lock: AV1ColdStartValidationCandidateLockV1
+    payload_sha256: str
+
+    def __post_init__(self) -> None:
+        if not self.plan_id.startswith("av1vdplan1_"):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation candidate-lock envelope plan is invalid"
+            )
+        if not self.authorization_id.startswith("av1vderivation1_"):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation candidate-lock envelope authorization is invalid"
+            )
+        if not self.proposal_id.startswith("av1vdproposal1_"):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation candidate-lock envelope proposal is invalid"
+            )
+        for digest in (
+            self.plan_payload_sha256,
+            self.authorization_payload_sha256,
+            self.proposal_payload_sha256,
+            self.review_set_sha256,
+            self.artifact_root_binding_sha256,
+            self.payload_sha256,
+        ):
+            _require_sha256(digest, "candidate-lock envelope digest")
+        semantic_payload = self.semantic_payload()
+        if self.envelope_id != _derivation_id("lock_envelope", semantic_payload):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation candidate-lock envelope ID does not match its payload"
+            )
+        if self.payload_sha256 != _payload_sha256({
+            "envelope_id": self.envelope_id,
+            **semantic_payload,
+        }):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation candidate-lock envelope digest does not match its payload"
+            )
+
+    def semantic_payload(self) -> dict[str, Any]:
+        return {
+            "schema": AV1_VALIDATION_DERIVATION_LOCK_ENVELOPE_SCHEMA,
+            "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+            "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+            "plan_id": self.plan_id,
+            "plan_payload_sha256": self.plan_payload_sha256,
+            "authorization_id": self.authorization_id,
+            "authorization_payload_sha256": self.authorization_payload_sha256,
+            "proposal_id": self.proposal_id,
+            "proposal_payload_sha256": self.proposal_payload_sha256,
+            "review_set_sha256": self.review_set_sha256,
+            "artifact_root_binding_sha256": self.artifact_root_binding_sha256,
+            "candidate_lock": self.candidate_lock.to_payload(),
+        }
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "envelope_id": self.envelope_id,
+            **self.semantic_payload(),
+            "payload_sha256": self.payload_sha256,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AV1ValidationDerivationCandidateEvaluation:
+    cell_plan_id: str
+    derivation_snapshot_sha256: str
+    derivation_conflict_count: int
+    blockers: tuple[str, ...]
+    proposal: AV1ValidationDerivationCandidateProposal | None
+
+
+def build_av1_validation_derivation_plan(
+        *,
+        manifest: AV1ValidationManifestV2,
+        partition: AV1ValidationPrivatePartition,
+        authorization: AV1ValidationV2DerivationAuthorization,
+        runtime_context_sha256: str,
+) -> AV1ValidationDerivationPlan:
+    assert_preregistered_av1_validation_manifest_v2(manifest)
+    if (
+        manifest.criteria.minimum_derivation_evidence_count
+        != AV1_COLD_START_VALIDATION_REQUIRED_DERIVATION_EVIDENCE_COUNT
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation preregistration must require exactly twelve observations"
+        )
+    if partition.manifest_id != manifest.manifest_id or partition.manifest_payload_sha256 != manifest.payload_sha256:
+        raise AV1ValidationDerivationError("AV1 derivation partition does not match the manifest")
+    if authorization.manifest_id != manifest.manifest_id or authorization.manifest_payload_sha256 != manifest.payload_sha256:
+        raise AV1ValidationDerivationError("AV1 derivation authorization does not match the manifest")
+    if authorization.selection_lock_sha256 != partition.selection_lock_sha256:
+        raise AV1ValidationDerivationError("AV1 derivation authorization selection lock does not match")
+    if authorization.derivation_partition_sha256 != partition.derivation_partition_sha256:
+        raise AV1ValidationDerivationError("AV1 derivation authorization partition does not match")
+    if authorization.runtime_context_sha256 != runtime_context_sha256:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation authorization runtime context does not match"
+        )
+    if (
+        authorization.statistics_contract_sha256
+        != av1_validation_derivation_statistics_contract_sha256(manifest)
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation authorization statistics contract does not match"
+        )
+    selected_at = _parse_timestamp(partition.selected_at, "partition selection")
+    authorized_at = _parse_timestamp(authorization.authorized_at, "derivation authorization")
+    valid_until = _parse_timestamp(authorization.valid_until, "derivation authorization expiration")
+    manifest_valid_until = _parse_timestamp(manifest.valid_until, "manifest expiration")
+    if authorized_at < selected_at or valid_until > manifest_valid_until:
+        raise AV1ValidationDerivationError("AV1 derivation authorization chronology is invalid")
+    publication_plan_ids = {
+        plan.cell_plan_id
+        for plan in manifest.cell_plans
+        if plan.mode == "publication_candidate"
+    }
+    assignments = tuple(sorted(
+        (
+            assignment
+            for assignment in partition.assignments
+            if assignment.role == "derivation"
+        ),
+        key=_assignment_sort_key,
+    ))
+    if {assignment.cell_plan_id for assignment in assignments} != publication_plan_ids:
+        raise AV1ValidationDerivationError("AV1 derivation worklist does not cover the candidate plans")
+    semantic_payload = _plan_semantic_payload(
+        manifest=manifest,
+        partition=partition,
+        authorization=authorization,
+        runtime_context_sha256=runtime_context_sha256,
+        assignments=assignments,
+    )
+    plan_id = _derivation_id("plan", semantic_payload)
+    return AV1ValidationDerivationPlan(
+        plan_id=plan_id,
+        manifest_id=manifest.manifest_id,
+        manifest_payload_sha256=manifest.payload_sha256,
+        partition_id=partition.partition_id,
+        partition_payload_sha256=partition.payload_sha256,
+        selection_lock_sha256=partition.selection_lock_sha256,
+        derivation_partition_sha256=partition.derivation_partition_sha256,
+        runtime_context_sha256=runtime_context_sha256,
+        authorization=authorization,
+        assignments=assignments,
+        payload_sha256=_payload_sha256({"plan_id": plan_id, **semantic_payload}),
+    )
+
+
+def build_av1_validation_derivation_attempt(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        partition: AV1ValidationPrivatePartition,
+        assignment_id: str,
+        started_at: str,
+        completed_at: str,
+        status: AV1ValidationDerivationAttemptStatus,
+        reason_code: str | None = None,
+        calibration_payload: Mapping[str, Any] | None = None,
+) -> AV1ValidationDerivationAttempt:
+    _validate_plan_partition(plan, partition)
+    assignment = _assignment_by_id(plan, assignment_id)
+    source_identity = _partition_source_identity(partition, assignment.local_item_id)
+    started = _parse_timestamp(started_at, "attempt start")
+    completed = _parse_timestamp(completed_at, "attempt completion")
+    authorized_at = _parse_timestamp(plan.authorization.authorized_at, "derivation authorization")
+    valid_until = _parse_timestamp(plan.authorization.valid_until, "derivation authorization expiration")
+    if started < authorized_at or started >= valid_until or completed < started:
+        raise AV1ValidationDerivationError("AV1 derivation attempt is outside its authorization window")
+    if completed >= valid_until and not (
+        status == "failed" and reason_code == "authorization_expired"
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation attempt crossed its authorization expiration"
+        )
+    calibration = object_dict(calibration_payload)
+    calibration_json = None
+    calibration_sha256 = None
+    if status == "review_pending":
+        _validate_calibration_payload(
+            assignment,
+            calibration,
+            source_identity=source_identity,
+        )
+        calibration_json = canonical_json_bytes(calibration).decode("utf-8")
+        calibration_sha256 = _payload_sha256(calibration)
+    semantic_payload = _attempt_semantic_payload(
+        plan=plan,
+        assignment=assignment,
+        started_at=started_at,
+        completed_at=completed_at,
+        status=status,
+        reason_code=reason_code,
+        calibration_payload=calibration if calibration_json is not None else None,
+        calibration_payload_sha256=calibration_sha256,
+    )
+    attempt_id = _derivation_id("attempt", semantic_payload)
+    return AV1ValidationDerivationAttempt(
+        attempt_id=attempt_id,
+        plan_id=plan.plan_id,
+        authorization_id=plan.authorization.authorization_id,
+        assignment_id=assignment.assignment_id,
+        cell_plan_id=assignment.cell_plan_id,
+        ordinal=assignment.ordinal,
+        started_at=started_at,
+        completed_at=completed_at,
+        status=status,
+        reason_code=reason_code,
+        calibration_payload_json=calibration_json,
+        calibration_payload_sha256=calibration_sha256,
+        payload_sha256=_payload_sha256({"attempt_id": attempt_id, **semantic_payload}),
+    )
+
+
+def build_av1_validation_derivation_terminal_record(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        partition: AV1ValidationPrivatePartition,
+        attempt: AV1ValidationDerivationAttempt,
+        observation: ContentIntentBoundaryObservation | None = None,
+        observation_exclusion_reason: str | None = None,
+) -> AV1ValidationDerivationTerminalRecord:
+    validate_av1_validation_derivation_attempt_binding(
+        plan=plan,
+        partition=partition,
+        attempt=attempt,
+    )
+    assignment = _assignment_by_id(plan, attempt.assignment_id)
+    projection = None
+    status: AV1ValidationDerivationTerminalStatus
+    reason_code = attempt.reason_code
+    if attempt.status == "review_pending":
+        if observation is not None and observation_exclusion_reason is None:
+            status = "observed"
+            reason_code = None
+            projection = _observation_projection(
+                plan=plan,
+                partition=partition,
+                assignment=assignment,
+                attempt=attempt,
+                observation=observation,
+            )
+        elif observation is None and observation_exclusion_reason == "content_intent_observation_excluded":
+            status = "excluded"
+            reason_code = observation_exclusion_reason
+        else:
+            raise AV1ValidationDerivationError(
+                "AV1 review-pending attempt requires one observation outcome"
+            )
+    else:
+        if observation is not None:
+            raise AV1ValidationDerivationError("AV1 non-observed attempt cannot carry an observation")
+        status = cast(AV1ValidationDerivationTerminalStatus, attempt.status)
+    semantic_payload = _terminal_semantic_payload(
+        plan=plan,
+        assignment=assignment,
+        attempt=attempt,
+        status=status,
+        reason_code=reason_code,
+        observation=projection,
+    )
+    record_id = _derivation_id("terminal", semantic_payload)
+    return AV1ValidationDerivationTerminalRecord(
+        record_id=record_id,
+        plan_id=plan.plan_id,
+        authorization_id=plan.authorization.authorization_id,
+        attempt_id=attempt.attempt_id,
+        attempt_payload_sha256=attempt.payload_sha256,
+        assignment_id=assignment.assignment_id,
+        cell_plan_id=assignment.cell_plan_id,
+        ordinal=assignment.ordinal,
+        started_at=attempt.started_at,
+        completed_at=attempt.completed_at,
+        status=status,
+        reason_code=reason_code,
+        observation=projection,
+        payload_sha256=_payload_sha256({"record_id": record_id, **semantic_payload}),
+    )
+
+
+def validate_av1_validation_derivation_attempt_binding(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        partition: AV1ValidationPrivatePartition,
+        attempt: AV1ValidationDerivationAttempt,
+) -> None:
+    _validate_plan_partition(plan, partition)
+    assignment = _assignment_by_id(plan, attempt.assignment_id)
+    if (
+        attempt.plan_id != plan.plan_id
+        or attempt.authorization_id != plan.authorization.authorization_id
+        or attempt.cell_plan_id != assignment.cell_plan_id
+        or attempt.ordinal != assignment.ordinal
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation attempt is bound to another work item")
+    if attempt.status == "review_pending":
+        _validate_calibration_payload(
+            assignment,
+            attempt.calibration_payload(),
+            source_identity=_partition_source_identity(
+                partition,
+                assignment.local_item_id,
+            ),
+        )
+
+
+def validate_av1_validation_derivation_plan_binding(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        partition: AV1ValidationPrivatePartition,
+) -> None:
+    _validate_plan_partition(plan, partition)
+
+
+def assert_av1_validation_derivation_authorization_active(
+        plan: AV1ValidationDerivationPlan,
+        *,
+        at: str,
+) -> None:
+    timestamp = _parse_timestamp(at, "derivation execution timestamp")
+    if not (
+        _parse_timestamp(
+            plan.authorization.authorized_at,
+            "derivation authorization",
+        )
+        <= timestamp
+        < _parse_timestamp(
+            plan.authorization.valid_until,
+            "derivation authorization expiration",
+        )
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation assignment cannot start outside its authorization window"
+        )
+
+
+def evaluate_av1_validation_derivation_candidate(
+        *,
+        manifest: AV1ValidationManifestV2,
+        plan: AV1ValidationDerivationPlan,
+        partition: AV1ValidationPrivatePartition,
+        cell_plan_id: str,
+        attempts: Sequence[AV1ValidationDerivationAttempt],
+        records: Sequence[AV1ValidationDerivationTerminalRecord],
+        current_observations: Mapping[str, ContentIntentBoundaryObservation],
+        proposed_at: str,
+) -> AV1ValidationDerivationCandidateEvaluation:
+    assert_preregistered_av1_validation_manifest_v2(manifest)
+    _validate_plan_partition(plan, partition)
+    if manifest.manifest_id != plan.manifest_id or manifest.payload_sha256 != plan.manifest_payload_sha256:
+        raise AV1ValidationDerivationError("AV1 derivation proposal manifest drifted")
+    if (
+        plan.authorization.statistics_contract_sha256
+        != av1_validation_derivation_statistics_contract_sha256(manifest)
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation statistics contract drifted after authorization"
+        )
+    proposed = _parse_timestamp(proposed_at, "proposal timestamp")
+    authorized = _parse_timestamp(
+        plan.authorization.authorized_at,
+        "derivation authorization",
+    )
+    if (
+        proposed < authorized
+        or proposed >= _parse_timestamp(
+            plan.authorization.valid_until,
+            "authorization expiration",
+        )
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation proposal is outside its authorization window")
+    plan_by_id = {item.assignment_id: item for item in plan.assignments}
+    expected = tuple(item for item in plan.assignments if item.cell_plan_id == cell_plan_id)
+    if len(expected) != AV1_VALIDATION_DERIVATION_RESERVATION_COUNT:
+        raise AV1ValidationDerivationError("AV1 derivation candidate plan is not reserved")
+    attempts_by_id: dict[str, AV1ValidationDerivationAttempt] = {}
+    for attempt in attempts:
+        if attempt.plan_id != plan.plan_id or attempt.authorization_id != plan.authorization.authorization_id:
+            raise AV1ValidationDerivationError("AV1 derivation attempt is bound to another plan")
+        assignment = plan_by_id.get(attempt.assignment_id)
+        if assignment is None or attempt.cell_plan_id != assignment.cell_plan_id or attempt.ordinal != assignment.ordinal:
+            raise AV1ValidationDerivationError("AV1 derivation attempt slot drifted")
+        if attempt.assignment_id in attempts_by_id:
+            raise AV1ValidationDerivationError("AV1 derivation assignment has multiple attempts")
+        attempts_by_id[attempt.assignment_id] = attempt
+    records_by_id: dict[str, AV1ValidationDerivationTerminalRecord] = {}
+    blockers: list[str] = []
+    for record in records:
+        if record.plan_id != plan.plan_id or record.authorization_id != plan.authorization.authorization_id:
+            raise AV1ValidationDerivationError("AV1 derivation terminal record is bound to another plan")
+        assignment = plan_by_id.get(record.assignment_id)
+        if assignment is None or record.cell_plan_id != assignment.cell_plan_id or record.ordinal != assignment.ordinal:
+            raise AV1ValidationDerivationError("AV1 derivation terminal record slot drifted")
+        if record.assignment_id in records_by_id:
+            raise AV1ValidationDerivationError("AV1 derivation assignment has multiple terminal records")
+        attempt = attempts_by_id.get(record.assignment_id)
+        if (
+            attempt is None
+            or record.attempt_id != attempt.attempt_id
+            or record.attempt_payload_sha256 != attempt.payload_sha256
+        ):
+            raise AV1ValidationDerivationError("AV1 derivation terminal record does not match its attempt")
+        records_by_id[record.assignment_id] = record
+    snapshot_payload = [
+        {
+            "assignment_id": assignment.assignment_id,
+            "attempt_sha256": (
+                attempts_by_id[assignment.assignment_id].payload_sha256
+                if assignment.assignment_id in attempts_by_id
+                else None
+            ),
+            "terminal_record_sha256": (
+                records_by_id[assignment.assignment_id].payload_sha256
+                if assignment.assignment_id in records_by_id
+                else None
+            ),
+        }
+        for assignment in expected
+    ]
+    snapshot_sha256 = _payload_sha256({
+        "plan_id": plan.plan_id,
+        "cell_plan_id": cell_plan_id,
+        "terminal_records": snapshot_payload,
+    })
+    observations: list[AV1ValidationDerivationObservationProjection] = []
+    conflicting_assignment_ids: set[str] = set()
+    for assignment in expected:
+        if assignment.assignment_id not in attempts_by_id:
+            blockers.append("missing_attempt")
+            continue
+        record = records_by_id.get(assignment.assignment_id)
+        if record is None:
+            blockers.append("missing_terminal_record")
+            continue
+        if record.status != "observed" or record.observation is None:
+            blockers.append(f"terminal_{record.status}")
+            continue
+        current_observation = current_observations.get(assignment.assignment_id)
+        if current_observation is None:
+            blockers.append("observation_not_current")
+            continue
+        try:
+            current_record = build_av1_validation_derivation_terminal_record(
+                plan=plan,
+                partition=partition,
+                attempt=attempts_by_id[assignment.assignment_id],
+                observation=current_observation,
+            )
+        except AV1ValidationDerivationError:
+            blockers.append("observation_current_contract_invalid")
+            conflicting_assignment_ids.add(assignment.source_token)
+            continue
+        if current_record != record:
+            blockers.append("terminal_projection_mismatch")
+            conflicting_assignment_ids.add(assignment.source_token)
+            continue
+        observation = current_record.observation
+        if observation is None:
+            blockers.append("observation_current_contract_invalid")
+            conflicting_assignment_ids.add(assignment.source_token)
+            continue
+        if observation.verdict != "acceptable":
+            blockers.append("observation_unacceptable")
+            conflicting_assignment_ids.add(assignment.source_token)
+        if not observation.quality_floor_met:
+            blockers.append("quality_floor_miss")
+            conflicting_assignment_ids.add(assignment.source_token)
+        observation_timestamp = _parse_timestamp(
+            observation.recorded_at,
+            "observation timestamp",
+        )
+        if observation_timestamp > proposed:
+            blockers.append("observation_after_proposal")
+        if observation_timestamp < proposed - timedelta(
+            days=manifest.criteria.maximum_derivation_age_days
+        ):
+            blockers.append("observation_stale")
+        observations.append(observation)
+    if len(observations) != AV1_VALIDATION_DERIVATION_RESERVATION_COUNT:
+        blockers.append("insufficient_eligible_observations")
+    source_tokens = tuple(sorted({item.source_token for item in observations}))
+    title_tokens = tuple(sorted({item.title_token for item in observations}))
+    series_tokens = tuple(sorted({item.series_token for item in observations}))
+    group_tokens = tuple(sorted({item.source_group_token for item in observations}))
+    group_observation_tokens = tuple(sorted(item.source_group_token for item in observations))
+    if len(source_tokens) < manifest.criteria.minimum_derivation_source_count:
+        blockers.append("insufficient_independent_sources")
+    if len(source_tokens) != AV1_VALIDATION_DERIVATION_RESERVATION_COUNT:
+        blockers.append("derivation_source_reuse")
+    if len(title_tokens) != AV1_VALIDATION_DERIVATION_RESERVATION_COUNT:
+        blockers.append("derivation_title_reuse")
+    if len(series_tokens) != AV1_VALIDATION_DERIVATION_RESERVATION_COUNT:
+        blockers.append("derivation_series_reuse")
+    group_counts = Counter(item.source_group_token for item in observations)
+    if len(group_tokens) < AV1_VALIDATION_MINIMUM_SOURCE_GROUP_COUNT:
+        blockers.append("insufficient_source_groups")
+    if any(count > AV1_VALIDATION_DERIVATION_RESERVATION_COUNT // 3 for count in group_counts.values()):
+        blockers.append("source_group_concentration")
+    for attribute, blocker in (
+        ("traits", "trait_drift"),
+        ("intent_level", "intent_drift"),
+        ("compatibility_signature", "compatibility_drift"),
+        ("policy_signature", "policy_drift"),
+        ("observation_compatibility_key", "observation_compatibility_conflict"),
+        ("observation_policy_hash", "observation_policy_conflict"),
+        ("quality_metric", "quality_contract_drift"),
+        ("quality_target", "quality_contract_drift"),
+        ("minimum_quality_score", "quality_contract_drift"),
+    ):
+        values = {getattr(item, attribute) for item in observations}
+        if len(values) > 1:
+            blockers.append(blocker)
+            expected_value = getattr(observations[0], attribute)
+            conflicting_assignment_ids.update(
+                item.source_token
+                for item in observations
+                if getattr(item, attribute) != expected_value
+            )
+    derivation_conflict_count = len(conflicting_assignment_ids)
+    if blockers:
+        return AV1ValidationDerivationCandidateEvaluation(
+            cell_plan_id=cell_plan_id,
+            derivation_snapshot_sha256=snapshot_sha256,
+            derivation_conflict_count=derivation_conflict_count,
+            blockers=tuple(sorted(set(blockers))),
+            proposal=None,
+        )
+    crfs = sorted(item.chosen_crf for item in observations)
+    crf_center = round(float(median(crfs)), 3)
+    crf_mad = round(float(median(abs(value - crf_center) for value in crfs)), 3)
+    crf_lower = round(crfs[0], 3)
+    crf_upper = round(crfs[-1], 3)
+    if crf_mad > AV1_VALIDATION_DERIVATION_MAXIMUM_CRF_MAD:
+        blockers.append("crf_dispersion_too_wide")
+    if crf_upper - crf_lower > manifest.criteria.maximum_candidate_crf_span:
+        blockers.append("crf_span_too_wide")
+    if math.ceil(crf_lower) > math.floor(crf_upper):
+        blockers.append("crf_range_has_no_executable_integer")
+    bitrates = sorted(item.boundary_bitrate_bps for item in observations)
+    bitrate_center = round(median(bitrates))
+    bitrate_mad = round(median(abs(value - bitrate_center) for value in bitrates))
+    relative_mad = bitrate_mad / bitrate_center if bitrate_center > 0 else math.inf
+    confidence_level = (
+        "high"
+        if relative_mad <= AV1_VALIDATION_DERIVATION_HIGH_CONFIDENCE_RELATIVE_MAD
+        else "moderate"
+        if relative_mad <= AV1_VALIDATION_DERIVATION_MODERATE_CONFIDENCE_RELATIVE_MAD
+        else "limited"
+    )
+    confidence_score = round(max(0.0, min(1.0, 1 - relative_mad)), 3)
+    required_confidence_levels = (
+        {"high"}
+        if manifest.criteria.confidence_level == "high"
+        else {"moderate", "high"}
+    )
+    if (
+        confidence_level not in required_confidence_levels
+        or confidence_score < manifest.criteria.confidence_score
+    ):
+        blockers.append("confidence_insufficient")
+    if blockers:
+        return AV1ValidationDerivationCandidateEvaluation(
+            cell_plan_id=cell_plan_id,
+            derivation_snapshot_sha256=snapshot_sha256,
+            derivation_conflict_count=derivation_conflict_count,
+            blockers=tuple(sorted(set(blockers))),
+            proposal=None,
+        )
+    proposed_payload = _proposal_semantic_payload(
+        plan=plan,
+        cell_plan_id=cell_plan_id,
+        observations=observations,
+        crf_lower=crf_lower,
+        crf_center=crf_center,
+        crf_upper=crf_upper,
+        crf_mad=crf_mad,
+        bitrate_relative_mad=relative_mad,
+        statistics_contract_sha256=plan.authorization.statistics_contract_sha256,
+        bitrate_min=bitrates[0],
+        bitrate_max=bitrates[-1],
+        confidence_level=cast(Literal["moderate", "high"], confidence_level),
+        confidence_score=confidence_score,
+        derivation_conflict_count=derivation_conflict_count,
+        snapshot_sha256=snapshot_sha256,
+        proposed_at=proposed_at,
+    )
+    proposal_id = _derivation_id("proposal", proposed_payload)
+    proposal = AV1ValidationDerivationCandidateProposal(
+        proposal_id=proposal_id,
+        plan_id=plan.plan_id,
+        manifest_id=plan.manifest_id,
+        cell_plan_id=cell_plan_id,
+        exact_traits=observations[0].traits,
+        crf_lower=crf_lower,
+        crf_center=crf_center,
+        crf_upper=crf_upper,
+        crf_mad=crf_mad,
+        bitrate_relative_mad=relative_mad,
+        statistics_contract_sha256=plan.authorization.statistics_contract_sha256,
+        compatibility_signature=observations[0].compatibility_signature,
+        policy_signature=observations[0].policy_signature,
+        target_video_bitrate_min_bps=bitrates[0],
+        target_video_bitrate_max_bps=bitrates[-1],
+        minimum_quality_score=observations[0].minimum_quality_score,
+        confidence_level=cast(Literal["moderate", "high"], confidence_level),
+        confidence_score=confidence_score,
+        derivation_evidence_count=len(observations),
+        derivation_source_count=len(source_tokens),
+        derivation_source_tokens=source_tokens,
+        derivation_title_tokens=title_tokens,
+        derivation_series_tokens=series_tokens,
+        derivation_source_group_tokens=group_tokens,
+        derivation_source_group_observation_tokens=group_observation_tokens,
+        derivation_oldest_recorded_at=min(item.recorded_at for item in observations),
+        derivation_newest_recorded_at=max(item.recorded_at for item in observations),
+        derivation_conflict_count=derivation_conflict_count,
+        derivation_snapshot_sha256=snapshot_sha256,
+        selection_lock_sha256=plan.selection_lock_sha256,
+        proposed_at=proposed_at,
+        payload_sha256=_payload_sha256({"proposal_id": proposal_id, **proposed_payload}),
+    )
+    return AV1ValidationDerivationCandidateEvaluation(
+        cell_plan_id=cell_plan_id,
+        derivation_snapshot_sha256=snapshot_sha256,
+        derivation_conflict_count=derivation_conflict_count,
+        blockers=(),
+        proposal=proposal,
+    )
+
+
+def build_av1_validation_derivation_review_attestation(
+        *,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        lane: AV1ValidationDerivationReviewLane,
+        reviewer_token: str,
+        review_evidence_sha256: str,
+        decision: AV1ValidationDerivationReviewDecision,
+        reviewed_at: str,
+) -> AV1ValidationDerivationReviewAttestation:
+    reviewed = _parse_timestamp(reviewed_at, "review timestamp")
+    if reviewed < _parse_timestamp(
+        proposal.proposed_at, "proposal timestamp"
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation review predates its proposal")
+    normalized_reviewed_at = _utc_timestamp(reviewed)
+    semantic_payload = {
+        "schema": AV1_VALIDATION_DERIVATION_REVIEW_SCHEMA,
+        "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "proposal_id": proposal.proposal_id,
+        "proposal_payload_sha256": proposal.payload_sha256,
+        "lane": lane,
+        "reviewer_token": reviewer_token,
+        "review_evidence_sha256": review_evidence_sha256,
+        "decision": decision,
+        "reviewed_at": normalized_reviewed_at,
+    }
+    attestation_id = _derivation_id("review", semantic_payload)
+    return AV1ValidationDerivationReviewAttestation(
+        attestation_id=attestation_id,
+        proposal_id=proposal.proposal_id,
+        proposal_payload_sha256=proposal.payload_sha256,
+        lane=lane,
+        reviewer_token=reviewer_token,
+        review_evidence_sha256=review_evidence_sha256,
+        decision=decision,
+        reviewed_at=normalized_reviewed_at,
+        payload_sha256=_payload_sha256({"attestation_id": attestation_id, **semantic_payload}),
+    )
+
+
+def build_av1_validation_derivation_review_envelope(
+        *,
+        review: AV1ValidationDerivationReviewAttestation,
+        evidence: bytes,
+) -> AV1ValidationDerivationReviewEnvelope:
+    validate_av1_validation_derivation_review_run_evidence(
+        evidence,
+        review=review,
+    )
+    try:
+        evidence_payload = object_dict(json.loads(evidence.decode("utf-8")))
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError) as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review run evidence is invalid"
+        ) from exc
+    semantic_payload = {
+        "schema": AV1_VALIDATION_DERIVATION_REVIEW_ENVELOPE_SCHEMA,
+        "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "review": review.to_payload(),
+        "review_run_evidence": evidence_payload,
+    }
+    envelope_id = _derivation_id("review_envelope", semantic_payload)
+    return AV1ValidationDerivationReviewEnvelope(
+        envelope_id=envelope_id,
+        review=review,
+        review_run_payload_json=canonical_json_bytes(evidence_payload).decode("utf-8"),
+        payload_sha256=_payload_sha256({
+            "envelope_id": envelope_id,
+            **semantic_payload,
+        }),
+    )
+
+
+def _av1_validation_derivation_review_set_sha256(
+        envelopes: Sequence[AV1ValidationDerivationReviewEnvelope],
+) -> str:
+    reviews = tuple(envelope.review for envelope in envelopes)
+    if (
+        len(envelopes) != len(AV1_VALIDATION_DERIVATION_REVIEW_LANES)
+        or {review.lane for review in reviews}
+        != set(AV1_VALIDATION_DERIVATION_REVIEW_LANES)
+        or len({review.reviewer_token for review in reviews}) != len(reviews)
+        or len({review.review_evidence_sha256 for review in reviews}) != len(reviews)
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review set is incomplete or not independent"
+        )
+    return _payload_sha256({
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "reviews": [
+            {
+                "lane": envelope.review.lane,
+                "envelope_id": envelope.envelope_id,
+                "envelope_payload_sha256": envelope.payload_sha256,
+            }
+            for envelope in sorted(envelopes, key=lambda item: item.review.lane)
+        ],
+    })
+
+
+def finalize_av1_validation_derivation_candidate_lock(
+        *,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        reviews: Sequence[AV1ValidationDerivationReviewAttestation],
+        current_evaluation: AV1ValidationDerivationCandidateEvaluation,
+        locked_at: str,
+) -> AV1ColdStartValidationCandidateLockV1:
+    current_proposal = current_evaluation.proposal
+    locked = _parse_timestamp(locked_at, "candidate lock timestamp")
+    if (
+        current_evaluation.blockers
+        or current_proposal is None
+        or current_evaluation.cell_plan_id != proposal.cell_plan_id
+        or current_evaluation.derivation_snapshot_sha256
+        != proposal.derivation_snapshot_sha256
+        or _proposal_lock_inputs(current_proposal) != _proposal_lock_inputs(proposal)
+        or _parse_timestamp(
+            current_proposal.proposed_at,
+            "current proposal timestamp",
+        )
+        != locked
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation candidate is no longer current at lock time"
+        )
+    if {review.lane for review in reviews} != set(AV1_VALIDATION_DERIVATION_REVIEW_LANES):
+        raise AV1ValidationDerivationError("AV1 derivation candidate requires all five review lanes")
+    if len(reviews) != len(AV1_VALIDATION_DERIVATION_REVIEW_LANES):
+        raise AV1ValidationDerivationError("AV1 derivation candidate has duplicate review lanes")
+    if len({review.reviewer_token for review in reviews}) != len(reviews):
+        raise AV1ValidationDerivationError("AV1 derivation reviewers must be independent")
+    if len({review.review_evidence_sha256 for review in reviews}) != len(reviews):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review evidence must come from independent agent runs"
+        )
+    for review in reviews:
+        reviewed = _parse_timestamp(review.reviewed_at, "review timestamp")
+        if (
+            review.proposal_id != proposal.proposal_id
+            or review.proposal_payload_sha256 != proposal.payload_sha256
+            or review.decision != "approved"
+            or reviewed < _parse_timestamp(
+                proposal.proposed_at,
+                "proposal timestamp",
+            )
+            or reviewed > locked
+        ):
+            raise AV1ValidationDerivationError("AV1 derivation candidate review did not approve the proposal")
+    normalized_locked_at = _utc_timestamp(locked)
+    return build_av1_cold_start_validation_candidate_lock(
+        manifest_id=current_proposal.manifest_id,
+        cell_plan_id=current_proposal.cell_plan_id,
+        exact_traits=current_proposal.exact_traits,
+        crf_lower=current_proposal.crf_lower,
+        crf_center=current_proposal.crf_center,
+        crf_upper=current_proposal.crf_upper,
+        compatibility_signature=current_proposal.compatibility_signature,
+        policy_signature=current_proposal.policy_signature,
+        target_video_bitrate_min_bps=current_proposal.target_video_bitrate_min_bps,
+        target_video_bitrate_max_bps=current_proposal.target_video_bitrate_max_bps,
+        minimum_quality_score=current_proposal.minimum_quality_score,
+        confidence_level=current_proposal.confidence_level,
+        confidence_score=current_proposal.confidence_score,
+        derivation_evidence_count=current_proposal.derivation_evidence_count,
+        derivation_source_count=current_proposal.derivation_source_count,
+        derivation_source_tokens=current_proposal.derivation_source_tokens,
+        derivation_title_tokens=current_proposal.derivation_title_tokens,
+        derivation_series_tokens=current_proposal.derivation_series_tokens,
+        derivation_source_group_tokens=current_proposal.derivation_source_group_tokens,
+        derivation_source_group_observation_tokens=(
+            current_proposal.derivation_source_group_observation_tokens
+        ),
+        derivation_oldest_recorded_at=current_proposal.derivation_oldest_recorded_at,
+        derivation_newest_recorded_at=current_proposal.derivation_newest_recorded_at,
+        derivation_conflict_count=current_proposal.derivation_conflict_count,
+        derivation_snapshot_sha256=current_proposal.derivation_snapshot_sha256,
+        selection_lock_sha256=current_proposal.selection_lock_sha256,
+        locked_at=normalized_locked_at,
+        reviewed_at=normalized_locked_at,
+    )
+
+
+def _finalize_and_write_av1_validation_derivation_candidate_lock(
+        artifact_root: Path,
+        *,
+        plan: AV1ValidationDerivationPlan,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        review_envelopes: Sequence[AV1ValidationDerivationReviewEnvelope],
+        current_evaluation: AV1ValidationDerivationCandidateEvaluation,
+        locked_at: str,
+) -> AV1ValidationDerivationCandidateLockEnvelope:
+    reviews = tuple(envelope.review for envelope in review_envelopes)
+    candidate_lock = finalize_av1_validation_derivation_candidate_lock(
+        proposal=proposal,
+        reviews=reviews,
+        current_evaluation=current_evaluation,
+        locked_at=locked_at,
+    )
+    root = _bind_av1_validation_derivation_artifact_root(artifact_root, plan)
+    if (
+        candidate_lock.manifest_id != plan.manifest_id
+        or candidate_lock.selection_lock_sha256 != plan.selection_lock_sha256
+        or candidate_lock.cell_plan_id not in {
+            assignment.cell_plan_id for assignment in plan.assignments
+        }
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation candidate lock is bound to another plan"
+        )
+    directory = root / "candidate-locks"
+    _bind_owner_only_directory(
+        directory,
+        kind="candidate_locks",
+        binding_id=plan.plan_id,
+        binding_digest=plan.authorization.authorization_id,
+    )
+    root_binding = _read_owner_only_bytes(
+        root / ".binding",
+        "derivation artifact-root binding",
+    )
+    semantic_payload = {
+        "schema": AV1_VALIDATION_DERIVATION_LOCK_ENVELOPE_SCHEMA,
+        "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "plan_id": plan.plan_id,
+        "plan_payload_sha256": plan.payload_sha256,
+        "authorization_id": plan.authorization.authorization_id,
+        "authorization_payload_sha256": plan.authorization.payload_sha256,
+        "proposal_id": proposal.proposal_id,
+        "proposal_payload_sha256": proposal.payload_sha256,
+        "review_set_sha256": _av1_validation_derivation_review_set_sha256(
+            review_envelopes
+        ),
+        "artifact_root_binding_sha256": (
+            f"sha256:{hashlib.sha256(root_binding).hexdigest()}"
+        ),
+        "candidate_lock": candidate_lock.to_payload(),
+    }
+    envelope_id = _derivation_id("lock_envelope", semantic_payload)
+    envelope = AV1ValidationDerivationCandidateLockEnvelope(
+        envelope_id=envelope_id,
+        plan_id=plan.plan_id,
+        plan_payload_sha256=plan.payload_sha256,
+        authorization_id=plan.authorization.authorization_id,
+        authorization_payload_sha256=plan.authorization.payload_sha256,
+        proposal_id=proposal.proposal_id,
+        proposal_payload_sha256=proposal.payload_sha256,
+        review_set_sha256=semantic_payload["review_set_sha256"],
+        artifact_root_binding_sha256=semantic_payload[
+            "artifact_root_binding_sha256"
+        ],
+        candidate_lock=candidate_lock,
+        payload_sha256=_payload_sha256({
+            "envelope_id": envelope_id,
+            **semantic_payload,
+        }),
+    )
+    path = directory / f"{candidate_lock.cell_plan_id}.json"
+    _write_owner_only(path, canonical_json_bytes(envelope.to_payload()))
+    return envelope
+
+
+def _load_av1_validation_derivation_candidate_lock_envelope(
+        artifact_root: Path,
+        *,
+        plan: AV1ValidationDerivationPlan,
+        cell_plan_id: str,
+) -> AV1ValidationDerivationCandidateLockEnvelope:
+    if cell_plan_id not in {
+        assignment.cell_plan_id for assignment in plan.assignments
+    }:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation candidate-lock cell is not authorized"
+        )
+    root = _assert_av1_validation_derivation_artifact_root_binding(
+        artifact_root,
+        plan,
+    )
+    directory = root / "candidate-locks"
+    binding = _load_owner_only_directory_binding(
+        directory,
+        expected_kind="candidate_locks",
+    )
+    if (
+        binding["binding_id"] != plan.plan_id
+        or binding["binding_digest"] != plan.authorization.authorization_id
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation candidate-lock directory binding drifted"
+        )
+    payload, raw = _load_owner_only_json(
+        directory / f"{cell_plan_id}.json",
+        "derivation candidate-lock envelope",
+    )
+    envelope = av1_validation_derivation_candidate_lock_envelope_from_payload(
+        payload,
+        raw=raw,
+    )
+    return envelope
+
+
+def _load_verified_av1_validation_derivation_candidate_lock(
+        artifact_root: Path,
+        *,
+        plan: AV1ValidationDerivationPlan,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        review_envelopes: Sequence[AV1ValidationDerivationReviewEnvelope],
+        current_evaluation: AV1ValidationDerivationCandidateEvaluation,
+        cell_plan_id: str,
+) -> AV1ValidationDerivationCandidateLockEnvelope:
+    root = _assert_av1_validation_derivation_artifact_root_binding(
+        artifact_root,
+        plan,
+    )
+    envelope = _load_av1_validation_derivation_candidate_lock_envelope(
+        root,
+        plan=plan,
+        cell_plan_id=cell_plan_id,
+    )
+    reviews = tuple(item.review for item in review_envelopes)
+    expected_lock = finalize_av1_validation_derivation_candidate_lock(
+        proposal=proposal,
+        reviews=reviews,
+        current_evaluation=current_evaluation,
+        locked_at=envelope.candidate_lock.locked_at,
+    )
+    root_binding = _read_owner_only_bytes(
+        root / ".binding",
+        "derivation artifact-root binding",
+    )
+    expected_values = {
+        "plan_id": plan.plan_id,
+        "plan_payload_sha256": plan.payload_sha256,
+        "authorization_id": plan.authorization.authorization_id,
+        "authorization_payload_sha256": plan.authorization.payload_sha256,
+        "proposal_id": proposal.proposal_id,
+        "proposal_payload_sha256": proposal.payload_sha256,
+        "review_set_sha256": _av1_validation_derivation_review_set_sha256(
+            review_envelopes
+        ),
+        "artifact_root_binding_sha256": (
+            f"sha256:{hashlib.sha256(root_binding).hexdigest()}"
+        ),
+    }
+    if (
+        envelope.candidate_lock != expected_lock
+        or any(getattr(envelope, key) != value for key, value in expected_values.items())
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation candidate-lock provenance chain is invalid"
+        )
+    return envelope
+
+
+def _av1_validation_derivation_artifact_root_path(
+        artifact_root: Path,
+        plan: AV1ValidationDerivationPlan,
+) -> Path:
+    root = artifact_root.expanduser().resolve()
+    if (
+        root.name != plan.plan_id
+        or root.parent.name != AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation artifacts must use the plan-global canonical root"
+        )
+    return root
+
+
+def _bind_av1_validation_derivation_artifact_root(
+        artifact_root: Path,
+        plan: AV1ValidationDerivationPlan,
+) -> Path:
+    root = _av1_validation_derivation_artifact_root_path(artifact_root, plan)
+    _bind_owner_only_directory(
+        root,
+        kind="artifact_root",
+        binding_id=plan.plan_id,
+        binding_digest=plan.authorization.authorization_id,
+    )
+    return root
+
+
+def _assert_av1_validation_derivation_artifact_root_binding(
+        artifact_root: Path,
+        plan: AV1ValidationDerivationPlan,
+) -> Path:
+    root = _av1_validation_derivation_artifact_root_path(artifact_root, plan)
+    binding = _load_owner_only_directory_binding(
+        root,
+        expected_kind="artifact_root",
+    )
+    if (
+        binding["binding_id"] != plan.plan_id
+        or binding["binding_digest"] != plan.authorization.authorization_id
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation artifact-root binding drifted"
+        )
+    return root
+
+
+def validate_av1_validation_derivation_artifact_root_binding(
+        artifact_root: Path,
+        plan: AV1ValidationDerivationPlan,
+) -> None:
+    _assert_av1_validation_derivation_artifact_root_binding(
+        artifact_root,
+        plan,
+    )
+
+
+def write_av1_validation_derivation_plan(
+        artifact_root: Path,
+        plan: AV1ValidationDerivationPlan,
+) -> Path:
+    root = _bind_av1_validation_derivation_artifact_root(artifact_root, plan)
+    path = root / "plan.json"
+    _write_owner_only(path, canonical_json_bytes(plan.to_payload()))
+    return path
+
+
+def load_av1_validation_derivation_plan(path: Path) -> AV1ValidationDerivationPlan:
+    payload, raw = _load_owner_only_json(path, "derivation plan")
+    return av1_validation_derivation_plan_from_payload(payload, raw=raw)
+
+
+def write_av1_validation_derivation_attempt(
+        directory: Path,
+        attempt: AV1ValidationDerivationAttempt,
+) -> Path:
+    _bind_owner_only_directory(
+        directory,
+        kind="attempts",
+        binding_id=attempt.plan_id,
+        binding_digest=attempt.authorization_id,
+    )
+    path = directory / f"{attempt.assignment_id}.json"
+    _write_owner_only(path, canonical_json_bytes(attempt.to_payload()))
+    return path
+
+
+def load_av1_validation_derivation_attempts(
+        directory: Path,
+) -> tuple[AV1ValidationDerivationAttempt, ...]:
+    binding = _load_owner_only_directory_binding(directory, expected_kind="attempts")
+    attempts_list: list[AV1ValidationDerivationAttempt] = []
+    for path in sorted(directory.glob("*.json")):
+        payload, raw = _load_owner_only_json(path, "derivation attempt")
+        attempts_list.append(
+            av1_validation_derivation_attempt_from_payload(payload, raw=raw)
+        )
+    attempts = tuple(attempts_list)
+    assignment_ids = [attempt.assignment_id for attempt in attempts]
+    if len(assignment_ids) != len(set(assignment_ids)):
+        raise AV1ValidationDerivationError("AV1 derivation attempt directory repeats an assignment")
+    if any(
+        attempt.plan_id != binding["binding_id"]
+        or attempt.authorization_id != binding["binding_digest"]
+        for attempt in attempts
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation attempt directory binding drifted")
+    return attempts
+
+
+def write_av1_validation_derivation_terminal_record(
+        directory: Path,
+        record: AV1ValidationDerivationTerminalRecord,
+) -> Path:
+    _bind_owner_only_directory(
+        directory,
+        kind="terminal_records",
+        binding_id=record.plan_id,
+        binding_digest=record.authorization_id,
+    )
+    path = directory / f"{record.assignment_id}.json"
+    _write_owner_only(path, canonical_json_bytes(record.to_payload()))
+    return path
+
+
+def ensure_av1_validation_derivation_terminal_intent(
+        directory: Path,
+        record: AV1ValidationDerivationTerminalRecord,
+) -> Path:
+    return _ensure_av1_validation_derivation_terminal_artifact(
+        directory,
+        kind="terminal_intents",
+        label="terminal intent",
+        record=record,
+    )
+
+
+def resolve_av1_validation_derivation_verdict_intent(
+        directory: Path,
+        *,
+        plan: AV1ValidationDerivationPlan,
+        attempt: AV1ValidationDerivationAttempt,
+        verdict: str,
+        concern_tags: Sequence[str],
+        evidence_ids: Sequence[str],
+        moment_indexes: Sequence[int],
+        recorded_at: str,
+) -> dict[str, Any]:
+    if attempt.plan_id != plan.plan_id or attempt.status != "review_pending":
+        raise AV1ValidationDerivationError(
+            "AV1 derivation verdict intent is bound to another attempt"
+        )
+    if verdict not in {"approved", "rejected"}:
+        raise AV1ValidationDerivationError("AV1 derivation verdict intent is invalid")
+    normalized_concerns = sorted({
+        str(value).strip().lower()
+        for value in concern_tags
+        if str(value).strip()
+    })
+    normalized_evidence_ids = sorted({
+        str(value).strip()
+        for value in evidence_ids
+        if str(value).strip()
+    })
+    normalized_moments = sorted({
+        int(value)
+        for value in moment_indexes
+        if int(value) > 0
+    })
+    timestamp = _parse_timestamp(recorded_at, "verdict timestamp")
+    semantic_payload = {
+        "schema": AV1_VALIDATION_DERIVATION_VERDICT_INTENT_SCHEMA,
+        "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "plan_id": plan.plan_id,
+        "authorization_id": plan.authorization.authorization_id,
+        "attempt_id": attempt.attempt_id,
+        "attempt_payload_sha256": attempt.payload_sha256,
+        "assignment_id": attempt.assignment_id,
+        "verdict": verdict,
+        "concern_tags": normalized_concerns,
+        "evidence_ids": normalized_evidence_ids,
+        "moment_indexes": normalized_moments,
+        "recorded_at": _utc_timestamp(timestamp),
+    }
+    payload = {
+        **semantic_payload,
+        "payload_sha256": _payload_sha256(semantic_payload),
+    }
+    _bind_owner_only_directory(
+        directory,
+        kind="verdict_intents",
+        binding_id=plan.plan_id,
+        binding_digest=plan.authorization.authorization_id,
+    )
+    path = directory / f"{attempt.assignment_id}.json"
+    if not path.exists() and not path.is_symlink():
+        if not (
+            _parse_timestamp(attempt.completed_at, "attempt completion")
+            <= timestamp
+            < _parse_timestamp(
+                plan.authorization.valid_until,
+                "derivation authorization expiration",
+            )
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation verdict intent is outside its authorization window"
+            )
+        try:
+            _write_owner_only(path, canonical_json_bytes(payload))
+            return payload
+        except AV1ValidationDerivationError:
+            if not path.exists():
+                raise
+    existing, raw = _load_owner_only_json(path, "derivation verdict intent")
+    _require_exact_keys(existing, set(payload), "derivation verdict intent")
+    if (
+        existing.get("schema") != AV1_VALIDATION_DERIVATION_VERDICT_INTENT_SCHEMA
+        or existing.get("schema_version")
+        != AV1_VALIDATION_DERIVATION_SCHEMA_VERSION
+        or existing.get("contract_version")
+        != AV1_VALIDATION_DERIVATION_CONTRACT_VERSION
+        or existing.get("payload_sha256")
+        != _payload_sha256({
+            key: value
+            for key, value in existing.items()
+            if key != "payload_sha256"
+        })
+        or raw != canonical_json_bytes(existing)
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation verdict intent integrity is invalid"
+        )
+    stable_keys = set(payload) - {"recorded_at", "payload_sha256"}
+    if any(existing.get(key) != payload.get(key) for key in stable_keys):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation verdict retry does not match its immutable intent"
+        )
+    existing_timestamp = _parse_timestamp(
+        str(existing.get("recorded_at") or ""),
+        "verdict timestamp",
+    )
+    if not (
+        _parse_timestamp(attempt.completed_at, "attempt completion")
+        <= existing_timestamp
+        < _parse_timestamp(
+            plan.authorization.valid_until,
+            "derivation authorization expiration",
+        )
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation verdict intent chronology is invalid"
+        )
+    return existing
+
+
+def ensure_av1_validation_derivation_terminal_record(
+        directory: Path,
+        record: AV1ValidationDerivationTerminalRecord,
+) -> Path:
+    return _ensure_av1_validation_derivation_terminal_artifact(
+        directory,
+        kind="terminal_records",
+        label="terminal record",
+        record=record,
+    )
+
+
+def write_av1_validation_derivation_assignment_claim(
+        directory: Path,
+        *,
+        assignment_id: str,
+        plan_id: str,
+        authorization_id: str,
+) -> Path:
+    bind_av1_validation_derivation_attempt_directory(
+        directory,
+        plan_id=plan_id,
+        authorization_id=authorization_id,
+    )
+    path = directory / f"{assignment_id}.claim"
+    _write_owner_only(path, canonical_json_bytes({
+        "schema": "mediaforce.av1_cold_start_derivation_assignment_claim",
+        "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "plan_id": plan_id,
+        "authorization_id": authorization_id,
+        "assignment_id": assignment_id,
+    }))
+    return path
+
+
+def load_av1_validation_derivation_terminal_records(
+        directory: Path,
+) -> tuple[AV1ValidationDerivationTerminalRecord, ...]:
+    binding = _load_owner_only_directory_binding(
+        directory,
+        expected_kind="terminal_records",
+    )
+    records_list: list[AV1ValidationDerivationTerminalRecord] = []
+    for path in sorted(directory.glob("*.json")):
+        payload, raw = _load_owner_only_json(path, "derivation terminal record")
+        records_list.append(
+            av1_validation_derivation_terminal_record_from_payload(payload, raw=raw)
+        )
+    records = tuple(records_list)
+    assignment_ids = [record.assignment_id for record in records]
+    if len(assignment_ids) != len(set(assignment_ids)):
+        raise AV1ValidationDerivationError("AV1 derivation terminal directory repeats an assignment")
+    if any(
+        record.plan_id != binding["binding_id"]
+        or record.authorization_id != binding["binding_digest"]
+        for record in records
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation terminal directory binding drifted")
+    return records
+
+
+def write_av1_validation_derivation_candidate_proposal(
+        artifact_root: Path,
+        *,
+        plan: AV1ValidationDerivationPlan,
+        proposal: AV1ValidationDerivationCandidateProposal,
+) -> Path:
+    root = _bind_av1_validation_derivation_artifact_root(artifact_root, plan)
+    if (
+        proposal.plan_id != plan.plan_id
+        or proposal.manifest_id != plan.manifest_id
+        or proposal.selection_lock_sha256 != plan.selection_lock_sha256
+        or proposal.cell_plan_id not in {
+            assignment.cell_plan_id
+            for assignment in plan.assignments
+        }
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation proposal is bound to another plan"
+        )
+    directory = root / "proposals"
+    _bind_owner_only_directory(
+        directory,
+        kind="candidate_proposals",
+        binding_id=plan.plan_id,
+        binding_digest=plan.authorization.authorization_id,
+    )
+    path = directory / f"{proposal.cell_plan_id}.json"
+    _write_owner_only(path, canonical_json_bytes(proposal.to_payload()))
+    return path
+
+
+def load_av1_validation_derivation_candidate_proposal(
+        artifact_root: Path,
+        *,
+        plan: AV1ValidationDerivationPlan,
+        cell_plan_id: str,
+) -> AV1ValidationDerivationCandidateProposal:
+    if not _SAFE_TOKEN_RE.fullmatch(cell_plan_id) or cell_plan_id not in {
+        assignment.cell_plan_id for assignment in plan.assignments
+    }:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation proposal cell plan is not authorized"
+        )
+    root = _assert_av1_validation_derivation_artifact_root_binding(
+        artifact_root,
+        plan,
+    )
+    directory = root / "proposals"
+    binding = _load_owner_only_directory_binding(
+        directory,
+        expected_kind="candidate_proposals",
+    )
+    if (
+        binding["binding_id"] != plan.plan_id
+        or binding["binding_digest"] != plan.authorization.authorization_id
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation proposal directory binding drifted"
+        )
+    path = directory / f"{cell_plan_id}.json"
+    payload, raw = _load_owner_only_json(path, "derivation candidate proposal")
+    proposal = av1_validation_derivation_candidate_proposal_from_payload(
+        payload,
+        raw=raw,
+    )
+    if (
+        proposal.plan_id != plan.plan_id
+        or proposal.manifest_id != plan.manifest_id
+        or proposal.selection_lock_sha256 != plan.selection_lock_sha256
+        or proposal.cell_plan_id != cell_plan_id
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation proposal is bound to another plan"
+        )
+    return proposal
+
+
+def write_av1_validation_derivation_review_envelope(
+        artifact_root: Path,
+        *,
+        plan: AV1ValidationDerivationPlan,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        envelope: AV1ValidationDerivationReviewEnvelope,
+) -> Path:
+    review = envelope.review
+    root = _bind_av1_validation_derivation_artifact_root(artifact_root, plan)
+    if (
+        proposal.plan_id != plan.plan_id
+        or proposal.manifest_id != plan.manifest_id
+        or review.proposal_id != proposal.proposal_id
+        or review.proposal_payload_sha256 != proposal.payload_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review envelope is bound to another run or proposal"
+        )
+    directory = root / "reviews" / proposal.proposal_id
+    _bind_owner_only_directory(
+        directory,
+        kind="reviews",
+        binding_id=review.proposal_id,
+        binding_digest=review.proposal_payload_sha256,
+    )
+    path = directory / f"{review.lane}.json"
+    _write_owner_only(path, canonical_json_bytes(envelope.to_payload()))
+    return path
+
+
+def load_av1_validation_derivation_review_envelopes(
+        artifact_root: Path,
+        *,
+        plan: AV1ValidationDerivationPlan,
+        proposal: AV1ValidationDerivationCandidateProposal,
+) -> tuple[AV1ValidationDerivationReviewEnvelope, ...]:
+    root = _assert_av1_validation_derivation_artifact_root_binding(
+        artifact_root,
+        plan,
+    )
+    if proposal.plan_id != plan.plan_id or proposal.manifest_id != plan.manifest_id:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation proposal is bound to another plan"
+        )
+    directory = root / "reviews" / proposal.proposal_id
+    binding = _load_owner_only_directory_binding(directory, expected_kind="reviews")
+    expected_paths = {
+        f"{lane}.json" for lane in AV1_VALIDATION_DERIVATION_REVIEW_LANES
+    }
+    actual_paths = {path.name for path in directory.glob("*.json")}
+    if actual_paths != expected_paths:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review directory must contain exactly five lane envelopes"
+        )
+    envelopes_list: list[AV1ValidationDerivationReviewEnvelope] = []
+    for lane in AV1_VALIDATION_DERIVATION_REVIEW_LANES:
+        payload, raw = _load_owner_only_json(
+            directory / f"{lane}.json",
+            "derivation review envelope",
+        )
+        envelopes_list.append(
+            av1_validation_derivation_review_envelope_from_payload(
+                payload,
+                raw=raw,
+            )
+        )
+    envelopes = tuple(envelopes_list)
+    reviews = tuple(envelope.review for envelope in envelopes)
+    lanes = [review.lane for review in reviews]
+    if len(lanes) != len(set(lanes)):
+        raise AV1ValidationDerivationError("AV1 derivation review directory repeats a lane")
+    if any(
+        review.proposal_id != binding["binding_id"]
+        or review.proposal_payload_sha256 != binding["binding_digest"]
+        for review in reviews
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation review directory binding drifted")
+    _av1_validation_derivation_review_set_sha256(envelopes)
+    return envelopes
+
+
+def validate_av1_validation_derivation_review_run_evidence(
+        evidence: bytes,
+        *,
+        review: AV1ValidationDerivationReviewAttestation,
+) -> None:
+    try:
+        payload = object_dict(json.loads(evidence.decode("utf-8")))
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError) as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review run evidence is invalid"
+        ) from exc
+    _require_exact_keys(payload, {
+        "schema", "schema_version", "review_run_id", "reviewer_token",
+        "proposal_id", "proposal_payload_sha256", "lane", "decision",
+        "code_binary_sha256", "prompt_sha256", "stdout", "stderr", "returncode",
+    }, "derivation review run evidence")
+    review_run_id = _required_text(payload.get("review_run_id"), "review run ID")
+    stdout = payload.get("stdout")
+    stderr = payload.get("stderr")
+    returncode = payload.get("returncode")
+    if (
+        payload.get("schema") != "mediaforce.av1_derivation_agent_review_run"
+        or int_value(payload.get("schema_version")) != 1
+        or payload.get("reviewer_token") != review.reviewer_token
+        or review.reviewer_token != f"agent:{review_run_id}"
+        or payload.get("proposal_id") != review.proposal_id
+        or payload.get("proposal_payload_sha256") != review.proposal_payload_sha256
+        or payload.get("lane") != review.lane
+        or payload.get("decision") != review.decision
+        or type(returncode) is not int
+        or returncode != 0
+        or not isinstance(stdout, str)
+        or not isinstance(stderr, str)
+        or evidence != canonical_json_bytes(payload)
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review run evidence does not match its attestation"
+        )
+    _require_sha256(
+        _required_text(payload.get("code_binary_sha256"), "Code binary digest"),
+        "Code binary digest",
+    )
+    prompt_sha256 = _required_text(payload.get("prompt_sha256"), "review prompt digest")
+    _require_sha256(prompt_sha256, "review prompt digest")
+    final_message, prompt = _completed_code_review_message(stdout)
+    if prompt_sha256 != f"sha256:{hashlib.sha256(prompt.encode('utf-8')).hexdigest()}":
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review prompt digest does not match its completed run"
+        )
+    for bound_value in (
+        review_run_id,
+        review.proposal_id,
+        review.proposal_payload_sha256,
+        review.lane,
+    ):
+        if bound_value not in prompt:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review prompt is not bound to its attestation"
+            )
+    marker = _code_review_marker(final_message)
+    if marker != {
+        "decision": review.decision,
+        "lane": review.lane,
+        "proposal_id": review.proposal_id,
+        "proposal_payload_sha256": review.proposal_payload_sha256,
+        "review_run_id": review_run_id,
+    }:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review completion marker does not match its attestation"
+        )
+
+
+def _completed_code_review_message(stdout: str) -> tuple[str, str]:
+    config_seen = False
+    prompt: str | None = None
+    messages: list[str] = []
+    completed_message: str | None = None
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = object_dict(json.loads(line))
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review transcript is not canonical JSONL"
+            ) from exc
+        if {"provider", "model", "workdir", "approval", "sandbox"}.issubset(event):
+            if event.get("approval") != "never" or event.get("sandbox") != "read-only":
+                raise AV1ValidationDerivationError(
+                    "AV1 derivation review did not run read-only"
+                )
+            config_seen = True
+        if set(event) == {"prompt"} and isinstance(event.get("prompt"), str):
+            prompt = event["prompt"]
+        message = event.get("msg")
+        if not isinstance(message, dict):
+            continue
+        if message.get("type") == "agent_message" and isinstance(
+            message.get("message"), str
+        ):
+            messages.append(message["message"])
+        if (
+            message.get("type") == "task_lifecycle"
+            and message.get("phase") == "quiescent"
+            and isinstance(message.get("last_agent_message"), str)
+        ):
+            completed_message = message["last_agent_message"]
+    if (
+        not config_seen
+        or prompt is None
+        or not messages
+        or completed_message != messages[-1]
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review transcript lacks a completed Code run"
+        )
+    return messages[-1], prompt
+
+
+def _code_review_marker(message: str) -> dict[str, Any]:
+    nonempty_lines = [line.strip() for line in message.splitlines() if line.strip()]
+    marker_lines = [
+        line
+        for line in nonempty_lines
+        if line.startswith(AV1_VALIDATION_DERIVATION_AGENT_REVIEW_MARKER)
+    ]
+    if (
+        not nonempty_lines
+        or len(marker_lines) != 1
+        or marker_lines[0] != nonempty_lines[-1]
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review transcript lacks one terminal marker"
+        )
+    try:
+        marker = object_dict(json.loads(
+            marker_lines[0][len(AV1_VALIDATION_DERIVATION_AGENT_REVIEW_MARKER):]
+        ))
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review completion marker is invalid"
+        ) from exc
+    _require_exact_keys(marker, {
+        "decision", "lane", "proposal_id", "proposal_payload_sha256", "review_run_id",
+    }, "derivation review completion marker")
+    return marker
+
+
+def av1_validation_derivation_plan_public_summary(
+        plan: AV1ValidationDerivationPlan,
+) -> dict[str, Any]:
+    payload = {
+        "schema": "mediaforce.av1_cold_start_derivation_plan_summary",
+        "schema_version": 1,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "plan_id": plan.plan_id,
+        "manifest_id": plan.manifest_id,
+        "selection_lock_sha256": plan.selection_lock_sha256,
+        "derivation_partition_sha256": plan.derivation_partition_sha256,
+        "runtime_context_bound": True,
+        "authorization_id": plan.authorization.authorization_id,
+        "derivation_assignment_count": len(plan.assignments),
+        "candidate_count": len({assignment.cell_plan_id for assignment in plan.assignments}),
+        "derivation_execution_authorized": True,
+        "holdout_execution_authorized": False,
+        "guided_probe_allowed": False,
+        "public_bundle_activation_allowed": False,
+    }
+    assert_av1_cold_start_public_payload_safe(payload)
+    return payload
+
+
+def av1_validation_derivation_candidate_evaluation_public_summary(
+        evaluation: AV1ValidationDerivationCandidateEvaluation,
+) -> dict[str, Any]:
+    payload = {
+        "schema": "mediaforce.av1_cold_start_derivation_candidate_summary",
+        "schema_version": 1,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "cell_plan_id": evaluation.cell_plan_id,
+        "derivation_snapshot_sha256": evaluation.derivation_snapshot_sha256,
+        "blockers": list(evaluation.blockers),
+        "candidate_proposal_id": (
+            evaluation.proposal.proposal_id
+            if evaluation.proposal is not None
+            else None
+        ),
+        "candidate_proposal_sha256": (
+            evaluation.proposal.payload_sha256
+            if evaluation.proposal is not None
+            else None
+        ),
+        "candidate_lock_created": False,
+        "holdout_execution_authorized": False,
+        "public_bundle_activation_allowed": False,
+    }
+    assert_av1_cold_start_public_payload_safe(payload)
+    return payload
+
+
+def av1_validation_derivation_plan_from_payload(
+        payload: Mapping[str, Any],
+        *,
+        raw: bytes | None = None,
+) -> AV1ValidationDerivationPlan:
+    value = object_dict(payload)
+    _require_exact_keys(value, {
+        "plan_id", "schema", "schema_version", "contract_version", "manifest_id",
+        "manifest_payload_sha256", "partition_id", "partition_payload_sha256",
+        "selection_lock_sha256", "derivation_partition_sha256", "runtime_context_sha256",
+        "authorization",
+        "execution_scope", "search_mode", "derivation_execution_authorized",
+        "cold_start_warm_start_allowed", "validation_harness_allowed", "guided_probe_allowed",
+        "holdout_execution_authorized", "retry_substitution_backfill_allowed",
+        "public_bundle_activation_allowed", "assignments", "payload_sha256",
+    }, "derivation plan")
+    if (
+        value.get("schema") != AV1_VALIDATION_DERIVATION_PLAN_SCHEMA
+        or int_value(value.get("schema_version")) != AV1_VALIDATION_DERIVATION_SCHEMA_VERSION
+        or value.get("contract_version") != AV1_VALIDATION_DERIVATION_CONTRACT_VERSION
+        or value.get("execution_scope") != AV1_VALIDATION_DERIVATION_EXECUTION_SCOPE
+        or value.get("search_mode") != AV1_VALIDATION_DERIVATION_SEARCH_MODE
+        or value.get("derivation_execution_authorized") is not True
+        or value.get("cold_start_warm_start_allowed") is not False
+        or value.get("validation_harness_allowed") is not False
+        or value.get("guided_probe_allowed") is not False
+        or value.get("holdout_execution_authorized") is not False
+        or value.get("retry_substitution_backfill_allowed") is not False
+        or value.get("public_bundle_activation_allowed") is not False
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation plan authority is invalid")
+    from mediaforce.tuning.av1_validation_v2 import av1_validation_v2_derivation_authorization_from_payload
+
+    plan = AV1ValidationDerivationPlan(
+        plan_id=_required_text(value.get("plan_id"), "plan ID"),
+        manifest_id=_required_text(value.get("manifest_id"), "manifest ID"),
+        manifest_payload_sha256=_required_text(value.get("manifest_payload_sha256"), "manifest digest"),
+        partition_id=_required_text(value.get("partition_id"), "partition ID"),
+        partition_payload_sha256=_required_text(value.get("partition_payload_sha256"), "partition digest"),
+        selection_lock_sha256=_required_text(value.get("selection_lock_sha256"), "selection-lock digest"),
+        derivation_partition_sha256=_required_text(value.get("derivation_partition_sha256"), "derivation-partition digest"),
+        runtime_context_sha256=_required_text(
+            value.get("runtime_context_sha256"),
+            "runtime-context digest",
+        ),
+        authorization=av1_validation_v2_derivation_authorization_from_payload(object_dict(value.get("authorization"))),
+        assignments=tuple(_assignment_from_payload(object_dict(item)) for item in object_list(value.get("assignments"))),
+        payload_sha256=_required_text(value.get("payload_sha256"), "plan digest"),
+    )
+    if raw is not None and raw != canonical_json_bytes(plan.to_payload()):
+        raise AV1ValidationDerivationError("AV1 derivation plan JSON is not canonical")
+    return plan
+
+
+def av1_validation_derivation_attempt_from_payload(
+        payload: Mapping[str, Any],
+        *,
+        raw: bytes | None = None,
+) -> AV1ValidationDerivationAttempt:
+    value = object_dict(payload)
+    _require_exact_keys(value, {
+        "attempt_id", "schema", "schema_version", "contract_version", "plan_id",
+        "authorization_id", "assignment_id", "cell_plan_id", "ordinal", "started_at",
+        "completed_at", "status", "reason_code", "calibration_payload",
+        "calibration_payload_sha256", "payload_sha256",
+    }, "derivation attempt")
+    if (
+        value.get("schema") != AV1_VALIDATION_DERIVATION_ATTEMPT_SCHEMA
+        or int_value(value.get("schema_version")) != AV1_VALIDATION_DERIVATION_SCHEMA_VERSION
+        or value.get("contract_version") != AV1_VALIDATION_DERIVATION_CONTRACT_VERSION
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation attempt contract is invalid")
+    calibration_payload = value.get("calibration_payload")
+    attempt = AV1ValidationDerivationAttempt(
+        attempt_id=_required_text(value.get("attempt_id"), "attempt ID"),
+        plan_id=_required_text(value.get("plan_id"), "plan ID"),
+        authorization_id=_required_text(value.get("authorization_id"), "authorization ID"),
+        assignment_id=_required_text(value.get("assignment_id"), "assignment ID"),
+        cell_plan_id=_required_text(value.get("cell_plan_id"), "cell-plan ID"),
+        ordinal=int_value(value.get("ordinal")),
+        started_at=_required_text(value.get("started_at"), "attempt start"),
+        completed_at=_required_text(value.get("completed_at"), "attempt completion"),
+        status=cast(AV1ValidationDerivationAttemptStatus, _required_text(value.get("status"), "status")),
+        reason_code=(str(value.get("reason_code")) if value.get("reason_code") is not None else None),
+        calibration_payload_json=(
+            canonical_json_bytes(object_dict(calibration_payload)).decode("utf-8")
+            if calibration_payload is not None
+            else None
+        ),
+        calibration_payload_sha256=(
+            str(value.get("calibration_payload_sha256"))
+            if value.get("calibration_payload_sha256") is not None
+            else None
+        ),
+        payload_sha256=_required_text(value.get("payload_sha256"), "attempt digest"),
+    )
+    if raw is not None and raw != canonical_json_bytes(attempt.to_payload()):
+        raise AV1ValidationDerivationError("AV1 derivation attempt JSON is not canonical")
+    return attempt
+
+
+def av1_validation_derivation_terminal_record_from_payload(
+        payload: Mapping[str, Any],
+        *,
+        raw: bytes | None = None,
+) -> AV1ValidationDerivationTerminalRecord:
+    value = object_dict(payload)
+    _require_exact_keys(value, {
+        "record_id", "schema", "schema_version", "contract_version", "plan_id",
+        "authorization_id", "attempt_id", "attempt_payload_sha256", "assignment_id",
+        "cell_plan_id", "ordinal", "started_at", "completed_at", "status",
+        "reason_code", "observation", "payload_sha256",
+    }, "derivation terminal record")
+    if (
+        value.get("schema") != AV1_VALIDATION_DERIVATION_TERMINAL_SCHEMA
+        or int_value(value.get("schema_version")) != AV1_VALIDATION_DERIVATION_SCHEMA_VERSION
+        or value.get("contract_version") != AV1_VALIDATION_DERIVATION_CONTRACT_VERSION
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation terminal contract is invalid")
+    observation_payload = value.get("observation")
+    record = AV1ValidationDerivationTerminalRecord(
+        record_id=_required_text(value.get("record_id"), "record ID"),
+        plan_id=_required_text(value.get("plan_id"), "plan ID"),
+        authorization_id=_required_text(value.get("authorization_id"), "authorization ID"),
+        attempt_id=_required_text(value.get("attempt_id"), "attempt ID"),
+        attempt_payload_sha256=_required_text(value.get("attempt_payload_sha256"), "attempt digest"),
+        assignment_id=_required_text(value.get("assignment_id"), "assignment ID"),
+        cell_plan_id=_required_text(value.get("cell_plan_id"), "cell-plan ID"),
+        ordinal=int_value(value.get("ordinal")),
+        started_at=_required_text(value.get("started_at"), "attempt start"),
+        completed_at=_required_text(value.get("completed_at"), "attempt completion"),
+        status=cast(AV1ValidationDerivationTerminalStatus, _required_text(value.get("status"), "status")),
+        reason_code=(str(value.get("reason_code")) if value.get("reason_code") is not None else None),
+        observation=(
+            _observation_projection_from_payload(object_dict(observation_payload))
+            if observation_payload is not None
+            else None
+        ),
+        payload_sha256=_required_text(value.get("payload_sha256"), "record digest"),
+    )
+    if raw is not None and raw != canonical_json_bytes(record.to_payload()):
+        raise AV1ValidationDerivationError("AV1 derivation terminal JSON is not canonical")
+    return record
+
+
+def av1_validation_derivation_candidate_proposal_from_payload(
+        payload: Mapping[str, Any],
+        *,
+        raw: bytes | None = None,
+) -> AV1ValidationDerivationCandidateProposal:
+    value = object_dict(payload)
+    _require_exact_keys(value, {
+        "proposal_id", "schema", "schema_version", "contract_version", "plan_id",
+        "manifest_id", "cell_plan_id", "exact_traits", "crf_lower", "crf_center",
+        "crf_upper", "crf_mad", "bitrate_relative_mad",
+        "statistics_contract_sha256", "compatibility_signature", "policy_signature",
+        "target_video_bitrate_min_bps", "target_video_bitrate_max_bps",
+        "minimum_quality_score", "confidence_level", "confidence_score",
+        "derivation_evidence_count", "derivation_source_count", "derivation_source_tokens",
+        "derivation_title_tokens", "derivation_series_tokens",
+        "derivation_source_group_tokens",
+        "derivation_source_group_observation_tokens",
+        "derivation_oldest_recorded_at", "derivation_newest_recorded_at",
+        "derivation_conflict_count",
+        "derivation_snapshot_sha256", "selection_lock_sha256", "proposed_at",
+        "review_state", "holdout_execution_authorized", "public_bundle_activation_allowed",
+        "payload_sha256",
+    }, "derivation candidate proposal")
+    if (
+        value.get("schema") != AV1_VALIDATION_DERIVATION_PROPOSAL_SCHEMA
+        or int_value(value.get("schema_version")) != AV1_VALIDATION_DERIVATION_SCHEMA_VERSION
+        or value.get("contract_version") != AV1_VALIDATION_DERIVATION_CONTRACT_VERSION
+        or value.get("review_state") != "pending_independent_review"
+        or value.get("holdout_execution_authorized") is not False
+        or value.get("public_bundle_activation_allowed") is not False
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation candidate proposal contract is invalid")
+    proposal = AV1ValidationDerivationCandidateProposal(
+        proposal_id=_required_text(value.get("proposal_id"), "proposal ID"),
+        plan_id=_required_text(value.get("plan_id"), "plan ID"),
+        manifest_id=_required_text(value.get("manifest_id"), "manifest ID"),
+        cell_plan_id=_required_text(value.get("cell_plan_id"), "cell-plan ID"),
+        exact_traits=tuple(str(item) for item in object_list(value.get("exact_traits"))),
+        crf_lower=float_value(value.get("crf_lower")),
+        crf_center=float_value(value.get("crf_center")),
+        crf_upper=float_value(value.get("crf_upper")),
+        crf_mad=float_value(value.get("crf_mad")),
+        bitrate_relative_mad=float_value(value.get("bitrate_relative_mad")),
+        statistics_contract_sha256=_required_text(
+            value.get("statistics_contract_sha256"),
+            "statistics contract digest",
+        ),
+        compatibility_signature=_required_text(value.get("compatibility_signature"), "compatibility signature"),
+        policy_signature=_required_text(value.get("policy_signature"), "policy signature"),
+        target_video_bitrate_min_bps=int_value(value.get("target_video_bitrate_min_bps")),
+        target_video_bitrate_max_bps=int_value(value.get("target_video_bitrate_max_bps")),
+        minimum_quality_score=float_value(value.get("minimum_quality_score")),
+        confidence_level=cast(Literal["moderate", "high"], _required_text(value.get("confidence_level"), "confidence")),
+        confidence_score=float_value(value.get("confidence_score")),
+        derivation_evidence_count=int_value(value.get("derivation_evidence_count")),
+        derivation_source_count=int_value(value.get("derivation_source_count")),
+        derivation_source_tokens=tuple(str(item) for item in object_list(value.get("derivation_source_tokens"))),
+        derivation_title_tokens=tuple(
+            str(item)
+            for item in object_list(value.get("derivation_title_tokens"))
+        ),
+        derivation_series_tokens=tuple(str(item) for item in object_list(value.get("derivation_series_tokens"))),
+        derivation_source_group_tokens=tuple(str(item) for item in object_list(value.get("derivation_source_group_tokens"))),
+        derivation_source_group_observation_tokens=tuple(
+            str(item)
+            for item in object_list(value.get("derivation_source_group_observation_tokens"))
+        ),
+        derivation_oldest_recorded_at=_required_text(value.get("derivation_oldest_recorded_at"), "oldest observation"),
+        derivation_newest_recorded_at=_required_text(value.get("derivation_newest_recorded_at"), "newest observation"),
+        derivation_conflict_count=int_value(value.get("derivation_conflict_count")),
+        derivation_snapshot_sha256=_required_text(value.get("derivation_snapshot_sha256"), "derivation snapshot"),
+        selection_lock_sha256=_required_text(value.get("selection_lock_sha256"), "selection-lock digest"),
+        proposed_at=_required_text(value.get("proposed_at"), "proposal timestamp"),
+        payload_sha256=_required_text(value.get("payload_sha256"), "proposal digest"),
+    )
+    if raw is not None and raw != canonical_json_bytes(proposal.to_payload()):
+        raise AV1ValidationDerivationError("AV1 derivation candidate proposal JSON is not canonical")
+    return proposal
+
+
+def av1_validation_derivation_review_attestation_from_payload(
+        payload: Mapping[str, Any],
+        *,
+        raw: bytes | None = None,
+) -> AV1ValidationDerivationReviewAttestation:
+    value = object_dict(payload)
+    _require_exact_keys(value, {
+        "attestation_id", "schema", "schema_version", "contract_version", "proposal_id",
+        "proposal_payload_sha256", "lane", "reviewer_token", "review_evidence_sha256",
+        "decision", "reviewed_at", "payload_sha256",
+    }, "derivation review attestation")
+    if (
+        value.get("schema") != AV1_VALIDATION_DERIVATION_REVIEW_SCHEMA
+        or int_value(value.get("schema_version")) != AV1_VALIDATION_DERIVATION_SCHEMA_VERSION
+        or value.get("contract_version") != AV1_VALIDATION_DERIVATION_CONTRACT_VERSION
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation review contract is invalid")
+    review = AV1ValidationDerivationReviewAttestation(
+        attestation_id=_required_text(value.get("attestation_id"), "attestation ID"),
+        proposal_id=_required_text(value.get("proposal_id"), "proposal ID"),
+        proposal_payload_sha256=_required_text(value.get("proposal_payload_sha256"), "proposal digest"),
+        lane=cast(AV1ValidationDerivationReviewLane, _required_text(value.get("lane"), "review lane")),
+        reviewer_token=_required_text(value.get("reviewer_token"), "reviewer token"),
+        review_evidence_sha256=_required_text(
+            value.get("review_evidence_sha256"),
+            "review evidence digest",
+        ),
+        decision=cast(AV1ValidationDerivationReviewDecision, _required_text(value.get("decision"), "decision")),
+        reviewed_at=_required_text(value.get("reviewed_at"), "review timestamp"),
+        payload_sha256=_required_text(value.get("payload_sha256"), "review digest"),
+    )
+    if raw is not None and raw != canonical_json_bytes(review.to_payload()):
+        raise AV1ValidationDerivationError("AV1 derivation review JSON is not canonical")
+    return review
+
+
+def av1_validation_derivation_review_envelope_from_payload(
+        payload: Mapping[str, Any],
+        *,
+        raw: bytes | None = None,
+) -> AV1ValidationDerivationReviewEnvelope:
+    value = object_dict(payload)
+    _require_exact_keys(value, {
+        "envelope_id",
+        "schema",
+        "schema_version",
+        "contract_version",
+        "review",
+        "review_run_evidence",
+        "payload_sha256",
+    }, "derivation review envelope")
+    if (
+        value.get("schema") != AV1_VALIDATION_DERIVATION_REVIEW_ENVELOPE_SCHEMA
+        or int_value(value.get("schema_version"))
+        != AV1_VALIDATION_DERIVATION_SCHEMA_VERSION
+        or value.get("contract_version")
+        != AV1_VALIDATION_DERIVATION_CONTRACT_VERSION
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review envelope contract is invalid"
+        )
+    review_payload = object_dict(value.get("review"))
+    evidence_payload = object_dict(value.get("review_run_evidence"))
+    envelope = AV1ValidationDerivationReviewEnvelope(
+        envelope_id=_required_text(value.get("envelope_id"), "review envelope ID"),
+        review=av1_validation_derivation_review_attestation_from_payload(
+            review_payload,
+            raw=canonical_json_bytes(review_payload),
+        ),
+        review_run_payload_json=canonical_json_bytes(evidence_payload).decode("utf-8"),
+        payload_sha256=_required_text(
+            value.get("payload_sha256"),
+            "review envelope digest",
+        ),
+    )
+    if raw is not None and raw != canonical_json_bytes(envelope.to_payload()):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review envelope JSON is not canonical"
+        )
+    return envelope
+
+
+def av1_validation_derivation_candidate_lock_envelope_from_payload(
+        payload: Mapping[str, Any],
+        *,
+        raw: bytes | None = None,
+) -> AV1ValidationDerivationCandidateLockEnvelope:
+    value = object_dict(payload)
+    _require_exact_keys(value, {
+        "envelope_id",
+        "schema",
+        "schema_version",
+        "contract_version",
+        "plan_id",
+        "plan_payload_sha256",
+        "authorization_id",
+        "authorization_payload_sha256",
+        "proposal_id",
+        "proposal_payload_sha256",
+        "review_set_sha256",
+        "artifact_root_binding_sha256",
+        "candidate_lock",
+        "payload_sha256",
+    }, "derivation candidate-lock envelope")
+    if (
+        value.get("schema") != AV1_VALIDATION_DERIVATION_LOCK_ENVELOPE_SCHEMA
+        or int_value(value.get("schema_version"))
+        != AV1_VALIDATION_DERIVATION_SCHEMA_VERSION
+        or value.get("contract_version")
+        != AV1_VALIDATION_DERIVATION_CONTRACT_VERSION
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation candidate-lock envelope contract is invalid"
+        )
+    envelope = AV1ValidationDerivationCandidateLockEnvelope(
+        envelope_id=_required_text(value.get("envelope_id"), "lock envelope ID"),
+        plan_id=_required_text(value.get("plan_id"), "plan ID"),
+        plan_payload_sha256=_required_text(
+            value.get("plan_payload_sha256"),
+            "plan digest",
+        ),
+        authorization_id=_required_text(
+            value.get("authorization_id"),
+            "authorization ID",
+        ),
+        authorization_payload_sha256=_required_text(
+            value.get("authorization_payload_sha256"),
+            "authorization digest",
+        ),
+        proposal_id=_required_text(value.get("proposal_id"), "proposal ID"),
+        proposal_payload_sha256=_required_text(
+            value.get("proposal_payload_sha256"),
+            "proposal digest",
+        ),
+        review_set_sha256=_required_text(
+            value.get("review_set_sha256"),
+            "review-set digest",
+        ),
+        artifact_root_binding_sha256=_required_text(
+            value.get("artifact_root_binding_sha256"),
+            "artifact-root binding digest",
+        ),
+        candidate_lock=_candidate_lock_from_payload(
+            object_dict(value.get("candidate_lock"))
+        ),
+        payload_sha256=_required_text(
+            value.get("payload_sha256"),
+            "lock envelope digest",
+        ),
+    )
+    if raw is not None and raw != canonical_json_bytes(envelope.to_payload()):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation candidate-lock envelope JSON is not canonical"
+        )
+    return envelope
+
+
+def _plan_semantic_payload(
+        *,
+        manifest: AV1ValidationManifestV2,
+        partition: AV1ValidationPrivatePartition,
+        authorization: AV1ValidationV2DerivationAuthorization,
+        runtime_context_sha256: str,
+        assignments: Sequence[AV1ValidationPartitionAssignment],
+) -> dict[str, Any]:
+    return {
+        "schema": AV1_VALIDATION_DERIVATION_PLAN_SCHEMA,
+        "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "manifest_id": manifest.manifest_id,
+        "manifest_payload_sha256": manifest.payload_sha256,
+        "partition_id": partition.partition_id,
+        "partition_payload_sha256": partition.payload_sha256,
+        "selection_lock_sha256": partition.selection_lock_sha256,
+        "derivation_partition_sha256": partition.derivation_partition_sha256,
+        "runtime_context_sha256": runtime_context_sha256,
+        "authorization": authorization.to_payload(),
+        "execution_scope": AV1_VALIDATION_DERIVATION_EXECUTION_SCOPE,
+        "search_mode": AV1_VALIDATION_DERIVATION_SEARCH_MODE,
+        "derivation_execution_authorized": True,
+        "cold_start_warm_start_allowed": False,
+        "validation_harness_allowed": False,
+        "guided_probe_allowed": False,
+        "holdout_execution_authorized": False,
+        "retry_substitution_backfill_allowed": False,
+        "public_bundle_activation_allowed": False,
+        "assignments": [assignment.to_payload() for assignment in assignments],
+    }
+
+
+def _terminal_semantic_payload(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        assignment: AV1ValidationPartitionAssignment,
+        attempt: AV1ValidationDerivationAttempt,
+        status: AV1ValidationDerivationTerminalStatus,
+        reason_code: str | None,
+        observation: AV1ValidationDerivationObservationProjection | None,
+) -> dict[str, Any]:
+    return {
+        "schema": AV1_VALIDATION_DERIVATION_TERMINAL_SCHEMA,
+        "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "plan_id": plan.plan_id,
+        "authorization_id": plan.authorization.authorization_id,
+        "attempt_id": attempt.attempt_id,
+        "attempt_payload_sha256": attempt.payload_sha256,
+        "assignment_id": assignment.assignment_id,
+        "cell_plan_id": assignment.cell_plan_id,
+        "ordinal": assignment.ordinal,
+        "started_at": attempt.started_at,
+        "completed_at": attempt.completed_at,
+        "status": status,
+        "reason_code": reason_code,
+        "observation": observation.to_payload() if observation is not None else None,
+    }
+
+
+def _attempt_semantic_payload(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        assignment: AV1ValidationPartitionAssignment,
+        started_at: str,
+        completed_at: str,
+        status: AV1ValidationDerivationAttemptStatus,
+        reason_code: str | None,
+        calibration_payload: Mapping[str, Any] | None,
+        calibration_payload_sha256: str | None,
+) -> dict[str, Any]:
+    return {
+        "schema": AV1_VALIDATION_DERIVATION_ATTEMPT_SCHEMA,
+        "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "plan_id": plan.plan_id,
+        "authorization_id": plan.authorization.authorization_id,
+        "assignment_id": assignment.assignment_id,
+        "cell_plan_id": assignment.cell_plan_id,
+        "ordinal": assignment.ordinal,
+        "started_at": started_at,
+        "completed_at": completed_at,
+        "status": status,
+        "reason_code": reason_code,
+        "calibration_payload": dict(calibration_payload) if calibration_payload is not None else None,
+        "calibration_payload_sha256": calibration_payload_sha256,
+    }
+
+
+def _proposal_semantic_payload(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        cell_plan_id: str,
+        observations: Sequence[AV1ValidationDerivationObservationProjection],
+        crf_lower: float,
+        crf_center: float,
+        crf_upper: float,
+        crf_mad: float,
+        bitrate_relative_mad: float,
+        statistics_contract_sha256: str,
+        bitrate_min: int,
+        bitrate_max: int,
+        confidence_level: Literal["moderate", "high"],
+        confidence_score: float,
+        derivation_conflict_count: int,
+        snapshot_sha256: str,
+        proposed_at: str,
+) -> dict[str, Any]:
+    source_tokens = sorted({item.source_token for item in observations})
+    title_tokens = sorted({item.title_token for item in observations})
+    return {
+        "schema": AV1_VALIDATION_DERIVATION_PROPOSAL_SCHEMA,
+        "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "plan_id": plan.plan_id,
+        "manifest_id": plan.manifest_id,
+        "cell_plan_id": cell_plan_id,
+        "exact_traits": list(observations[0].traits),
+        "crf_lower": crf_lower,
+        "crf_center": crf_center,
+        "crf_upper": crf_upper,
+        "crf_mad": crf_mad,
+        "bitrate_relative_mad": bitrate_relative_mad,
+        "statistics_contract_sha256": statistics_contract_sha256,
+        "compatibility_signature": observations[0].compatibility_signature,
+        "policy_signature": observations[0].policy_signature,
+        "target_video_bitrate_min_bps": bitrate_min,
+        "target_video_bitrate_max_bps": bitrate_max,
+        "minimum_quality_score": observations[0].minimum_quality_score,
+        "confidence_level": confidence_level,
+        "confidence_score": confidence_score,
+        "derivation_evidence_count": len(observations),
+        "derivation_source_count": len(source_tokens),
+        "derivation_source_tokens": source_tokens,
+        "derivation_title_tokens": title_tokens,
+        "derivation_series_tokens": sorted({item.series_token for item in observations}),
+        "derivation_source_group_tokens": sorted({item.source_group_token for item in observations}),
+        "derivation_source_group_observation_tokens": sorted(
+            item.source_group_token for item in observations
+        ),
+        "derivation_oldest_recorded_at": min(item.recorded_at for item in observations),
+        "derivation_newest_recorded_at": max(item.recorded_at for item in observations),
+        "derivation_conflict_count": derivation_conflict_count,
+        "derivation_snapshot_sha256": snapshot_sha256,
+        "selection_lock_sha256": plan.selection_lock_sha256,
+        "proposed_at": proposed_at,
+        "review_state": "pending_independent_review",
+        "holdout_execution_authorized": False,
+        "public_bundle_activation_allowed": False,
+    }
+
+
+def _proposal_lock_inputs(
+        proposal: AV1ValidationDerivationCandidateProposal,
+) -> dict[str, Any]:
+    return {
+        "plan_id": proposal.plan_id,
+        "manifest_id": proposal.manifest_id,
+        "cell_plan_id": proposal.cell_plan_id,
+        "exact_traits": list(proposal.exact_traits),
+        "crf_lower": proposal.crf_lower,
+        "crf_center": proposal.crf_center,
+        "crf_upper": proposal.crf_upper,
+        "crf_mad": proposal.crf_mad,
+        "bitrate_relative_mad": proposal.bitrate_relative_mad,
+        "statistics_contract_sha256": proposal.statistics_contract_sha256,
+        "compatibility_signature": proposal.compatibility_signature,
+        "policy_signature": proposal.policy_signature,
+        "target_video_bitrate_min_bps": proposal.target_video_bitrate_min_bps,
+        "target_video_bitrate_max_bps": proposal.target_video_bitrate_max_bps,
+        "minimum_quality_score": proposal.minimum_quality_score,
+        "confidence_level": proposal.confidence_level,
+        "confidence_score": proposal.confidence_score,
+        "derivation_evidence_count": proposal.derivation_evidence_count,
+        "derivation_source_count": proposal.derivation_source_count,
+        "derivation_source_tokens": list(proposal.derivation_source_tokens),
+        "derivation_title_tokens": list(proposal.derivation_title_tokens),
+        "derivation_series_tokens": list(proposal.derivation_series_tokens),
+        "derivation_source_group_tokens": list(
+            proposal.derivation_source_group_tokens
+        ),
+        "derivation_source_group_observation_tokens": list(
+            proposal.derivation_source_group_observation_tokens
+        ),
+        "derivation_oldest_recorded_at": proposal.derivation_oldest_recorded_at,
+        "derivation_newest_recorded_at": proposal.derivation_newest_recorded_at,
+        "derivation_conflict_count": proposal.derivation_conflict_count,
+        "derivation_snapshot_sha256": proposal.derivation_snapshot_sha256,
+        "selection_lock_sha256": proposal.selection_lock_sha256,
+    }
+
+
+def _observation_projection(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        partition: AV1ValidationPrivatePartition,
+        assignment: AV1ValidationPartitionAssignment,
+        attempt: AV1ValidationDerivationAttempt,
+        observation: ContentIntentBoundaryObservation,
+) -> AV1ValidationDerivationObservationProjection:
+    if not content_intent_boundary_observation_integrity_valid(observation):
+        raise AV1ValidationDerivationError("AV1 derivation observation integrity is invalid")
+    if (
+        observation.personalization_eligible
+        or observation.exclusion_reason
+        != AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation observation is not quarantined from personalization"
+        )
+    source = next(
+        (item for item in partition.inventory_sources if item.local_item_id == assignment.local_item_id),
+        None,
+    )
+    if source is None:
+        raise AV1ValidationDerivationError("AV1 derivation assignment source is missing")
+    try:
+        traits = tuple(sorted(str(item) for item in json.loads(observation.content_traits_json)))
+        assessment = object_dict(json.loads(observation.assessment_json))
+        compatibility = object_dict(json.loads(observation.compatibility_json))
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise AV1ValidationDerivationError("AV1 derivation observation payload is invalid") from exc
+    chosen_crf = float_value(assessment.get("chosen_crf"))
+    calibration = attempt.calibration_payload()
+    calibration_sample_item = object_dict(calibration.get("sample_item"))
+    calibration_sample_result = object_dict(calibration.get("sample_result"))
+    calibration_quality_score = float_value(
+        calibration_sample_result.get("quality_score")
+    )
+    calibration_chosen_crf = float_value(
+        calibration_sample_result.get("chosen_crf")
+    )
+    calibration_duration_seconds = float_value(
+        calibration_sample_item.get("duration_seconds")
+    )
+    calibration_predicted_video_bytes = int_value(
+        calibration_sample_result.get("predicted_video_size_bytes")
+    )
+    calibration_boundary_bitrate_bps = (
+        round(
+            (calibration_predicted_video_bytes * 8)
+            / calibration_duration_seconds
+        )
+        if calibration_duration_seconds > 0
+        and calibration_predicted_video_bytes > 0
+        else 0
+    )
+    calibration_compatibility = object_dict(
+        calibration_sample_result.get("content_intent_compatibility")
+    )
+    try:
+        calibration_compatibility_key = (
+            content_intent_boundary_compatibility_from_payload(
+                calibration_compatibility
+            ).compatibility_key
+        )
+    except ValueError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation calibration compatibility is invalid"
+        ) from exc
+    recorded_at = _parse_timestamp(observation.recorded_at, "observation timestamp")
+    authorized_at = _parse_timestamp(plan.authorization.authorized_at, "derivation authorization")
+    valid_until = _parse_timestamp(plan.authorization.valid_until, "derivation authorization expiration")
+    if (
+        not authorized_at <= recorded_at < valid_until
+        or recorded_at < _parse_timestamp(
+            attempt.completed_at,
+            "attempt completion",
+        )
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation observation is outside its authorization window")
+    expected_kind = "visual_approval" if observation.verdict == "acceptable" else "visual_rejection"
+    if (
+        observation.revision != 0
+            or observation.supersedes_observation_id is not None
+            or observation.authority != "runtime_native"
+            or observation.disposition != "active"
+            or observation.personalization_eligible is not False
+            or observation.exclusion_reason
+            != AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON
+        or observation.source_event_kind != "post_test_review"
+        or observation.observation_kind != expected_kind
+        or observation.library_item_id != assignment.local_item_id
+        or observation.content_fingerprint != source.source_identity
+        or observation.job_id != str(calibration.get("job_id") or "")
+        or observation.artifact_fingerprint
+        != str(calibration.get("review_artifact_fingerprint") or "")
+        or observation.compatibility_key
+        != calibration_compatibility_key
+        or int_value(calibration_sample_item.get("library_item_id")) != assignment.local_item_id
+        or traits != assignment.traits
+        or observation.intent_level != assignment.intent_level
+        or observation.quality_metric.casefold() != assignment.quality_metric.casefold()
+        or not math.isclose(
+            chosen_crf,
+            calibration_chosen_crf,
+            rel_tol=0.0,
+            abs_tol=0.001,
+        )
+        or observation.boundary_bitrate_bps
+        != calibration_boundary_bitrate_bps
+        or not math.isclose(
+            observation.measured_quality_score,
+            calibration_quality_score,
+            rel_tol=0.0,
+            abs_tol=0.001,
+        )
+        or observation.quality_floor_met
+        != (
+            calibration_quality_score
+            >= assignment.minimum_quality_score
+        )
+        or not math.isclose(observation.quality_target, assignment.quality_target, rel_tol=0.0, abs_tol=0.001)
+        or not math.isclose(
+            observation.minimum_quality_score,
+            assignment.minimum_quality_score,
+            rel_tol=0.0,
+            abs_tol=0.001,
+        )
+        or compatibility.get("measurement_basis") != "sample_projection"
+        or compatibility.get("assessment_contract") != BOUNDARY_ASSESSMENT_CONTRACT
+        or not math.isfinite(chosen_crf)
+        or not 0 <= chosen_crf <= 63
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation observation does not match its reserved assignment")
+    return AV1ValidationDerivationObservationProjection(
+        observation_id=observation.observation_id,
+        observation_payload_sha256=f"sha256:{observation.payload_sha256}",
+        local_item_id=assignment.local_item_id,
+        source_token=assignment.source_token,
+        title_token=assignment.title_token,
+        series_token=assignment.series_token,
+        source_group_token=assignment.source_group_token,
+        traits=assignment.traits,
+        intent_level=assignment.intent_level,
+        compatibility_signature=assignment.compatibility_signature,
+        policy_signature=assignment.policy_signature,
+        observation_compatibility_key=observation.compatibility_key,
+        observation_policy_hash=observation.policy_hash,
+        verdict=observation.verdict,
+        chosen_crf=round(chosen_crf, 3),
+        boundary_bitrate_bps=observation.boundary_bitrate_bps,
+        quality_metric=assignment.quality_metric,
+        quality_target=assignment.quality_target,
+        minimum_quality_score=assignment.minimum_quality_score,
+        measured_quality_score=observation.measured_quality_score,
+        quality_floor_met=observation.quality_floor_met,
+        recorded_at=_utc_timestamp(recorded_at),
+    )
+
+
+def _validate_calibration_payload(
+        assignment: AV1ValidationPartitionAssignment,
+        calibration: Mapping[str, Any],
+        *,
+        source_identity: str,
+) -> None:
+    _validate_calibration_execution(calibration)
+    sample_item = object_dict(calibration.get("sample_item"))
+    sample_result = object_dict(calibration.get("sample_result"))
+    target_trace = object_dict(sample_result.get("target_size_trace"))
+    quality_floor = object_dict(target_trace.get("quality_floor"))
+    selected_candidate = object_dict(target_trace.get("selected_candidate"))
+    quality_target = float_value(sample_result.get("quality_target"))
+    quality_score = float_value(sample_result.get("quality_score"))
+    chosen_crf = float_value(sample_result.get("chosen_crf"))
+    duration_seconds = float_value(sample_item.get("duration_seconds"))
+    predicted_video_size_bytes = int_value(
+        sample_result.get("predicted_video_size_bytes")
+    )
+    if (
+        int_value(sample_item.get("library_item_id")) != assignment.local_item_id
+        or str(sample_item.get("content_version_fingerprint") or "")
+        != source_identity
+        or str(sample_result.get("quality_metric") or "").casefold()
+        != assignment.quality_metric.casefold()
+        or not math.isclose(quality_target, assignment.quality_target, rel_tol=0.0, abs_tol=0.001)
+        or not math.isfinite(quality_score)
+        or duration_seconds <= 0
+        or predicted_video_size_bytes <= 0
+        or str(quality_floor.get("metric") or "").casefold()
+        != assignment.quality_metric.casefold()
+        or not math.isclose(
+            float_value(quality_floor.get("target")),
+            assignment.quality_target,
+            rel_tol=0.0,
+            abs_tol=0.001,
+        )
+        or not math.isclose(
+            float_value(quality_floor.get("minimum")),
+            assignment.minimum_quality_score,
+            rel_tol=0.0,
+            abs_tol=0.001,
+        )
+        or not math.isclose(
+            float_value(selected_candidate.get("crf")),
+            chosen_crf,
+            rel_tol=0.0,
+            abs_tol=0.001,
+        )
+        or not math.isclose(
+            float_value(selected_candidate.get("metric_score")),
+            quality_score,
+            rel_tol=0.0,
+            abs_tol=0.001,
+        )
+        or str(selected_candidate.get("metric") or "").casefold()
+        != assignment.quality_metric.casefold()
+        or not math.isclose(
+            float_value(selected_candidate.get("metric_target")),
+            assignment.quality_target,
+            rel_tol=0.0,
+            abs_tol=0.001,
+        )
+        or not math.isclose(
+            float_value(selected_candidate.get("min_metric_score")),
+            assignment.minimum_quality_score,
+            rel_tol=0.0,
+            abs_tol=0.001,
+        )
+        or selected_candidate.get("quality_floor_met")
+        is not (quality_score >= assignment.minimum_quality_score)
+        or int_value(selected_candidate.get("predicted_video_bytes"))
+        != predicted_video_size_bytes
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation calibration does not prove unchanged measured full search"
+        )
+
+
+def _validate_calibration_execution(calibration: Mapping[str, Any]) -> None:
+    sample_result = object_dict(calibration.get("sample_result"))
+    cold_start = object_dict(sample_result.get("av1_cold_start_prior"))
+    target_trace = object_dict(sample_result.get("target_size_trace"))
+    compatibility = object_dict(sample_result.get("content_intent_compatibility"))
+    chosen_crf = float_value(sample_result.get("chosen_crf"))
+    host = object_dict(calibration.get("host"))
+    candidates = [object_dict(value) for value in object_list(target_trace.get("candidates"))]
+    selected_candidate = object_dict(target_trace.get("selected_candidate"))
+    curve = object_dict(target_trace.get("curve"))
+    retry_policy = object_dict(target_trace.get("retry_policy"))
+    candidate_attempts = [int_value(candidate.get("attempt")) for candidate in candidates]
+    candidate_roles = [str(candidate.get("role") or "") for candidate in candidates]
+    required_candidate_fields = {
+        "attempt",
+        "role",
+        "crf",
+        "metric",
+        "metric_score",
+        "min_metric_score",
+        "quality_floor_met",
+        "sampled_clip_bytes",
+        "predicted_video_bytes",
+        "predicted_whole_episode_bytes",
+        "within_sample_band",
+        "violates_source_cap",
+    }
+    review_fingerprint = str(calibration.get("review_artifact_fingerprint") or "").strip()
+    if (
+        calibration.get("mode") != "sample"
+        or calibration.get("action") != "av1_derivation"
+        or host.get("mode") != "local"
+        or host.get("media_access") != "direct"
+        or cold_start.get("status") != "unavailable"
+        or cold_start.get("reason") != "cold_start_planner_unavailable"
+        or cold_start.get("execution") not in (None, {})
+        or not target_trace
+        or int_value(target_trace.get("schema_version")) != 1
+        or target_trace.get("status") != "selected"
+        or target_trace.get("warm_start") not in (None, {})
+        or not candidates
+        or candidate_attempts != list(range(1, len(candidates) + 1))
+        or candidate_roles[0] != "target_seed"
+        or any(
+            role not in {
+                "target_seed",
+                "compression_floor",
+                "expanded_bound",
+                "refine",
+            }
+            for role in candidate_roles
+        )
+        or any(
+            not required_candidate_fields.issubset(candidate)
+            for candidate in candidates
+        )
+        or int_value(curve.get("candidate_count")) != len(candidates)
+        or str(curve.get("shape") or "") not in {
+            "single_point",
+            "monotonic",
+            "non_monotonic",
+        }
+        or int_value(curve.get("max_candidates")) < len(candidates)
+        or int_value(retry_policy.get("max_final_output_retries")) != 1
+        or not selected_candidate
+        or selected_candidate not in candidates
+        or not compatibility
+        or compatibility.get("measurement_basis") != "sample_projection"
+        or compatibility.get("assessment_contract") != BOUNDARY_ASSESSMENT_CONTRACT
+        or not math.isfinite(chosen_crf)
+        or not 0 <= chosen_crf <= 63
+        or not review_fingerprint
+        or calibration.get("current_review_artifact_fingerprint") != review_fingerprint
+        or calibration.get("review_media_ready") is not True
+        or calibration.get("boundary_review_media_ready") is not True
+        or not str(calibration.get("job_id") or "").strip()
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation calibration does not prove unchanged measured full search"
+        )
+
+
+def _validate_plan_partition(
+        plan: AV1ValidationDerivationPlan,
+        partition: AV1ValidationPrivatePartition,
+) -> None:
+    derivation_assignments = tuple(sorted(
+        (
+            assignment
+            for assignment in partition.assignments
+            if assignment.role == "derivation"
+        ),
+        key=_assignment_sort_key,
+    ))
+    if (
+        plan.partition_id != partition.partition_id
+        or plan.partition_payload_sha256 != partition.payload_sha256
+        or plan.selection_lock_sha256 != partition.selection_lock_sha256
+        or plan.derivation_partition_sha256 != partition.derivation_partition_sha256
+        or plan.assignments != derivation_assignments
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation plan does not match the private partition")
+
+
+def _assignment_by_id(
+        plan: AV1ValidationDerivationPlan,
+        assignment_id: str,
+) -> AV1ValidationPartitionAssignment:
+    assignment = next((item for item in plan.assignments if item.assignment_id == assignment_id), None)
+    if assignment is None:
+        raise AV1ValidationDerivationError("AV1 derivation assignment is not in the worklist")
+    return assignment
+
+
+def _partition_source_identity(
+        partition: AV1ValidationPrivatePartition,
+        local_item_id: int,
+) -> str:
+    source = next(
+        (
+            item
+            for item in partition.inventory_sources
+            if item.local_item_id == local_item_id
+        ),
+        None,
+    )
+    if source is None:
+        raise AV1ValidationDerivationError("AV1 derivation assignment source is missing")
+    return source.source_identity
+
+
+def _assignment_sort_key(assignment: AV1ValidationPartitionAssignment) -> tuple[object, ...]:
+    return assignment.cell_plan_id, assignment.ordinal, assignment.assignment_id
+
+
+def _assignment_from_payload(payload: Mapping[str, Any]) -> AV1ValidationPartitionAssignment:
+    _require_exact_keys(payload, {
+        "assignment_id", "role", "cell_plan_id", "ordinal", "local_item_id", "traits",
+        "intent_level", "source_token", "title_token", "series_token", "source_group_token",
+        "compatibility_signature", "policy_signature", "target_video_bitrate_bps",
+        "quality_metric", "quality_target", "minimum_quality_score", "evidence_summary_sha256",
+    }, "derivation assignment")
+    return AV1ValidationPartitionAssignment(
+        assignment_id=_required_text(payload.get("assignment_id"), "assignment ID"),
+        role=cast(Literal["holdout", "derivation"], _required_text(payload.get("role"), "role")),
+        cell_plan_id=_required_text(payload.get("cell_plan_id"), "cell-plan ID"),
+        ordinal=int_value(payload.get("ordinal")),
+        local_item_id=int_value(payload.get("local_item_id")),
+        traits=tuple(str(item) for item in object_list(payload.get("traits"))),
+        intent_level=_required_text(payload.get("intent_level"), "intent"),
+        source_token=_required_text(payload.get("source_token"), "source token"),
+        title_token=_required_text(payload.get("title_token"), "title token"),
+        series_token=_required_text(payload.get("series_token"), "series token"),
+        source_group_token=_required_text(payload.get("source_group_token"), "source-group token"),
+        compatibility_signature=_required_text(payload.get("compatibility_signature"), "compatibility signature"),
+        policy_signature=_required_text(payload.get("policy_signature"), "policy signature"),
+        target_video_bitrate_bps=int_value(payload.get("target_video_bitrate_bps")),
+        quality_metric=_required_text(payload.get("quality_metric"), "quality metric"),
+        quality_target=float_value(payload.get("quality_target")),
+        minimum_quality_score=float_value(payload.get("minimum_quality_score")),
+        evidence_summary_sha256=_required_text(payload.get("evidence_summary_sha256"), "evidence digest"),
+    )
+
+
+def _observation_projection_from_payload(
+        payload: Mapping[str, Any],
+) -> AV1ValidationDerivationObservationProjection:
+    _require_exact_keys(payload, {
+        "observation_id", "observation_payload_sha256", "local_item_id", "source_token",
+        "title_token", "series_token", "source_group_token", "traits", "intent_level",
+        "compatibility_signature", "policy_signature", "observation_compatibility_key",
+        "observation_policy_hash", "verdict", "chosen_crf", "boundary_bitrate_bps",
+        "quality_metric", "quality_target", "minimum_quality_score", "measured_quality_score",
+        "quality_floor_met", "recorded_at",
+    }, "derivation observation projection")
+    return AV1ValidationDerivationObservationProjection(
+        observation_id=_required_text(payload.get("observation_id"), "observation ID"),
+        observation_payload_sha256=_required_text(payload.get("observation_payload_sha256"), "observation digest"),
+        local_item_id=int_value(payload.get("local_item_id")),
+        source_token=_required_text(payload.get("source_token"), "source token"),
+        title_token=_required_text(payload.get("title_token"), "title token"),
+        series_token=_required_text(payload.get("series_token"), "series token"),
+        source_group_token=_required_text(payload.get("source_group_token"), "source-group token"),
+        traits=tuple(str(item) for item in object_list(payload.get("traits"))),
+        intent_level=_required_text(payload.get("intent_level"), "intent"),
+        compatibility_signature=_required_text(payload.get("compatibility_signature"), "compatibility signature"),
+        policy_signature=_required_text(payload.get("policy_signature"), "policy signature"),
+        observation_compatibility_key=_required_text(payload.get("observation_compatibility_key"), "observation compatibility"),
+        observation_policy_hash=_required_text(payload.get("observation_policy_hash"), "observation policy"),
+        verdict=cast(Literal["acceptable", "unacceptable"], _required_text(payload.get("verdict"), "verdict")),
+        chosen_crf=float_value(payload.get("chosen_crf")),
+        boundary_bitrate_bps=int_value(payload.get("boundary_bitrate_bps")),
+        quality_metric=_required_text(payload.get("quality_metric"), "quality metric"),
+        quality_target=float_value(payload.get("quality_target")),
+        minimum_quality_score=float_value(payload.get("minimum_quality_score")),
+        measured_quality_score=float_value(payload.get("measured_quality_score")),
+        quality_floor_met=payload.get("quality_floor_met") is True,
+        recorded_at=_required_text(payload.get("recorded_at"), "recorded timestamp"),
+    )
+
+
+def _load_owner_only_json(path: Path, label: str) -> tuple[dict[str, Any], bytes]:
+    raw = _read_owner_only_bytes(path, label)
+    try:
+        return object_dict(json.loads(raw.decode("utf-8"))), raw
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, TypeError) as exc:
+        raise AV1ValidationDerivationError(f"AV1 {label} is not valid JSON") from exc
+
+
+def _write_owner_only(path: Path, data: bytes) -> None:
+    _ensure_owner_only_directory(path.parent)
+    temporary_path = path.parent / (
+        f".{path.name}.{secrets.token_hex(12)}.tmp"
+    )
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(temporary_path, flags, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            descriptor = -1
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(temporary_path, path, follow_symlinks=False)
+        except FileExistsError as exc:
+            raise AV1ValidationDerivationError(
+                "AV1 private derivation artifact already exists"
+            ) from exc
+        _fsync_directory(path.parent)
+        temporary_path.unlink()
+        _fsync_directory(path.parent)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary_path.unlink(missing_ok=True)
+
+
+def _ensure_owner_only_directory(path: Path) -> None:
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    _assert_owner_only_directory(path)
+
+
+def bind_av1_validation_derivation_attempt_directory(
+        directory: Path,
+        *,
+        plan_id: str,
+        authorization_id: str,
+) -> None:
+    _bind_owner_only_directory(
+        directory,
+        kind="attempts",
+        binding_id=plan_id,
+        binding_digest=authorization_id,
+    )
+
+
+def _bind_owner_only_directory(
+        path: Path,
+        *,
+        kind: str,
+        binding_id: str,
+        binding_digest: str,
+) -> None:
+    _ensure_owner_only_directory(path)
+    payload = {
+        "schema": AV1_VALIDATION_DERIVATION_DIRECTORY_BINDING_SCHEMA,
+        "schema_version": AV1_VALIDATION_DERIVATION_SCHEMA_VERSION,
+        "contract_version": AV1_VALIDATION_DERIVATION_CONTRACT_VERSION,
+        "kind": kind,
+        "binding_id": binding_id,
+        "binding_digest": binding_digest,
+    }
+    binding_path = path / ".binding"
+    if not binding_path.exists() and not binding_path.is_symlink():
+        try:
+            _write_owner_only(binding_path, canonical_json_bytes(payload))
+            return
+        except AV1ValidationDerivationError:
+            if not binding_path.exists():
+                raise
+    current, raw = _load_owner_only_json(binding_path, "derivation directory binding")
+    if current != payload or raw != canonical_json_bytes(payload):
+        raise AV1ValidationDerivationError("AV1 derivation directory is bound to another artifact set")
+
+
+def _load_owner_only_directory_binding(
+        path: Path,
+        *,
+        expected_kind: str,
+) -> dict[str, Any]:
+    _assert_owner_only_directory(path)
+    binding_path = path / ".binding"
+    payload, raw = _load_owner_only_json(binding_path, "derivation directory binding")
+    _require_exact_keys(payload, {
+        "schema",
+        "schema_version",
+        "contract_version",
+        "kind",
+        "binding_id",
+        "binding_digest",
+    }, "derivation directory binding")
+    if (
+        payload.get("schema") != AV1_VALIDATION_DERIVATION_DIRECTORY_BINDING_SCHEMA
+        or int_value(payload.get("schema_version")) != AV1_VALIDATION_DERIVATION_SCHEMA_VERSION
+        or payload.get("contract_version") != AV1_VALIDATION_DERIVATION_CONTRACT_VERSION
+        or payload.get("kind") != expected_kind
+        or not _SAFE_TOKEN_RE.fullmatch(str(payload.get("binding_id") or ""))
+        or not _SAFE_TOKEN_RE.fullmatch(str(payload.get("binding_digest") or ""))
+        or raw != canonical_json_bytes(payload)
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation directory binding is invalid")
+    return payload
+
+
+def _assert_owner_only_directory(path: Path) -> None:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise AV1ValidationDerivationError("AV1 private derivation directory is unavailable") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise AV1ValidationDerivationError("AV1 private derivation directory is invalid")
+    if info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) & 0o077:
+        raise AV1ValidationDerivationError("AV1 private derivation directory must be owner-only")
+
+
+def _read_owner_only_bytes(path: Path, label: str) -> bytes:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise AV1ValidationDerivationError(f"AV1 {label} is unavailable") from exc
+    try:
+        info = os.fstat(descriptor)
+        if not stat.S_ISREG(info.st_mode):
+            raise AV1ValidationDerivationError(f"AV1 {label} must be a regular file")
+        if info.st_uid != os.getuid() or stat.S_IMODE(info.st_mode) & 0o077:
+            raise AV1ValidationDerivationError(f"AV1 {label} must be owner-only")
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            return handle.read()
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _ensure_av1_validation_derivation_terminal_artifact(
+        directory: Path,
+        *,
+        kind: str,
+        label: str,
+        record: AV1ValidationDerivationTerminalRecord,
+) -> Path:
+    _bind_owner_only_directory(
+        directory,
+        kind=kind,
+        binding_id=record.plan_id,
+        binding_digest=record.authorization_id,
+    )
+    path = directory / f"{record.assignment_id}.json"
+    if path.exists() or path.is_symlink():
+        payload, raw = _load_owner_only_json(path, f"derivation {label}")
+        existing = av1_validation_derivation_terminal_record_from_payload(
+            payload,
+            raw=raw,
+        )
+        if existing != record:
+            raise AV1ValidationDerivationError(
+                f"AV1 derivation {label} conflicts with the immutable artifact"
+            )
+        return path
+    _write_owner_only(path, canonical_json_bytes(record.to_payload()))
+    return path
+
+
+def _fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        flags |= os.O_DIRECTORY
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _derivation_id(kind: str, payload: Mapping[str, Any]) -> str:
+    prefixes = {
+        "plan": "av1vdplan1",
+        "attempt": "av1vdattempt1",
+        "terminal": "av1vdterminal1",
+        "proposal": "av1vdproposal1",
+        "review": "av1vdreview1",
+        "review_envelope": "av1vdreviewenv1",
+        "lock_envelope": "av1vdlockenv1",
+    }
+    return f"{prefixes[kind]}_{hashlib.sha256(canonical_json_bytes(payload)).hexdigest()[:32]}"
+
+
+def _payload_sha256(payload: Mapping[str, Any]) -> str:
+    return f"sha256:{hashlib.sha256(canonical_json_bytes(payload)).hexdigest()}"
+
+
+def _parse_timestamp(value: str, label: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise AV1ValidationDerivationError(f"AV1 {label} is invalid") from exc
+    if parsed.tzinfo is None:
+        raise AV1ValidationDerivationError(f"AV1 {label} must include a UTC offset")
+    return parsed.astimezone(UTC)
+
+
+def _utc_timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _require_sha256(value: str, label: str) -> None:
+    if not _SHA256_RE.fullmatch(value):
+        raise AV1ValidationDerivationError(f"AV1 {label} is invalid")
+
+
+def _required_text(value: object, label: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise AV1ValidationDerivationError(f"AV1 {label} is required")
+    return normalized
+
+
+def _require_exact_keys(
+        payload: Mapping[str, Any],
+        expected: set[str],
+        label: str,
+) -> None:
+    if set(payload) != expected:
+        raise AV1ValidationDerivationError(f"AV1 {label} fields are invalid")

--- a/mediaforce/tuning/av1_validation_derivation.py
+++ b/mediaforce/tuning/av1_validation_derivation.py
@@ -1690,6 +1690,42 @@ def build_av1_validation_derivation_review_claim(
     )
 
 
+def build_av1_validation_derivation_review_prompt(
+        *,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        claim: AV1ValidationDerivationReviewClaim,
+) -> str:
+    if (
+        claim.plan_id != proposal.plan_id
+        or claim.proposal_id != proposal.proposal_id
+        or claim.proposal_payload_sha256 != proposal.payload_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review prompt inputs are not bound"
+        )
+    marker = {
+        "decision": "approved|rejected",
+        "lane": claim.lane,
+        "proposal_id": proposal.proposal_id,
+        "proposal_payload_sha256": proposal.payload_sha256,
+        "review_claim_id": claim.claim_id,
+        "review_claim_payload_sha256": claim.payload_sha256,
+        "review_run_id": claim.review_run_id,
+    }
+    proposal_json = canonical_json_bytes(proposal.to_payload()).decode("utf-8")
+    marker_json = canonical_json_bytes(marker).decode("utf-8")
+    return (
+        "Perform one independent, read-only AV1 derivation candidate review. "
+        "Do not modify files, invoke another agent, reveal opaque tokens, or infer private media identity. "
+        f"Review lane: {claim.lane}. Review the repository implementation and this canonical proposal payload:\n"
+        f"Immutable review claim: {claim.claim_id} ({claim.payload_sha256}).\n"
+        f"{proposal_json}\n"
+        "Reject on any actionable gate failure; otherwise approve. Explain findings concisely. "
+        "End with exactly one final marker line using valid JSON and replace the decision placeholder:\n"
+        f"{AV1_VALIDATION_DERIVATION_AGENT_REVIEW_MARKER}{marker_json}"
+    )
+
+
 def build_av1_validation_derivation_review_attestation(
         *,
         proposal: AV1ValidationDerivationCandidateProposal,
@@ -2785,8 +2821,24 @@ def validate_av1_validation_derivation_review_run_evidence(
         "proposal_id", "proposal_payload_sha256", "review_claim_id",
         "review_claim_payload_sha256", "lane", "decision",
         "review_runner_canonical_path_sha256", "review_runner_binary_sha256",
-        "prompt_sha256", "stdout", "stderr", "returncode",
+        "proposal", "review_claim", "prompt_sha256", "stdout", "stderr",
+        "returncode",
     }, "derivation review run evidence")
+    try:
+        proposal_payload = object_dict(payload.get("proposal"))
+        claim_payload = object_dict(payload.get("review_claim"))
+        proposal = av1_validation_derivation_candidate_proposal_from_payload(
+            proposal_payload,
+            raw=canonical_json_bytes(proposal_payload),
+        )
+        claim = av1_validation_derivation_review_claim_from_payload(
+            claim_payload,
+            raw=canonical_json_bytes(claim_payload),
+        )
+    except (TypeError, ValueError) as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review run evidence bindings are invalid"
+        ) from exc
     review_run_id = _required_text(payload.get("review_run_id"), "review run ID")
     stdout = payload.get("stdout")
     stderr = payload.get("stderr")
@@ -2807,6 +2859,11 @@ def validate_av1_validation_derivation_review_run_evidence(
         != review.review_runner_canonical_path_sha256
         or payload.get("review_runner_binary_sha256")
         != review.review_runner_binary_sha256
+        or proposal.proposal_id != review.proposal_id
+        or proposal.payload_sha256 != review.proposal_payload_sha256
+        or claim.review_run_id != review_run_id
+        or claim.plan_id != proposal.plan_id
+        or not _av1_validation_derivation_review_matches_claim(review, claim)
         or type(returncode) is not int
         or returncode != 0
         or not isinstance(stdout, str)
@@ -2840,22 +2897,18 @@ def validate_av1_validation_derivation_review_run_evidence(
     prompt_sha256 = _required_text(payload.get("prompt_sha256"), "review prompt digest")
     _require_sha256(prompt_sha256, "review prompt digest")
     final_message, prompt = _completed_code_review_message(stdout)
-    if prompt_sha256 != f"sha256:{hashlib.sha256(prompt.encode('utf-8')).hexdigest()}":
+    expected_prompt = build_av1_validation_derivation_review_prompt(
+        proposal=proposal,
+        claim=claim,
+    )
+    if prompt != expected_prompt:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review prompt does not match its frozen inputs"
+        )
+    if prompt_sha256 != f"sha256:{hashlib.sha256(expected_prompt.encode('utf-8')).hexdigest()}":
         raise AV1ValidationDerivationError(
             "AV1 derivation review prompt digest does not match its completed run"
         )
-    for bound_value in (
-        review_run_id,
-        review.proposal_id,
-        review.proposal_payload_sha256,
-        review.review_claim_id,
-        review.review_claim_payload_sha256,
-        review.lane,
-    ):
-        if bound_value not in prompt:
-            raise AV1ValidationDerivationError(
-                "AV1 derivation review prompt is not bound to its attestation"
-            )
     marker = _code_review_marker(final_message)
     if marker != {
         "decision": review.decision,
@@ -2871,28 +2924,84 @@ def validate_av1_validation_derivation_review_run_evidence(
         )
 
 
+def _review_transcript_json_object(
+        pairs: list[tuple[str, Any]],
+) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review JSON contains duplicate JSON keys"
+            )
+        value[key] = item
+    return value
+
+
 def _completed_code_review_message(stdout: str) -> tuple[str, str]:
-    config_seen = False
+    stage = "config"
     prompt: str | None = None
     messages: list[str] = []
     completed_message: str | None = None
-    for line in stdout.splitlines():
+    config_keys = {"provider", "model", "workdir", "approval", "sandbox"}
+    reserved_event_keys = {"prompt", "msg", "id", "event_seq", "order"}
+    for line in stdout.split("\n"):
+        if line.endswith("\r"):
+            line = line[:-1]
         if not line.strip():
             continue
+        if completed_message is not None:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review transcript has events after completion"
+            )
         try:
-            event = object_dict(json.loads(line))
+            event = object_dict(json.loads(
+                line,
+                object_pairs_hook=_review_transcript_json_object,
+            ))
         except (json.JSONDecodeError, TypeError) as exc:
             raise AV1ValidationDerivationError(
                 "AV1 derivation review transcript is not canonical JSONL"
             ) from exc
-        if {"provider", "model", "workdir", "approval", "sandbox"}.issubset(event):
-            if event.get("approval") != "never" or event.get("sandbox") != "read-only":
-                raise AV1ValidationDerivationError(
-                    "AV1 derivation review did not run read-only"
+        has_config_fields = bool(config_keys.intersection(event))
+        is_config = config_keys.issubset(event)
+        is_prompt = set(event) == {"prompt"}
+        if stage == "config":
+            if (
+                not is_config
+                or any(
+                    not isinstance(event.get(key), str)
+                    or not str(event[key]).strip()
+                    for key in ("provider", "model", "workdir")
                 )
-            config_seen = True
-        if set(event) == {"prompt"} and isinstance(event.get("prompt"), str):
+                or event.get("approval") != "never"
+                or event.get("sandbox") != "read-only"
+                or reserved_event_keys.intersection(event)
+            ):
+                raise AV1ValidationDerivationError(
+                    "AV1 derivation review transcript configuration is invalid"
+                )
+            stage = "prompt"
+            continue
+        if has_config_fields:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review transcript configuration is duplicated or out of order"
+            )
+        if stage == "prompt":
+            if (
+                not is_prompt
+                or not isinstance(event.get("prompt"), str)
+                or not event["prompt"]
+            ):
+                raise AV1ValidationDerivationError(
+                    "AV1 derivation review transcript prompt is missing or out of order"
+                )
             prompt = event["prompt"]
+            stage = "events"
+            continue
+        if "prompt" in event:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review transcript prompt is duplicated or out of order"
+            )
         message = event.get("msg")
         if not isinstance(message, dict):
             continue
@@ -2903,11 +3012,19 @@ def _completed_code_review_message(stdout: str) -> tuple[str, str]:
         if (
             message.get("type") == "task_lifecycle"
             and message.get("phase") == "quiescent"
-            and isinstance(message.get("last_agent_message"), str)
         ):
-            completed_message = message["last_agent_message"]
+            last_agent_message = message.get("last_agent_message")
+            if (
+                not isinstance(last_agent_message, str)
+                or not messages
+                or last_agent_message != messages[-1]
+            ):
+                raise AV1ValidationDerivationError(
+                    "AV1 derivation review transcript completion is invalid"
+                )
+            completed_message = last_agent_message
     if (
-        not config_seen
+        stage != "events"
         or prompt is None
         or not messages
         or completed_message != messages[-1]
@@ -2935,7 +3052,8 @@ def _code_review_marker(message: str) -> dict[str, Any]:
         )
     try:
         marker = object_dict(json.loads(
-            marker_lines[0][len(AV1_VALIDATION_DERIVATION_AGENT_REVIEW_MARKER):]
+            marker_lines[0][len(AV1_VALIDATION_DERIVATION_AGENT_REVIEW_MARKER):],
+            object_pairs_hook=_review_transcript_json_object,
         ))
     except (json.JSONDecodeError, TypeError) as exc:
         raise AV1ValidationDerivationError(

--- a/mediaforce/tuning/av1_validation_partition.py
+++ b/mediaforce/tuning/av1_validation_partition.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import re
 import secrets
 import stat
-from typing import Any, Literal, Mapping, Sequence
+from typing import Any, Callable, Literal, Mapping, Sequence
 
 from mediaforce.core.evidence import canonical_json_bytes, stable_json_hash
 from mediaforce.core.type_defs import float_value, int_value, object_dict, object_list
@@ -189,6 +189,7 @@ class AV1ValidationPartitionAssignment:
     source_group_token: str
     compatibility_signature: str
     policy_signature: str
+    source_sha256: str
     target_video_bitrate_bps: int
     quality_metric: str
     quality_target: float
@@ -245,6 +246,7 @@ class AV1ValidationPartitionAssignment:
             raise AV1ValidationPartitionError(
                 "AV1 partition assignment quality floor exceeds target"
             )
+        _require_sha256(self.source_sha256, "assignment source digest")
         _require_sha256(self.evidence_summary_sha256, "assignment evidence digest")
 
     def token_payload(self) -> dict[str, Any]:
@@ -261,6 +263,7 @@ class AV1ValidationPartitionAssignment:
             "source_group_token": self.source_group_token,
             "compatibility_signature": self.compatibility_signature,
             "policy_signature": self.policy_signature,
+            "source_sha256": self.source_sha256,
             "target_video_bitrate_bps": self.target_video_bitrate_bps,
             "quality_metric": self.quality_metric,
             "quality_target": self.quality_target,
@@ -493,6 +496,7 @@ def build_av1_validation_private_partition(
     token_key: bytes,
     expected_token_key_id: str,
     selected_at: str,
+    source_sha256_resolver: Callable[[AV1ValidationPartitionSource], str],
 ) -> AV1ValidationPrivatePartition:
     assert_preregistered_av1_validation_manifest_v2(manifest)
     _assert_partition_criteria(manifest)
@@ -606,7 +610,12 @@ def build_av1_validation_private_partition(
         sorted(
             (
                 _assignment_for_source(
-                    slot, selected[slot.assignment_id], token_key=token_key
+                    slot,
+                    selected[slot.assignment_id],
+                    token_key=token_key,
+                    source_sha256=source_sha256_resolver(
+                        selected[slot.assignment_id]
+                    ),
                 )
                 for slot in slots
             ),
@@ -688,6 +697,7 @@ def validate_av1_validation_private_partition(
         token_key=token_key,
         expected_token_key_id=partition.token_key_id,
         selected_at=partition.selected_at,
+        source_sha256_resolver=_frozen_source_sha256_resolver(partition),
     )
     if rebuilt != partition:
         raise AV1ValidationPartitionError(
@@ -702,6 +712,7 @@ def validate_av1_validation_partition_current_inputs(
     sources: Sequence[AV1ValidationPartitionSource],
     expectations: AV1ValidationPartitionExpectations,
     token_key: bytes,
+    source_sha256_resolver: Callable[[AV1ValidationPartitionSource], str] | None = None,
 ) -> None:
     rebuilt = build_av1_validation_private_partition(
         manifest=manifest,
@@ -712,11 +723,34 @@ def validate_av1_validation_partition_current_inputs(
         token_key=token_key,
         expected_token_key_id=partition.token_key_id,
         selected_at=partition.selected_at,
+        source_sha256_resolver=(
+            source_sha256_resolver
+            or _frozen_source_sha256_resolver(partition)
+        ),
     )
     if rebuilt != partition:
         raise AV1ValidationPartitionError(
             "AV1 private partition does not match current inventory or policy inputs"
         )
+
+
+def _frozen_source_sha256_resolver(
+    partition: AV1ValidationPrivatePartition,
+) -> Callable[[AV1ValidationPartitionSource], str]:
+    source_sha256_by_item_id = {
+        assignment.local_item_id: assignment.source_sha256
+        for assignment in partition.assignments
+    }
+
+    def resolve(source: AV1ValidationPartitionSource) -> str:
+        source_sha256 = source_sha256_by_item_id.get(source.local_item_id)
+        if source_sha256 is None:
+            raise AV1ValidationPartitionError(
+                "AV1 partition selected source lacks a frozen full digest"
+            )
+        return source_sha256
+
+    return resolve
 
 
 def serialize_av1_validation_private_partition(
@@ -1157,6 +1191,7 @@ def _assignment_for_source(
     source: AV1ValidationPartitionSource,
     *,
     token_key: bytes,
+    source_sha256: str,
 ) -> AV1ValidationPartitionAssignment:
     return AV1ValidationPartitionAssignment(
         assignment_id=slot.assignment_id,
@@ -1182,6 +1217,7 @@ def _assignment_for_source(
         policy_signature=_plan_policy_signature(
             source.base_policy_signature, slot.plan
         ),
+        source_sha256=source_sha256,
         target_video_bitrate_bps=source.target_video_bitrate_bps,
         quality_metric=source.quality_metric,
         quality_target=source.quality_target,
@@ -1917,6 +1953,7 @@ def _assignment_from_payload(
             "source_group_token",
             "compatibility_signature",
             "policy_signature",
+            "source_sha256",
             "target_video_bitrate_bps",
             "quality_metric",
             "quality_target",
@@ -1950,6 +1987,7 @@ def _assignment_from_payload(
         policy_signature=_required_text(
             data.get("policy_signature"), "policy signature"
         ),
+        source_sha256=_required_text(data.get("source_sha256"), "source digest"),
         target_video_bitrate_bps=int_value(data.get("target_video_bitrate_bps")),
         quality_metric=_required_text(data.get("quality_metric"), "quality metric"),
         quality_target=float_value(data.get("quality_target")),

--- a/mediaforce/tuning/av1_validation_partition.py
+++ b/mediaforce/tuning/av1_validation_partition.py
@@ -67,12 +67,11 @@ class AV1ValidationPartitionExpectations:
                 raise AV1ValidationPartitionError(f"AV1 partition {label} is invalid")
         if not _QUALITY_METRIC_RE.fullmatch(self.quality_metric):
             raise AV1ValidationPartitionError("AV1 partition quality metric is invalid")
-        if not all(
-            math.isfinite(value) and value >= 0
-            for value in (
-                self.quality_target,
-                self.minimum_quality_score,
-            )
+        if (
+            not math.isfinite(self.quality_target)
+            or self.quality_target < 0
+            or not math.isfinite(self.minimum_quality_score)
+            or self.minimum_quality_score <= 0
         ):
             raise AV1ValidationPartitionError(
                 "AV1 partition quality expectations are invalid"
@@ -727,8 +726,7 @@ def serialize_av1_validation_private_partition(
 
 
 def load_av1_validation_private_partition(path: Path) -> AV1ValidationPrivatePartition:
-    _assert_owner_only_regular_file(path, label="private partition")
-    raw = path.read_bytes()
+    raw = _read_owner_only_regular_file(path, label="private partition")
     try:
         payload = object_dict(json.loads(raw.decode("utf-8")))
     except (UnicodeDecodeError, json.JSONDecodeError, TypeError) as exc:
@@ -921,8 +919,7 @@ def create_av1_validation_partition_key(path: Path) -> str:
 
 
 def load_av1_validation_partition_key(path: Path) -> bytes:
-    _assert_owner_only_regular_file(path, label="partition key")
-    key = path.read_bytes()
+    key = _read_owner_only_regular_file(path, label="partition key")
     _validate_key(key)
     return key
 
@@ -1735,7 +1732,7 @@ def _required_text(value: object, label: str) -> str:
 def _assert_owner_only_directory(path: Path) -> None:
     if os.name != "posix":
         return
-    directory_stat = path.stat()
+    directory_stat = path.lstat()
     if not stat.S_ISDIR(directory_stat.st_mode):
         raise AV1ValidationPartitionError(
             "AV1 private artifact parent is not a directory"
@@ -1747,13 +1744,35 @@ def _assert_owner_only_directory(path: Path) -> None:
 
 
 def _assert_owner_only_regular_file(path: Path, *, label: str) -> None:
-    file_stat = path.stat()
+    file_stat = path.lstat()
     if not stat.S_ISREG(file_stat.st_mode):
         raise AV1ValidationPartitionError(f"AV1 {label} is not a regular file")
     if os.name == "posix" and (
         file_stat.st_uid != os.getuid() or file_stat.st_mode & 0o077
     ):
         raise AV1ValidationPartitionError(f"AV1 {label} permissions must be owner-only")
+
+
+def _read_owner_only_regular_file(path: Path, *, label: str) -> bytes:
+    _assert_owner_only_regular_file(path, label=label)
+    descriptor = -1
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        file_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise AV1ValidationPartitionError(f"AV1 {label} is not a regular file")
+        if os.name == "posix" and (
+            file_stat.st_uid != os.getuid() or file_stat.st_mode & 0o077
+        ):
+            raise AV1ValidationPartitionError(f"AV1 {label} permissions must be owner-only")
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            return handle.read()
+    except OSError as exc:
+        raise AV1ValidationPartitionError(f"AV1 {label} could not be read safely") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
 
 
 def _expectations_from_payload(

--- a/mediaforce/tuning/av1_validation_partition_inventory.py
+++ b/mediaforce/tuning/av1_validation_partition_inventory.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass
+import hashlib
 import json
 import math
+import os
+import stat
+import subprocess
 import unicodedata
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 from sqlalchemy import select
 
@@ -13,13 +17,25 @@ from mediaforce.core.config import MediaforceConfig
 from mediaforce.core.db import DBClient
 from mediaforce.core.db_tables import library_item_evidence_state, library_items
 from mediaforce.core.evidence import stable_json_hash
+from mediaforce.core.file_integrity import (
+    FileIntegrityError,
+    MacOSFileIntegrityGuard,
+)
 from mediaforce.core.type_defs import object_dict
+from mediaforce.core.utils import (
+    descriptor_content_version_fingerprint,
+    descriptor_sha256,
+    file_stat_signature,
+)
+from mediaforce.encoding.helpers import resolve_item_source_path
 from mediaforce.encoding.fingerprint import MEDIA_FINGERPRINT_EVIDENCE_KIND
+from mediaforce.hosts.config import host_media_access_for_host
 from mediaforce.library.media_scopes import (
     media_group_scope_for_rel_path,
     normalize_scope_prefix,
     tv_series_scope_for_rel_path,
 )
+from mediaforce.library.probe import probe_evidence
 from mediaforce.tuning.av1_trait_projection import (
     AV1_COLD_START_TRAIT_PROJECTION_CONTRACT_VERSION,
     AV1ColdStartTraitProjectionError,
@@ -28,6 +44,7 @@ from mediaforce.tuning.av1_trait_projection import (
 from mediaforce.tuning.av1_validation_partition import (
     AV1_VALIDATION_PARTITION_CONTRACT_VERSION,
     AV1ValidationPartitionExpectations,
+    AV1ValidationPartitionError,
     AV1ValidationPartitionSource,
 )
 from mediaforce.tuning.stream_budget import (
@@ -58,6 +75,149 @@ class _EvidenceCompatibility:
             "analyzer_runtime_version": self.analyzer_runtime_version,
             "analyzer_policy_digest": self.analyzer_policy_digest,
         }
+
+
+def av1_validation_partition_source_sha256_resolver(
+    connection: DBClient,
+    *,
+    config: MediaforceConfig,
+    verify_evidence: bool = False,
+) -> Callable[[AV1ValidationPartitionSource], str]:
+    digest_by_item_id: dict[int, str] = {}
+
+    def resolve(source: AV1ValidationPartitionSource) -> str:
+        cached = digest_by_item_id.get(source.local_item_id)
+        if cached is not None:
+            return cached
+        row = connection.execute(
+            select(
+                library_items.c.id,
+                library_items.c.source_path,
+                library_items.c.rel_path,
+                library_items.c.media_root,
+                library_items.c.content_version_fingerprint,
+                library_items.c.size_bytes,
+            ).where(library_items.c.id == source.local_item_id)
+        ).mappings().one_or_none()
+        if row is None:
+            raise AV1ValidationPartitionError(
+                "AV1 partition selected source is no longer in the inventory"
+            )
+        source_path = resolve_item_source_path(
+            config,
+            dict(row),
+            host=None,
+            host_media_access_for_host=host_media_access_for_host,
+        )
+        if not hasattr(os, "O_NOFOLLOW"):
+            raise AV1ValidationPartitionError(
+                "AV1 partition secure source hashing is unavailable"
+            )
+        source_descriptor = -1
+        source_guard: MacOSFileIntegrityGuard | None = None
+        try:
+            source_descriptor = os.open(
+                source_path,
+                os.O_RDONLY | os.O_NOFOLLOW,
+            )
+            source_guard = MacOSFileIntegrityGuard(
+                path=source_path,
+                descriptor=source_descriptor,
+                require_single_link=False,
+            )
+            source_path = source_guard.path
+            source_initial = os.fstat(source_descriptor)
+            source_path_initial = source_path.lstat()
+            expected_size_bytes = int(row.get("size_bytes") or 0)
+            expected_content_version = str(
+                row.get("content_version_fingerprint") or ""
+            )
+            if (
+                expected_content_version != source.source_identity
+                or expected_size_bytes <= 0
+                or not stat.S_ISREG(source_initial.st_mode)
+                or not stat.S_ISREG(source_path_initial.st_mode)
+                or (source_initial.st_dev, source_initial.st_ino)
+                != (source_path_initial.st_dev, source_path_initial.st_ino)
+                or source_initial.st_size != expected_size_bytes
+                or descriptor_content_version_fingerprint(
+                    source_descriptor,
+                    size_bytes=source_initial.st_size,
+                ) != source.source_identity
+            ):
+                raise AV1ValidationPartitionError(
+                    "AV1 partition selected source drifted before full hashing"
+                )
+            source_sha256 = descriptor_sha256(source_descriptor)
+            source_guard.assert_quiet()
+            if verify_evidence:
+                summary = probe_evidence(
+                    source_path,
+                    MEDIA_FINGERPRINT_EVIDENCE_KIND,
+                )
+                summary_json = json.dumps(
+                    summary,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+                summary_sha256 = (
+                    f"sha256:{hashlib.sha256(
+                        summary_json.encode(),
+                        usedforsecurity=False,
+                    ).hexdigest()}"
+                )
+                if summary_sha256 != source.evidence_summary_sha256:
+                    raise AV1ValidationPartitionError(
+                        "AV1 partition selected source evidence does not replay from its frozen bytes"
+                    )
+                source_guard.assert_quiet()
+            if descriptor_sha256(source_descriptor) != source_sha256:
+                raise AV1ValidationPartitionError(
+                    "AV1 partition selected source changed during evidence replay"
+                )
+            source_guard.assert_quiet()
+            source_final = os.fstat(source_descriptor)
+            source_path_final = source_path.lstat()
+            if (
+                file_stat_signature(source_initial)
+                != file_stat_signature(source_final)
+                or not stat.S_ISREG(source_path_final.st_mode)
+                or (source_final.st_dev, source_final.st_ino)
+                != (source_path_final.st_dev, source_path_final.st_ino)
+                or descriptor_content_version_fingerprint(
+                    source_descriptor,
+                    size_bytes=source_final.st_size,
+                ) != source.source_identity
+            ):
+                raise AV1ValidationPartitionError(
+                    "AV1 partition selected source changed during full hashing"
+                )
+        except FileIntegrityError as exc:
+            raise AV1ValidationPartitionError(
+                "AV1 partition selected source integrity monitoring failed"
+            ) from exc
+        except AV1ValidationPartitionError:
+            raise
+        except (
+            OSError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+            json.JSONDecodeError,
+            subprocess.SubprocessError,
+        ) as exc:
+            raise AV1ValidationPartitionError(
+                "AV1 partition selected source could not be securely hashed"
+            ) from exc
+        finally:
+            if source_guard is not None:
+                source_guard.close()
+            if source_descriptor >= 0:
+                os.close(source_descriptor)
+        digest_by_item_id[source.local_item_id] = source_sha256
+        return source_sha256
+
+    return resolve
 
 
 def load_av1_validation_partition_inventory(

--- a/mediaforce/tuning/av1_validation_v2.py
+++ b/mediaforce/tuning/av1_validation_v2.py
@@ -376,6 +376,9 @@ class AV1ValidationV2DerivationAuthorization:
     manifest_payload_sha256: str
     selection_lock_sha256: str
     derivation_partition_sha256: str
+    runtime_context_sha256: str
+    execution_environment_sha256: str
+    statistics_contract_sha256: str
     authorized_at: str
     valid_until: str
     review_state: str
@@ -388,6 +391,9 @@ class AV1ValidationV2DerivationAuthorization:
             (self.manifest_payload_sha256, "manifest digest"),
             (self.selection_lock_sha256, "selection-lock digest"),
             (self.derivation_partition_sha256, "derivation-partition digest"),
+            (self.runtime_context_sha256, "runtime-context digest"),
+            (self.execution_environment_sha256, "execution-environment digest"),
+            (self.statistics_contract_sha256, "statistics-contract digest"),
         ):
             _require_sha256(value, label)
         authorized = _parse_timestamp(self.authorized_at, "derivation authorization")
@@ -412,6 +418,9 @@ class AV1ValidationV2DerivationAuthorization:
             manifest_payload_sha256=self.manifest_payload_sha256,
             selection_lock_sha256=self.selection_lock_sha256,
             derivation_partition_sha256=self.derivation_partition_sha256,
+            runtime_context_sha256=self.runtime_context_sha256,
+            execution_environment_sha256=self.execution_environment_sha256,
+            statistics_contract_sha256=self.statistics_contract_sha256,
             authorized_at=self.authorized_at,
             valid_until=self.valid_until,
             review_state=self.review_state,
@@ -627,6 +636,9 @@ def build_av1_validation_v2_derivation_authorization(
         manifest: AV1ValidationManifestV2,
         selection_lock_sha256: str,
         derivation_partition_sha256: str,
+        runtime_context_sha256: str,
+        execution_environment_sha256: str,
+        statistics_contract_sha256: str,
         authorized_at: str,
         valid_until: str,
 ) -> AV1ValidationV2DerivationAuthorization:
@@ -636,6 +648,9 @@ def build_av1_validation_v2_derivation_authorization(
         manifest_payload_sha256=manifest.payload_sha256,
         selection_lock_sha256=selection_lock_sha256,
         derivation_partition_sha256=derivation_partition_sha256,
+        runtime_context_sha256=runtime_context_sha256,
+        execution_environment_sha256=execution_environment_sha256,
+        statistics_contract_sha256=statistics_contract_sha256,
         authorized_at=authorized_at,
         valid_until=valid_until,
         review_state="approved_for_derivation",
@@ -647,6 +662,9 @@ def build_av1_validation_v2_derivation_authorization(
         manifest_payload_sha256=manifest.payload_sha256,
         selection_lock_sha256=selection_lock_sha256,
         derivation_partition_sha256=derivation_partition_sha256,
+        runtime_context_sha256=runtime_context_sha256,
+        execution_environment_sha256=execution_environment_sha256,
+        statistics_contract_sha256=statistics_contract_sha256,
         authorized_at=authorized_at,
         valid_until=valid_until,
         review_state="approved_for_derivation",
@@ -739,6 +757,11 @@ def av1_validation_v2_derivation_authorization_from_payload(
         manifest_payload_sha256=str(value.get("manifest_payload_sha256") or ""),
         selection_lock_sha256=str(value.get("selection_lock_sha256") or ""),
         derivation_partition_sha256=str(value.get("derivation_partition_sha256") or ""),
+        runtime_context_sha256=str(value.get("runtime_context_sha256") or ""),
+        execution_environment_sha256=str(
+            value.get("execution_environment_sha256") or ""
+        ),
+        statistics_contract_sha256=str(value.get("statistics_contract_sha256") or ""),
         authorized_at=str(value.get("authorized_at") or ""),
         valid_until=str(value.get("valid_until") or ""),
         review_state=str(value.get("review_state") or ""),
@@ -973,6 +996,9 @@ def _derivation_authorization_semantic_payload(
         manifest_payload_sha256: str,
         selection_lock_sha256: str,
         derivation_partition_sha256: str,
+        runtime_context_sha256: str,
+        execution_environment_sha256: str,
+        statistics_contract_sha256: str,
         authorized_at: str,
         valid_until: str,
         review_state: str,
@@ -994,6 +1020,9 @@ def _derivation_authorization_semantic_payload(
         "manifest_payload_sha256": manifest_payload_sha256,
         "selection_lock_sha256": selection_lock_sha256,
         "derivation_partition_sha256": derivation_partition_sha256,
+        "runtime_context_sha256": runtime_context_sha256,
+        "execution_environment_sha256": execution_environment_sha256,
+        "statistics_contract_sha256": statistics_contract_sha256,
         "authorized_at": authorized_at,
         "valid_until": valid_until,
         "review_state": review_state,
@@ -1205,6 +1234,9 @@ def _require_derivation_authorization_contract(value: Mapping[str, Any]) -> None
         "manifest_payload_sha256",
         "selection_lock_sha256",
         "derivation_partition_sha256",
+        "runtime_context_sha256",
+        "execution_environment_sha256",
+        "statistics_contract_sha256",
         "authorized_at",
         "valid_until",
         "review_state",

--- a/mediaforce/tuning/av1_validation_v2.py
+++ b/mediaforce/tuning/av1_validation_v2.py
@@ -15,7 +15,12 @@ from mediaforce.tuning.av1_cold_start import (
     AV1_COLD_START_TRAITS,
     assert_av1_cold_start_public_payload_safe,
 )
-from mediaforce.tuning.av1_cold_start_evaluation import AV1ColdStartValidationCriteriaV1
+from mediaforce.tuning.av1_cold_start_evaluation import (
+    AV1_COLD_START_VALIDATION_MAXIMUM_CANDIDATE_CRF_SPAN,
+    AV1_COLD_START_VALIDATION_MAXIMUM_DERIVATION_AGE_DAYS,
+    AV1_COLD_START_VALIDATION_MINIMUM_DERIVATION_SOURCE_COUNT,
+    AV1ColdStartValidationCriteriaV1,
+)
 from mediaforce.tuning.av1_trait_feasibility import AV1_COLD_START_TRAIT_FEASIBILITY_CONTRACT_VERSION
 from mediaforce.tuning.av1_trait_projection import AV1_COLD_START_TRAIT_PROJECTION_CONTRACT_VERSION
 from mediaforce.tuning.av1_validation_harness import AV1_VALIDATION_HARNESS_CONTRACT_VERSION
@@ -379,6 +384,8 @@ class AV1ValidationV2DerivationAuthorization:
     runtime_context_sha256: str
     execution_environment_sha256: str
     statistics_contract_sha256: str
+    review_runner_canonical_path_sha256: str
+    review_runner_binary_sha256: str
     authorized_at: str
     valid_until: str
     review_state: str
@@ -394,6 +401,11 @@ class AV1ValidationV2DerivationAuthorization:
             (self.runtime_context_sha256, "runtime-context digest"),
             (self.execution_environment_sha256, "execution-environment digest"),
             (self.statistics_contract_sha256, "statistics-contract digest"),
+            (
+                self.review_runner_canonical_path_sha256,
+                "review-runner canonical-path digest",
+            ),
+            (self.review_runner_binary_sha256, "review-runner binary digest"),
         ):
             _require_sha256(value, label)
         authorized = _parse_timestamp(self.authorized_at, "derivation authorization")
@@ -421,6 +433,10 @@ class AV1ValidationV2DerivationAuthorization:
             runtime_context_sha256=self.runtime_context_sha256,
             execution_environment_sha256=self.execution_environment_sha256,
             statistics_contract_sha256=self.statistics_contract_sha256,
+            review_runner_canonical_path_sha256=(
+                self.review_runner_canonical_path_sha256
+            ),
+            review_runner_binary_sha256=self.review_runner_binary_sha256,
             authorized_at=self.authorized_at,
             valid_until=self.valid_until,
             review_state=self.review_state,
@@ -639,6 +655,8 @@ def build_av1_validation_v2_derivation_authorization(
         runtime_context_sha256: str,
         execution_environment_sha256: str,
         statistics_contract_sha256: str,
+        review_runner_canonical_path_sha256: str,
+        review_runner_binary_sha256: str,
         authorized_at: str,
         valid_until: str,
 ) -> AV1ValidationV2DerivationAuthorization:
@@ -651,6 +669,10 @@ def build_av1_validation_v2_derivation_authorization(
         runtime_context_sha256=runtime_context_sha256,
         execution_environment_sha256=execution_environment_sha256,
         statistics_contract_sha256=statistics_contract_sha256,
+        review_runner_canonical_path_sha256=(
+            review_runner_canonical_path_sha256
+        ),
+        review_runner_binary_sha256=review_runner_binary_sha256,
         authorized_at=authorized_at,
         valid_until=valid_until,
         review_state="approved_for_derivation",
@@ -665,6 +687,10 @@ def build_av1_validation_v2_derivation_authorization(
         runtime_context_sha256=runtime_context_sha256,
         execution_environment_sha256=execution_environment_sha256,
         statistics_contract_sha256=statistics_contract_sha256,
+        review_runner_canonical_path_sha256=(
+            review_runner_canonical_path_sha256
+        ),
+        review_runner_binary_sha256=review_runner_binary_sha256,
         authorized_at=authorized_at,
         valid_until=valid_until,
         review_state="approved_for_derivation",
@@ -762,6 +788,12 @@ def av1_validation_v2_derivation_authorization_from_payload(
             value.get("execution_environment_sha256") or ""
         ),
         statistics_contract_sha256=str(value.get("statistics_contract_sha256") or ""),
+        review_runner_canonical_path_sha256=str(
+            value.get("review_runner_canonical_path_sha256") or ""
+        ),
+        review_runner_binary_sha256=str(
+            value.get("review_runner_binary_sha256") or ""
+        ),
         authorized_at=str(value.get("authorized_at") or ""),
         valid_until=str(value.get("valid_until") or ""),
         review_state=str(value.get("review_state") or ""),
@@ -819,11 +851,17 @@ def _v2_execution_semantics() -> dict[str, Any]:
 def _v2_criteria() -> AV1ColdStartValidationCriteriaV1:
     return AV1ColdStartValidationCriteriaV1(
         minimum_derivation_evidence_count=12,
-        minimum_derivation_source_count=6,
+        minimum_derivation_source_count=(
+            AV1_COLD_START_VALIDATION_MINIMUM_DERIVATION_SOURCE_COUNT
+        ),
         minimum_holdout_count=16,
         minimum_holdout_source_count=6,
-        maximum_derivation_age_days=180,
-        maximum_candidate_crf_span=6.0,
+        maximum_derivation_age_days=(
+            AV1_COLD_START_VALIDATION_MAXIMUM_DERIVATION_AGE_DAYS
+        ),
+        maximum_candidate_crf_span=(
+            AV1_COLD_START_VALIDATION_MAXIMUM_CANDIDATE_CRF_SPAN
+        ),
         range_hit_null_rate=0.5,
         maximum_one_sided_p_value=0.025,
         maximum_safety_regression_count=0,
@@ -999,6 +1037,8 @@ def _derivation_authorization_semantic_payload(
         runtime_context_sha256: str,
         execution_environment_sha256: str,
         statistics_contract_sha256: str,
+        review_runner_canonical_path_sha256: str,
+        review_runner_binary_sha256: str,
         authorized_at: str,
         valid_until: str,
         review_state: str,
@@ -1023,6 +1063,10 @@ def _derivation_authorization_semantic_payload(
         "runtime_context_sha256": runtime_context_sha256,
         "execution_environment_sha256": execution_environment_sha256,
         "statistics_contract_sha256": statistics_contract_sha256,
+        "review_runner_canonical_path_sha256": (
+            review_runner_canonical_path_sha256
+        ),
+        "review_runner_binary_sha256": review_runner_binary_sha256,
         "authorized_at": authorized_at,
         "valid_until": valid_until,
         "review_state": review_state,
@@ -1237,6 +1281,8 @@ def _require_derivation_authorization_contract(value: Mapping[str, Any]) -> None
         "runtime_context_sha256",
         "execution_environment_sha256",
         "statistics_contract_sha256",
+        "review_runner_canonical_path_sha256",
+        "review_runner_binary_sha256",
         "authorized_at",
         "valid_until",
         "review_state",

--- a/mediaforce/tuning/content_intent_observations.py
+++ b/mediaforce/tuning/content_intent_observations.py
@@ -29,6 +29,12 @@ CONTENT_INTENT_COMPATIBILITY_SCHEMA_VERSION = 1
 CONTENT_PROFILE_SCHEMA_VERSION = 1
 CONTENT_VERSION_FINGERPRINT_KIND = "mediaforce_content_version_v1"
 BOUNDARY_ASSESSMENT_CONTRACT = "operator_visual_v1"
+AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON = (
+    "av1_validation_derivation_quarantine"
+)
+PROTECTED_PERSONALIZATION_EXCLUSION_REASONS = frozenset({
+    AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON,
+})
 MAX_CORRECTION_REBASE_ATTEMPTS = 8
 VISUAL_BOUNDARY_CONCERN_TAGS = frozenset({
     "softness_detail_loss",
@@ -425,8 +431,14 @@ def build_visual_content_intent_observation(
         evidence_ids: Sequence[str],
         moment_indexes: Sequence[int],
         recorded_at: str,
+        personalization_eligible: bool = True,
+        personalization_exclusion_reason: str | None = None,
 ) -> ContentIntentObservationBuildResult:
     normalized_recorded_at = _timestamp(recorded_at, "recorded timestamp")
+    if personalization_eligible == (personalization_exclusion_reason is not None):
+        raise ValueError(
+            "Visual boundary personalization eligibility requires one consistent exclusion state"
+        )
     if verdict not in {"approved", "rejected"}:
         raise ValueError("Visual boundary observations require an approved or rejected verdict")
     normalized_concerns = tuple(
@@ -436,6 +448,18 @@ def build_visual_content_intent_observation(
         return ContentIntentObservationBuildResult(None, "visual_rejection_reason_missing")
     item = object_dict(sample_item)
     calibration_payload = object_dict(calibration)
+    calibration_action = str(calibration_payload.get("action") or "sample").strip()
+    if (
+        calibration_action == "av1_derivation"
+        and (
+            personalization_eligible
+            or personalization_exclusion_reason
+            != AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON
+        )
+    ):
+        raise ValueError(
+            "AV1 derivation observations must remain quarantined from personalization"
+        )
     policy = object_dict(calibration_payload.get("policy"))
     sample_result = object_dict(calibration_payload.get("sample_result"))
     compatibility_payload = object_dict(sample_result.get("content_intent_compatibility"))
@@ -607,8 +631,8 @@ def build_visual_content_intent_observation(
             supersession_reason=None,
             authority="runtime_native",
             disposition="active",
-            personalization_eligible=True,
-            exclusion_reason=None,
+            personalization_eligible=personalization_eligible,
+            exclusion_reason=personalization_exclusion_reason,
             library_item_id=library_item_id,
             prefix=normalized_prefix,
             source_rel_path=source_rel_path,
@@ -759,6 +783,14 @@ def correct_content_intent_boundary_observation(
 ) -> ContentIntentBoundaryObservation:
     if previous.disposition == "withdrawn":
         raise ValueError("Withdrawn boundary evidence cannot be corrected")
+    if (
+        previous.exclusion_reason in PROTECTED_PERSONALIZATION_EXCLUSION_REASONS
+        and (
+            personalization_eligible
+            or exclusion_reason != previous.exclusion_reason
+        )
+    ):
+        raise ValueError("Protected boundary evidence quarantine cannot be lifted")
     successor_recorded_at = _successor_timestamp(previous.recorded_at, recorded_at)
     observation_kind: BoundaryObservationKind = (
         "visual_approval" if verdict == "acceptable" else "visual_rejection"
@@ -835,11 +867,16 @@ def withdraw_content_intent_boundary_observation(
         reason_code: str,
         recorded_at: str,
 ) -> ContentIntentBoundaryObservation:
+    exclusion_reason = (
+        previous.exclusion_reason
+        if previous.exclusion_reason in PROTECTED_PERSONALIZATION_EXCLUSION_REASONS
+        else _required_text(reason_code, "withdrawal reason")
+    )
     correction = correct_content_intent_boundary_observation(
         previous,
         verdict=previous.verdict,
         personalization_eligible=False,
-        exclusion_reason=_required_text(reason_code, "withdrawal reason"),
+        exclusion_reason=exclusion_reason,
         reason_code=reason_code,
         recorded_at=recorded_at,
     )
@@ -1046,6 +1083,7 @@ def _content_intent_replay_scope_rows(
         and str(observation.get("compatibility_key")) == compatibility_key
         and str(observation.get("disposition")) == "active"
         and bool(observation.get("personalization_eligible"))
+        and not _observation_has_derivation_provenance(observation)
         and _observation_integrity_valid(observation)
     ]
     exact = [
@@ -1074,6 +1112,18 @@ def _content_intent_replay_scope_rows(
         ],
         "operator": profile_compatible,
     }
+
+
+def _observation_has_derivation_provenance(
+        observation: Mapping[str, Any],
+) -> bool:
+    try:
+        provenance = object_dict(
+            json.loads(str(observation.get("provenance_json") or "{}"))
+        )
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return True
+    return str(provenance.get("calibration_action") or "") == "av1_derivation"
 
 
 def content_intent_replay_context(
@@ -1436,6 +1486,24 @@ def _observation_integrity_valid(observation: Mapping[str, Any]) -> bool:
         rebuilt.observation_id == str(observation.get("observation_id") or "")
         and rebuilt.payload_sha256 == str(observation.get("payload_sha256") or "")
     )
+
+
+def content_intent_boundary_observation_integrity_valid(
+        observation: ContentIntentBoundaryObservation,
+) -> bool:
+    return _observation_integrity_valid(observation.values())
+
+
+def content_intent_boundary_observation_from_values(
+        values: Mapping[str, Any],
+) -> ContentIntentBoundaryObservation:
+    observation = _rehash_observation(values)
+    if (
+        observation.observation_id != str(values.get("observation_id") or "")
+        or observation.payload_sha256 != str(values.get("payload_sha256") or "")
+    ):
+        raise ValueError("Boundary observation digest does not match its payload")
+    return observation
 
 
 def _same_visual_review(

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -163,6 +163,12 @@ from mediaforce.web.runtime.calibration_runtime import CalibrationRunDeps, \
     run_full_calibration as runtime_run_full_calibration, \
     run_sampled_calibration as runtime_run_sampled_calibration, \
     remove_path as runtime_remove_path, snapshot_staged_artifact as runtime_snapshot_staged_artifact
+from mediaforce.web.runtime_lock import (
+    MediaforceRuntimeBusyError,
+    exclusive_mediaforce_runtime_lock,
+    mediaforce_runtime_lock_owner,
+    mediaforce_runtime_lock_path,
+)
 from mediaforce.web.runtime.host_runtime import lifecycle_command_error_detail as runtime_lifecycle_command_error_detail
 from mediaforce.web.runtime.worker_leadership import WorkerLeadershipLease
 from mediaforce.web.runtime.encode_runtime import EncodeQueueRuntimeDeps, \
@@ -2273,31 +2279,18 @@ def _default_web_port() -> int:
 
 @contextmanager
 def _exclusive_web_server_lock(config: MediaforceConfig, settings: WebStartupSettings) -> Iterator[None]:
-    lock_path = _web_server_lock_path(config)
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a+", encoding="utf-8") as lock_file:
-        try:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError as exc:
-            owner = _web_server_lock_owner(lock_path)
-            owner_detail = f" ({owner})" if owner else ""
-            raise SystemExit(f"mediaforce-web is already running{owner_detail}") from exc
-
-        lock_file.seek(0)
-        lock_file.truncate()
-        lock_file.write(json.dumps(_web_server_lock_payload(config, settings), indent=2, sort_keys=True))
-        lock_file.write("\n")
-        lock_file.flush()
-        os.fsync(lock_file.fileno())
-        try:
+    try:
+        with exclusive_mediaforce_runtime_lock(
+            config,
+            owner_payload=_web_server_lock_payload(config, settings),
+        ):
             yield
-        finally:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
-            _remove_web_server_lock(lock_path)
+    except MediaforceRuntimeBusyError as exc:
+        raise SystemExit(str(exc).replace("Mediaforce runtime", "mediaforce-web")) from exc
 
 
 def _web_server_lock_path(config: MediaforceConfig) -> Path:
-    return config.paths.web_state_dir.parent / "mediaforce-web.lock"
+    return mediaforce_runtime_lock_path(config)
 
 
 def _web_server_lock_payload(config: MediaforceConfig, settings: WebStartupSettings) -> dict[str, object]:
@@ -2312,27 +2305,12 @@ def _web_server_lock_payload(config: MediaforceConfig, settings: WebStartupSetti
 
 
 def _web_server_lock_owner(lock_path: Path) -> str | None:
-    try:
-        payload = json.loads(lock_path.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return None
-    if not isinstance(payload, dict):
-        return None
-    pid = payload.get("pid")
-    host = payload.get("host")
-    port = payload.get("port")
-    if pid and host and port:
-        return f"pid {pid} on {host}:{port}"
-    if pid:
-        return f"pid {pid}"
-    return None
+    return mediaforce_runtime_lock_owner(lock_path)
 
 
 def _remove_web_server_lock(lock_path: Path) -> None:
-    try:
-        lock_path.unlink()
-    except FileNotFoundError:
-        return
+    if lock_path.exists():
+        lock_path.write_text("", encoding="utf-8")
 
 
 def create_reloadable_app() -> FastAPI:

--- a/mediaforce/web/app.py
+++ b/mediaforce/web/app.py
@@ -4373,6 +4373,7 @@ def _run_sampled_calibration(
         sample_item: dict[str, Any],
         calibration_run_id: str,
         process_controller: ManagedProcessController,
+        source_path_override: Path | None = None,
 ) -> tuple[dict[str, Any], Path | None]:
     return runtime_run_sampled_calibration(
         config=config,
@@ -4386,6 +4387,7 @@ def _run_sampled_calibration(
         calibration_run_id=calibration_run_id,
         process_controller=process_controller,
         deps=_calibration_run_deps(),
+        source_path_override=source_path_override,
     )
 
 

--- a/mediaforce/web/runtime/av1_validation_derivation.py
+++ b/mediaforce/web/runtime/av1_validation_derivation.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from copy import copy, deepcopy
+from dataclasses import dataclass
 from datetime import UTC, datetime
 import hashlib
 import os
@@ -8,7 +10,8 @@ from pathlib import Path
 import platform
 import shutil
 import stat
-from typing import Any, Callable, Mapping, cast
+import sys
+from typing import Any, Callable, Iterator, Mapping, cast
 from urllib.parse import unquote, urlparse
 
 from sqlalchemy import select
@@ -17,8 +20,21 @@ from mediaforce.core.config import MediaforceConfig, load_config
 from mediaforce.core.db import DBClient, open_db, open_readonly_db
 from mediaforce.core.db_tables import library_items, staged_artifacts
 from mediaforce.core.evidence import canonical_json_bytes
+from mediaforce.core.file_integrity import (
+    FileIntegrityError,
+    MACOS_FILE_INTEGRITY_CONTRACT_VERSION,
+    MacOSFileIntegrityGuard,
+    assert_macos_file_integrity_capability,
+    probe_macos_file_integrity,
+)
 from mediaforce.core.process_control import ManagedProcessController, ProcessCancelledError
-from mediaforce.core.type_defs import float_value, mapping_dict, object_dict, object_list
+from mediaforce.core.type_defs import float_value, int_value, mapping_dict, object_dict, object_list
+from mediaforce.core.utils import (
+    descriptor_content_version_fingerprint,
+    descriptor_sha256,
+    file_stat_signature,
+)
+from mediaforce.encoding.helpers import resolve_item_source_path
 from mediaforce.encoding.quality import quality_toolchain_identity, run_sample_encode, select_quality_metric
 from mediaforce.execution import (
     build_svt_params,
@@ -29,6 +45,7 @@ from mediaforce.execution import (
 )
 from mediaforce.library.media_scopes import media_group_scope_for_rel_path
 from mediaforce.library.planner import build_manifest_item
+from mediaforce.hosts.config import host_media_access_for_host
 from mediaforce.review import (
     default_review_timestamps,
     encode_preview_clips,
@@ -110,6 +127,314 @@ from mediaforce.web.runtime_lock import (
 
 
 AV1_VALIDATION_DERIVATION_MINIMUM_FREE_BYTES = 5 * 1024 ** 3
+_AV1_VALIDATION_DERIVATION_SOURCE_SNAPSHOT_DIRECTORY = "source-snapshots"
+_AV1_VALIDATION_DERIVATION_COPY_CHUNK_BYTES = 4 * 1024 * 1024
+_AV1_VALIDATION_DERIVATION_HOST_DATA = {
+    "key": "av1-derivation-local",
+    "label": "AV1 derivation local",
+    "mode": "local",
+    "media_access": "direct",
+}
+_AV1_VALIDATION_DERIVATION_IMPLEMENTATION_FILES = (
+    "core/file_integrity.py",
+    "core/utils.py",
+    "tuning/av1_validation_partition.py",
+    "tuning/av1_validation_partition_inventory.py",
+    "tuning/av1_validation_derivation.py",
+    "web/runtime/av1_validation_derivation.py",
+    "web/runtime/calibration_runtime.py",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _PinnedDerivationSource:
+    path: Path
+    content_version_fingerprint: str
+    content_sha256: str
+    size_bytes: int
+    device: int
+    inode: int
+
+
+def _write_all(descriptor: int, payload: bytes) -> None:
+    view = memoryview(payload)
+    written = 0
+    while written < len(view):
+        count = os.write(descriptor, view[written:])
+        if count <= 0:
+            raise OSError("AV1 derivation source snapshot write did not progress")
+        written += count
+
+
+def _prepare_owner_only_directory(path: Path, *, label: str) -> Path:
+    try:
+        path.mkdir(mode=0o700)
+    except FileExistsError:
+        pass
+    try:
+        path_info = path.lstat()
+    except OSError as exc:
+        raise AV1ValidationDerivationError(
+            f"AV1 derivation {label} directory is unavailable"
+        ) from exc
+    if (
+        not stat.S_ISDIR(path_info.st_mode)
+        or path_info.st_uid != os.getuid()
+        or path_info.st_mode & 0o077
+    ):
+        raise AV1ValidationDerivationError(
+            f"AV1 derivation {label} directory must be owner-only"
+        )
+    return path
+
+
+def _remove_owner_only_tree(path: Path) -> None:
+    try:
+        path_info = path.lstat()
+    except FileNotFoundError:
+        return
+    if path_info.st_uid != os.getuid():
+        raise AV1ValidationDerivationError(
+            "AV1 derivation source snapshot tree must be owned by the current user"
+        )
+    if stat.S_ISREG(path_info.st_mode):
+        path.chmod(0o600, follow_symlinks=False)
+        path.unlink()
+        return
+    if not stat.S_ISDIR(path_info.st_mode):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation source snapshot tree must not contain links or special files"
+        )
+    path.chmod(0o700, follow_symlinks=False)
+    for child in path.iterdir():
+        _remove_owner_only_tree(child)
+    path.rmdir()
+
+
+def _purge_derivation_source_snapshots(artifact_root: Path) -> None:
+    _remove_owner_only_tree(
+        artifact_root / _AV1_VALIDATION_DERIVATION_SOURCE_SNAPSHOT_DIRECTORY
+    )
+
+
+def _assert_pinned_source_guard_quiet(
+        guard: MacOSFileIntegrityGuard,
+) -> None:
+    try:
+        guard.assert_quiet()
+    except FileIntegrityError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation pinned source changed during media execution"
+        ) from exc
+
+
+def _validate_pinned_derivation_source(
+        pinned: _PinnedDerivationSource,
+        *,
+        descriptor: int,
+        process_controller: ManagedProcessController,
+) -> None:
+    descriptor_info = os.fstat(descriptor)
+    try:
+        path_info = pinned.path.lstat()
+    except OSError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation pinned source path is unavailable"
+        ) from exc
+    if (
+        not stat.S_ISREG(descriptor_info.st_mode)
+        or not stat.S_ISREG(path_info.st_mode)
+        or path_info.st_uid != os.getuid()
+        or path_info.st_mode & 0o377
+        or (descriptor_info.st_dev, descriptor_info.st_ino)
+        != (pinned.device, pinned.inode)
+        or (path_info.st_dev, path_info.st_ino)
+        != (pinned.device, pinned.inode)
+        or descriptor_info.st_nlink != 1
+        or path_info.st_nlink != 1
+        or descriptor_info.st_size != pinned.size_bytes
+        or descriptor_content_version_fingerprint(
+            descriptor,
+            size_bytes=pinned.size_bytes,
+        ) != pinned.content_version_fingerprint
+        or descriptor_sha256(
+            descriptor,
+            check_cancelled=process_controller.throw_if_cancelled,
+        ) != pinned.content_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation pinned source changed during media execution"
+        )
+
+
+@contextmanager
+def _pinned_derivation_source(
+        *,
+        artifact_root: Path,
+        assignment_id: str,
+        source_path: Path,
+        expected_content_version_fingerprint: str,
+        expected_source_sha256: str,
+        expected_size_bytes: int,
+        process_controller: ManagedProcessController,
+) -> Iterator[_PinnedDerivationSource]:
+    snapshot_root = _prepare_owner_only_directory(
+        artifact_root / _AV1_VALIDATION_DERIVATION_SOURCE_SNAPSHOT_DIRECTORY,
+        label="source-snapshot",
+    )
+    assignment_root = snapshot_root / assignment_id
+    if assignment_root.exists():
+        raise AV1ValidationDerivationError(
+            "AV1 derivation source snapshot already exists for this assignment"
+        )
+    _prepare_owner_only_directory(
+        assignment_root,
+        label="assignment source-snapshot",
+    )
+    snapshot_path = assignment_root / "source-media"
+    source_descriptor = -1
+    snapshot_descriptor = -1
+    snapshot_guard: MacOSFileIntegrityGuard | None = None
+    try:
+        source_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            source_descriptor = os.open(source_path, source_flags)
+        except FileNotFoundError:
+            raise
+        except OSError as exc:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation source could not be opened without following links"
+            ) from exc
+        source_initial = os.fstat(source_descriptor)
+        try:
+            source_path_info = source_path.lstat()
+        except OSError as exc:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation source path could not be verified"
+            ) from exc
+        if (
+            not stat.S_ISREG(source_initial.st_mode)
+            or not stat.S_ISREG(source_path_info.st_mode)
+            or (source_initial.st_dev, source_initial.st_ino)
+            != (source_path_info.st_dev, source_path_info.st_ino)
+            or source_initial.st_size != expected_size_bytes
+            or expected_size_bytes <= 0
+            or descriptor_content_version_fingerprint(
+                source_descriptor,
+                size_bytes=source_initial.st_size,
+            ) != expected_content_version_fingerprint
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation source bytes drifted from the frozen reservation"
+            )
+        if (
+            shutil.disk_usage(snapshot_root).free
+            < source_initial.st_size + AV1_VALIDATION_DERIVATION_MINIMUM_FREE_BYTES
+        ):
+            raise OSError("AV1 derivation source snapshot storage floor is not available")
+        snapshot_flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
+        snapshot_flags |= getattr(os, "O_NOFOLLOW", 0)
+        snapshot_descriptor = os.open(snapshot_path, snapshot_flags, 0o600)
+        digest = hashlib.sha256()
+        os.lseek(source_descriptor, 0, os.SEEK_SET)
+        while True:
+            process_controller.throw_if_cancelled()
+            chunk = os.read(
+                source_descriptor,
+                _AV1_VALIDATION_DERIVATION_COPY_CHUNK_BYTES,
+            )
+            if not chunk:
+                break
+            digest.update(chunk)
+            _write_all(snapshot_descriptor, chunk)
+        os.fsync(snapshot_descriptor)
+        source_final = os.fstat(source_descriptor)
+        try:
+            source_path_final = source_path.lstat()
+        except OSError as exc:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation source path changed during snapshot creation"
+            ) from exc
+        snapshot_info = os.fstat(snapshot_descriptor)
+        copied_sha256 = f"sha256:{digest.hexdigest()}"
+        if (
+            file_stat_signature(source_initial)
+            != file_stat_signature(source_final)
+            or (source_final.st_dev, source_final.st_ino)
+            != (source_path_final.st_dev, source_path_final.st_ino)
+            or not stat.S_ISREG(source_path_final.st_mode)
+            or snapshot_info.st_size != source_initial.st_size
+            or descriptor_content_version_fingerprint(
+                snapshot_descriptor,
+                size_bytes=snapshot_info.st_size,
+            ) != expected_content_version_fingerprint
+            or descriptor_sha256(
+                snapshot_descriptor,
+                check_cancelled=process_controller.throw_if_cancelled,
+            ) != copied_sha256
+            or copied_sha256 != expected_source_sha256
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation source changed while its snapshot was created"
+            )
+        os.fchmod(snapshot_descriptor, 0o400)
+        os.fsync(snapshot_descriptor)
+        assignment_root.chmod(0o500, follow_symlinks=False)
+        os.close(snapshot_descriptor)
+        snapshot_descriptor = os.open(
+            snapshot_path,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        )
+        reopened_snapshot_info = os.fstat(snapshot_descriptor)
+        if (
+            reopened_snapshot_info.st_dev != snapshot_info.st_dev
+            or reopened_snapshot_info.st_ino != snapshot_info.st_ino
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation source snapshot changed before monitoring"
+            )
+        try:
+            snapshot_guard = MacOSFileIntegrityGuard(
+                path=snapshot_path,
+                descriptor=snapshot_descriptor,
+                require_single_link=True,
+            )
+        except FileIntegrityError as exc:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation source snapshot monitoring is unavailable"
+            ) from exc
+        pinned = _PinnedDerivationSource(
+            path=snapshot_guard.path,
+            content_version_fingerprint=expected_content_version_fingerprint,
+            content_sha256=copied_sha256,
+            size_bytes=int(snapshot_info.st_size),
+            device=int(snapshot_info.st_dev),
+            inode=int(snapshot_info.st_ino),
+        )
+        _validate_pinned_derivation_source(
+            pinned,
+            descriptor=snapshot_descriptor,
+            process_controller=process_controller,
+        )
+        _assert_pinned_source_guard_quiet(snapshot_guard)
+        try:
+            yield pinned
+        finally:
+            _assert_pinned_source_guard_quiet(snapshot_guard)
+            _validate_pinned_derivation_source(
+                pinned,
+                descriptor=snapshot_descriptor,
+                process_controller=process_controller,
+            )
+            _assert_pinned_source_guard_quiet(snapshot_guard)
+    finally:
+        if snapshot_guard is not None:
+            snapshot_guard.close()
+        if snapshot_descriptor >= 0:
+            os.close(snapshot_descriptor)
+        if source_descriptor >= 0:
+            os.close(source_descriptor)
+        _purge_derivation_source_snapshots(artifact_root)
 
 
 def av1_validation_derivation_runtime_context_sha256(
@@ -123,10 +448,39 @@ def av1_validation_derivation_runtime_context_sha256(
     return f"sha256:{hashlib.sha256(canonical_json_bytes(payload)).hexdigest()}"
 
 
+def _av1_validation_derivation_implementation_sha256() -> str:
+    package_root = Path(__file__).resolve().parents[2]
+    try:
+        file_digests = {
+            relative_path: f"sha256:{hashlib.sha256(
+                (package_root / relative_path).read_bytes()
+            ).hexdigest()}"
+            for relative_path in _AV1_VALIDATION_DERIVATION_IMPLEMENTATION_FILES
+        }
+        python_sha256 = f"sha256:{hashlib.sha256(
+            Path(sys.executable).resolve(strict=True).read_bytes()
+        ).hexdigest()}"
+    except OSError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation implementation identity is unavailable"
+        ) from exc
+    return f"sha256:{hashlib.sha256(canonical_json_bytes({
+        'files': file_digests,
+        'python_sha256': python_sha256,
+        'python_version': platform.python_version(),
+    })).hexdigest()}"
+
+
 def av1_validation_derivation_execution_environment_sha256(
         *,
         quality_metric: str,
 ) -> str:
+    try:
+        assert_macos_file_integrity_capability()
+    except FileIntegrityError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation source-integrity monitoring is unavailable"
+        ) from exc
     toolchain = quality_toolchain_identity(quality_metric=quality_metric)
     if toolchain.get("status") != "available":
         raise AV1ValidationDerivationError(
@@ -139,7 +493,9 @@ def av1_validation_derivation_execution_environment_sha256(
             "machine": platform.machine(),
             "node": platform.node(),
         },
+        "implementation_sha256": _av1_validation_derivation_implementation_sha256(),
         "quality_metric": quality_metric.strip().casefold(),
+        "source_integrity_contract": MACOS_FILE_INTEGRITY_CONTRACT_VERSION,
         "toolchain": toolchain,
     }
     return f"sha256:{hashlib.sha256(canonical_json_bytes(payload)).hexdigest()}"
@@ -173,7 +529,7 @@ def assert_av1_validation_derivation_execution_environment(
         != plan.authorization.execution_environment_sha256
     ):
         raise AV1ValidationDerivationError(
-            "AV1 derivation machine or toolchain drifted after authorization"
+            "AV1 derivation execution environment drifted after authorization"
         )
 
 
@@ -419,13 +775,15 @@ def _run_av1_validation_derivation_assignment_locked(
         )
     clock = now_iso or _now_iso
     recovery_completed_at = clock()
-    if _recover_interrupted_derivation_state(
+    interrupted_state_recovered = _recover_interrupted_derivation_state(
         plan=plan,
         partition=partition,
         attempts_directory=attempts_directory,
         terminal_records_directory=terminal_records_directory,
         completed_at=recovery_completed_at,
-    ):
+    )
+    _purge_derivation_source_snapshots(artifact_root)
+    if interrupted_state_recovered:
         raise AV1ValidationDerivationError(
             "AV1 derivation interrupted state was terminalized; retry the next canonical assignment"
         )
@@ -449,6 +807,12 @@ def _run_av1_validation_derivation_assignment_locked(
     )
     if source is None:
         raise AV1ValidationDerivationError("AV1 derivation source is absent from the partition")
+    try:
+        probe_macos_file_integrity(artifact_root)
+    except FileIntegrityError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation source-integrity probe failed before assignment claim"
+        ) from exc
     _assert_next_assignment(
         plan=plan,
         assignment_id=assignment.assignment_id,
@@ -500,28 +864,45 @@ def _run_av1_validation_derivation_assignment_locked(
                 run_deps.staged_artifact_columns,
             )
             staged_snapshot_taken = True
+        host_data = dict(_AV1_VALIDATION_DERIVATION_HOST_DATA)
+        source_path = resolve_item_source_path(
+            config,
+            sample_item,
+            host=host_data,
+            host_media_access_for_host=host_media_access_for_host,
+        )
         prefix = _derivation_prefix(config, sample_item)
         calibration_run_id = _run_id(plan.plan_id, assignment.assignment_id, started_at)
         review_root = _prepare_derivation_review_root(artifact_root)
         calibration_config = _config_with_review_directory(config, review_root)
-        payload, _ = run_sampled_calibration(
-            config=calibration_config,
-            prefix=prefix,
-            action="av1_derivation",
-            host_data={
-                "key": "av1-derivation-local",
-                "label": "AV1 derivation local",
-                "mode": "local",
-                "media_access": "direct",
-            },
-            notes="Bounded AV1 v2 derivation observation",
-            policy=object_dict(sample_item.get("resolved_policy")),
-            seed_metadata=None,
-            sample_item=sample_item,
-            calibration_run_id=calibration_run_id,
+        with _pinned_derivation_source(
+            artifact_root=artifact_root,
+            assignment_id=assignment.assignment_id,
+            source_path=source_path,
+            expected_content_version_fingerprint=source.source_identity,
+            expected_source_sha256=assignment.source_sha256,
+            expected_size_bytes=int_value(sample_item.get("source_size_bytes")),
             process_controller=controller,
-            deps=run_deps,
-        )
+        ) as pinned_source:
+            sample_item["source_snapshot_sha256"] = pinned_source.content_sha256
+            sample_item["source_snapshot_size_bytes"] = pinned_source.size_bytes
+            sample_item["source_snapshot_content_version_fingerprint"] = (
+                pinned_source.content_version_fingerprint
+            )
+            payload, _ = run_sampled_calibration(
+                config=calibration_config,
+                prefix=prefix,
+                action="av1_derivation",
+                host_data=host_data,
+                notes="Bounded AV1 v2 derivation observation",
+                policy=object_dict(sample_item.get("resolved_policy")),
+                seed_metadata=None,
+                sample_item=sample_item,
+                calibration_run_id=calibration_run_id,
+                process_controller=controller,
+                deps=run_deps,
+                source_path_override=pinned_source.path,
+            )
         assert_av1_validation_derivation_execution_contract(manifest, plan)
         _secure_derivation_review_media(review_root)
         current_review_fingerprint = _current_derivation_review_artifact_fingerprint(

--- a/mediaforce/web/runtime/av1_validation_derivation.py
+++ b/mediaforce/web/runtime/av1_validation_derivation.py
@@ -196,6 +196,13 @@ def av1_validation_derivation_artifact_root(
         plan: AV1ValidationDerivationPlan,
 ) -> Path:
     assert_av1_validation_derivation_runtime_context(config, plan)
+    return _av1_validation_derivation_state_root(config, plan)
+
+
+def _av1_validation_derivation_state_root(
+        config: MediaforceConfig,
+        plan: AV1ValidationDerivationPlan,
+) -> Path:
     return (
         config.paths.web_state_dir
         / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
@@ -384,12 +391,7 @@ def _run_av1_validation_derivation_assignment_locked(
         plan=plan,
         partition=partition,
     )
-    assert_av1_validation_derivation_execution_contract(manifest, plan)
-    artifact_root = av1_validation_derivation_artifact_root(config, plan)
-    validate_av1_validation_derivation_artifact_root_binding(
-        artifact_root,
-        plan,
-    )
+    artifact_root = attempts_directory.expanduser().resolve().parent
     if (
         attempts_directory.resolve()
         != (artifact_root / "attempts").resolve()
@@ -398,6 +400,39 @@ def _run_av1_validation_derivation_assignment_locked(
     ):
         raise AV1ValidationDerivationError(
             "AV1 derivation runtime artifacts must use the partition-global canonical directory"
+        )
+    expected_state_root = _av1_validation_derivation_state_root(
+        config,
+        plan,
+    ).expanduser().resolve()
+    if artifact_root != expected_state_root:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation recovery requires the canonical runtime state root"
+        )
+    validate_av1_validation_derivation_artifact_root_binding(
+        artifact_root,
+        plan,
+    )
+    if load_av1_validation_derivation_plan(artifact_root / "plan.json") != plan:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation runtime plan does not match the frozen artifact root"
+        )
+    clock = now_iso or _now_iso
+    recovery_completed_at = clock()
+    if _recover_interrupted_derivation_state(
+        plan=plan,
+        partition=partition,
+        attempts_directory=attempts_directory,
+        terminal_records_directory=terminal_records_directory,
+        completed_at=recovery_completed_at,
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation interrupted state was terminalized; retry the next canonical assignment"
+        )
+    assert_av1_validation_derivation_execution_contract(manifest, plan)
+    if av1_validation_derivation_artifact_root(config, plan).resolve() != artifact_root:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation runtime artifacts drifted from the immutable runtime context"
         )
     with open_readonly_db(config.paths.db_path) as connection:
         inventory = load_av1_validation_partition_inventory(connection, config=config)
@@ -414,25 +449,14 @@ def _run_av1_validation_derivation_assignment_locked(
     )
     if source is None:
         raise AV1ValidationDerivationError("AV1 derivation source is absent from the partition")
-    clock = now_iso or _now_iso
-    started_at = clock()
-    if _recover_interrupted_derivation_state(
-        plan=plan,
-        partition=partition,
-        attempts_directory=attempts_directory,
-        terminal_records_directory=terminal_records_directory,
-        completed_at=started_at,
-    ):
-        raise AV1ValidationDerivationError(
-            "AV1 derivation interrupted state was terminalized; retry the next canonical assignment"
-        )
-    assert_av1_validation_derivation_authorization_active(plan, at=started_at)
     _assert_next_assignment(
         plan=plan,
         assignment_id=assignment.assignment_id,
         attempts_directory=attempts_directory,
         terminal_records_directory=terminal_records_directory,
     )
+    started_at = clock()
+    assert_av1_validation_derivation_authorization_active(plan, at=started_at)
     write_av1_validation_derivation_assignment_claim(
         attempts_directory,
         assignment_id=assignment.assignment_id,

--- a/mediaforce/web/runtime/av1_validation_derivation.py
+++ b/mediaforce/web/runtime/av1_validation_derivation.py
@@ -55,6 +55,7 @@ from mediaforce.tuning.av1_validation_derivation import (
     evaluate_av1_validation_derivation_candidate,
     ensure_av1_validation_derivation_terminal_intent,
     ensure_av1_validation_derivation_terminal_record,
+    load_av1_validation_derivation_assignment_claims,
     load_av1_validation_derivation_attempts,
     load_av1_validation_derivation_candidate_proposal,
     load_av1_validation_derivation_plan,
@@ -415,6 +416,16 @@ def _run_av1_validation_derivation_assignment_locked(
         raise AV1ValidationDerivationError("AV1 derivation source is absent from the partition")
     clock = now_iso or _now_iso
     started_at = clock()
+    if _recover_interrupted_derivation_state(
+        plan=plan,
+        partition=partition,
+        attempts_directory=attempts_directory,
+        terminal_records_directory=terminal_records_directory,
+        completed_at=started_at,
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation interrupted state was terminalized; retry the next canonical assignment"
+        )
     assert_av1_validation_derivation_authorization_active(plan, at=started_at)
     _assert_next_assignment(
         plan=plan,
@@ -427,6 +438,7 @@ def _run_av1_validation_derivation_assignment_locked(
         assignment_id=assignment.assignment_id,
         plan_id=plan.plan_id,
         authorization_id=plan.authorization.authorization_id,
+        claimed_at=started_at,
     )
     controller = process_controller or ManagedProcessController()
     run_deps = deps or build_av1_validation_derivation_calibration_deps()
@@ -1284,6 +1296,89 @@ def _assert_next_assignment(
         raise AV1ValidationDerivationError(
             "AV1 derivation assignment is not next in the immutable worklist"
         )
+
+
+def _recover_interrupted_derivation_state(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        partition: AV1ValidationPrivatePartition,
+        attempts_directory: Path,
+        terminal_records_directory: Path,
+        completed_at: str,
+) -> bool:
+    attempts = (
+        load_av1_validation_derivation_attempts(attempts_directory)
+        if attempts_directory.exists()
+        else ()
+    )
+    records = (
+        load_av1_validation_derivation_terminal_records(
+            terminal_records_directory
+        )
+        if terminal_records_directory.exists()
+        else ()
+    )
+    terminal_attempt_ids = {record.attempt_id for record in records}
+    unterminated = [
+        attempt
+        for attempt in attempts
+        if attempt.attempt_id not in terminal_attempt_ids
+        and attempt.status != "review_pending"
+    ]
+    if len(unterminated) > 1:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation has multiple unterminated attempts"
+        )
+    if unterminated:
+        terminal = build_av1_validation_derivation_terminal_record(
+            plan=plan,
+            partition=partition,
+            attempt=unterminated[0],
+        )
+        write_av1_validation_derivation_terminal_record(
+            terminal_records_directory,
+            terminal,
+        )
+        return True
+    attempted_ids = {attempt.assignment_id for attempt in attempts}
+    claims = load_av1_validation_derivation_assignment_claims(attempts_directory)
+    orphaned = [
+        claim for claim in claims if claim["assignment_id"] not in attempted_ids
+    ]
+    if len(orphaned) > 1:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation has multiple interrupted claimed assignments"
+        )
+    if not orphaned:
+        return False
+    claim = orphaned[0]
+    if (
+        claim["plan_id"] != plan.plan_id
+        or claim["authorization_id"] != plan.authorization.authorization_id
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation interrupted claim is bound to another plan"
+        )
+    attempt = _failed_attempt(
+        plan=plan,
+        partition=partition,
+        assignment_id=str(claim["assignment_id"]),
+        started_at=str(claim["claimed_at"]),
+        completed_at=completed_at,
+        status="stopped",
+        reason_code="interrupted_claim",
+    )
+    write_av1_validation_derivation_attempt(attempts_directory, attempt)
+    terminal = build_av1_validation_derivation_terminal_record(
+        plan=plan,
+        partition=partition,
+        attempt=attempt,
+    )
+    write_av1_validation_derivation_terminal_record(
+        terminal_records_directory,
+        terminal,
+    )
+    return True
 
 
 def _current_derivation_review_artifact_fingerprint(

--- a/mediaforce/web/runtime/av1_validation_derivation.py
+++ b/mediaforce/web/runtime/av1_validation_derivation.py
@@ -58,6 +58,7 @@ from mediaforce.tuning.av1_validation_derivation import (
     load_av1_validation_derivation_attempts,
     load_av1_validation_derivation_candidate_proposal,
     load_av1_validation_derivation_plan,
+    load_av1_validation_derivation_review_claims,
     load_av1_validation_derivation_review_envelopes,
     load_av1_validation_derivation_terminal_records,
     _finalize_and_write_av1_validation_derivation_candidate_lock,
@@ -197,7 +198,7 @@ def av1_validation_derivation_artifact_root(
     return (
         config.paths.web_state_dir
         / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
-        / plan.plan_id
+        / plan.partition_id
     )
 
 
@@ -395,7 +396,7 @@ def _run_av1_validation_derivation_assignment_locked(
         != (artifact_root / "terminal-records").resolve()
     ):
         raise AV1ValidationDerivationError(
-            "AV1 derivation runtime artifacts must use the plan-global canonical directory"
+            "AV1 derivation runtime artifacts must use the partition-global canonical directory"
         )
     with open_readonly_db(config.paths.db_path) as connection:
         inventory = load_av1_validation_partition_inventory(connection, config=config)
@@ -683,10 +684,16 @@ def finalize_av1_validation_derivation_candidate_lock(
             records = load_av1_validation_derivation_terminal_records(
                 artifact_root / "terminal-records"
             )
+            review_claims = load_av1_validation_derivation_review_claims(
+                artifact_root,
+                plan=plan,
+                proposal=proposal,
+            )
             review_envelopes = load_av1_validation_derivation_review_envelopes(
                 artifact_root,
                 plan=plan,
                 proposal=proposal,
+                claims=review_claims,
             )
             locked_at = clock()
             with open_db(config.paths.db_path) as connection:
@@ -725,6 +732,7 @@ def finalize_av1_validation_derivation_candidate_lock(
                     artifact_root,
                     plan=plan,
                     proposal=proposal,
+                    review_claims=review_claims,
                     review_envelopes=review_envelopes,
                     current_evaluation=current_evaluation,
                     locked_at=locked_at,
@@ -779,10 +787,16 @@ def load_verified_av1_validation_derivation_candidate_lock(
             records = load_av1_validation_derivation_terminal_records(
                 artifact_root / "terminal-records"
             )
+            review_claims = load_av1_validation_derivation_review_claims(
+                artifact_root,
+                plan=plan,
+                proposal=proposal,
+            )
             review_envelopes = load_av1_validation_derivation_review_envelopes(
                 artifact_root,
                 plan=plan,
                 proposal=proposal,
+                claims=review_claims,
             )
             persisted = _load_av1_validation_derivation_candidate_lock_envelope(
                 artifact_root,
@@ -825,6 +839,7 @@ def load_verified_av1_validation_derivation_candidate_lock(
                     artifact_root,
                     plan=plan,
                     proposal=proposal,
+                    review_claims=review_claims,
                     review_envelopes=review_envelopes,
                     current_evaluation=current_evaluation,
                     cell_plan_id=cell_plan_id,
@@ -838,8 +853,55 @@ def load_verified_av1_validation_derivation_candidate_lock(
 def record_av1_validation_derivation_visual_verdict(
         *,
         config_path: Path,
+        manifest: AV1ValidationManifestV2,
         plan: AV1ValidationDerivationPlan,
         partition: AV1ValidationPrivatePartition,
+        token_key: bytes,
+        attempt: AV1ValidationDerivationAttempt,
+        terminal_records_directory: Path,
+        verdict: str,
+        concern_tags: list[str],
+        evidence_ids: list[str],
+        moment_indexes: list[int],
+        recorded_at: str,
+) -> AV1ValidationDerivationTerminalRecord:
+    config = load_config(config_path)
+    try:
+        with exclusive_mediaforce_runtime_lock(
+            config,
+            owner_payload={
+                "purpose": "av1-derivation-verdict",
+                "plan_id": plan.plan_id,
+                "assignment_id": attempt.assignment_id,
+            },
+        ):
+            return _record_av1_validation_derivation_visual_verdict_locked(
+                config=config,
+                manifest=manifest,
+                plan=plan,
+                partition=partition,
+                token_key=token_key,
+                attempt=attempt,
+                terminal_records_directory=terminal_records_directory,
+                verdict=verdict,
+                concern_tags=concern_tags,
+                evidence_ids=evidence_ids,
+                moment_indexes=moment_indexes,
+                recorded_at=recorded_at,
+            )
+    except MediaforceRuntimeBusyError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation verdict requires the Mediaforce runtime to be paused"
+        ) from exc
+
+
+def _record_av1_validation_derivation_visual_verdict_locked(
+        *,
+        config: MediaforceConfig,
+        manifest: AV1ValidationManifestV2,
+        plan: AV1ValidationDerivationPlan,
+        partition: AV1ValidationPrivatePartition,
+        token_key: bytes,
         attempt: AV1ValidationDerivationAttempt,
         terminal_records_directory: Path,
         verdict: str,
@@ -852,109 +914,153 @@ def record_av1_validation_derivation_visual_verdict(
         raise AV1ValidationDerivationError("AV1 derivation attempt is not awaiting visual review")
     if verdict not in {"approved", "rejected"}:
         raise AV1ValidationDerivationError("AV1 derivation visual verdict is invalid")
+    assert_preregistered_av1_validation_manifest_v2(manifest)
+    validate_av1_validation_private_partition(
+        partition,
+        manifest=manifest,
+        token_key=token_key,
+    )
+    validate_av1_validation_derivation_plan_binding(
+        plan=plan,
+        partition=partition,
+    )
     validate_av1_validation_derivation_attempt_binding(
         plan=plan,
         partition=partition,
         attempt=attempt,
     )
-    calibration = attempt.calibration_payload()
-    sample_item = object_dict(calibration.get("sample_item"))
-    config = load_config(config_path)
     artifact_root = av1_validation_derivation_artifact_root(config, plan)
     validate_av1_validation_derivation_artifact_root_binding(
         artifact_root,
         plan,
     )
+    persisted_plan = load_av1_validation_derivation_plan(
+        artifact_root / "plan.json"
+    )
+    if persisted_plan != plan:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation verdict plan is not the canonical partition authority"
+        )
+    persisted_attempt = next(
+        (
+            item
+            for item in load_av1_validation_derivation_attempts(
+                artifact_root / "attempts"
+            )
+            if item.assignment_id == attempt.assignment_id
+        ),
+        None,
+    )
+    if persisted_attempt != attempt:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation verdict attempt is not the immutable current attempt"
+        )
     if terminal_records_directory.resolve() != (
         artifact_root / "terminal-records"
     ).resolve():
         raise AV1ValidationDerivationError(
-            "AV1 derivation terminal artifacts must use the plan-global canonical directory"
+            "AV1 derivation terminal artifacts must use the partition-global canonical directory"
         )
-    review_root = _prepare_derivation_review_root(artifact_root)
-    _secure_derivation_review_media(review_root)
-    current_review_fingerprint = _current_derivation_review_artifact_fingerprint(
-        review_root=review_root,
-        calibration=calibration,
-    )
-    if (
-        current_review_fingerprint is None
-        or current_review_fingerprint
-        != str(calibration.get("review_artifact_fingerprint") or "")
-    ):
-        raise AV1ValidationDerivationError(
-            "AV1 derivation review media is unavailable or changed"
+    calibration = attempt.calibration_payload()
+    sample_item = object_dict(calibration.get("sample_item"))
+    with open_db(config.paths.db_path) as connection:
+        connection.exec_driver_sql("BEGIN IMMEDIATE")
+        inventory = load_av1_validation_partition_inventory(
+            connection,
+            config=config,
         )
-    verdict_intent = resolve_av1_validation_derivation_verdict_intent(
-        artifact_root / "verdict-intents",
-        plan=plan,
-        attempt=attempt,
-        verdict=verdict,
-        concern_tags=concern_tags,
-        evidence_ids=evidence_ids,
-        moment_indexes=moment_indexes,
-        recorded_at=recorded_at,
-    )
-    verdict = str(verdict_intent["verdict"])
-    concern_tags = [
-        str(value) for value in object_list(verdict_intent["concern_tags"])
-    ]
-    evidence_ids = [
-        str(value) for value in object_list(verdict_intent["evidence_ids"])
-    ]
-    moment_indexes = [
-        int(value) for value in object_list(verdict_intent["moment_indexes"])
-    ]
-    recorded_at = str(verdict_intent["recorded_at"])
-    calibration["current_review_artifact_fingerprint"] = current_review_fingerprint
-    prefix = _derivation_prefix(config, sample_item)
-    result = build_visual_content_intent_observation(
-        prefix=prefix,
-        sample_item=sample_item,
-        calibration=calibration,
-        verdict=verdict,
-        concern_tags=concern_tags,
-        evidence_ids=evidence_ids,
-        moment_indexes=moment_indexes,
-        recorded_at=recorded_at,
-        personalization_eligible=False,
-        personalization_exclusion_reason=(
-            AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON
-        ),
-    )
-    if result.observation is None:
-        terminal = build_av1_validation_derivation_terminal_record(
+        validate_av1_validation_partition_current_inputs(
+            partition,
+            manifest=manifest,
+            sources=inventory.sources,
+            expectations=inventory.expectations,
+            token_key=token_key,
+        )
+        assert_av1_validation_derivation_execution_contract(manifest, plan)
+        review_root = _prepare_derivation_review_root(artifact_root)
+        _secure_derivation_review_media(review_root)
+        current_review_fingerprint = _current_derivation_review_artifact_fingerprint(
+            review_root=review_root,
+            calibration=calibration,
+        )
+        if (
+            current_review_fingerprint is None
+            or current_review_fingerprint
+            != str(calibration.get("review_artifact_fingerprint") or "")
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review media is unavailable or changed"
+            )
+        verdict_intent = resolve_av1_validation_derivation_verdict_intent(
+            artifact_root / "verdict-intents",
             plan=plan,
-            partition=partition,
             attempt=attempt,
-            observation_exclusion_reason="content_intent_observation_excluded",
+            verdict=verdict,
+            concern_tags=concern_tags,
+            evidence_ids=evidence_ids,
+            moment_indexes=moment_indexes,
+            recorded_at=recorded_at,
         )
-        ensure_av1_validation_derivation_terminal_intent(
-            artifact_root / "terminal-intents",
-            terminal,
+        frozen_verdict = str(verdict_intent["verdict"])
+        frozen_concern_tags = [
+            str(value) for value in object_list(verdict_intent["concern_tags"])
+        ]
+        frozen_evidence_ids = [
+            str(value) for value in object_list(verdict_intent["evidence_ids"])
+        ]
+        frozen_moment_indexes = [
+            int(value) for value in object_list(verdict_intent["moment_indexes"])
+        ]
+        frozen_recorded_at = str(verdict_intent["recorded_at"])
+        calibration["current_review_artifact_fingerprint"] = (
+            current_review_fingerprint
         )
-        ensure_av1_validation_derivation_terminal_record(
-            terminal_records_directory,
-            terminal,
+        result = build_visual_content_intent_observation(
+            prefix=_derivation_prefix(config, sample_item),
+            sample_item=sample_item,
+            calibration=calibration,
+            verdict=frozen_verdict,
+            concern_tags=frozen_concern_tags,
+            evidence_ids=frozen_evidence_ids,
+            moment_indexes=frozen_moment_indexes,
+            recorded_at=frozen_recorded_at,
+            personalization_eligible=False,
+            personalization_exclusion_reason=(
+                AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON
+            ),
         )
-        return terminal
-    terminal = build_av1_validation_derivation_terminal_record(
-        plan=plan,
-        partition=partition,
-        attempt=attempt,
-        observation=result.observation,
-    )
-    ensure_av1_validation_derivation_terminal_intent(
-        artifact_root / "terminal-intents",
-        terminal,
-    )
-    try:
-        with open_db(config.paths.db_path) as connection:
-            append_content_intent_boundary_observation(connection, result.observation)
-    except ContentIntentObservationConflictError as exc:
-        raise AV1ValidationDerivationError(
-            "AV1 derivation visual observation conflicts with existing evidence"
-        ) from exc
+        if result.observation is None:
+            terminal = build_av1_validation_derivation_terminal_record(
+                plan=plan,
+                partition=partition,
+                attempt=attempt,
+                observation_exclusion_reason="content_intent_observation_excluded",
+            )
+            ensure_av1_validation_derivation_terminal_intent(
+                artifact_root / "terminal-intents",
+                terminal,
+            )
+        else:
+            terminal = build_av1_validation_derivation_terminal_record(
+                plan=plan,
+                partition=partition,
+                attempt=attempt,
+                observation=result.observation,
+            )
+            ensure_av1_validation_derivation_terminal_intent(
+                artifact_root / "terminal-intents",
+                terminal,
+            )
+            try:
+                append_content_intent_boundary_observation(
+                    connection,
+                    result.observation,
+                )
+            except ContentIntentObservationConflictError as exc:
+                raise AV1ValidationDerivationError(
+                    "AV1 derivation visual observation conflicts with existing evidence"
+                ) from exc
+    assert_av1_validation_derivation_execution_contract(manifest, plan)
     ensure_av1_validation_derivation_terminal_record(
         terminal_records_directory,
         terminal,
@@ -1089,24 +1195,6 @@ def _assert_next_assignment(
                 "AV1 derivation attempt is bound to another work item"
             )
         attempts_by_id[attempt.assignment_id] = attempt
-    attempted_ids = set(attempts_by_id)
-    expected_prefix = tuple(
-        assignment.assignment_id
-        for assignment in plan.assignments[:len(attempted_ids)]
-    )
-    actual_prefix = tuple(
-        assignment.assignment_id
-        for assignment in plan.assignments
-        if assignment.assignment_id in attempted_ids
-    )
-    if actual_prefix != expected_prefix:
-        raise AV1ValidationDerivationError(
-            "AV1 derivation attempts are not an ordered prefix of the immutable worklist"
-        )
-    if any(attempt.status != "review_pending" for attempt in attempts):
-        raise AV1ValidationDerivationError(
-            "AV1 derivation has a terminal unsuccessful attempt and cannot continue"
-        )
     records = (
         load_av1_validation_derivation_terminal_records(terminal_records_directory)
         if terminal_records_directory.exists()
@@ -1137,20 +1225,11 @@ def _assert_next_assignment(
                 "AV1 derivation terminal record does not match its attempt"
             )
         records_by_id[record.assignment_id] = record
+    attempted_ids = set(attempts_by_id)
     record_ids = set(records_by_id)
     if attempted_ids != record_ids:
         raise AV1ValidationDerivationError(
             "AV1 derivation must record the prior human visual terminal before continuing"
-        )
-    if any(
-        record.status != "observed"
-        or record.observation is None
-        or record.observation.verdict != "acceptable"
-        or not record.observation.quality_floor_met
-        for record in records
-    ):
-        raise AV1ValidationDerivationError(
-            "AV1 derivation has an unfavorable terminal record and cannot continue"
         )
     claim_ids = {
         path.stem
@@ -1160,12 +1239,46 @@ def _assert_next_assignment(
         raise AV1ValidationDerivationError(
             "AV1 derivation has an interrupted claimed assignment and cannot continue"
         )
-    next_assignment = next(
-        (item.assignment_id for item in plan.assignments if item.assignment_id not in attempted_ids),
-        None,
-    )
+    stopped_cells: set[str] = set()
+    next_assignment: str | None = None
+    for assignment in plan.assignments:
+        attempt = attempts_by_id.get(assignment.assignment_id)
+        if assignment.cell_plan_id in stopped_cells:
+            if attempt is not None:
+                raise AV1ValidationDerivationError(
+                    "AV1 derivation attempted a later assignment in an affected stopped cell"
+                )
+            continue
+        if attempt is None:
+            if next_assignment is None:
+                next_assignment = assignment.assignment_id
+            continue
+        if next_assignment is not None:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation attempts do not preserve the immutable canonical order"
+            )
+        record = records_by_id[assignment.assignment_id]
+        if (
+            attempt.status != "review_pending"
+            or record.status != "observed"
+            or record.observation is None
+            or record.observation.verdict != "acceptable"
+            or not record.observation.quality_floor_met
+        ):
+            stopped_cells.add(assignment.cell_plan_id)
     if next_assignment is None:
-        raise AV1ValidationDerivationError("AV1 derivation worklist is already complete")
+        raise AV1ValidationDerivationError(
+            "AV1 derivation worklist has no remaining assignment"
+        )
+    requested_assignment = assignments_by_id.get(assignment_id)
+    if requested_assignment is None:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation assignment is not authorized"
+        )
+    if requested_assignment.cell_plan_id in stopped_cells:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation assignment belongs to an affected stopped cell"
+        )
     if assignment_id != next_assignment:
         raise AV1ValidationDerivationError(
             "AV1 derivation assignment is not next in the immutable worklist"

--- a/mediaforce/web/runtime/av1_validation_derivation.py
+++ b/mediaforce/web/runtime/av1_validation_derivation.py
@@ -1,0 +1,1299 @@
+from __future__ import annotations
+
+from copy import copy, deepcopy
+from datetime import UTC, datetime
+import hashlib
+import os
+from pathlib import Path
+import platform
+import shutil
+import stat
+from typing import Any, Callable, Mapping, cast
+from urllib.parse import unquote, urlparse
+
+from sqlalchemy import select
+
+from mediaforce.core.config import MediaforceConfig, load_config
+from mediaforce.core.db import DBClient, open_db, open_readonly_db
+from mediaforce.core.db_tables import library_items, staged_artifacts
+from mediaforce.core.evidence import canonical_json_bytes
+from mediaforce.core.process_control import ManagedProcessController, ProcessCancelledError
+from mediaforce.core.type_defs import float_value, mapping_dict, object_dict, object_list
+from mediaforce.encoding.quality import quality_toolchain_identity, run_sample_encode, select_quality_metric
+from mediaforce.execution import (
+    build_svt_params,
+    detect_video_crop,
+    effective_video_preset,
+    resolve_stream_budget_ledger,
+    search_quality_for_source,
+)
+from mediaforce.library.media_scopes import media_group_scope_for_rel_path
+from mediaforce.library.planner import build_manifest_item
+from mediaforce.review import (
+    default_review_timestamps,
+    encode_preview_clips,
+    generate_compare_clips_from_review_pairs,
+    recommend_review_moments,
+    recommend_review_timestamps,
+    render_source_review_clips,
+    review_moment_payload,
+)
+from mediaforce.reviewing.artifact_identity import reviewed_artifact_fingerprint
+from mediaforce.state_cleanup import purge_transient_artifacts
+from mediaforce.tuning.av1_validation_derivation import (
+    AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY,
+    AV1ValidationDerivationAttempt,
+    AV1ValidationDerivationAttemptStatus,
+    AV1ValidationDerivationCandidateLockEnvelope,
+    AV1ValidationDerivationError,
+    AV1ValidationDerivationPlan,
+    AV1ValidationDerivationTerminalRecord,
+    assert_av1_validation_derivation_authorization_active,
+    av1_validation_derivation_statistics_contract_sha256,
+    build_av1_validation_derivation_attempt,
+    build_av1_validation_derivation_terminal_record,
+    evaluate_av1_validation_derivation_candidate,
+    ensure_av1_validation_derivation_terminal_intent,
+    ensure_av1_validation_derivation_terminal_record,
+    load_av1_validation_derivation_attempts,
+    load_av1_validation_derivation_candidate_proposal,
+    load_av1_validation_derivation_plan,
+    load_av1_validation_derivation_review_envelopes,
+    load_av1_validation_derivation_terminal_records,
+    _finalize_and_write_av1_validation_derivation_candidate_lock,
+    _load_av1_validation_derivation_candidate_lock_envelope,
+    _load_verified_av1_validation_derivation_candidate_lock,
+    resolve_av1_validation_derivation_verdict_intent,
+    validate_av1_validation_derivation_artifact_root_binding,
+    validate_av1_validation_derivation_attempt_binding,
+    validate_av1_validation_derivation_plan_binding,
+    write_av1_validation_derivation_attempt,
+    write_av1_validation_derivation_assignment_claim,
+    write_av1_validation_derivation_terminal_record,
+)
+from mediaforce.tuning.av1_validation_partition import (
+    AV1ValidationPrivatePartition,
+    validate_av1_validation_partition_current_inputs,
+    validate_av1_validation_private_partition,
+)
+from mediaforce.tuning.av1_validation_partition_inventory import (
+    load_av1_validation_partition_inventory,
+)
+from mediaforce.tuning.av1_validation_v2 import (
+    AV1ValidationManifestV2,
+    assert_preregistered_av1_validation_manifest_v2,
+)
+from mediaforce.tuning.size_goals import operator_intent_from_policy
+from mediaforce.tuning.stream_budget import stream_budget_projection_blocker
+from mediaforce.tuning.target_size_search import TargetSizeSearchError
+from mediaforce.tuning.content_intent_observations import (
+    AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON,
+    ContentIntentObservationConflictError,
+    ContentIntentBoundaryObservation,
+    append_content_intent_boundary_observation,
+    build_visual_content_intent_observation,
+    content_intent_boundary_observation_from_values,
+    load_current_content_intent_boundary_observations,
+)
+from mediaforce.web.runtime.calibration_runtime import (
+    CalibrationRunDeps,
+    restore_staged_artifact,
+    run_sampled_calibration,
+    snapshot_staged_artifact,
+)
+from mediaforce.web.runtime_lock import (
+    MediaforceRuntimeBusyError,
+    exclusive_mediaforce_runtime_lock,
+)
+
+
+AV1_VALIDATION_DERIVATION_MINIMUM_FREE_BYTES = 5 * 1024 ** 3
+
+
+def av1_validation_derivation_runtime_context_sha256(
+        config: MediaforceConfig,
+) -> str:
+    payload = {
+        "db_path": str(config.paths.db_path.expanduser().resolve()),
+        "review_dir": str(config.paths.review_dir.expanduser().resolve()),
+        "web_state_dir": str(config.paths.web_state_dir.expanduser().resolve()),
+    }
+    return f"sha256:{hashlib.sha256(canonical_json_bytes(payload)).hexdigest()}"
+
+
+def av1_validation_derivation_execution_environment_sha256(
+        *,
+        quality_metric: str,
+) -> str:
+    toolchain = quality_toolchain_identity(quality_metric=quality_metric)
+    if toolchain.get("status") != "available":
+        raise AV1ValidationDerivationError(
+            "AV1 derivation execution toolchain is unavailable"
+        )
+    payload = {
+        "machine": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+            "node": platform.node(),
+        },
+        "quality_metric": quality_metric.strip().casefold(),
+        "toolchain": toolchain,
+    }
+    return f"sha256:{hashlib.sha256(canonical_json_bytes(payload)).hexdigest()}"
+
+
+def assert_av1_validation_derivation_runtime_context(
+        config: MediaforceConfig,
+        plan: AV1ValidationDerivationPlan,
+) -> None:
+    if (
+        av1_validation_derivation_runtime_context_sha256(config)
+        != plan.runtime_context_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation config does not match the immutable runtime context"
+        )
+
+
+def assert_av1_validation_derivation_execution_environment(
+        plan: AV1ValidationDerivationPlan,
+) -> None:
+    quality_metrics = {assignment.quality_metric for assignment in plan.assignments}
+    if len(quality_metrics) != 1:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation plan quality metric is not uniform"
+        )
+    if (
+        av1_validation_derivation_execution_environment_sha256(
+            quality_metric=next(iter(quality_metrics)),
+        )
+        != plan.authorization.execution_environment_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation machine or toolchain drifted after authorization"
+        )
+
+
+def assert_av1_validation_derivation_execution_contract(
+        manifest: AV1ValidationManifestV2,
+        plan: AV1ValidationDerivationPlan,
+) -> None:
+    assert_av1_validation_derivation_execution_environment(plan)
+    if (
+        av1_validation_derivation_statistics_contract_sha256(manifest)
+        != plan.authorization.statistics_contract_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation statistics contract drifted after authorization"
+        )
+
+
+def av1_validation_derivation_artifact_root(
+        config: MediaforceConfig,
+        plan: AV1ValidationDerivationPlan,
+) -> Path:
+    assert_av1_validation_derivation_runtime_context(config, plan)
+    return (
+        config.paths.web_state_dir
+        / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
+        / plan.plan_id
+    )
+
+
+def load_av1_validation_derivation_sample_item(
+        connection: DBClient,
+        *,
+        config: MediaforceConfig,
+        local_item_id: int,
+) -> dict[str, Any]:
+    row = connection.execute(
+        select(library_items).where(library_items.c.id == local_item_id)
+    ).mappings().one_or_none()
+    if row is None:
+        raise AV1ValidationDerivationError("AV1 derivation source is no longer in the library")
+    return build_manifest_item(mapping_dict(row), config)
+
+
+def _load_canonical_av1_validation_derivation_plan(
+        *,
+        config: MediaforceConfig,
+        plan_path: Path,
+) -> tuple[AV1ValidationDerivationPlan, Path]:
+    plan = load_av1_validation_derivation_plan(plan_path)
+    artifact_root = av1_validation_derivation_artifact_root(config, plan)
+    if plan_path.expanduser().resolve() != (artifact_root / "plan.json").resolve():
+        raise AV1ValidationDerivationError(
+            "AV1 derivation plan must use the config-derived canonical root"
+        )
+    validate_av1_validation_derivation_artifact_root_binding(
+        artifact_root,
+        plan,
+    )
+    return plan, artifact_root
+
+
+def _load_current_derivation_observations_from_connection(
+        *,
+        connection: DBClient,
+        records: tuple[AV1ValidationDerivationTerminalRecord, ...],
+) -> dict[str, ContentIntentBoundaryObservation]:
+    current_rows = load_current_content_intent_boundary_observations(
+        connection,
+        include_withdrawn=True,
+    )
+    current_by_id = {
+        str(row.get("observation_id") or ""):
+        content_intent_boundary_observation_from_values(row)
+        for row in current_rows
+    }
+    current_observations: dict[str, ContentIntentBoundaryObservation] = {}
+    for record in records:
+        if record.observation is None:
+            continue
+        observation = current_by_id.get(record.observation.observation_id)
+        if observation is not None:
+            current_observations[record.assignment_id] = observation
+    return current_observations
+
+
+def load_current_av1_validation_derivation_observations(
+        *,
+        config_path: Path,
+        records: tuple[AV1ValidationDerivationTerminalRecord, ...],
+) -> dict[str, ContentIntentBoundaryObservation]:
+    config = load_config(config_path)
+    with open_readonly_db(config.paths.db_path) as connection:
+        return _load_current_derivation_observations_from_connection(
+            connection=connection,
+            records=records,
+        )
+
+
+def build_av1_validation_derivation_calibration_deps() -> CalibrationRunDeps:
+    staged_columns = tuple(column.name for column in staged_artifacts.columns)
+    return CalibrationRunDeps(
+        now_iso=_now_iso,
+        ensure_sample_host_ready=_unused,
+        load_job_state=_unused,
+        sample_item=_unused,
+        save_job_state=_unused,
+        update_job_telemetry=_unused,
+        calibration_job_compatibility_key=_unused,
+        calibration_heartbeat_seconds=5.0,
+        save_calibration_state=_unused,
+        record_run_verdict=_unused,
+        summarize_calibration_result=_unused,
+        calibration_mode_for_action=_unused,
+        effective_video_preset=effective_video_preset,
+        search_quality_for_source=search_quality_for_source,
+        run_sample_encode=run_sample_encode,
+        detect_video_crop=detect_video_crop,
+        recommend_review_timestamps=recommend_review_timestamps,
+        recommend_review_moments=recommend_review_moments,
+        review_moment_payload=review_moment_payload,
+        default_review_timestamps=default_review_timestamps,
+        encode_preview_clips=encode_preview_clips,
+        render_source_review_clips=render_source_review_clips,
+        generate_compare_clips_from_review_pairs=generate_compare_clips_from_review_pairs,
+        resolve_stream_budget_ledger=resolve_stream_budget_ledger,
+        build_svt_params=build_svt_params,
+        review_url=_review_url,
+        encode_manifest_items=_unused,
+        validate_manifest_items=_unused,
+        generate_compare_clips=_unused,
+        staged_artifact_columns=staged_columns,
+        quality_toolchain_identity=quality_toolchain_identity,
+        select_quality_metric=select_quality_metric,
+        plan_av1_cold_start=None,
+    )
+
+
+def run_av1_validation_derivation_assignment(
+        *,
+        config_path: Path,
+        manifest: AV1ValidationManifestV2,
+        partition: AV1ValidationPrivatePartition,
+        token_key: bytes,
+        plan: AV1ValidationDerivationPlan,
+        assignment_id: str,
+        attempts_directory: Path,
+        terminal_records_directory: Path,
+        process_controller: ManagedProcessController | None = None,
+        deps: CalibrationRunDeps | None = None,
+        now_iso: Callable[[], str] | None = None,
+) -> AV1ValidationDerivationAttempt:
+    config = load_config(config_path)
+    try:
+        with exclusive_mediaforce_runtime_lock(
+            config,
+            owner_payload={
+                "purpose": "av1-derivation",
+                "plan_id": plan.plan_id,
+                "assignment_id": assignment_id,
+            },
+        ):
+            return _run_av1_validation_derivation_assignment_locked(
+                config=config,
+                manifest=manifest,
+                partition=partition,
+                token_key=token_key,
+                plan=plan,
+                assignment_id=assignment_id,
+                attempts_directory=attempts_directory,
+                terminal_records_directory=terminal_records_directory,
+                process_controller=process_controller,
+                deps=deps,
+                now_iso=now_iso,
+            )
+    except MediaforceRuntimeBusyError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation requires the Mediaforce runtime to be paused"
+        ) from exc
+
+
+def _run_av1_validation_derivation_assignment_locked(
+        *,
+        config: MediaforceConfig,
+        manifest: AV1ValidationManifestV2,
+        partition: AV1ValidationPrivatePartition,
+        token_key: bytes,
+        plan: AV1ValidationDerivationPlan,
+        assignment_id: str,
+        attempts_directory: Path,
+        terminal_records_directory: Path,
+        process_controller: ManagedProcessController | None = None,
+        deps: CalibrationRunDeps | None = None,
+        now_iso: Callable[[], str] | None = None,
+) -> AV1ValidationDerivationAttempt:
+    assert_preregistered_av1_validation_manifest_v2(manifest)
+    assignment = next(
+        (item for item in plan.assignments if item.assignment_id == assignment_id),
+        None,
+    )
+    if assignment is None:
+        raise AV1ValidationDerivationError("AV1 derivation assignment is not authorized")
+    validate_av1_validation_private_partition(
+        partition,
+        manifest=manifest,
+        token_key=token_key,
+    )
+    validate_av1_validation_derivation_plan_binding(
+        plan=plan,
+        partition=partition,
+    )
+    assert_av1_validation_derivation_execution_contract(manifest, plan)
+    artifact_root = av1_validation_derivation_artifact_root(config, plan)
+    validate_av1_validation_derivation_artifact_root_binding(
+        artifact_root,
+        plan,
+    )
+    if (
+        attempts_directory.resolve()
+        != (artifact_root / "attempts").resolve()
+        or terminal_records_directory.resolve()
+        != (artifact_root / "terminal-records").resolve()
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation runtime artifacts must use the plan-global canonical directory"
+        )
+    with open_readonly_db(config.paths.db_path) as connection:
+        inventory = load_av1_validation_partition_inventory(connection, config=config)
+    validate_av1_validation_partition_current_inputs(
+        partition,
+        manifest=manifest,
+        sources=inventory.sources,
+        expectations=inventory.expectations,
+        token_key=token_key,
+    )
+    source = next(
+        (item for item in partition.inventory_sources if item.local_item_id == assignment.local_item_id),
+        None,
+    )
+    if source is None:
+        raise AV1ValidationDerivationError("AV1 derivation source is absent from the partition")
+    clock = now_iso or _now_iso
+    started_at = clock()
+    assert_av1_validation_derivation_authorization_active(plan, at=started_at)
+    _assert_next_assignment(
+        plan=plan,
+        assignment_id=assignment.assignment_id,
+        attempts_directory=attempts_directory,
+        terminal_records_directory=terminal_records_directory,
+    )
+    write_av1_validation_derivation_assignment_claim(
+        attempts_directory,
+        assignment_id=assignment.assignment_id,
+        plan_id=plan.plan_id,
+        authorization_id=plan.authorization.authorization_id,
+    )
+    controller = process_controller or ManagedProcessController()
+    run_deps = deps or build_av1_validation_derivation_calibration_deps()
+    attempt: AV1ValidationDerivationAttempt | None = None
+    staged_snapshot: dict[str, Any] | None = None
+    staged_snapshot_taken = False
+    sample_item: dict[str, Any] | None = None
+    try:
+        if (
+            shutil.disk_usage(config.paths.review_dir.parent).free
+            < AV1_VALIDATION_DERIVATION_MINIMUM_FREE_BYTES
+        ):
+            raise OSError("AV1 derivation storage safety floor is not available")
+        purge_transient_artifacts(config, force=True)
+        controller.throw_if_cancelled()
+        with open_db(config.paths.db_path) as connection:
+            sample_item = load_av1_validation_derivation_sample_item(
+                connection,
+                config=config,
+                local_item_id=assignment.local_item_id,
+            )
+            _bind_derivation_intent(
+                config=config,
+                sample_item=sample_item,
+                intent_level=assignment.intent_level,
+            )
+            _validate_bound_sample_item(
+                assignment=assignment,
+                source_identity=source.source_identity,
+                sample_item=sample_item,
+            )
+            staged_snapshot = snapshot_staged_artifact(
+                connection,
+                assignment.local_item_id,
+                run_deps.staged_artifact_columns,
+            )
+            staged_snapshot_taken = True
+        prefix = _derivation_prefix(config, sample_item)
+        calibration_run_id = _run_id(plan.plan_id, assignment.assignment_id, started_at)
+        review_root = _prepare_derivation_review_root(artifact_root)
+        calibration_config = _config_with_review_directory(config, review_root)
+        payload, _ = run_sampled_calibration(
+            config=calibration_config,
+            prefix=prefix,
+            action="av1_derivation",
+            host_data={
+                "key": "av1-derivation-local",
+                "label": "AV1 derivation local",
+                "mode": "local",
+                "media_access": "direct",
+            },
+            notes="Bounded AV1 v2 derivation observation",
+            policy=object_dict(sample_item.get("resolved_policy")),
+            seed_metadata=None,
+            sample_item=sample_item,
+            calibration_run_id=calibration_run_id,
+            process_controller=controller,
+            deps=run_deps,
+        )
+        assert_av1_validation_derivation_execution_contract(manifest, plan)
+        _secure_derivation_review_media(review_root)
+        current_review_fingerprint = _current_derivation_review_artifact_fingerprint(
+            review_root=review_root,
+            calibration=payload,
+        )
+        if (
+            current_review_fingerprint is None
+            or current_review_fingerprint
+            != str(payload.get("review_artifact_fingerprint") or "")
+        ):
+            raise TargetSizeSearchError(
+                "AV1 derivation review media could not be secured without identity drift"
+            )
+        payload["job_id"] = f"av1vdjob1_{calibration_run_id}"
+        payload["review_media_ready"] = bool(payload.get("preview_clips") and payload.get("source_clips"))
+        payload["boundary_review_media_ready"] = payload["review_media_ready"]
+        payload["current_review_artifact_fingerprint"] = payload.get("review_artifact_fingerprint")
+        completed_at = clock()
+        if _authorization_expired(plan, completed_at):
+            attempt = _failed_attempt(
+                plan=plan,
+                partition=partition,
+                assignment_id=assignment.assignment_id,
+                started_at=started_at,
+                completed_at=completed_at,
+                status="failed",
+                reason_code="authorization_expired",
+            )
+        else:
+            attempt = build_av1_validation_derivation_attempt(
+                plan=plan,
+                partition=partition,
+                assignment_id=assignment.assignment_id,
+                started_at=started_at,
+                completed_at=completed_at,
+                status="review_pending",
+                calibration_payload=payload,
+            )
+    except ProcessCancelledError:
+        attempt = _failed_attempt(
+            plan=plan,
+            partition=partition,
+            assignment_id=assignment.assignment_id,
+            started_at=started_at,
+            completed_at=clock(),
+            status="stopped",
+            reason_code="operator_stop",
+        )
+    except TargetSizeSearchError:
+        attempt = _failed_attempt(
+            plan=plan,
+            partition=partition,
+            assignment_id=assignment.assignment_id,
+            started_at=started_at,
+            completed_at=clock(),
+            status="failed",
+            reason_code="metrics_incomplete",
+        )
+    except FileNotFoundError:
+        attempt = _failed_attempt(
+            plan=plan,
+            partition=partition,
+            assignment_id=assignment.assignment_id,
+            started_at=started_at,
+            completed_at=clock(),
+            status="failed",
+            reason_code="media_unavailable",
+        )
+    except TimeoutError:
+        attempt = _failed_attempt(
+            plan=plan,
+            partition=partition,
+            assignment_id=assignment.assignment_id,
+            started_at=started_at,
+            completed_at=clock(),
+            status="failed",
+            reason_code="timeout",
+        )
+    except AV1ValidationDerivationError:
+        attempt = _failed_attempt(
+            plan=plan,
+            partition=partition,
+            assignment_id=assignment.assignment_id,
+            started_at=started_at,
+            completed_at=clock(),
+            status="stopped",
+            reason_code="safety_stop",
+        )
+    except OSError:
+        attempt = _failed_attempt(
+            plan=plan,
+            partition=partition,
+            assignment_id=assignment.assignment_id,
+            started_at=started_at,
+            completed_at=clock(),
+            status="failed",
+            reason_code="storage_stop",
+        )
+    except Exception:
+        attempt = _failed_attempt(
+            plan=plan,
+            partition=partition,
+            assignment_id=assignment.assignment_id,
+            started_at=started_at,
+            completed_at=clock(),
+            status="failed",
+            reason_code="runtime_failure",
+        )
+    finally:
+        cleanup_failed = False
+        if staged_snapshot_taken:
+            try:
+                with open_db(config.paths.db_path) as connection:
+                    restore_staged_artifact(
+                        connection,
+                        assignment.local_item_id,
+                        staged_snapshot,
+                        run_deps.staged_artifact_columns,
+                    )
+            except Exception:
+                cleanup_failed = True
+        try:
+            purge_transient_artifacts(config, force=True)
+        except Exception:
+            cleanup_failed = True
+        if cleanup_failed:
+            attempt = _failed_attempt(
+                plan=plan,
+                partition=partition,
+                assignment_id=assignment.assignment_id,
+                started_at=started_at,
+                completed_at=clock(),
+                status="failed",
+                reason_code="runtime_failure",
+            )
+    if attempt is None:
+        raise AV1ValidationDerivationError("AV1 derivation attempt did not reach a terminal state")
+    write_av1_validation_derivation_attempt(attempts_directory, attempt)
+    if attempt.status != "review_pending":
+        terminal = build_av1_validation_derivation_terminal_record(
+            plan=plan,
+            partition=partition,
+            attempt=attempt,
+        )
+        write_av1_validation_derivation_terminal_record(
+            terminal_records_directory,
+            terminal,
+        )
+    return attempt
+
+
+def finalize_av1_validation_derivation_candidate_lock(
+        *,
+        config_path: Path,
+        manifest: AV1ValidationManifestV2,
+        partition: AV1ValidationPrivatePartition,
+        token_key: bytes,
+        plan_path: Path,
+        cell_plan_id: str,
+        now_iso: Callable[[], str] | None = None,
+) -> AV1ValidationDerivationCandidateLockEnvelope:
+    config = load_config(config_path)
+    plan, artifact_root = _load_canonical_av1_validation_derivation_plan(
+        config=config,
+        plan_path=plan_path,
+    )
+    validate_av1_validation_private_partition(
+        partition,
+        manifest=manifest,
+        token_key=token_key,
+    )
+    validate_av1_validation_derivation_plan_binding(
+        plan=plan,
+        partition=partition,
+    )
+    assert_av1_validation_derivation_execution_contract(manifest, plan)
+    clock = now_iso or _now_iso
+    try:
+        with exclusive_mediaforce_runtime_lock(
+            config,
+            owner_payload={
+                "purpose": "av1-derivation-finalization",
+                "plan_id": plan.plan_id,
+                "cell_plan_id": cell_plan_id,
+            },
+        ):
+            proposal = load_av1_validation_derivation_candidate_proposal(
+                artifact_root,
+                plan=plan,
+                cell_plan_id=cell_plan_id,
+            )
+            attempts = load_av1_validation_derivation_attempts(
+                artifact_root / "attempts"
+            )
+            records = load_av1_validation_derivation_terminal_records(
+                artifact_root / "terminal-records"
+            )
+            review_envelopes = load_av1_validation_derivation_review_envelopes(
+                artifact_root,
+                plan=plan,
+                proposal=proposal,
+            )
+            locked_at = clock()
+            with open_db(config.paths.db_path) as connection:
+                connection.exec_driver_sql("BEGIN IMMEDIATE")
+                inventory = load_av1_validation_partition_inventory(
+                    connection,
+                    config=config,
+                )
+                validate_av1_validation_partition_current_inputs(
+                    partition,
+                    manifest=manifest,
+                    sources=inventory.sources,
+                    expectations=inventory.expectations,
+                    token_key=token_key,
+                )
+                current_evaluation = evaluate_av1_validation_derivation_candidate(
+                    manifest=manifest,
+                    plan=plan,
+                    partition=partition,
+                    cell_plan_id=cell_plan_id,
+                    attempts=attempts,
+                    records=records,
+                    current_observations=(
+                        _load_current_derivation_observations_from_connection(
+                            connection=connection,
+                            records=records,
+                        )
+                    ),
+                    proposed_at=locked_at,
+                )
+                assert_av1_validation_derivation_execution_contract(
+                    manifest,
+                    plan,
+                )
+                return _finalize_and_write_av1_validation_derivation_candidate_lock(
+                    artifact_root,
+                    plan=plan,
+                    proposal=proposal,
+                    review_envelopes=review_envelopes,
+                    current_evaluation=current_evaluation,
+                    locked_at=locked_at,
+                )
+    except MediaforceRuntimeBusyError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation finalization requires the Mediaforce runtime to be paused"
+        ) from exc
+
+
+def load_verified_av1_validation_derivation_candidate_lock(
+        *,
+        config_path: Path,
+        manifest: AV1ValidationManifestV2,
+        partition: AV1ValidationPrivatePartition,
+        token_key: bytes,
+        plan_path: Path,
+        cell_plan_id: str,
+) -> AV1ValidationDerivationCandidateLockEnvelope:
+    config = load_config(config_path)
+    plan, artifact_root = _load_canonical_av1_validation_derivation_plan(
+        config=config,
+        plan_path=plan_path,
+    )
+    validate_av1_validation_private_partition(
+        partition,
+        manifest=manifest,
+        token_key=token_key,
+    )
+    validate_av1_validation_derivation_plan_binding(
+        plan=plan,
+        partition=partition,
+    )
+    assert_av1_validation_derivation_execution_contract(manifest, plan)
+    try:
+        with exclusive_mediaforce_runtime_lock(
+            config,
+            owner_payload={
+                "purpose": "av1-candidate-lock-verification",
+                "plan_id": plan.plan_id,
+                "cell_plan_id": cell_plan_id,
+            },
+        ):
+            proposal = load_av1_validation_derivation_candidate_proposal(
+                artifact_root,
+                plan=plan,
+                cell_plan_id=cell_plan_id,
+            )
+            attempts = load_av1_validation_derivation_attempts(
+                artifact_root / "attempts"
+            )
+            records = load_av1_validation_derivation_terminal_records(
+                artifact_root / "terminal-records"
+            )
+            review_envelopes = load_av1_validation_derivation_review_envelopes(
+                artifact_root,
+                plan=plan,
+                proposal=proposal,
+            )
+            persisted = _load_av1_validation_derivation_candidate_lock_envelope(
+                artifact_root,
+                plan=plan,
+                cell_plan_id=cell_plan_id,
+            )
+            with open_db(config.paths.db_path) as connection:
+                connection.exec_driver_sql("BEGIN IMMEDIATE")
+                inventory = load_av1_validation_partition_inventory(
+                    connection,
+                    config=config,
+                )
+                validate_av1_validation_partition_current_inputs(
+                    partition,
+                    manifest=manifest,
+                    sources=inventory.sources,
+                    expectations=inventory.expectations,
+                    token_key=token_key,
+                )
+                current_evaluation = evaluate_av1_validation_derivation_candidate(
+                    manifest=manifest,
+                    plan=plan,
+                    partition=partition,
+                    cell_plan_id=cell_plan_id,
+                    attempts=attempts,
+                    records=records,
+                    current_observations=(
+                        _load_current_derivation_observations_from_connection(
+                            connection=connection,
+                            records=records,
+                        )
+                    ),
+                    proposed_at=persisted.candidate_lock.locked_at,
+                )
+                assert_av1_validation_derivation_execution_contract(
+                    manifest,
+                    plan,
+                )
+                return _load_verified_av1_validation_derivation_candidate_lock(
+                    artifact_root,
+                    plan=plan,
+                    proposal=proposal,
+                    review_envelopes=review_envelopes,
+                    current_evaluation=current_evaluation,
+                    cell_plan_id=cell_plan_id,
+                )
+    except MediaforceRuntimeBusyError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 candidate-lock verification requires the Mediaforce runtime to be paused"
+        ) from exc
+
+
+def record_av1_validation_derivation_visual_verdict(
+        *,
+        config_path: Path,
+        plan: AV1ValidationDerivationPlan,
+        partition: AV1ValidationPrivatePartition,
+        attempt: AV1ValidationDerivationAttempt,
+        terminal_records_directory: Path,
+        verdict: str,
+        concern_tags: list[str],
+        evidence_ids: list[str],
+        moment_indexes: list[int],
+        recorded_at: str,
+) -> AV1ValidationDerivationTerminalRecord:
+    if attempt.status != "review_pending":
+        raise AV1ValidationDerivationError("AV1 derivation attempt is not awaiting visual review")
+    if verdict not in {"approved", "rejected"}:
+        raise AV1ValidationDerivationError("AV1 derivation visual verdict is invalid")
+    validate_av1_validation_derivation_attempt_binding(
+        plan=plan,
+        partition=partition,
+        attempt=attempt,
+    )
+    calibration = attempt.calibration_payload()
+    sample_item = object_dict(calibration.get("sample_item"))
+    config = load_config(config_path)
+    artifact_root = av1_validation_derivation_artifact_root(config, plan)
+    validate_av1_validation_derivation_artifact_root_binding(
+        artifact_root,
+        plan,
+    )
+    if terminal_records_directory.resolve() != (
+        artifact_root / "terminal-records"
+    ).resolve():
+        raise AV1ValidationDerivationError(
+            "AV1 derivation terminal artifacts must use the plan-global canonical directory"
+        )
+    review_root = _prepare_derivation_review_root(artifact_root)
+    _secure_derivation_review_media(review_root)
+    current_review_fingerprint = _current_derivation_review_artifact_fingerprint(
+        review_root=review_root,
+        calibration=calibration,
+    )
+    if (
+        current_review_fingerprint is None
+        or current_review_fingerprint
+        != str(calibration.get("review_artifact_fingerprint") or "")
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review media is unavailable or changed"
+        )
+    verdict_intent = resolve_av1_validation_derivation_verdict_intent(
+        artifact_root / "verdict-intents",
+        plan=plan,
+        attempt=attempt,
+        verdict=verdict,
+        concern_tags=concern_tags,
+        evidence_ids=evidence_ids,
+        moment_indexes=moment_indexes,
+        recorded_at=recorded_at,
+    )
+    verdict = str(verdict_intent["verdict"])
+    concern_tags = [
+        str(value) for value in object_list(verdict_intent["concern_tags"])
+    ]
+    evidence_ids = [
+        str(value) for value in object_list(verdict_intent["evidence_ids"])
+    ]
+    moment_indexes = [
+        int(value) for value in object_list(verdict_intent["moment_indexes"])
+    ]
+    recorded_at = str(verdict_intent["recorded_at"])
+    calibration["current_review_artifact_fingerprint"] = current_review_fingerprint
+    prefix = _derivation_prefix(config, sample_item)
+    result = build_visual_content_intent_observation(
+        prefix=prefix,
+        sample_item=sample_item,
+        calibration=calibration,
+        verdict=verdict,
+        concern_tags=concern_tags,
+        evidence_ids=evidence_ids,
+        moment_indexes=moment_indexes,
+        recorded_at=recorded_at,
+        personalization_eligible=False,
+        personalization_exclusion_reason=(
+            AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON
+        ),
+    )
+    if result.observation is None:
+        terminal = build_av1_validation_derivation_terminal_record(
+            plan=plan,
+            partition=partition,
+            attempt=attempt,
+            observation_exclusion_reason="content_intent_observation_excluded",
+        )
+        ensure_av1_validation_derivation_terminal_intent(
+            artifact_root / "terminal-intents",
+            terminal,
+        )
+        ensure_av1_validation_derivation_terminal_record(
+            terminal_records_directory,
+            terminal,
+        )
+        return terminal
+    terminal = build_av1_validation_derivation_terminal_record(
+        plan=plan,
+        partition=partition,
+        attempt=attempt,
+        observation=result.observation,
+    )
+    ensure_av1_validation_derivation_terminal_intent(
+        artifact_root / "terminal-intents",
+        terminal,
+    )
+    try:
+        with open_db(config.paths.db_path) as connection:
+            append_content_intent_boundary_observation(connection, result.observation)
+    except ContentIntentObservationConflictError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation visual observation conflicts with existing evidence"
+        ) from exc
+    ensure_av1_validation_derivation_terminal_record(
+        terminal_records_directory,
+        terminal,
+    )
+    return terminal
+
+
+def _failed_attempt(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        partition: AV1ValidationPrivatePartition,
+        assignment_id: str,
+        started_at: str,
+        completed_at: str,
+        status: AV1ValidationDerivationAttemptStatus,
+        reason_code: str,
+) -> AV1ValidationDerivationAttempt:
+    if _authorization_expired(plan, completed_at):
+        status = "failed"
+        reason_code = "authorization_expired"
+    return build_av1_validation_derivation_attempt(
+        plan=plan,
+        partition=partition,
+        assignment_id=assignment_id,
+        started_at=started_at,
+        completed_at=completed_at,
+        status=status,
+        reason_code=reason_code,
+    )
+
+
+def _authorization_expired(
+        plan: AV1ValidationDerivationPlan,
+        completed_at: str,
+) -> bool:
+    return _timestamp(completed_at) >= _timestamp(plan.authorization.valid_until)
+
+
+def _bind_derivation_intent(
+        *,
+        config: MediaforceConfig,
+        sample_item: dict[str, Any],
+        intent_level: str,
+) -> None:
+    policy = deepcopy(config.resolve_policy(str(sample_item.get("rel_path") or "")))
+    video = dict(object_dict(policy.get("video")))
+    video.update({
+        "compression_intent_schema_version": 1,
+        "compression_intent": intent_level,
+        "compression_intent_source": "operator",
+        "compression_intent_confirmed": True,
+    })
+    policy["video"] = video
+    intent = operator_intent_from_policy(
+        video,
+        default_video_policy=config.video,
+        audio_policy=object_dict(policy.get("audio")),
+        subtitle_policy=object_dict(policy.get("subtitle")),
+    )
+    duration_seconds = float_value(sample_item.get("duration_seconds")) or None
+    sample_item["resolved_policy"] = policy
+    sample_item["resolved_operator_intent"] = intent.to_payload(
+        item_runtime_seconds=duration_seconds
+    )
+    sample_item["compression_intent"] = intent.compression_intent.to_payload()
+    ledger = resolve_stream_budget_ledger(
+        sample_item,
+        default_video_policy=config.video,
+        output_container=config.output_container,
+        resolved_size_goal=intent.size_goal.resolve(duration_seconds),
+        prefer_persisted=False,
+    )
+    sample_item["stream_budget_ledger"] = ledger.to_payload()
+
+
+def _validate_bound_sample_item(
+        *,
+        assignment: Any,
+        source_identity: str,
+        sample_item: Mapping[str, Any],
+) -> None:
+    ledger = resolve_stream_budget_ledger(
+        sample_item,
+        default_video_policy=object_dict(object_dict(sample_item.get("resolved_policy")).get("video")),
+        output_container=str(sample_item.get("output_container") or "mkv"),
+    )
+    if (
+        int(sample_item.get("library_item_id") or 0) != assignment.local_item_id
+        or str(sample_item.get("content_version_fingerprint") or "") != source_identity
+        or object_dict(sample_item.get("compression_intent")).get("level") != assignment.intent_level
+        or ledger.remaining_video_bitrate_bps != assignment.target_video_bitrate_bps
+        or stream_budget_projection_blocker(ledger) is not None
+    ):
+        raise AV1ValidationDerivationError("AV1 derivation sample item drifted from its reservation")
+
+
+def _derivation_prefix(config: MediaforceConfig, sample_item: Mapping[str, Any]) -> str:
+    rel_path = str(sample_item.get("rel_path") or "")
+    scope = media_group_scope_for_rel_path(rel_path, library_types=config.library_type_map)
+    if scope is not None and scope.prefix:
+        return scope.prefix
+    return str(Path(rel_path).parent).strip(".")
+
+
+def _assert_next_assignment(
+        *,
+        plan: AV1ValidationDerivationPlan,
+        assignment_id: str,
+        attempts_directory: Path,
+        terminal_records_directory: Path,
+) -> None:
+    assignments_by_id = {
+        assignment.assignment_id: assignment
+        for assignment in plan.assignments
+    }
+    attempts = (
+        load_av1_validation_derivation_attempts(attempts_directory)
+        if attempts_directory.exists()
+        else ()
+    )
+    attempts_by_id: dict[str, AV1ValidationDerivationAttempt] = {}
+    for attempt in attempts:
+        assignment = assignments_by_id.get(attempt.assignment_id)
+        if (
+            assignment is None
+            or attempt.plan_id != plan.plan_id
+            or attempt.authorization_id != plan.authorization.authorization_id
+            or attempt.cell_plan_id != assignment.cell_plan_id
+            or attempt.ordinal != assignment.ordinal
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation attempt is bound to another work item"
+            )
+        attempts_by_id[attempt.assignment_id] = attempt
+    attempted_ids = set(attempts_by_id)
+    expected_prefix = tuple(
+        assignment.assignment_id
+        for assignment in plan.assignments[:len(attempted_ids)]
+    )
+    actual_prefix = tuple(
+        assignment.assignment_id
+        for assignment in plan.assignments
+        if assignment.assignment_id in attempted_ids
+    )
+    if actual_prefix != expected_prefix:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation attempts are not an ordered prefix of the immutable worklist"
+        )
+    if any(attempt.status != "review_pending" for attempt in attempts):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation has a terminal unsuccessful attempt and cannot continue"
+        )
+    records = (
+        load_av1_validation_derivation_terminal_records(terminal_records_directory)
+        if terminal_records_directory.exists()
+        else ()
+    )
+    records_by_id: dict[str, AV1ValidationDerivationTerminalRecord] = {}
+    for record in records:
+        assignment = assignments_by_id.get(record.assignment_id)
+        attempt = attempts_by_id.get(record.assignment_id)
+        if (
+            assignment is None
+            or record.plan_id != plan.plan_id
+            or record.authorization_id != plan.authorization.authorization_id
+            or record.cell_plan_id != assignment.cell_plan_id
+            or record.ordinal != assignment.ordinal
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation terminal record is bound to another work item"
+            )
+        if (
+            attempt is None
+            or record.attempt_id != attempt.attempt_id
+            or record.attempt_payload_sha256 != attempt.payload_sha256
+            or record.started_at != attempt.started_at
+            or record.completed_at != attempt.completed_at
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation terminal record does not match its attempt"
+            )
+        records_by_id[record.assignment_id] = record
+    record_ids = set(records_by_id)
+    if attempted_ids != record_ids:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation must record the prior human visual terminal before continuing"
+        )
+    if any(
+        record.status != "observed"
+        or record.observation is None
+        or record.observation.verdict != "acceptable"
+        or not record.observation.quality_floor_met
+        for record in records
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation has an unfavorable terminal record and cannot continue"
+        )
+    claim_ids = {
+        path.stem
+        for path in attempts_directory.glob("*.claim")
+    } if attempts_directory.exists() else set()
+    if claim_ids - attempted_ids:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation has an interrupted claimed assignment and cannot continue"
+        )
+    next_assignment = next(
+        (item.assignment_id for item in plan.assignments if item.assignment_id not in attempted_ids),
+        None,
+    )
+    if next_assignment is None:
+        raise AV1ValidationDerivationError("AV1 derivation worklist is already complete")
+    if assignment_id != next_assignment:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation assignment is not next in the immutable worklist"
+        )
+
+
+def _current_derivation_review_artifact_fingerprint(
+        *,
+        review_root: Path,
+        calibration: dict[str, Any],
+) -> str | None:
+    resolved_review_root = review_root.resolve()
+    clips: list[tuple[str, Path, float, float]] = []
+    for role, key in (("preview", "preview_clips"), ("source", "source_clips")):
+        for value in calibration.get(key, []):
+            clip = object_dict(value)
+            parsed = urlparse(str(clip.get("path") or ""))
+            if parsed.scheme != "file" or parsed.netloc not in {"", "localhost"}:
+                return None
+            candidate_path = Path(unquote(parsed.path))
+            try:
+                candidate_info = candidate_path.lstat()
+            except OSError:
+                return None
+            if stat.S_ISLNK(candidate_info.st_mode):
+                return None
+            path = candidate_path.resolve()
+            if not path.is_relative_to(resolved_review_root):
+                return None
+            try:
+                path_info = path.lstat()
+            except OSError:
+                return None
+            if (
+                not stat.S_ISREG(path_info.st_mode)
+                or path_info.st_uid != os.getuid()
+                or path_info.st_mode & 0o077
+            ):
+                return None
+            clips.append((
+                role,
+                path,
+                float_value(clip.get("timestamp_seconds")),
+                float_value(clip.get("duration_seconds")),
+            ))
+    return reviewed_artifact_fingerprint(clips)
+
+
+def _prepare_derivation_review_root(artifact_root: Path) -> Path:
+    review_root = artifact_root / "review-media"
+    try:
+        review_root.mkdir(mode=0o700)
+    except FileExistsError:
+        pass
+    try:
+        root_info = review_root.lstat()
+    except OSError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review-media directory is unavailable"
+        ) from exc
+    if (
+        not stat.S_ISDIR(root_info.st_mode)
+        or root_info.st_uid != os.getuid()
+        or root_info.st_mode & 0o077
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review-media directory must be owner-only"
+        )
+    return review_root
+
+
+def _secure_derivation_review_media(review_root: Path) -> None:
+    _prepare_derivation_review_root(review_root.parent)
+    for path in sorted(review_root.rglob("*")):
+        try:
+            path_info = path.lstat()
+        except OSError as exc:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review media could not be inspected safely"
+            ) from exc
+        if path_info.st_uid != os.getuid():
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review media must be owned by the current user"
+            )
+        if stat.S_ISDIR(path_info.st_mode):
+            path.chmod(0o700, follow_symlinks=False)
+        elif stat.S_ISREG(path_info.st_mode):
+            path.chmod(0o600, follow_symlinks=False)
+        else:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation review media must not contain links or special files"
+            )
+
+
+def _config_with_review_directory(
+        config: MediaforceConfig,
+        review_root: Path,
+) -> MediaforceConfig:
+    runtime_config = copy(config)
+    runtime_paths = copy(config.paths)
+    object.__setattr__(runtime_paths, "review_dir", review_root)
+    object.__setattr__(runtime_config, "paths", runtime_paths)
+    return cast(MediaforceConfig, runtime_config)
+
+
+def _run_id(plan_id: str, assignment_id: str, started_at: str) -> str:
+    digest = hashlib.sha256(canonical_json_bytes({
+        "plan_id": plan_id,
+        "assignment_id": assignment_id,
+        "started_at": started_at,
+    })).hexdigest()
+    return digest[:12]
+
+
+def _review_url(_config: MediaforceConfig, path: Path) -> str:
+    return path.resolve().as_uri()
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise AV1ValidationDerivationError("AV1 derivation timestamp must include a UTC offset")
+    return parsed.astimezone(UTC)
+
+
+def _unused(*_args: Any, **_kwargs: Any) -> Any:
+    raise AV1ValidationDerivationError("AV1 derivation invoked an unsupported runtime dependency")

--- a/mediaforce/web/runtime/av1_validation_derivation.py
+++ b/mediaforce/web/runtime/av1_validation_derivation.py
@@ -1051,6 +1051,7 @@ def _record_av1_validation_derivation_visual_verdict_locked(
                 artifact_root / "terminal-intents",
                 terminal,
             )
+        if result.observation is not None:
             try:
                 append_content_intent_boundary_observation(
                     connection,
@@ -1060,11 +1061,11 @@ def _record_av1_validation_derivation_visual_verdict_locked(
                 raise AV1ValidationDerivationError(
                     "AV1 derivation visual observation conflicts with existing evidence"
                 ) from exc
+        ensure_av1_validation_derivation_terminal_record(
+            terminal_records_directory,
+            terminal,
+        )
     assert_av1_validation_derivation_execution_contract(manifest, plan)
-    ensure_av1_validation_derivation_terminal_record(
-        terminal_records_directory,
-        terminal,
-    )
     return terminal
 
 

--- a/mediaforce/web/runtime/calibration_runtime.py
+++ b/mediaforce/web/runtime/calibration_runtime.py
@@ -171,6 +171,11 @@ def _stored_sample_item_payload(sample_item: dict[str, Any]) -> dict[str, Any]:
         "source_fingerprint": sample_item.get("source_fingerprint"),
         "content_version_fingerprint": sample_item.get("content_version_fingerprint"),
         "source_size_bytes": sample_item.get("source_size_bytes"),
+        "source_snapshot_sha256": sample_item.get("source_snapshot_sha256"),
+        "source_snapshot_size_bytes": sample_item.get("source_snapshot_size_bytes"),
+        "source_snapshot_content_version_fingerprint": sample_item.get(
+            "source_snapshot_content_version_fingerprint"
+        ),
         "video_codec": sample_item.get("video_codec"),
         "video_bitrate": sample_item.get("video_bitrate"),
         "width": sample_item.get("width"),
@@ -630,17 +635,22 @@ def run_sampled_calibration(
         calibration_run_id: str,
         process_controller: ManagedProcessController,
         deps: CalibrationRunDeps,
+        source_path_override: Path | None = None,
         progress_callback: Any | None = None,
 ) -> tuple[dict[str, Any], Path | None]:
     _ = prefix
-    controller_source_path = Path(sample_item["source_path"])
     quality_host = _quality_host_data(config, host_data)
-    quality_source_path = resolve_item_source_path(
-        config,
-        sample_item,
-        host=quality_host,
-        host_media_access_for_host=host_media_access_for_host,
-    )
+    if source_path_override is None:
+        controller_source_path = Path(sample_item["source_path"])
+        quality_source_path = resolve_item_source_path(
+            config,
+            sample_item,
+            host=quality_host,
+            host_media_access_for_host=host_media_access_for_host,
+        )
+    else:
+        controller_source_path = source_path_override
+        quality_source_path = source_path_override
     quality_temp_dir = _quality_temp_dir_for_host(config, quality_host)
     video_policy = object_dict(policy.get("video"))
     stream_budget = deps.resolve_stream_budget_ledger(

--- a/mediaforce/web/runtime_lock.py
+++ b/mediaforce/web/runtime_lock.py
@@ -1,0 +1,72 @@
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+import fcntl
+import json
+import os
+from pathlib import Path
+
+from mediaforce.core.config import MediaforceConfig
+
+
+class MediaforceRuntimeBusyError(RuntimeError):
+    pass
+
+
+def mediaforce_runtime_lock_path(config: MediaforceConfig) -> Path:
+    return config.paths.web_state_dir.parent / "mediaforce-web.lock"
+
+
+def mediaforce_runtime_lock_owner(lock_path: Path) -> str | None:
+    try:
+        payload = json.loads(lock_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    pid = payload.get("pid")
+    host = payload.get("host")
+    port = payload.get("port")
+    purpose = str(payload.get("purpose") or "").strip()
+    if pid and host and port:
+        return f"pid {pid} on {host}:{port}"
+    if pid and purpose:
+        return f"pid {pid} ({purpose})"
+    if pid:
+        return f"pid {pid}"
+    return purpose or None
+
+
+@contextmanager
+def exclusive_mediaforce_runtime_lock(
+        config: MediaforceConfig,
+        *,
+        owner_payload: Mapping[str, object],
+) -> Iterator[None]:
+    lock_path = mediaforce_runtime_lock_path(config)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        os.chmod(lock_path, 0o600)
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            owner = mediaforce_runtime_lock_owner(lock_path)
+            owner_detail = f" ({owner})" if owner else ""
+            raise MediaforceRuntimeBusyError(
+                f"Mediaforce runtime is already active{owner_detail}"
+            ) from exc
+
+        payload = {"pid": os.getpid(), **dict(owner_payload)}
+        lock_file.seek(0)
+        lock_file.truncate()
+        lock_file.write(json.dumps(payload, indent=2, sort_keys=True))
+        lock_file.write("\n")
+        lock_file.flush()
+        os.fsync(lock_file.fileno())
+        try:
+            yield
+        finally:
+            lock_file.seek(0)
+            lock_file.truncate()
+            lock_file.flush()
+            os.fsync(lock_file.fileno())
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/mediaforce/web/runtime_lock.py
+++ b/mediaforce/web/runtime_lock.py
@@ -4,6 +4,7 @@ import fcntl
 import json
 import os
 from pathlib import Path
+import stat
 
 from mediaforce.core.config import MediaforceConfig
 
@@ -36,6 +37,45 @@ def mediaforce_runtime_lock_owner(lock_path: Path) -> str | None:
     return purpose or None
 
 
+def _acquire_nonblocking_lock(
+        descriptor: int,
+        *,
+        lock_path: Path,
+) -> None:
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        owner = mediaforce_runtime_lock_owner(lock_path)
+        owner_detail = f" ({owner})" if owner else ""
+        raise MediaforceRuntimeBusyError(
+            f"Mediaforce runtime is already active{owner_detail}"
+        ) from exc
+
+
+def _open_runtime_lock_file(lock_path: Path) -> int:
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(lock_path, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        descriptor_info = os.fstat(descriptor)
+        path_info = lock_path.lstat()
+        if (
+            not stat.S_ISREG(descriptor_info.st_mode)
+            or stat.S_ISLNK(path_info.st_mode)
+            or (descriptor_info.st_dev, descriptor_info.st_ino)
+            != (path_info.st_dev, path_info.st_ino)
+        ):
+            raise MediaforceRuntimeBusyError(
+                "Mediaforce runtime lock identity is invalid"
+            )
+        return descriptor
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
 @contextmanager
 def exclusive_mediaforce_runtime_lock(
         config: MediaforceConfig,
@@ -44,29 +84,45 @@ def exclusive_mediaforce_runtime_lock(
 ) -> Iterator[None]:
     lock_path = mediaforce_runtime_lock_path(config)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    with lock_path.open("a+", encoding="utf-8") as lock_file:
-        os.chmod(lock_path, 0o600)
-        try:
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError as exc:
-            owner = mediaforce_runtime_lock_owner(lock_path)
-            owner_detail = f" ({owner})" if owner else ""
-            raise MediaforceRuntimeBusyError(
-                f"Mediaforce runtime is already active{owner_detail}"
-            ) from exc
-
-        payload = {"pid": os.getpid(), **dict(owner_payload)}
-        lock_file.seek(0)
-        lock_file.truncate()
-        lock_file.write(json.dumps(payload, indent=2, sort_keys=True))
-        lock_file.write("\n")
-        lock_file.flush()
-        os.fsync(lock_file.fileno())
-        try:
-            yield
-        finally:
+    directory_flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        directory_flags |= os.O_DIRECTORY
+    directory_descriptor = os.open(lock_path.parent, directory_flags)
+    lock_descriptor = -1
+    directory_locked = False
+    try:
+        _acquire_nonblocking_lock(
+            directory_descriptor,
+            lock_path=lock_path,
+        )
+        directory_locked = True
+        lock_descriptor = _open_runtime_lock_file(lock_path)
+        _acquire_nonblocking_lock(
+            lock_descriptor,
+            lock_path=lock_path,
+        )
+        with os.fdopen(lock_descriptor, "r+", encoding="utf-8") as lock_file:
+            lock_descriptor = -1
+            payload = {"pid": os.getpid(), **dict(owner_payload)}
             lock_file.seek(0)
             lock_file.truncate()
+            lock_file.write(json.dumps(payload, indent=2, sort_keys=True))
+            lock_file.write("\n")
             lock_file.flush()
             os.fsync(lock_file.fileno())
-            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            try:
+                yield
+            finally:
+                lock_file.seek(0)
+                lock_file.truncate()
+                lock_file.flush()
+                os.fsync(lock_file.fileno())
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    finally:
+        if lock_descriptor >= 0:
+            os.close(lock_descriptor)
+        try:
+            if directory_locked:
+                fcntl.flock(directory_descriptor, fcntl.LOCK_UN)
+        finally:
+            os.close(directory_descriptor)

--- a/mediaforce/web/runtime_lock.py
+++ b/mediaforce/web/runtime_lock.py
@@ -14,7 +14,10 @@ class MediaforceRuntimeBusyError(RuntimeError):
 
 
 def mediaforce_runtime_lock_path(config: MediaforceConfig) -> Path:
-    return config.paths.web_state_dir.parent / "mediaforce-web.lock"
+    return (
+        config.paths.web_state_dir.expanduser().resolve().parent
+        / "mediaforce-web.lock"
+    )
 
 
 def mediaforce_runtime_lock_owner(lock_path: Path) -> str | None:

--- a/scripts/mediaforce-dev.sh
+++ b/scripts/mediaforce-dev.sh
@@ -328,7 +328,7 @@ stop_backend() {
 		pid="$(mediaforce_backend_root_pid "${pid}")"
 		kill_pid_tree "${pid}"
 		wait_for_no_managed_listener "${BACKEND_PORT}" pid_matches_mediaforce_backend || true
-		rm -f "${BACKEND_PID_FILE}" "${BACKEND_LOCK_FILE}"
+		rm -f "${BACKEND_PID_FILE}"
 		echo "backend: stopped pid ${pid}"
 		return 0
 	fi
@@ -340,11 +340,11 @@ stop_backend() {
 			kill_pid_tree "${listener_pid}"
 		done <<<"${managed_pids}"
 		wait_for_no_managed_listener "${BACKEND_PORT}" pid_matches_mediaforce_backend || true
-		rm -f "${BACKEND_PID_FILE}" "${BACKEND_LOCK_FILE}"
+		rm -f "${BACKEND_PID_FILE}"
 		echo "backend: stopped listener $(printf '%s' "${managed_pids}" | paste -sd ',' -)"
 		return 0
 	fi
-	rm -f "${BACKEND_PID_FILE}" "${BACKEND_LOCK_FILE}"
+	rm -f "${BACKEND_PID_FILE}"
 	echo "backend: stopped"
 }
 

--- a/scripts/verify_av1_cold_start_preregistration.py
+++ b/scripts/verify_av1_cold_start_preregistration.py
@@ -1,11 +1,18 @@
 import argparse
+from datetime import UTC, datetime
+import hashlib
 import json
+import os
 from pathlib import Path
+import shutil
+import subprocess
 import sys
 from typing import Sequence, TypeAlias
+import uuid
 
-from mediaforce.core.config import DEFAULT_CONFIG_PATH, load_config
+from mediaforce.core.config import DEFAULT_CONFIG_PATH, MediaforceConfig, load_config
 from mediaforce.core.db import open_readonly_db
+from mediaforce.tuning.av1_cold_start import assert_av1_cold_start_public_payload_safe
 from mediaforce.tuning.av1_cold_start_evaluation import (
     AV1ColdStartValidationError,
     AV1ColdStartValidationManifestV1,
@@ -20,11 +27,44 @@ from mediaforce.tuning.av1_validation_v2 import (
     AV1ValidationV2Error,
     assert_preregistered_av1_validation_manifest_v2,
     assert_preregistered_av1_validation_v2_eligibility,
+    build_av1_validation_v2_derivation_authorization,
     load_av1_validation_manifest_v2,
     load_av1_validation_v2_eligibility,
 )
+from mediaforce.tuning.av1_validation_derivation import (
+    AV1_VALIDATION_DERIVATION_AGENT_REVIEW_MARKER,
+    AV1ValidationDerivationCandidateProposal,
+    AV1ValidationDerivationError,
+    AV1ValidationDerivationPlan,
+    AV1ValidationDerivationReviewDecision,
+    av1_validation_derivation_candidate_evaluation_public_summary,
+    av1_validation_derivation_plan_public_summary,
+    av1_validation_derivation_statistics_contract_sha256,
+    build_av1_validation_derivation_plan,
+    build_av1_validation_derivation_review_attestation,
+    build_av1_validation_derivation_review_envelope,
+    evaluate_av1_validation_derivation_candidate,
+    load_av1_validation_derivation_attempts,
+    load_av1_validation_derivation_candidate_proposal,
+    load_av1_validation_derivation_plan,
+    load_av1_validation_derivation_terminal_records,
+    validate_av1_validation_derivation_artifact_root_binding,
+    write_av1_validation_derivation_candidate_proposal,
+    write_av1_validation_derivation_plan,
+    write_av1_validation_derivation_review_envelope,
+)
+from mediaforce.web.runtime.av1_validation_derivation import (
+    av1_validation_derivation_artifact_root,
+    av1_validation_derivation_execution_environment_sha256,
+    av1_validation_derivation_runtime_context_sha256,
+    finalize_av1_validation_derivation_candidate_lock,
+    load_current_av1_validation_derivation_observations,
+    record_av1_validation_derivation_visual_verdict,
+    run_av1_validation_derivation_assignment,
+)
 from mediaforce.tuning.av1_validation_partition import (
     AV1ValidationPartitionError,
+    AV1ValidationPrivatePartition,
     assert_private_artifact_path,
     av1_validation_partition_key_id,
     av1_validation_partition_public_summary,
@@ -39,12 +79,16 @@ from mediaforce.tuning.av1_validation_partition import (
 from mediaforce.tuning.av1_validation_partition_inventory import (
     load_av1_validation_partition_inventory,
 )
-
-
 ValidationManifest: TypeAlias = (
     AV1ColdStartValidationManifestV1 | AV1ValidationManifestV2
 )
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+_AGENT_REVIEW_MARKER = AV1_VALIDATION_DERIVATION_AGENT_REVIEW_MARKER
+_AGENT_REVIEW_MAX_SECONDS = 1800
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -97,6 +141,104 @@ def build_parser() -> argparse.ArgumentParser:
     validate_partition.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
     validate_partition.add_argument("--json", action="store_true", dest="json_output")
 
+    create_derivation_plan = actions.add_parser(
+        "create-derivation-plan",
+        help="Create the immutable owner-only v2 derivation authorization and 24-slot worklist",
+    )
+    create_derivation_plan.add_argument("manifest", type=Path)
+    create_derivation_plan.add_argument("eligibility", type=Path)
+    create_derivation_plan.add_argument("partition", type=Path)
+    create_derivation_plan.add_argument("--key", type=Path, required=True)
+    create_derivation_plan.add_argument("--valid-until", required=True)
+    create_derivation_plan.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    create_derivation_plan.add_argument("--json", action="store_true", dest="json_output")
+
+    validate_derivation_plan = actions.add_parser(
+        "validate-derivation-plan",
+        help="Validate the private v2 derivation plan against current locked inputs",
+    )
+    validate_derivation_plan.add_argument("manifest", type=Path)
+    validate_derivation_plan.add_argument("eligibility", type=Path)
+    validate_derivation_plan.add_argument("partition", type=Path)
+    validate_derivation_plan.add_argument("plan", type=Path)
+    validate_derivation_plan.add_argument("--key", type=Path, required=True)
+    validate_derivation_plan.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    validate_derivation_plan.add_argument("--json", action="store_true", dest="json_output")
+
+    run_derivation = actions.add_parser(
+        "run-derivation-assignment",
+        help="Run one exact authorized derivation assignment through unchanged measured full search",
+    )
+    run_derivation.add_argument("manifest", type=Path)
+    run_derivation.add_argument("partition", type=Path)
+    run_derivation.add_argument("plan", type=Path)
+    run_derivation.add_argument("assignment_id")
+    run_derivation.add_argument("--key", type=Path, required=True)
+    run_derivation.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    run_derivation.add_argument("--json", action="store_true", dest="json_output")
+
+    derivation_status = actions.add_parser(
+        "derivation-status",
+        help="Report privacy-safe derivation attempt and terminal counts",
+    )
+    derivation_status.add_argument("plan", type=Path)
+    derivation_status.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    derivation_status.add_argument("--json", action="store_true", dest="json_output")
+
+    record_verdict = actions.add_parser(
+        "record-derivation-verdict",
+        help="Append one human visual verdict and freeze its terminal derivation record",
+    )
+    record_verdict.add_argument("partition", type=Path)
+    record_verdict.add_argument("plan", type=Path)
+    record_verdict.add_argument("assignment_id")
+    record_verdict.add_argument("--verdict", choices=("approved", "rejected"), required=True)
+    record_verdict.add_argument("--concern-tag", action="append", default=[])
+    record_verdict.add_argument("--evidence-id", action="append", default=[])
+    record_verdict.add_argument("--moment-index", action="append", type=int, default=[])
+    record_verdict.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    record_verdict.add_argument("--json", action="store_true", dest="json_output")
+
+    build_proposal = actions.add_parser(
+        "build-derivation-proposal",
+        help="Build one deterministic unapproved candidate proposal or exact no-go",
+    )
+    build_proposal.add_argument("manifest", type=Path)
+    build_proposal.add_argument("partition", type=Path)
+    build_proposal.add_argument("plan", type=Path)
+    build_proposal.add_argument("cell_plan_id")
+    build_proposal.add_argument("--key", type=Path, required=True)
+    build_proposal.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    build_proposal.add_argument("--json", action="store_true", dest="json_output")
+
+    record_review = actions.add_parser(
+        "record-derivation-review",
+        help="Record one immutable proposal-bound independent review lane",
+    )
+    record_review.add_argument("plan", type=Path)
+    record_review.add_argument("cell_plan_id")
+    record_review.add_argument("--lane", choices=(
+        "architecture",
+        "statistical_model_contract",
+        "privacy_security",
+        "experimental_design",
+        "adversarial",
+    ), required=True)
+    record_review.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    record_review.add_argument("--json", action="store_true", dest="json_output")
+
+    finalize_lock = actions.add_parser(
+        "finalize-derivation-lock",
+        help="Finalize one owner-only candidate lock after all five clean review lanes",
+    )
+    finalize_lock.add_argument("manifest", type=Path)
+    finalize_lock.add_argument("partition", type=Path)
+    finalize_lock.add_argument("plan", type=Path)
+    finalize_lock.add_argument("cell_plan_id")
+    finalize_lock.add_argument("--key", type=Path, required=True)
+    finalize_lock.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    finalize_lock.add_argument("--json", action="store_true", dest="json_output")
+
     report = actions.add_parser(
         "report", help="Build a deterministic aggregate acceptance report"
     )
@@ -145,6 +287,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             _print_partition_payload(payload, json_output=args.json_output)
             return 0
 
+        if args.action in {
+            "create-derivation-plan",
+            "validate-derivation-plan",
+            "run-derivation-assignment",
+            "derivation-status",
+            "record-derivation-verdict",
+            "build-derivation-proposal",
+            "record-derivation-review",
+            "finalize-derivation-lock",
+        }:
+            return _run_derivation_action(args)
+
         manifest = _load_manifest(args.manifest)
         if isinstance(manifest, AV1ValidationManifestV2):
             assert_preregistered_av1_validation_manifest_v2(manifest)
@@ -187,6 +341,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
     except (
         AV1ColdStartValidationError,
+        AV1ValidationDerivationError,
         AV1ValidationPartitionError,
         AV1ValidationV2Error,
         json.JSONDecodeError,
@@ -256,7 +411,611 @@ def _run_partition_action(args: argparse.Namespace) -> int:
     return 0
 
 
+def _run_derivation_action(args: argparse.Namespace) -> int:
+    if args.action in {"create-derivation-plan", "validate-derivation-plan"}:
+        manifest, partition, token_key = _load_current_derivation_inputs(args)
+        config = load_config(args.config)
+        runtime_context_sha256 = (
+            av1_validation_derivation_runtime_context_sha256(config)
+        )
+        quality_metrics = {
+            assignment.quality_metric
+            for assignment in partition.assignments
+            if assignment.role == "derivation"
+        }
+        if len(quality_metrics) != 1:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation partition quality metric is not uniform"
+            )
+        execution_environment_sha256 = (
+            av1_validation_derivation_execution_environment_sha256(
+                quality_metric=next(iter(quality_metrics)),
+            )
+        )
+        statistics_contract_sha256 = (
+            av1_validation_derivation_statistics_contract_sha256(manifest)
+        )
+        if args.action == "create-derivation-plan":
+            authorization = build_av1_validation_v2_derivation_authorization(
+                manifest=manifest,
+                selection_lock_sha256=partition.selection_lock_sha256,
+                derivation_partition_sha256=partition.derivation_partition_sha256,
+                runtime_context_sha256=runtime_context_sha256,
+                execution_environment_sha256=execution_environment_sha256,
+                statistics_contract_sha256=statistics_contract_sha256,
+                authorized_at=_now_iso(),
+                valid_until=args.valid_until,
+            )
+            plan = build_av1_validation_derivation_plan(
+                manifest=manifest,
+                partition=partition,
+                authorization=authorization,
+                runtime_context_sha256=runtime_context_sha256,
+            )
+            artifact_root = _derivation_artifact_root_for_plan(
+                config=load_config(args.config),
+                plan=plan,
+            )
+            write_av1_validation_derivation_plan(artifact_root, plan)
+        else:
+            plan, _artifact_root = _load_canonical_derivation_plan(
+                plan_path=args.plan,
+                config_path=args.config,
+            )
+            if (
+                plan.authorization.execution_environment_sha256
+                != execution_environment_sha256
+                or plan.authorization.statistics_contract_sha256
+                != statistics_contract_sha256
+            ):
+                raise AV1ValidationDerivationError(
+                    "AV1 derivation plan execution contract drifted"
+                )
+            rebuilt = build_av1_validation_derivation_plan(
+                manifest=manifest,
+                partition=partition,
+                authorization=plan.authorization,
+                runtime_context_sha256=runtime_context_sha256,
+            )
+            if rebuilt != plan:
+                raise AV1ValidationDerivationError(
+                    "AV1 derivation plan does not match current locked inputs"
+                )
+        _print_partition_payload(
+            av1_validation_derivation_plan_public_summary(plan),
+            json_output=args.json_output,
+        )
+        return 0
+
+    if args.action == "run-derivation-assignment":
+        for path in (args.partition, args.plan, args.key):
+            assert_private_artifact_path(path, repository_root=REPOSITORY_ROOT)
+        manifest = load_av1_validation_manifest_v2(args.manifest)
+        partition = load_av1_validation_private_partition(args.partition)
+        plan, artifact_root = _load_canonical_derivation_plan(
+            plan_path=args.plan,
+            config_path=args.config,
+        )
+        token_key = load_av1_validation_partition_key(args.key)
+        attempt = run_av1_validation_derivation_assignment(
+            config_path=args.config,
+            manifest=manifest,
+            partition=partition,
+            token_key=token_key,
+            plan=plan,
+            assignment_id=args.assignment_id,
+            attempts_directory=artifact_root / "attempts",
+            terminal_records_directory=artifact_root / "terminal-records",
+        )
+        _print_partition_payload(
+            {
+                "attempt_id": attempt.attempt_id,
+                "attempt_sha256": attempt.payload_sha256,
+                "status": attempt.status,
+                "review_required": attempt.status == "review_pending",
+                "holdout_execution_authorized": False,
+                "public_bundle_activation_allowed": False,
+            },
+            json_output=args.json_output,
+        )
+        return 0 if attempt.status == "review_pending" else 2
+
+    if args.action == "derivation-status":
+        plan, artifact_root = _load_canonical_derivation_plan(
+            plan_path=args.plan,
+            config_path=args.config,
+        )
+        attempts_directory = artifact_root / "attempts"
+        records_directory = artifact_root / "terminal-records"
+        attempts = (
+            load_av1_validation_derivation_attempts(attempts_directory)
+            if attempts_directory.exists()
+            else ()
+        )
+        records = (
+            load_av1_validation_derivation_terminal_records(records_directory)
+            if records_directory.exists()
+            else ()
+        )
+        attempt_counts = {
+            status: sum(attempt.status == status for attempt in attempts)
+            for status in ("review_pending", "failed", "excluded", "stopped")
+        }
+        record_counts = {
+            status: sum(record.status == status for record in records)
+            for status in ("observed", "failed", "excluded", "stopped")
+        }
+        _print_partition_payload(
+            {
+                "plan_id": plan.plan_id,
+                "registered_assignment_count": len(plan.assignments),
+                "attempt_count": len(attempts),
+                "terminal_record_count": len(records),
+                **{f"attempt_{key}_count": value for key, value in attempt_counts.items()},
+                **{f"terminal_{key}_count": value for key, value in record_counts.items()},
+                "holdout_execution_authorized": False,
+                "public_bundle_activation_allowed": False,
+            },
+            json_output=args.json_output,
+        )
+        return 0
+
+    if args.action == "record-derivation-verdict":
+        for path in (args.partition, args.plan):
+            assert_private_artifact_path(path, repository_root=REPOSITORY_ROOT)
+        partition = load_av1_validation_private_partition(args.partition)
+        plan, artifact_root = _load_canonical_derivation_plan(
+            plan_path=args.plan,
+            config_path=args.config,
+        )
+        attempts = load_av1_validation_derivation_attempts(
+            artifact_root / "attempts"
+        )
+        attempt = next(
+            (item for item in attempts if item.assignment_id == args.assignment_id),
+            None,
+        )
+        if attempt is None:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation assignment has no immutable attempt"
+            )
+        terminal = record_av1_validation_derivation_visual_verdict(
+            config_path=args.config,
+            plan=plan,
+            partition=partition,
+            attempt=attempt,
+            terminal_records_directory=artifact_root / "terminal-records",
+            verdict=args.verdict,
+            concern_tags=args.concern_tag,
+            evidence_ids=args.evidence_id,
+            moment_indexes=args.moment_index,
+            recorded_at=_now_iso(),
+        )
+        _print_partition_payload(
+            {
+                "terminal_record_sha256": terminal.payload_sha256,
+                "status": terminal.status,
+                "holdout_execution_authorized": False,
+                "public_bundle_activation_allowed": False,
+            },
+            json_output=args.json_output,
+        )
+        return 0 if terminal.status == "observed" else 2
+
+    if args.action == "build-derivation-proposal":
+        for path in (
+            args.partition,
+            args.key,
+            args.plan,
+        ):
+            assert_private_artifact_path(path, repository_root=REPOSITORY_ROOT)
+        manifest = load_av1_validation_manifest_v2(args.manifest)
+        assert_preregistered_av1_validation_manifest_v2(manifest)
+        partition = _load_derivation_partition_for_evaluation(
+            manifest=manifest,
+            partition_path=args.partition,
+            key_path=args.key,
+            config_path=args.config,
+        )
+        plan, artifact_root = _load_canonical_derivation_plan(
+            plan_path=args.plan,
+            config_path=args.config,
+        )
+        attempts = load_av1_validation_derivation_attempts(
+            artifact_root / "attempts"
+        )
+        records = load_av1_validation_derivation_terminal_records(
+            artifact_root / "terminal-records"
+        )
+        current_observations = load_current_av1_validation_derivation_observations(
+            config_path=args.config,
+            records=records,
+        )
+        proposed_at = _now_iso()
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=manifest,
+            plan=plan,
+            partition=partition,
+            cell_plan_id=args.cell_plan_id,
+            attempts=attempts,
+            records=records,
+            current_observations=current_observations,
+            proposed_at=proposed_at,
+        )
+        summary = av1_validation_derivation_candidate_evaluation_public_summary(
+            evaluation
+        )
+        _print_partition_payload(summary, json_output=args.json_output)
+        if evaluation.proposal is None:
+            return 2
+        write_av1_validation_derivation_candidate_proposal(
+            artifact_root,
+            plan=plan,
+            proposal=evaluation.proposal,
+        )
+        return 0
+
+    if args.action == "record-derivation-review":
+        plan, artifact_root = _load_canonical_derivation_plan(
+            plan_path=args.plan,
+            config_path=args.config,
+        )
+        proposal = load_av1_validation_derivation_candidate_proposal(
+            artifact_root,
+            plan=plan,
+            cell_plan_id=args.cell_plan_id,
+        )
+        reviewer_token, review_evidence, decision = _run_code_agent_review(
+            proposal=proposal,
+            lane=args.lane,
+        )
+        review_evidence_sha256 = f"sha256:{hashlib.sha256(review_evidence).hexdigest()}"
+        review = build_av1_validation_derivation_review_attestation(
+            proposal=proposal,
+            lane=args.lane,
+            reviewer_token=reviewer_token,
+            review_evidence_sha256=review_evidence_sha256,
+            decision=decision,
+            reviewed_at=_now_iso(),
+        )
+        envelope = build_av1_validation_derivation_review_envelope(
+            review=review,
+            evidence=review_evidence,
+        )
+        write_av1_validation_derivation_review_envelope(
+            artifact_root,
+            plan=plan,
+            proposal=proposal,
+            envelope=envelope,
+        )
+        _print_partition_payload(
+            {
+                "proposal_id": proposal.proposal_id,
+                "review_lane": review.lane,
+                "decision": review.decision,
+                "review_sha256": review.payload_sha256,
+                "candidate_lock_created": False,
+                "holdout_execution_authorized": False,
+            },
+            json_output=args.json_output,
+        )
+        return 0 if review.decision == "approved" else 2
+
+    if args.action == "finalize-derivation-lock":
+        for path in (
+            args.plan,
+            args.partition,
+            args.key,
+        ):
+            assert_private_artifact_path(path, repository_root=REPOSITORY_ROOT)
+        manifest = load_av1_validation_manifest_v2(args.manifest)
+        assert_preregistered_av1_validation_manifest_v2(manifest)
+        partition = load_av1_validation_private_partition(args.partition)
+        token_key = load_av1_validation_partition_key(args.key)
+        validate_av1_validation_private_partition(
+            partition,
+            manifest=manifest,
+            token_key=token_key,
+        )
+        lock_envelope = finalize_av1_validation_derivation_candidate_lock(
+            config_path=args.config,
+            manifest=manifest,
+            partition=partition,
+            token_key=token_key,
+            plan_path=args.plan,
+            cell_plan_id=args.cell_plan_id,
+            now_iso=_now_iso,
+        )
+        candidate_lock = lock_envelope.candidate_lock
+        _print_partition_payload(
+            {
+                "candidate_lock_id": candidate_lock.candidate_lock_id,
+                "candidate_lock_sha256": candidate_lock.payload_sha256,
+                "candidate_lock_envelope_sha256": lock_envelope.payload_sha256,
+                "candidate_lock_reviewed": True,
+                "holdout_execution_authorized": False,
+                "public_bundle_activation_allowed": False,
+            },
+            json_output=args.json_output,
+        )
+        return 0
+
+    raise AV1ValidationDerivationError("AV1 derivation action is unsupported")
+
+
+def _load_current_derivation_inputs(
+        args: argparse.Namespace,
+) -> tuple[AV1ValidationManifestV2, AV1ValidationPrivatePartition, bytes]:
+    for path in (args.eligibility, args.partition, args.key):
+        assert_private_artifact_path(path, repository_root=REPOSITORY_ROOT)
+    manifest = load_av1_validation_manifest_v2(args.manifest)
+    assert_preregistered_av1_validation_manifest_v2(manifest)
+    eligibility = load_av1_validation_v2_eligibility(args.eligibility)
+    assert_preregistered_av1_validation_v2_eligibility(eligibility)
+    partition = load_av1_validation_private_partition(args.partition)
+    token_key = load_av1_validation_partition_key(args.key)
+    validate_av1_validation_private_partition(
+        partition,
+        manifest=manifest,
+        token_key=token_key,
+    )
+    config = load_config(args.config)
+    with open_readonly_db(config.paths.db_path) as connection:
+        inventory = load_av1_validation_partition_inventory(connection, config=config)
+    validate_av1_validation_partition_current_inputs(
+        partition,
+        manifest=manifest,
+        sources=inventory.sources,
+        expectations=inventory.expectations,
+        token_key=token_key,
+    )
+    return manifest, partition, token_key
+
+
+def _load_derivation_partition_for_evaluation(
+        *,
+        manifest: AV1ValidationManifestV2,
+        partition_path: Path,
+        key_path: Path,
+        config_path: Path,
+) -> AV1ValidationPrivatePartition:
+    partition = load_av1_validation_private_partition(partition_path)
+    token_key = load_av1_validation_partition_key(key_path)
+    validate_av1_validation_private_partition(
+        partition,
+        manifest=manifest,
+        token_key=token_key,
+    )
+    config = load_config(config_path)
+    with open_readonly_db(config.paths.db_path) as connection:
+        inventory = load_av1_validation_partition_inventory(connection, config=config)
+    validate_av1_validation_partition_current_inputs(
+        partition,
+        manifest=manifest,
+        sources=inventory.sources,
+        expectations=inventory.expectations,
+        token_key=token_key,
+    )
+    return partition
+
+
+def _derivation_artifact_root_for_plan(
+        *,
+        config: MediaforceConfig,
+        plan: AV1ValidationDerivationPlan,
+) -> Path:
+    root = av1_validation_derivation_artifact_root(config, plan)
+    assert_private_artifact_path(root, repository_root=REPOSITORY_ROOT)
+    return root
+
+
+def _load_canonical_derivation_plan(
+        *,
+        plan_path: Path,
+        config_path: Path,
+        config: MediaforceConfig | None = None,
+) -> tuple[AV1ValidationDerivationPlan, Path]:
+    assert_private_artifact_path(plan_path, repository_root=REPOSITORY_ROOT)
+    plan = load_av1_validation_derivation_plan(plan_path)
+    artifact_root = _derivation_artifact_root_for_plan(
+        config=config or load_config(config_path),
+        plan=plan,
+    )
+    if plan_path.expanduser().resolve() != (artifact_root / "plan.json").resolve():
+        raise AV1ValidationDerivationError(
+            "AV1 derivation plan must use the plan-global canonical private state root"
+        )
+    validate_av1_validation_derivation_artifact_root_binding(
+        artifact_root,
+        plan,
+    )
+    return plan, artifact_root
+
+
+def _run_code_agent_review(
+        *,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        lane: str,
+) -> tuple[str, bytes, AV1ValidationDerivationReviewDecision]:
+    code_binary = shutil.which("code")
+    if code_binary is None:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review requires the Every Code executable"
+        )
+    resolved_binary = Path(code_binary).resolve(strict=True)
+    review_run_id = str(uuid.uuid4())
+    prompt = _agent_review_prompt(
+        proposal=proposal,
+        lane=lane,
+        review_run_id=review_run_id,
+    )
+    command = [
+        str(resolved_binary),
+        "-a",
+        "never",
+        "exec",
+        "-s",
+        "read-only",
+        "--json",
+        "--max-seconds",
+        str(_AGENT_REVIEW_MAX_SECONDS),
+        "-",
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=REPOSITORY_ROOT,
+            input=prompt,
+            text=True,
+            capture_output=True,
+            timeout=_AGENT_REVIEW_MAX_SECONDS + 30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation Every Code review did not complete"
+        ) from exc
+    if completed.returncode != 0:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation Every Code review failed"
+        )
+    final_message, completion_seen = _completed_agent_message(completed.stdout)
+    if not completion_seen or final_message is None:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation Every Code review lacks completed-run evidence"
+        )
+    decision = _agent_review_decision(
+        final_message,
+        proposal=proposal,
+        lane=lane,
+        review_run_id=review_run_id,
+    )
+    binary_sha256 = hashlib.sha256(resolved_binary.read_bytes()).hexdigest()
+    evidence = json.dumps(
+        {
+            "schema": "mediaforce.av1_derivation_agent_review_run",
+            "schema_version": 1,
+            "review_run_id": review_run_id,
+            "reviewer_token": f"agent:{review_run_id}",
+            "proposal_id": proposal.proposal_id,
+            "proposal_payload_sha256": proposal.payload_sha256,
+            "lane": lane,
+            "decision": decision,
+            "code_binary_sha256": f"sha256:{binary_sha256}",
+            "prompt_sha256": f"sha256:{hashlib.sha256(prompt.encode('utf-8')).hexdigest()}",
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+            "returncode": completed.returncode,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"agent:{review_run_id}", evidence, decision
+
+
+def _completed_agent_message(stdout: str) -> tuple[str | None, bool]:
+    messages: list[str] = []
+    completed_message: str | None = None
+    for line in stdout.splitlines():
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        message = event.get("msg")
+        if not isinstance(message, dict):
+            continue
+        if message.get("type") == "agent_message" and isinstance(
+            message.get("message"), str
+        ):
+            messages.append(message["message"])
+        if (
+            message.get("type") == "task_lifecycle"
+            and message.get("phase") == "quiescent"
+            and isinstance(message.get("last_agent_message"), str)
+        ):
+            completed_message = message["last_agent_message"]
+    if not messages or completed_message != messages[-1]:
+        return None, False
+    return messages[-1], True
+
+
+def _agent_review_decision(
+        message: str,
+        *,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        lane: str,
+        review_run_id: str,
+) -> AV1ValidationDerivationReviewDecision:
+    nonempty_lines = [line.strip() for line in message.splitlines() if line.strip()]
+    marker_lines = [
+        line for line in nonempty_lines if line.startswith(_AGENT_REVIEW_MARKER)
+    ]
+    if (
+        not nonempty_lines
+        or len(marker_lines) != 1
+        or marker_lines[0] != nonempty_lines[-1]
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review lacks one terminal structured verdict"
+        )
+    try:
+        marker = json.loads(marker_lines[0][len(_AGENT_REVIEW_MARKER):])
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review verdict is invalid"
+        ) from exc
+    if not isinstance(marker, dict) or set(marker) != {
+        "decision",
+        "lane",
+        "proposal_id",
+        "proposal_payload_sha256",
+        "review_run_id",
+    }:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review verdict contract is invalid"
+        )
+    decision = marker.get("decision")
+    if (
+        marker.get("proposal_id") != proposal.proposal_id
+        or marker.get("proposal_payload_sha256") != proposal.payload_sha256
+        or marker.get("lane") != lane
+        or marker.get("review_run_id") != review_run_id
+        or decision not in {"approved", "rejected"}
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation review verdict does not match its run, proposal, and lane"
+        )
+    return decision
+
+
+def _agent_review_prompt(
+        *,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        lane: str,
+        review_run_id: str,
+) -> str:
+    marker = {
+        "decision": "approved|rejected",
+        "lane": lane,
+        "proposal_id": proposal.proposal_id,
+        "proposal_payload_sha256": proposal.payload_sha256,
+        "review_run_id": review_run_id,
+    }
+    return (
+        "Perform one independent, read-only AV1 derivation candidate review. "
+        "Do not modify files, invoke another agent, reveal opaque tokens, or infer private media identity. "
+        f"Review lane: {lane}. Review the repository implementation and this canonical proposal payload:\n"
+        f"{json.dumps(proposal.to_payload(), sort_keys=True, separators=(',', ':'))}\n"
+        "Reject on any actionable gate failure; otherwise approve. Explain findings concisely. "
+        "End with exactly one final marker line using valid JSON and replace the decision placeholder:\n"
+        f"{_AGENT_REVIEW_MARKER}{json.dumps(marker, sort_keys=True, separators=(',', ':'))}"
+    )
+
+
 def _print_partition_payload(payload: dict[str, object], *, json_output: bool) -> None:
+    assert_av1_cold_start_public_payload_safe(payload)
     if json_output:
         print(json.dumps(payload, indent=2, sort_keys=True))
         return

--- a/scripts/verify_av1_cold_start_preregistration.py
+++ b/scripts/verify_av1_cold_start_preregistration.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import pwd
 import select
 import shutil
 import stat
@@ -93,6 +94,43 @@ ValidationManifest: TypeAlias = (
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 _AGENT_REVIEW_MARKER = AV1_VALIDATION_DERIVATION_AGENT_REVIEW_MARKER
 _AGENT_REVIEW_MAX_SECONDS = 1800
+_AGENT_REVIEW_SAFE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
+_MACH_O_MAGICS = frozenset({
+    b"\xce\xfa\xed\xfe",
+    b"\xfe\xed\xfa\xce",
+    b"\xcf\xfa\xed\xfe",
+    b"\xfe\xed\xfa\xcf",
+    b"\xca\xfe\xba\xbe",
+    b"\xbe\xba\xfe\xca",
+    b"\xca\xfe\xba\xbf",
+    b"\xbf\xba\xfe\xca",
+})
+_REVIEW_RUNNER_BLOCKED_ENVIRONMENT_NAMES = frozenset({
+    "ALL_PROXY",
+    "BASH_ENV",
+    "CDPATH",
+    "CODEX_HOME",
+    "CODE_HOME",
+    "CURL_CA_BUNDLE",
+    "ENV",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "LD_LIBRARY_PATH",
+    "LD_PRELOAD",
+    "NODE_OPTIONS",
+    "NODE_PATH",
+    "OPENAI_BASE_URL",
+    "OPENAI_WIRE_API",
+    "PERL5OPT",
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "REQUESTS_CA_BUNDLE",
+    "RUBYOPT",
+    "SHELL",
+    "SSL_CERT_DIR",
+    "SSL_CERT_FILE",
+    "ZDOTDIR",
+})
 
 
 def _now_iso() -> str:
@@ -903,6 +941,7 @@ def _review_runner_identity() -> tuple[Path, str, str, bytes]:
     finally:
         if descriptor >= 0:
             os.close(descriptor)
+    _assert_native_review_runner(binary_bytes)
     canonical_path_sha256 = (
         f"sha256:{hashlib.sha256(str(resolved_binary).encode('utf-8')).hexdigest()}"
     )
@@ -922,6 +961,74 @@ def _authorized_review_runner_identity(
             "AV1 derivation Every Code executable drifted from the authorization"
         )
     return identity
+
+
+def _assert_native_review_runner(binary_bytes: bytes) -> None:
+    if binary_bytes[:4] not in _MACH_O_MAGICS:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation Every Code executable must be a native Mach-O binary"
+        )
+
+
+def _review_runner_environment() -> dict[str, str]:
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key.upper() not in _REVIEW_RUNNER_BLOCKED_ENVIRONMENT_NAMES
+        and not key.upper().startswith(("DYLD_", "GIT_"))
+    }
+    environment.update({
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_PAGER": "cat",
+        "HOME": _review_user_home(),
+        "LANG": "C",
+        "LC_ALL": "C",
+        "LOGNAME": _review_user_name(),
+        "PAGER": "cat",
+        "PATH": _AGENT_REVIEW_SAFE_PATH,
+        "SHELL": "/bin/zsh",
+        "TMPDIR": "/tmp",
+        "USER": _review_user_name(),
+        "ZDOTDIR": "/var/empty",
+    })
+    return environment
+
+
+def _review_user_home() -> str:
+    return pwd.getpwuid(os.getuid()).pw_dir
+
+
+def _review_user_name() -> str:
+    return pwd.getpwuid(os.getuid()).pw_name
+
+
+def _review_shell_environment() -> dict[str, str]:
+    return {
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_PAGER": "cat",
+        "HOME": _review_user_home(),
+        "LANG": "C",
+        "LC_ALL": "C",
+        "PAGER": "cat",
+        "PATH": _AGENT_REVIEW_SAFE_PATH,
+        "SHELL": "/bin/zsh",
+        "TMPDIR": "/tmp",
+        "USER": _review_user_name(),
+        "ZDOTDIR": "/var/empty",
+    }
+
+
+def _review_shell_environment_overrides() -> tuple[str, ...]:
+    return (
+        'shell_environment_policy.inherit="none"',
+        "shell_environment_policy.ignore_default_excludes=false",
+        *(
+            f"shell_environment_policy.set.{key}={json.dumps(value)}"
+            for key, value in sorted(_review_shell_environment().items())
+        ),
+    )
 
 
 def _review_runner_descriptor_sha256(descriptor: int) -> str:
@@ -978,6 +1085,7 @@ def _private_review_runner(
         raise AV1ValidationDerivationError(
             "AV1 derivation secure Every Code execution monitoring is unavailable"
         )
+    _assert_native_review_runner(binary_bytes)
     if f"sha256:{hashlib.sha256(binary_bytes).hexdigest()}" != expected_sha256:
         raise AV1ValidationDerivationError(
             "AV1 derivation private Every Code executable does not match the authorization"
@@ -1097,11 +1205,15 @@ def _run_code_agent_review(
                 "exec",
                 "-s",
                 "read-only",
+            ]
+            for override in _review_shell_environment_overrides():
+                command.extend(("-c", override))
+            command.extend((
                 "--json",
                 "--max-seconds",
                 str(_AGENT_REVIEW_MAX_SECONDS),
                 "-",
-            ]
+            ))
             try:
                 completed = subprocess.run(
                     command,
@@ -1111,6 +1223,7 @@ def _run_code_agent_review(
                     capture_output=True,
                     timeout=_AGENT_REVIEW_MAX_SECONDS + 30,
                     check=False,
+                    env=_review_runner_environment(),
                 )
             except (OSError, subprocess.TimeoutExpired) as exc:
                 raise AV1ValidationDerivationError(

--- a/scripts/verify_av1_cold_start_preregistration.py
+++ b/scripts/verify_av1_cold_start_preregistration.py
@@ -5,6 +5,7 @@ import json
 import os
 from pathlib import Path
 import shutil
+import stat
 import subprocess
 import sys
 from typing import Sequence, TypeAlias
@@ -36,11 +37,14 @@ from mediaforce.tuning.av1_validation_derivation import (
     AV1ValidationDerivationCandidateProposal,
     AV1ValidationDerivationError,
     AV1ValidationDerivationPlan,
+    AV1ValidationDerivationReviewClaim,
     AV1ValidationDerivationReviewDecision,
+    AV1ValidationDerivationReviewLane,
     av1_validation_derivation_candidate_evaluation_public_summary,
     av1_validation_derivation_plan_public_summary,
     av1_validation_derivation_statistics_contract_sha256,
     build_av1_validation_derivation_plan,
+    build_av1_validation_derivation_review_claim,
     build_av1_validation_derivation_review_attestation,
     build_av1_validation_derivation_review_envelope,
     evaluate_av1_validation_derivation_candidate,
@@ -51,6 +55,7 @@ from mediaforce.tuning.av1_validation_derivation import (
     validate_av1_validation_derivation_artifact_root_binding,
     write_av1_validation_derivation_candidate_proposal,
     write_av1_validation_derivation_plan,
+    write_av1_validation_derivation_review_claim,
     write_av1_validation_derivation_review_envelope,
 )
 from mediaforce.web.runtime.av1_validation_derivation import (
@@ -189,9 +194,11 @@ def build_parser() -> argparse.ArgumentParser:
         "record-derivation-verdict",
         help="Append one human visual verdict and freeze its terminal derivation record",
     )
+    record_verdict.add_argument("manifest", type=Path)
     record_verdict.add_argument("partition", type=Path)
     record_verdict.add_argument("plan", type=Path)
     record_verdict.add_argument("assignment_id")
+    record_verdict.add_argument("--key", type=Path, required=True)
     record_verdict.add_argument("--verdict", choices=("approved", "rejected"), required=True)
     record_verdict.add_argument("--concern-tag", action="append", default=[])
     record_verdict.add_argument("--evidence-id", action="append", default=[])
@@ -435,6 +442,11 @@ def _run_derivation_action(args: argparse.Namespace) -> int:
         statistics_contract_sha256 = (
             av1_validation_derivation_statistics_contract_sha256(manifest)
         )
+        (
+            _review_runner_path,
+            review_runner_canonical_path_sha256,
+            review_runner_binary_sha256,
+        ) = _review_runner_identity()
         if args.action == "create-derivation-plan":
             authorization = build_av1_validation_v2_derivation_authorization(
                 manifest=manifest,
@@ -443,6 +455,10 @@ def _run_derivation_action(args: argparse.Namespace) -> int:
                 runtime_context_sha256=runtime_context_sha256,
                 execution_environment_sha256=execution_environment_sha256,
                 statistics_contract_sha256=statistics_contract_sha256,
+                review_runner_canonical_path_sha256=(
+                    review_runner_canonical_path_sha256
+                ),
+                review_runner_binary_sha256=review_runner_binary_sha256,
                 authorized_at=_now_iso(),
                 valid_until=args.valid_until,
             )
@@ -467,6 +483,10 @@ def _run_derivation_action(args: argparse.Namespace) -> int:
                 != execution_environment_sha256
                 or plan.authorization.statistics_contract_sha256
                 != statistics_contract_sha256
+                or plan.authorization.review_runner_canonical_path_sha256
+                != review_runner_canonical_path_sha256
+                or plan.authorization.review_runner_binary_sha256
+                != review_runner_binary_sha256
             ):
                 raise AV1ValidationDerivationError(
                     "AV1 derivation plan execution contract drifted"
@@ -561,9 +581,12 @@ def _run_derivation_action(args: argparse.Namespace) -> int:
         return 0
 
     if args.action == "record-derivation-verdict":
-        for path in (args.partition, args.plan):
+        for path in (args.partition, args.plan, args.key):
             assert_private_artifact_path(path, repository_root=REPOSITORY_ROOT)
+        manifest = load_av1_validation_manifest_v2(args.manifest)
+        assert_preregistered_av1_validation_manifest_v2(manifest)
         partition = load_av1_validation_private_partition(args.partition)
+        token_key = load_av1_validation_partition_key(args.key)
         plan, artifact_root = _load_canonical_derivation_plan(
             plan_path=args.plan,
             config_path=args.config,
@@ -581,8 +604,10 @@ def _run_derivation_action(args: argparse.Namespace) -> int:
             )
         terminal = record_av1_validation_derivation_visual_verdict(
             config_path=args.config,
+            manifest=manifest,
             plan=plan,
             partition=partition,
+            token_key=token_key,
             attempt=attempt,
             terminal_records_directory=artifact_root / "terminal-records",
             verdict=args.verdict,
@@ -665,15 +690,16 @@ def _run_derivation_action(args: argparse.Namespace) -> int:
             plan=plan,
             cell_plan_id=args.cell_plan_id,
         )
-        reviewer_token, review_evidence, decision = _run_code_agent_review(
+        claim, review_evidence, decision = _run_code_agent_review(
+            artifact_root=artifact_root,
+            plan=plan,
             proposal=proposal,
             lane=args.lane,
         )
         review_evidence_sha256 = f"sha256:{hashlib.sha256(review_evidence).hexdigest()}"
         review = build_av1_validation_derivation_review_attestation(
             proposal=proposal,
-            lane=args.lane,
-            reviewer_token=reviewer_token,
+            claim=claim,
             review_evidence_sha256=review_evidence_sha256,
             decision=decision,
             reviewed_at=_now_iso(),
@@ -686,6 +712,7 @@ def _run_derivation_action(args: argparse.Namespace) -> int:
             artifact_root,
             plan=plan,
             proposal=proposal,
+            claim=claim,
             envelope=envelope,
         )
         _print_partition_payload(
@@ -823,7 +850,7 @@ def _load_canonical_derivation_plan(
     )
     if plan_path.expanduser().resolve() != (artifact_root / "plan.json").resolve():
         raise AV1ValidationDerivationError(
-            "AV1 derivation plan must use the plan-global canonical private state root"
+            "AV1 derivation plan must use the partition-global canonical private state root"
         )
     validate_av1_validation_derivation_artifact_root_binding(
         artifact_root,
@@ -832,22 +859,99 @@ def _load_canonical_derivation_plan(
     return plan, artifact_root
 
 
-def _run_code_agent_review(
-        *,
-        proposal: AV1ValidationDerivationCandidateProposal,
-        lane: str,
-) -> tuple[str, bytes, AV1ValidationDerivationReviewDecision]:
+def _review_runner_identity() -> tuple[Path, str, str]:
     code_binary = shutil.which("code")
     if code_binary is None:
         raise AV1ValidationDerivationError(
             "AV1 derivation review requires the Every Code executable"
         )
-    resolved_binary = Path(code_binary).resolve(strict=True)
+    try:
+        resolved_binary = Path(code_binary).expanduser().resolve(strict=True)
+    except OSError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation Every Code executable is unavailable"
+        ) from exc
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(resolved_binary, flags)
+    except OSError as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation Every Code executable is unavailable"
+        ) from exc
+    try:
+        descriptor_info = os.fstat(descriptor)
+        path_info = resolved_binary.lstat()
+        if (
+            not stat.S_ISREG(descriptor_info.st_mode)
+            or stat.S_ISLNK(path_info.st_mode)
+            or (descriptor_info.st_dev, descriptor_info.st_ino)
+            != (path_info.st_dev, path_info.st_ino)
+            or not os.access(resolved_binary, os.X_OK)
+        ):
+            raise AV1ValidationDerivationError(
+                "AV1 derivation Every Code executable identity is invalid"
+            )
+        with os.fdopen(descriptor, "rb") as handle:
+            descriptor = -1
+            binary_bytes = handle.read()
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    canonical_path_sha256 = (
+        f"sha256:{hashlib.sha256(str(resolved_binary).encode('utf-8')).hexdigest()}"
+    )
+    binary_sha256 = f"sha256:{hashlib.sha256(binary_bytes).hexdigest()}"
+    return resolved_binary, canonical_path_sha256, binary_sha256
+
+
+def _authorized_review_runner_identity(
+        plan: AV1ValidationDerivationPlan,
+) -> tuple[Path, str, str]:
+    identity = _review_runner_identity()
+    if (
+        identity[1] != plan.authorization.review_runner_canonical_path_sha256
+        or identity[2] != plan.authorization.review_runner_binary_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation Every Code executable drifted from the authorization"
+        )
+    return identity
+
+
+def _run_code_agent_review(
+        *,
+        artifact_root: Path,
+        plan: AV1ValidationDerivationPlan,
+        proposal: AV1ValidationDerivationCandidateProposal,
+        lane: AV1ValidationDerivationReviewLane,
+) -> tuple[
+    AV1ValidationDerivationReviewClaim,
+    bytes,
+    AV1ValidationDerivationReviewDecision,
+]:
+    before_identity = _authorized_review_runner_identity(plan)
+    resolved_binary = before_identity[0]
     review_run_id = str(uuid.uuid4())
-    prompt = _agent_review_prompt(
+    claim = build_av1_validation_derivation_review_claim(
+        plan=plan,
         proposal=proposal,
         lane=lane,
         review_run_id=review_run_id,
+        review_runner_canonical_path_sha256=before_identity[1],
+        review_runner_binary_sha256=before_identity[2],
+        claimed_at=_now_iso(),
+    )
+    write_av1_validation_derivation_review_claim(
+        artifact_root,
+        plan=plan,
+        proposal=proposal,
+        claim=claim,
+    )
+    prompt = _agent_review_prompt(
+        proposal=proposal,
+        claim=claim,
     )
     command = [
         str(resolved_binary),
@@ -862,19 +966,26 @@ def _run_code_agent_review(
         "-",
     ]
     try:
-        completed = subprocess.run(
-            command,
-            cwd=REPOSITORY_ROOT,
-            input=prompt,
-            text=True,
-            capture_output=True,
-            timeout=_AGENT_REVIEW_MAX_SECONDS + 30,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        raise AV1ValidationDerivationError(
-            "AV1 derivation Every Code review did not complete"
-        ) from exc
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=REPOSITORY_ROOT,
+                input=prompt,
+                text=True,
+                capture_output=True,
+                timeout=_AGENT_REVIEW_MAX_SECONDS + 30,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation Every Code review did not complete"
+            ) from exc
+    finally:
+        after_identity = _authorized_review_runner_identity(plan)
+        if after_identity != before_identity:
+            raise AV1ValidationDerivationError(
+                "AV1 derivation Every Code executable changed during review"
+            )
     if completed.returncode != 0:
         raise AV1ValidationDerivationError(
             "AV1 derivation Every Code review failed"
@@ -887,10 +998,8 @@ def _run_code_agent_review(
     decision = _agent_review_decision(
         final_message,
         proposal=proposal,
-        lane=lane,
-        review_run_id=review_run_id,
+        claim=claim,
     )
-    binary_sha256 = hashlib.sha256(resolved_binary.read_bytes()).hexdigest()
     evidence = json.dumps(
         {
             "schema": "mediaforce.av1_derivation_agent_review_run",
@@ -899,9 +1008,12 @@ def _run_code_agent_review(
             "reviewer_token": f"agent:{review_run_id}",
             "proposal_id": proposal.proposal_id,
             "proposal_payload_sha256": proposal.payload_sha256,
-            "lane": lane,
+            "review_claim_id": claim.claim_id,
+            "review_claim_payload_sha256": claim.payload_sha256,
+            "lane": claim.lane,
             "decision": decision,
-            "code_binary_sha256": f"sha256:{binary_sha256}",
+            "review_runner_canonical_path_sha256": before_identity[1],
+            "review_runner_binary_sha256": before_identity[2],
             "prompt_sha256": f"sha256:{hashlib.sha256(prompt.encode('utf-8')).hexdigest()}",
             "stdout": completed.stdout,
             "stderr": completed.stderr,
@@ -910,7 +1022,7 @@ def _run_code_agent_review(
         sort_keys=True,
         separators=(",", ":"),
     ).encode("utf-8")
-    return f"agent:{review_run_id}", evidence, decision
+    return claim, evidence, decision
 
 
 def _completed_agent_message(stdout: str) -> tuple[str | None, bool]:
@@ -945,8 +1057,7 @@ def _agent_review_decision(
         message: str,
         *,
         proposal: AV1ValidationDerivationCandidateProposal,
-        lane: str,
-        review_run_id: str,
+        claim: AV1ValidationDerivationReviewClaim,
 ) -> AV1ValidationDerivationReviewDecision:
     nonempty_lines = [line.strip() for line in message.splitlines() if line.strip()]
     marker_lines = [
@@ -971,6 +1082,8 @@ def _agent_review_decision(
         "lane",
         "proposal_id",
         "proposal_payload_sha256",
+        "review_claim_id",
+        "review_claim_payload_sha256",
         "review_run_id",
     }:
         raise AV1ValidationDerivationError(
@@ -980,8 +1093,10 @@ def _agent_review_decision(
     if (
         marker.get("proposal_id") != proposal.proposal_id
         or marker.get("proposal_payload_sha256") != proposal.payload_sha256
-        or marker.get("lane") != lane
-        or marker.get("review_run_id") != review_run_id
+        or marker.get("review_claim_id") != claim.claim_id
+        or marker.get("review_claim_payload_sha256") != claim.payload_sha256
+        or marker.get("lane") != claim.lane
+        or marker.get("review_run_id") != claim.review_run_id
         or decision not in {"approved", "rejected"}
     ):
         raise AV1ValidationDerivationError(
@@ -993,20 +1108,22 @@ def _agent_review_decision(
 def _agent_review_prompt(
         *,
         proposal: AV1ValidationDerivationCandidateProposal,
-        lane: str,
-        review_run_id: str,
+        claim: AV1ValidationDerivationReviewClaim,
 ) -> str:
     marker = {
         "decision": "approved|rejected",
-        "lane": lane,
+        "lane": claim.lane,
         "proposal_id": proposal.proposal_id,
         "proposal_payload_sha256": proposal.payload_sha256,
-        "review_run_id": review_run_id,
+        "review_claim_id": claim.claim_id,
+        "review_claim_payload_sha256": claim.payload_sha256,
+        "review_run_id": claim.review_run_id,
     }
     return (
         "Perform one independent, read-only AV1 derivation candidate review. "
         "Do not modify files, invoke another agent, reveal opaque tokens, or infer private media identity. "
-        f"Review lane: {lane}. Review the repository implementation and this canonical proposal payload:\n"
+        f"Review lane: {claim.lane}. Review the repository implementation and this canonical proposal payload:\n"
+        f"Immutable review claim: {claim.claim_id} ({claim.payload_sha256}).\n"
         f"{json.dumps(proposal.to_payload(), sort_keys=True, separators=(',', ':'))}\n"
         "Reject on any actionable gate failure; otherwise approve. Explain findings concisely. "
         "End with exactly one final marker line using valid JSON and replace the decision placeholder:\n"

--- a/scripts/verify_av1_cold_start_preregistration.py
+++ b/scripts/verify_av1_cold_start_preregistration.py
@@ -18,6 +18,7 @@ import uuid
 
 from mediaforce.core.config import DEFAULT_CONFIG_PATH, MediaforceConfig, load_config
 from mediaforce.core.db import open_readonly_db
+from mediaforce.core.evidence import canonical_json_bytes
 from mediaforce.tuning.av1_cold_start import assert_av1_cold_start_public_payload_safe
 from mediaforce.tuning.av1_cold_start_evaluation import (
     AV1ColdStartValidationError,
@@ -38,17 +39,20 @@ from mediaforce.tuning.av1_validation_v2 import (
     load_av1_validation_v2_eligibility,
 )
 from mediaforce.tuning.av1_validation_derivation import (
-    AV1_VALIDATION_DERIVATION_AGENT_REVIEW_MARKER,
+    AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY,
     AV1ValidationDerivationCandidateProposal,
     AV1ValidationDerivationError,
     AV1ValidationDerivationPlan,
     AV1ValidationDerivationReviewClaim,
     AV1ValidationDerivationReviewDecision,
     AV1ValidationDerivationReviewLane,
+    _code_review_marker,
+    _completed_code_review_message,
     av1_validation_derivation_candidate_evaluation_public_summary,
     av1_validation_derivation_plan_public_summary,
     av1_validation_derivation_statistics_contract_sha256,
     build_av1_validation_derivation_plan,
+    build_av1_validation_derivation_review_prompt,
     build_av1_validation_derivation_review_claim,
     build_av1_validation_derivation_review_attestation,
     build_av1_validation_derivation_review_envelope,
@@ -93,7 +97,6 @@ ValidationManifest: TypeAlias = (
     AV1ColdStartValidationManifestV1 | AV1ValidationManifestV2
 )
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
-_AGENT_REVIEW_MARKER = AV1_VALIDATION_DERIVATION_AGENT_REVIEW_MARKER
 _AGENT_REVIEW_MAX_SECONDS = 1800
 _AGENT_REVIEW_SAFE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
 _MACH_O_MAGICS = frozenset({
@@ -105,32 +108,6 @@ _MACH_O_MAGICS = frozenset({
     b"\xbe\xba\xfe\xca",
     b"\xca\xfe\xba\xbf",
     b"\xbf\xba\xfe\xca",
-})
-_REVIEW_RUNNER_BLOCKED_ENVIRONMENT_NAMES = frozenset({
-    "ALL_PROXY",
-    "BASH_ENV",
-    "CDPATH",
-    "CODEX_HOME",
-    "CODE_HOME",
-    "CURL_CA_BUNDLE",
-    "ENV",
-    "HTTP_PROXY",
-    "HTTPS_PROXY",
-    "LD_LIBRARY_PATH",
-    "LD_PRELOAD",
-    "NODE_OPTIONS",
-    "NODE_PATH",
-    "OPENAI_BASE_URL",
-    "OPENAI_WIRE_API",
-    "PERL5OPT",
-    "PYTHONHOME",
-    "PYTHONPATH",
-    "REQUESTS_CA_BUNDLE",
-    "RUBYOPT",
-    "SHELL",
-    "SSL_CERT_DIR",
-    "SSL_CERT_FILE",
-    "ZDOTDIR",
 })
 
 
@@ -555,7 +532,7 @@ def _run_derivation_action(args: argparse.Namespace) -> int:
             assert_private_artifact_path(path, repository_root=REPOSITORY_ROOT)
         manifest = load_av1_validation_manifest_v2(args.manifest)
         partition = load_av1_validation_private_partition(args.partition)
-        plan, artifact_root = _load_canonical_derivation_plan(
+        plan, artifact_root = _load_recovery_capable_derivation_plan(
             plan_path=args.plan,
             config_path=args.config,
         )
@@ -885,15 +862,46 @@ def _load_canonical_derivation_plan(
         config_path: Path,
         config: MediaforceConfig | None = None,
 ) -> tuple[AV1ValidationDerivationPlan, Path]:
-    assert_private_artifact_path(plan_path, repository_root=REPOSITORY_ROOT)
-    plan = load_av1_validation_derivation_plan(plan_path)
+    plan, bound_artifact_root = _load_bound_derivation_plan(plan_path)
     artifact_root = _derivation_artifact_root_for_plan(
         config=config or load_config(config_path),
         plan=plan,
     )
-    if plan_path.expanduser().resolve() != (artifact_root / "plan.json").resolve():
+    if bound_artifact_root != artifact_root.expanduser().resolve():
         raise AV1ValidationDerivationError(
             "AV1 derivation plan must use the partition-global canonical private state root"
+        )
+    return plan, artifact_root
+
+
+def _load_recovery_capable_derivation_plan(
+        *,
+        plan_path: Path,
+        config_path: Path,
+) -> tuple[AV1ValidationDerivationPlan, Path]:
+    plan, artifact_root = _load_bound_derivation_plan(plan_path)
+    config = load_config(config_path)
+    expected_state_root = (
+        config.paths.web_state_dir
+        / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
+        / plan.partition_id
+    ).expanduser().resolve()
+    if artifact_root != expected_state_root:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation recovery requires the canonical runtime state root"
+        )
+    return plan, artifact_root
+
+
+def _load_bound_derivation_plan(
+        plan_path: Path,
+) -> tuple[AV1ValidationDerivationPlan, Path]:
+    assert_private_artifact_path(plan_path, repository_root=REPOSITORY_ROOT)
+    plan = load_av1_validation_derivation_plan(plan_path)
+    artifact_root = plan_path.expanduser().resolve().parent
+    if plan_path.expanduser().resolve() != artifact_root / "plan.json":
+        raise AV1ValidationDerivationError(
+            "AV1 derivation plan must use the frozen artifact-root plan path"
         )
     validate_av1_validation_derivation_artifact_root_binding(
         artifact_root,
@@ -1272,18 +1280,19 @@ def _run_code_agent_review(
         raise AV1ValidationDerivationError(
             "AV1 derivation Every Code review failed"
         )
-    final_message, completion_seen = _completed_agent_message(completed.stdout)
-    if not completion_seen or final_message is None:
+    final_message, transcript_prompt = _completed_code_review_message(
+        completed.stdout
+    )
+    if transcript_prompt != prompt:
         raise AV1ValidationDerivationError(
-            "AV1 derivation Every Code review lacks completed-run evidence"
+            "AV1 derivation Every Code review prompt drifted during execution"
         )
     decision = _agent_review_decision(
         final_message,
         proposal=proposal,
         claim=claim,
     )
-    evidence = json.dumps(
-        {
+    evidence = canonical_json_bytes({
             "schema": "mediaforce.av1_derivation_agent_review_run",
             "schema_version": 1,
             "review_run_id": review_run_id,
@@ -1296,43 +1305,14 @@ def _run_code_agent_review(
             "decision": decision,
             "review_runner_canonical_path_sha256": before_identity[1],
             "review_runner_binary_sha256": before_identity[2],
+            "proposal": proposal.to_payload(),
+            "review_claim": claim.to_payload(),
             "prompt_sha256": f"sha256:{hashlib.sha256(prompt.encode('utf-8')).hexdigest()}",
             "stdout": completed.stdout,
             "stderr": completed.stderr,
             "returncode": completed.returncode,
-        },
-        sort_keys=True,
-        separators=(",", ":"),
-    ).encode("utf-8")
+    })
     return claim, evidence, decision
-
-
-def _completed_agent_message(stdout: str) -> tuple[str | None, bool]:
-    messages: list[str] = []
-    completed_message: str | None = None
-    for line in stdout.splitlines():
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(event, dict):
-            continue
-        message = event.get("msg")
-        if not isinstance(message, dict):
-            continue
-        if message.get("type") == "agent_message" and isinstance(
-            message.get("message"), str
-        ):
-            messages.append(message["message"])
-        if (
-            message.get("type") == "task_lifecycle"
-            and message.get("phase") == "quiescent"
-            and isinstance(message.get("last_agent_message"), str)
-        ):
-            completed_message = message["last_agent_message"]
-    if not messages or completed_message != messages[-1]:
-        return None, False
-    return messages[-1], True
 
 
 def _agent_review_decision(
@@ -1341,36 +1321,7 @@ def _agent_review_decision(
         proposal: AV1ValidationDerivationCandidateProposal,
         claim: AV1ValidationDerivationReviewClaim,
 ) -> AV1ValidationDerivationReviewDecision:
-    nonempty_lines = [line.strip() for line in message.splitlines() if line.strip()]
-    marker_lines = [
-        line for line in nonempty_lines if line.startswith(_AGENT_REVIEW_MARKER)
-    ]
-    if (
-        not nonempty_lines
-        or len(marker_lines) != 1
-        or marker_lines[0] != nonempty_lines[-1]
-    ):
-        raise AV1ValidationDerivationError(
-            "AV1 derivation review lacks one terminal structured verdict"
-        )
-    try:
-        marker = json.loads(marker_lines[0][len(_AGENT_REVIEW_MARKER):])
-    except (json.JSONDecodeError, TypeError) as exc:
-        raise AV1ValidationDerivationError(
-            "AV1 derivation review verdict is invalid"
-        ) from exc
-    if not isinstance(marker, dict) or set(marker) != {
-        "decision",
-        "lane",
-        "proposal_id",
-        "proposal_payload_sha256",
-        "review_claim_id",
-        "review_claim_payload_sha256",
-        "review_run_id",
-    }:
-        raise AV1ValidationDerivationError(
-            "AV1 derivation review verdict contract is invalid"
-        )
+    marker = _code_review_marker(message)
     decision = marker.get("decision")
     if (
         marker.get("proposal_id") != proposal.proposal_id
@@ -1392,24 +1343,9 @@ def _agent_review_prompt(
         proposal: AV1ValidationDerivationCandidateProposal,
         claim: AV1ValidationDerivationReviewClaim,
 ) -> str:
-    marker = {
-        "decision": "approved|rejected",
-        "lane": claim.lane,
-        "proposal_id": proposal.proposal_id,
-        "proposal_payload_sha256": proposal.payload_sha256,
-        "review_claim_id": claim.claim_id,
-        "review_claim_payload_sha256": claim.payload_sha256,
-        "review_run_id": claim.review_run_id,
-    }
-    return (
-        "Perform one independent, read-only AV1 derivation candidate review. "
-        "Do not modify files, invoke another agent, reveal opaque tokens, or infer private media identity. "
-        f"Review lane: {claim.lane}. Review the repository implementation and this canonical proposal payload:\n"
-        f"Immutable review claim: {claim.claim_id} ({claim.payload_sha256}).\n"
-        f"{json.dumps(proposal.to_payload(), sort_keys=True, separators=(',', ':'))}\n"
-        "Reject on any actionable gate failure; otherwise approve. Explain findings concisely. "
-        "End with exactly one final marker line using valid JSON and replace the decision placeholder:\n"
-        f"{_AGENT_REVIEW_MARKER}{json.dumps(marker, sort_keys=True, separators=(',', ':'))}"
+    return build_av1_validation_derivation_review_prompt(
+        proposal=proposal,
+        claim=claim,
     )
 
 

--- a/scripts/verify_av1_cold_start_preregistration.py
+++ b/scripts/verify_av1_cold_start_preregistration.py
@@ -91,6 +91,7 @@ from mediaforce.tuning.av1_validation_partition import (
     write_av1_validation_private_partition,
 )
 from mediaforce.tuning.av1_validation_partition_inventory import (
+    av1_validation_partition_source_sha256_resolver,
     load_av1_validation_partition_inventory,
 )
 ValidationManifest: TypeAlias = (
@@ -394,16 +395,23 @@ def _run_partition_action(args: argparse.Namespace) -> int:
                 connection,
                 config=config,
             )
-        partition = build_av1_validation_private_partition(
-            manifest=manifest,
-            eligibility_attestation_id=eligibility.attestation_id,
-            eligibility_payload_sha256=eligibility.payload_sha256,
-            sources=inventory.sources,
-            expectations=inventory.expectations,
-            token_key=token_key,
-            expected_token_key_id=args.expected_token_key_id,
-            selected_at=args.selected_at,
-        )
+            partition = build_av1_validation_private_partition(
+                manifest=manifest,
+                eligibility_attestation_id=eligibility.attestation_id,
+                eligibility_payload_sha256=eligibility.payload_sha256,
+                sources=inventory.sources,
+                expectations=inventory.expectations,
+                token_key=token_key,
+                expected_token_key_id=args.expected_token_key_id,
+                selected_at=args.selected_at,
+                source_sha256_resolver=(
+                    av1_validation_partition_source_sha256_resolver(
+                        connection,
+                        config=config,
+                        verify_evidence=True,
+                    )
+                ),
+            )
         write_av1_validation_private_partition(args.output, partition)
     else:
         assert_private_artifact_path(args.partition, repository_root=REPOSITORY_ROOT)
@@ -423,13 +431,19 @@ def _run_partition_action(args: argparse.Namespace) -> int:
                 connection,
                 config=config,
             )
-        validate_av1_validation_partition_current_inputs(
-            partition,
-            manifest=manifest,
-            sources=inventory.sources,
-            expectations=inventory.expectations,
-            token_key=token_key,
-        )
+            validate_av1_validation_partition_current_inputs(
+                partition,
+                manifest=manifest,
+                sources=inventory.sources,
+                expectations=inventory.expectations,
+                token_key=token_key,
+                source_sha256_resolver=(
+                    av1_validation_partition_source_sha256_resolver(
+                        connection,
+                        config=config,
+                    )
+                ),
+            )
     _print_partition_payload(
         av1_validation_partition_public_summary(partition),
         json_output=args.json_output,
@@ -809,13 +823,19 @@ def _load_current_derivation_inputs(
     config = load_config(args.config)
     with open_readonly_db(config.paths.db_path) as connection:
         inventory = load_av1_validation_partition_inventory(connection, config=config)
-    validate_av1_validation_partition_current_inputs(
-        partition,
-        manifest=manifest,
-        sources=inventory.sources,
-        expectations=inventory.expectations,
-        token_key=token_key,
-    )
+        validate_av1_validation_partition_current_inputs(
+            partition,
+            manifest=manifest,
+            sources=inventory.sources,
+            expectations=inventory.expectations,
+            token_key=token_key,
+            source_sha256_resolver=(
+                av1_validation_partition_source_sha256_resolver(
+                    connection,
+                    config=config,
+                )
+            ),
+        )
     return manifest, partition, token_key
 
 
@@ -836,13 +856,19 @@ def _load_derivation_partition_for_evaluation(
     config = load_config(config_path)
     with open_readonly_db(config.paths.db_path) as connection:
         inventory = load_av1_validation_partition_inventory(connection, config=config)
-    validate_av1_validation_partition_current_inputs(
-        partition,
-        manifest=manifest,
-        sources=inventory.sources,
-        expectations=inventory.expectations,
-        token_key=token_key,
-    )
+        validate_av1_validation_partition_current_inputs(
+            partition,
+            manifest=manifest,
+            sources=inventory.sources,
+            expectations=inventory.expectations,
+            token_key=token_key,
+            source_sha256_resolver=(
+                av1_validation_partition_source_sha256_resolver(
+                    connection,
+                    config=config,
+                )
+            ),
+        )
     return partition
 
 

--- a/scripts/verify_av1_cold_start_preregistration.py
+++ b/scripts/verify_av1_cold_start_preregistration.py
@@ -1,5 +1,6 @@
 import argparse
 from contextlib import contextmanager
+import ctypes
 from datetime import UTC, datetime
 import hashlib
 import json
@@ -913,6 +914,10 @@ def _review_runner_identity() -> tuple[Path, str, str, bytes]:
         raise AV1ValidationDerivationError(
             "AV1 derivation Every Code executable is unavailable"
         ) from exc
+    if resolved_binary != _trusted_code_ancestor_path():
+        raise AV1ValidationDerivationError(
+            "AV1 derivation Every Code executable is not the active trusted runner"
+        )
     flags = os.O_RDONLY
     if hasattr(os, "O_NOFOLLOW"):
         flags |= os.O_NOFOLLOW
@@ -971,13 +976,7 @@ def _assert_native_review_runner(binary_bytes: bytes) -> None:
 
 
 def _review_runner_environment() -> dict[str, str]:
-    environment = {
-        key: value
-        for key, value in os.environ.items()
-        if key.upper() not in _REVIEW_RUNNER_BLOCKED_ENVIRONMENT_NAMES
-        and not key.upper().startswith(("DYLD_", "GIT_"))
-    }
-    environment.update({
+    return {
         "GIT_CONFIG_GLOBAL": "/dev/null",
         "GIT_CONFIG_NOSYSTEM": "1",
         "GIT_PAGER": "cat",
@@ -991,8 +990,42 @@ def _review_runner_environment() -> dict[str, str]:
         "TMPDIR": "/tmp",
         "USER": _review_user_name(),
         "ZDOTDIR": "/var/empty",
-    })
-    return environment
+    }
+
+
+def _trusted_code_ancestor_path() -> Path:
+    try:
+        libproc = ctypes.CDLL("/usr/lib/libproc.dylib")
+        proc_pidpath = libproc.proc_pidpath
+        proc_pidpath.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_uint32]
+        proc_pidpath.restype = ctypes.c_int
+    except (AttributeError, OSError) as exc:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation active Every Code runner identity is unavailable"
+        ) from exc
+    process_id = os.getppid()
+    for _ in range(16):
+        buffer = ctypes.create_string_buffer(4096)
+        if proc_pidpath(process_id, buffer, len(buffer)) > 0:
+            candidate = Path(buffer.value.decode("utf-8")).resolve()
+            if candidate.name == "code":
+                return candidate
+        parent = subprocess.run(
+            ["/bin/ps", "-o", "ppid=", "-p", str(process_id)],
+            text=True,
+            capture_output=True,
+            check=False,
+            env={"PATH": _AGENT_REVIEW_SAFE_PATH},
+        )
+        try:
+            process_id = int(parent.stdout.strip())
+        except ValueError:
+            break
+        if process_id <= 1:
+            break
+    raise AV1ValidationDerivationError(
+        "AV1 derivation must run from the active trusted Every Code session"
+    )
 
 
 def _review_user_home() -> str:

--- a/scripts/verify_av1_cold_start_preregistration.py
+++ b/scripts/verify_av1_cold_start_preregistration.py
@@ -1,14 +1,17 @@
 import argparse
+from contextlib import contextmanager
 from datetime import UTC, datetime
 import hashlib
 import json
 import os
 from pathlib import Path
+import select
 import shutil
 import stat
 import subprocess
 import sys
-from typing import Sequence, TypeAlias
+import tempfile
+from typing import cast, Iterator, Sequence, TypeAlias
 import uuid
 
 from mediaforce.core.config import DEFAULT_CONFIG_PATH, MediaforceConfig, load_config
@@ -446,6 +449,7 @@ def _run_derivation_action(args: argparse.Namespace) -> int:
             _review_runner_path,
             review_runner_canonical_path_sha256,
             review_runner_binary_sha256,
+            _review_runner_bytes,
         ) = _review_runner_identity()
         if args.action == "create-derivation-plan":
             authorization = build_av1_validation_v2_derivation_authorization(
@@ -859,7 +863,7 @@ def _load_canonical_derivation_plan(
     return plan, artifact_root
 
 
-def _review_runner_identity() -> tuple[Path, str, str]:
+def _review_runner_identity() -> tuple[Path, str, str, bytes]:
     code_binary = shutil.which("code")
     if code_binary is None:
         raise AV1ValidationDerivationError(
@@ -903,12 +907,12 @@ def _review_runner_identity() -> tuple[Path, str, str]:
         f"sha256:{hashlib.sha256(str(resolved_binary).encode('utf-8')).hexdigest()}"
     )
     binary_sha256 = f"sha256:{hashlib.sha256(binary_bytes).hexdigest()}"
-    return resolved_binary, canonical_path_sha256, binary_sha256
+    return resolved_binary, canonical_path_sha256, binary_sha256, binary_bytes
 
 
 def _authorized_review_runner_identity(
         plan: AV1ValidationDerivationPlan,
-) -> tuple[Path, str, str]:
+) -> tuple[Path, str, str, bytes]:
     identity = _review_runner_identity()
     if (
         identity[1] != plan.authorization.review_runner_canonical_path_sha256
@@ -918,6 +922,135 @@ def _authorized_review_runner_identity(
             "AV1 derivation Every Code executable drifted from the authorization"
         )
     return identity
+
+
+def _review_runner_descriptor_sha256(descriptor: int) -> str:
+    digest = hashlib.sha256()
+    offset = 0
+    while chunk := os.pread(descriptor, 1024 * 1024, offset):
+        digest.update(chunk)
+        offset += len(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _assert_private_review_runner_identity(
+        path: Path,
+        descriptor: int,
+        *,
+        expected_sha256: str,
+) -> None:
+    descriptor_info = os.fstat(descriptor)
+    path_info = path.lstat()
+    if (
+        not stat.S_ISREG(descriptor_info.st_mode)
+        or stat.S_ISLNK(path_info.st_mode)
+        or descriptor_info.st_uid != os.getuid()
+        or stat.S_IMODE(descriptor_info.st_mode) != 0o500
+        or (descriptor_info.st_dev, descriptor_info.st_ino)
+        != (path_info.st_dev, path_info.st_ino)
+        or not os.access(path, os.X_OK)
+        or _review_runner_descriptor_sha256(descriptor) != expected_sha256
+    ):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation private Every Code executable identity is invalid"
+        )
+
+
+@contextmanager
+def _private_review_runner(
+        binary_bytes: bytes,
+        *,
+        expected_sha256: str,
+) -> Iterator[Path]:
+    required_kqueue_names = (
+        "kqueue",
+        "kevent",
+        "KQ_FILTER_VNODE",
+        "KQ_EV_ADD",
+        "KQ_EV_CLEAR",
+        "KQ_NOTE_WRITE",
+        "KQ_NOTE_DELETE",
+        "KQ_NOTE_RENAME",
+        "KQ_NOTE_LINK",
+        "KQ_NOTE_REVOKE",
+    )
+    if any(not hasattr(select, name) for name in required_kqueue_names):
+        raise AV1ValidationDerivationError(
+            "AV1 derivation secure Every Code execution monitoring is unavailable"
+        )
+    if f"sha256:{hashlib.sha256(binary_bytes).hexdigest()}" != expected_sha256:
+        raise AV1ValidationDerivationError(
+            "AV1 derivation private Every Code executable does not match the authorization"
+        )
+    directory = Path(tempfile.mkdtemp(prefix="mediaforce-av1-review-runner-"))
+    path = directory / "code"
+    descriptor = -1
+    watcher = None
+    try:
+        directory.chmod(0o700)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        write_descriptor = os.open(path, flags, 0o500)
+        try:
+            view = memoryview(binary_bytes)
+            while view:
+                written = os.write(write_descriptor, view)
+                if written <= 0:
+                    raise AV1ValidationDerivationError(
+                        "AV1 derivation private Every Code executable could not be written"
+                    )
+                view = view[written:]
+            os.fchmod(write_descriptor, 0o500)
+            os.fsync(write_descriptor)
+        finally:
+            os.close(write_descriptor)
+        read_flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            read_flags |= os.O_NOFOLLOW
+        descriptor = os.open(path, read_flags)
+        watcher = select.kqueue()
+        vnode_flags = (
+            select.KQ_NOTE_WRITE
+            | select.KQ_NOTE_DELETE
+            | select.KQ_NOTE_RENAME
+            | select.KQ_NOTE_LINK
+            | select.KQ_NOTE_REVOKE
+        )
+        watcher.control(
+            [select.kevent(
+                descriptor,
+                filter=select.KQ_FILTER_VNODE,
+                flags=select.KQ_EV_ADD | select.KQ_EV_CLEAR,
+                fflags=vnode_flags,
+            )],
+            0,
+            0,
+        )
+        _assert_private_review_runner_identity(
+            path,
+            descriptor,
+            expected_sha256=expected_sha256,
+        )
+        try:
+            yield path
+        finally:
+            events = watcher.control(None, 8, 0)
+            if events:
+                raise AV1ValidationDerivationError(
+                    "AV1 derivation private Every Code executable changed during review"
+                )
+            _assert_private_review_runner_identity(
+                path,
+                descriptor,
+                expected_sha256=expected_sha256,
+            )
+    finally:
+        if watcher is not None:
+            watcher.close()
+        if descriptor >= 0:
+            os.close(descriptor)
+        shutil.rmtree(directory, ignore_errors=True)
 
 
 def _run_code_agent_review(
@@ -932,7 +1065,6 @@ def _run_code_agent_review(
     AV1ValidationDerivationReviewDecision,
 ]:
     before_identity = _authorized_review_runner_identity(plan)
-    resolved_binary = before_identity[0]
     review_run_id = str(uuid.uuid4())
     claim = build_av1_validation_derivation_review_claim(
         plan=plan,
@@ -953,36 +1085,40 @@ def _run_code_agent_review(
         proposal=proposal,
         claim=claim,
     )
-    command = [
-        str(resolved_binary),
-        "-a",
-        "never",
-        "exec",
-        "-s",
-        "read-only",
-        "--json",
-        "--max-seconds",
-        str(_AGENT_REVIEW_MAX_SECONDS),
-        "-",
-    ]
     try:
-        try:
-            completed = subprocess.run(
-                command,
-                cwd=REPOSITORY_ROOT,
-                input=prompt,
-                text=True,
-                capture_output=True,
-                timeout=_AGENT_REVIEW_MAX_SECONDS + 30,
-                check=False,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
-            raise AV1ValidationDerivationError(
-                "AV1 derivation Every Code review did not complete"
-            ) from exc
+        with _private_review_runner(
+            before_identity[3],
+            expected_sha256=before_identity[2],
+        ) as review_runner:
+            command = [
+                str(review_runner),
+                "-a",
+                "never",
+                "exec",
+                "-s",
+                "read-only",
+                "--json",
+                "--max-seconds",
+                str(_AGENT_REVIEW_MAX_SECONDS),
+                "-",
+            ]
+            try:
+                completed = subprocess.run(
+                    command,
+                    cwd=REPOSITORY_ROOT,
+                    input=prompt,
+                    text=True,
+                    capture_output=True,
+                    timeout=_AGENT_REVIEW_MAX_SECONDS + 30,
+                    check=False,
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                raise AV1ValidationDerivationError(
+                    "AV1 derivation Every Code review did not complete"
+                ) from exc
     finally:
         after_identity = _authorized_review_runner_identity(plan)
-        if after_identity != before_identity:
+        if after_identity[:3] != before_identity[:3]:
             raise AV1ValidationDerivationError(
                 "AV1 derivation Every Code executable changed during review"
             )
@@ -1102,7 +1238,7 @@ def _agent_review_decision(
         raise AV1ValidationDerivationError(
             "AV1 derivation review verdict does not match its run, proposal, and lane"
         )
-    return decision
+    return cast(AV1ValidationDerivationReviewDecision, decision)
 
 
 def _agent_review_prompt(

--- a/tests/test_av1_cold_start_evaluation.py
+++ b/tests/test_av1_cold_start_evaluation.py
@@ -167,15 +167,29 @@ class AV1ColdStartEvaluationTests(unittest.TestCase):
         self.assertIn("held_out_series_reused", cell.blocking_reasons)
         self.assertIn("local_evidence_contamination", cell.blocking_reasons)
 
-    def test_wide_candidate_and_derivation_overlap_are_rejected(self) -> None:
+    def test_wide_candidate_is_rejected_at_the_type_boundary(self) -> None:
+        manifest = self._manifest()
+        plan = self._plan(manifest, "animation_balanced_candidate")
+
+        with self.assertRaisesRegex(
+            AV1ColdStartValidationError,
+            "CRF span is too wide",
+        ):
+            self._candidate_lock(
+                manifest,
+                plan.cell_plan_id,
+                ("animation",),
+                crf_lower=18.0,
+                crf_upper=45.0,
+            )
+
+    def test_derivation_overlap_is_rejected(self) -> None:
         manifest = self._manifest()
         plan = self._plan(manifest, "animation_balanced_candidate")
         candidate_lock = self._candidate_lock(
             manifest,
             plan.cell_plan_id,
             ("animation",),
-            crf_lower=18.0,
-            crf_upper=45.0,
             derivation_source_tokens=(
                 "derivation.source.002",
                 "derivation.source.003",
@@ -192,7 +206,6 @@ class AV1ColdStartEvaluationTests(unittest.TestCase):
         cell = self._cell_report(report, plan.name)
 
         self.assertEqual(cell.decision, "rejected")
-        self.assertIn("candidate_range_too_wide", cell.blocking_reasons)
         self.assertIn("derivation_holdout_source_overlap", cell.blocking_reasons)
 
     def test_duplicate_reviews_are_preregistered_independent_and_safety_bounded(self) -> None:
@@ -397,7 +410,7 @@ class AV1ColdStartEvaluationTests(unittest.TestCase):
         self.assertEqual(first_report.cell_reports, second_report.cell_reports)
         self.assertNotEqual(first_report.report_id, second_report.report_id)
 
-    def test_stale_conflicting_low_confidence_derivation_is_rejected(self) -> None:
+    def test_conflicting_low_confidence_derivation_is_rejected(self) -> None:
         manifest = self._manifest()
         plan = self._plan(manifest, "animation_balanced_candidate")
         candidate_lock = self._candidate_lock(
@@ -406,7 +419,6 @@ class AV1ColdStartEvaluationTests(unittest.TestCase):
             ("animation",),
             confidence_level="limited",
             confidence_score=0.4,
-            derivation_oldest_recorded_at="2025-01-01T00:00:00Z",
             derivation_conflict_count=1,
         )
         results = self._candidate_results(manifest, plan.cell_plan_id, candidate_lock.candidate_lock_id)
@@ -415,8 +427,22 @@ class AV1ColdStartEvaluationTests(unittest.TestCase):
 
         self.assertEqual(cell.decision, "rejected")
         self.assertIn("candidate_confidence_insufficient", cell.blocking_reasons)
-        self.assertIn("derivation_evidence_stale", cell.blocking_reasons)
         self.assertIn("derivation_evidence_conflicting", cell.blocking_reasons)
+
+    def test_stale_derivation_is_rejected_at_the_type_boundary(self) -> None:
+        manifest = self._manifest()
+        plan = self._plan(manifest, "animation_balanced_candidate")
+
+        with self.assertRaisesRegex(
+            AV1ColdStartValidationError,
+            "derivation evidence is stale",
+        ):
+            self._candidate_lock(
+                manifest,
+                plan.cell_plan_id,
+                ("animation",),
+                derivation_oldest_recorded_at="2025-01-01T00:00:00Z",
+            )
 
     def test_oversized_json_number_uses_the_controlled_error_path(self) -> None:
         payload = self._manifest().to_payload()
@@ -521,7 +547,7 @@ class AV1ColdStartEvaluationTests(unittest.TestCase):
                 f"derivation.title.{index:03d}" for index in range(1, 13)
             ),
             derivation_series_tokens=tuple(
-                f"derivation.series.{index:03d}" for index in range(1, 7)
+                f"derivation.series.{index:03d}" for index in range(1, 13)
             ),
             derivation_source_group_tokens=tuple(
                 f"derivation.group.{index:03d}" for index in range(1, 7)

--- a/tests/test_av1_cold_start_evaluation.py
+++ b/tests/test_av1_cold_start_evaluation.py
@@ -427,6 +427,53 @@ class AV1ColdStartEvaluationTests(unittest.TestCase):
         with self.assertRaisesRegex(AV1ColdStartValidationError, "too large"):
             av1_cold_start_validation_manifest_from_payload(payload)
 
+    def test_manifest_rejects_unsatisfiable_derivation_evidence_count(self) -> None:
+        payload = self._manifest().to_payload()
+        criteria = dict(payload["criteria"])
+        criteria["minimum_derivation_evidence_count"] = 13
+        payload["criteria"] = criteria
+
+        with self.assertRaisesRegex(AV1ColdStartValidationError, "exactly twelve"):
+            av1_cold_start_validation_manifest_from_payload(payload)
+
+    def test_candidate_lock_requires_exact_derivation_evidence_count(self) -> None:
+        manifest = self._manifest()
+        plan = self._plan(manifest, "animation_balanced_candidate")
+        candidate_lock = self._candidate_lock(manifest, plan.cell_plan_id, ("animation",))
+
+        with self.assertRaisesRegex(AV1ColdStartValidationError, "requires exactly 12"):
+            replace(
+                candidate_lock,
+                derivation_evidence_count=11,
+                derivation_title_tokens=candidate_lock.derivation_title_tokens[:-1],
+            )
+
+    def test_candidate_lock_rejects_source_group_concentration(self) -> None:
+        manifest = self._manifest()
+        plan = self._plan(manifest, "animation_balanced_candidate")
+        candidate_lock = self._candidate_lock(manifest, plan.cell_plan_id, ("animation",))
+
+        with self.assertRaisesRegex(AV1ColdStartValidationError, "concentration"):
+            replace(
+                candidate_lock,
+                derivation_source_group_observation_tokens=(
+                    *("derivation.group.001",) * 5,
+                    *("derivation.group.002",) * 3,
+                    "derivation.group.003",
+                    "derivation.group.004",
+                    "derivation.group.005",
+                    "derivation.group.006",
+                ),
+            )
+
+    def test_candidate_lock_rejects_zero_quality_floor(self) -> None:
+        manifest = self._manifest()
+        plan = self._plan(manifest, "animation_balanced_candidate")
+        candidate_lock = self._candidate_lock(manifest, plan.cell_plan_id, ("animation",))
+
+        with self.assertRaisesRegex(AV1ColdStartValidationError, "quality floor"):
+            replace(candidate_lock, minimum_quality_score=0.0)
+
     def _manifest(self) -> AV1ColdStartValidationManifestV1:
         return build_preregistered_av1_cold_start_validation_manifest()
 
@@ -470,11 +517,19 @@ class AV1ColdStartEvaluationTests(unittest.TestCase):
             derivation_evidence_count=12,
             derivation_source_count=6,
             derivation_source_tokens=derivation_source_tokens,
+            derivation_title_tokens=tuple(
+                f"derivation.title.{index:03d}" for index in range(1, 13)
+            ),
             derivation_series_tokens=tuple(
                 f"derivation.series.{index:03d}" for index in range(1, 7)
             ),
             derivation_source_group_tokens=tuple(
                 f"derivation.group.{index:03d}" for index in range(1, 7)
+            ),
+            derivation_source_group_observation_tokens=tuple(
+                f"derivation.group.{index:03d}"
+                for index in range(1, 7)
+                for _ in range(2)
             ),
             derivation_oldest_recorded_at=derivation_oldest_recorded_at,
             derivation_newest_recorded_at=derivation_newest_recorded_at,
@@ -537,6 +592,7 @@ class AV1ColdStartEvaluationTests(unittest.TestCase):
             completed_at=f"2026-07-27T{source_index + 2:02d}:00:00Z",
             status="complete",
             source_token=f"source.token.{source_index:03d}",
+            title_token=f"title.token.{source_index:03d}",
             series_token=f"series.token.{source_index:03d}",
             source_group_token=f"source.group.{((source_index - 1) % 6) + 1:02d}",
             content_traits=traits,
@@ -570,6 +626,7 @@ class AV1ColdStartEvaluationTests(unittest.TestCase):
             "completed_at": result.completed_at,
             "status": result.status,
             "source_token": result.source_token,
+            "title_token": result.title_token,
             "series_token": result.series_token,
             "source_group_token": result.source_group_token,
             "content_traits": result.content_traits,

--- a/tests/test_av1_validation_derivation.py
+++ b/tests/test_av1_validation_derivation.py
@@ -107,7 +107,7 @@ V2_MANIFEST_PATH = Path("docs/validation/av1-cold-start-preregistration-v2.json"
 SELECTED_AT = "2026-07-27T22:50:00Z"
 AUTHORIZED_AT = "2026-07-28T00:00:00Z"
 VALID_UNTIL = "2026-08-01T00:00:00Z"
-REVIEW_RUNNER_BYTES = b"test-code-binary"
+REVIEW_RUNNER_BYTES = b"\xcf\xfa\xed\xfe" + b"test-code-binary"
 
 
 class AV1ValidationDerivationTests(unittest.TestCase):
@@ -497,6 +497,13 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             launched_runner = Path(run_review.call_args.args[0][0])
             self.assertNotEqual(launched_runner, code_binary)
             self.assertFalse(launched_runner.exists())
+            review_command = run_review.call_args.args[0]
+            self.assertIn('shell_environment_policy.inherit="none"', review_command)
+            review_environment = run_review.call_args.kwargs["env"]
+            self.assertEqual(
+                review_environment["PATH"],
+                verify_av1_cold_start_preregistration._AGENT_REVIEW_SAFE_PATH,
+            )
             evidence_payload = json.loads(evidence)
             self.assertEqual(evidence_payload["review_run_id"], agent_id)
             self.assertEqual(evidence_payload["returncode"], 0)
@@ -514,6 +521,61 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 evidence,
                 review=review,
             )
+
+    def test_review_runner_rejects_interpreter_script(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            runner = Path(directory) / "code"
+            runner.write_text("#!/usr/bin/env node\n", encoding="utf-8")
+            runner.chmod(0o700)
+            with (
+                patch.object(
+                    verify_av1_cold_start_preregistration.shutil,
+                    "which",
+                    return_value=str(runner),
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "native Mach-O",
+                ),
+            ):
+                verify_av1_cold_start_preregistration._review_runner_identity()
+
+    def test_review_runner_environment_removes_injection_overrides(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "DYLD_INSERT_LIBRARIES": "/private/injected.dylib",
+                "HOME": "/private/fake-home",
+                "GIT_EXEC_PATH": "/private/git-tools",
+                "LD_PRELOAD": "/private/injected.so",
+                "NODE_OPTIONS": "--require=/private/injected.js",
+                "OPENAI_BASE_URL": "https://invalid.example",
+                "PATH": "/private/bin:/usr/bin",
+                "SAFE_REVIEW_VALUE": "retained",
+            },
+            clear=False,
+        ):
+            environment = (
+                verify_av1_cold_start_preregistration._review_runner_environment()
+            )
+        self.assertEqual(
+            environment["PATH"],
+            verify_av1_cold_start_preregistration._AGENT_REVIEW_SAFE_PATH,
+        )
+        self.assertEqual(environment["SAFE_REVIEW_VALUE"], "retained")
+        self.assertEqual(
+            environment["HOME"],
+            verify_av1_cold_start_preregistration._review_user_home(),
+        )
+        self.assertEqual(environment["SHELL"], "/bin/zsh")
+        for key in (
+            "DYLD_INSERT_LIBRARIES",
+            "GIT_EXEC_PATH",
+            "LD_PRELOAD",
+            "NODE_OPTIONS",
+            "OPENAI_BASE_URL",
+        ):
+            self.assertNotIn(key, environment)
 
     def test_review_runner_rejects_path_substitution_before_launch(self) -> None:
         with (

--- a/tests/test_av1_validation_derivation.py
+++ b/tests/test_av1_validation_derivation.py
@@ -63,6 +63,7 @@ from mediaforce.web.runtime.av1_validation_derivation import (
     _assert_next_assignment,
     _current_derivation_review_artifact_fingerprint,
     _prepare_derivation_review_root,
+    _recover_interrupted_derivation_state,
     _secure_derivation_review_media,
     assert_av1_validation_derivation_execution_contract,
     av1_validation_derivation_execution_environment_sha256,
@@ -321,6 +322,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                     assignment_id=self.plan.assignments[0].assignment_id,
                     plan_id=self.plan.plan_id,
                     authorization_id=self.plan.authorization.authorization_id,
+                    claimed_at="2026-07-28T01:00:00Z",
                 )
             fsynced_paths = {
                 call.args[0] for call in fsync_directory.call_args_list
@@ -533,6 +535,11 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                     "which",
                     return_value=str(runner),
                 ),
+                patch.object(
+                    verify_av1_cold_start_preregistration,
+                    "_trusted_code_ancestor_path",
+                    return_value=runner.resolve(),
+                ),
                 self.assertRaisesRegex(
                     AV1ValidationDerivationError,
                     "native Mach-O",
@@ -562,13 +569,15 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             environment["PATH"],
             verify_av1_cold_start_preregistration._AGENT_REVIEW_SAFE_PATH,
         )
-        self.assertEqual(environment["SAFE_REVIEW_VALUE"], "retained")
+        self.assertNotIn("SAFE_REVIEW_VALUE", environment)
         self.assertEqual(
             environment["HOME"],
             verify_av1_cold_start_preregistration._review_user_home(),
         )
         self.assertEqual(environment["SHELL"], "/bin/zsh")
         for key in (
+            "AWS_SECRET_ACCESS_KEY",
+            "GITHUB_TOKEN",
             "DYLD_INSERT_LIBRARIES",
             "GIT_EXEC_PATH",
             "LD_PRELOAD",
@@ -576,6 +585,29 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             "OPENAI_BASE_URL",
         ):
             self.assertNotIn(key, environment)
+
+    def test_review_runner_rejects_non_ancestor_native_binary(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            runner = Path(directory) / "code"
+            runner.write_bytes(REVIEW_RUNNER_BYTES)
+            runner.chmod(0o700)
+            with (
+                patch.object(
+                    verify_av1_cold_start_preregistration.shutil,
+                    "which",
+                    return_value=str(runner),
+                ),
+                patch.object(
+                    verify_av1_cold_start_preregistration,
+                    "_trusted_code_ancestor_path",
+                    return_value=Path("/private/trusted/code"),
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "active trusted runner",
+                ),
+            ):
+                verify_av1_cold_start_preregistration._review_runner_identity()
 
     def test_review_runner_rejects_path_substitution_before_launch(self) -> None:
         with (
@@ -720,9 +752,11 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         persisted_ledger = sample_item["stream_budget_ledger"]
         assert isinstance(persisted_ledger, dict)
         ledger = dict(persisted_ledger)
-        ledger["remaining_video_bitrate_bps"] = (
+        totals = dict(ledger["totals"])
+        totals["remaining_video_bitrate_bps"] = (
             assignment.target_video_bitrate_bps + 1
         )
+        ledger["totals"] = totals
         sample_item["stream_budget_ledger"] = ledger
         with self.assertRaisesRegex(
             AV1ValidationDerivationError,
@@ -1499,6 +1533,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 assignment_id=assignment.assignment_id,
                 plan_id=self.plan.plan_id,
                 authorization_id=self.plan.authorization.authorization_id,
+                claimed_at="2026-07-28T01:00:00Z",
             )
             with self.assertRaisesRegex(
                 AV1ValidationDerivationError,
@@ -1510,6 +1545,49 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                     attempts_directory=attempts_dir,
                     terminal_records_directory=root / "records",
                 )
+
+    def test_interrupted_claim_is_terminalized_without_rerunning_media(self) -> None:
+        assignment = self.plan.assignments[0]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            attempts_dir = root / "attempts"
+            records_dir = root / "records"
+            write_av1_validation_derivation_assignment_claim(
+                attempts_dir,
+                assignment_id=assignment.assignment_id,
+                plan_id=self.plan.plan_id,
+                authorization_id=self.plan.authorization.authorization_id,
+                claimed_at="2026-07-28T01:00:00Z",
+            )
+            self.assertTrue(_recover_interrupted_derivation_state(
+                plan=self.plan,
+                partition=self.partition,
+                attempts_directory=attempts_dir,
+                terminal_records_directory=records_dir,
+                completed_at="2026-07-28T01:01:00Z",
+            ))
+            attempt = load_av1_validation_derivation_attempts(attempts_dir)[0]
+            terminal = load_av1_validation_derivation_terminal_records(records_dir)[0]
+            self.assertEqual(attempt.status, "stopped")
+            self.assertEqual(attempt.reason_code, "interrupted_claim")
+            self.assertEqual(terminal.attempt_id, attempt.attempt_id)
+
+    def test_nonreview_attempt_without_terminal_is_recovered(self) -> None:
+        attempt = self._failed_attempt(self.plan.assignments[0].assignment_id)
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            attempts_dir = root / "attempts"
+            records_dir = root / "records"
+            write_av1_validation_derivation_attempt(attempts_dir, attempt)
+            self.assertTrue(_recover_interrupted_derivation_state(
+                plan=self.plan,
+                partition=self.partition,
+                attempts_directory=attempts_dir,
+                terminal_records_directory=records_dir,
+                completed_at="2026-07-28T01:01:00Z",
+            ))
+            terminal = load_av1_validation_derivation_terminal_records(records_dir)[0]
+            self.assertEqual(terminal.attempt_id, attempt.attempt_id)
 
     def test_runtime_rejects_noncanonical_artifact_directories(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -3106,9 +3184,12 @@ def _calibration_payload(
             "content_version_fingerprint": source_identity,
             "duration_seconds": duration_seconds,
             "stream_budget_ledger": {
-                "remaining_video_bitrate_bps": (
-                    assignment.target_video_bitrate_bps
-                ),
+                "schema_version": 1,
+                "totals": {
+                    "remaining_video_bitrate_bps": (
+                        assignment.target_video_bitrate_bps
+                    ),
+                },
             },
         },
         "sample_result": {

--- a/tests/test_av1_validation_derivation.py
+++ b/tests/test_av1_validation_derivation.py
@@ -2,6 +2,7 @@ from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, nullcontext, redirect_stdout
 from dataclasses import replace
+import fcntl
 import hashlib
 import io
 import json
@@ -15,6 +16,9 @@ import unittest
 from unittest.mock import patch
 
 from mediaforce.core.evidence import canonical_json_bytes
+from mediaforce.core.file_integrity import FileIntegrityError, MacOSFileIntegrityGuard
+from mediaforce.core.process_control import ManagedProcessController
+from mediaforce.core.utils import content_version_fingerprint
 from mediaforce.tuning.av1_validation_derivation import (
     AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY,
     AV1_VALIDATION_DERIVATION_REVIEW_LANES,
@@ -66,10 +70,13 @@ from mediaforce.web.runtime.av1_validation_derivation import (
     _assert_next_assignment,
     _current_derivation_review_artifact_fingerprint,
     _prepare_derivation_review_root,
+    _pinned_derivation_source,
     _recover_interrupted_derivation_state,
     _run_av1_validation_derivation_assignment_locked,
     _secure_derivation_review_media,
+    _write_all,
     assert_av1_validation_derivation_execution_contract,
+    assert_av1_validation_derivation_execution_environment,
     av1_validation_derivation_execution_environment_sha256,
     av1_validation_derivation_runtime_context_sha256,
     finalize_av1_validation_derivation_candidate_lock as finalize_runtime_av1_validation_derivation_candidate_lock,
@@ -114,6 +121,10 @@ SELECTED_AT = "2026-07-27T22:50:00Z"
 AUTHORIZED_AT = "2026-07-28T00:00:00Z"
 VALID_UNTIL = "2026-08-01T00:00:00Z"
 REVIEW_RUNNER_BYTES = b"\xcf\xfa\xed\xfe" + b"test-code-binary"
+
+
+def _source_sha256(source: AV1ValidationPartitionSource) -> str:
+    return f"sha256:{hashlib.sha256(source.source_identity.encode()).hexdigest()}"
 
 
 class AV1ValidationDerivationTests(unittest.TestCase):
@@ -164,6 +175,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             token_key=self.token_key,
             expected_token_key_id=av1_validation_partition_key_id(self.token_key),
             selected_at=SELECTED_AT,
+            source_sha256_resolver=_source_sha256,
         )
         runtime_context_sha256 = av1_validation_derivation_runtime_context_sha256(
             self.runtime_config
@@ -222,6 +234,46 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         self.assertTrue(summary["derivation_execution_authorized"])
         self.assertFalse(summary["holdout_execution_authorized"])
         self.assertFalse(summary["guided_probe_allowed"])
+
+    def test_source_digest_drift_invalidates_existing_authorization(self) -> None:
+        changed_item_id = self.partition.assignments[0].local_item_id
+
+        def changed_source_sha256(source: AV1ValidationPartitionSource) -> str:
+            if source.local_item_id == changed_item_id:
+                return f"sha256:{'f' * 64}"
+            return _source_sha256(source)
+
+        drifted_partition = build_av1_validation_private_partition(
+            manifest=self.manifest,
+            eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+            eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+            sources=self.sources,
+            expectations=self.expectations,
+            token_key=self.token_key,
+            expected_token_key_id=av1_validation_partition_key_id(self.token_key),
+            selected_at=SELECTED_AT,
+            source_sha256_resolver=changed_source_sha256,
+        )
+        with self.assertRaises(AV1ValidationDerivationError):
+            build_av1_validation_derivation_plan(
+                manifest=self.manifest,
+                partition=drifted_partition,
+                authorization=self.authorization,
+                runtime_context_sha256=self.plan.runtime_context_sha256,
+            )
+
+    def test_implementation_drift_invalidates_execution_environment(self) -> None:
+        with (
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation._av1_validation_derivation_implementation_sha256",
+                return_value=f"sha256:{'f' * 64}",
+            ),
+            self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "execution environment drifted",
+            ),
+        ):
+            assert_av1_validation_derivation_execution_environment(self.plan)
 
     def test_plan_binding_rejects_digest_valid_assignment_drift(self) -> None:
         assignments = list(self.plan.assignments)
@@ -1014,6 +1066,49 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 status="review_pending",
                 calibration_payload=calibration,
             )
+
+    def test_attempt_requires_pinned_source_evidence(self) -> None:
+        assignment = self.plan.assignments[0]
+        source_identity = _source_identity(self.partition, assignment)
+        mutations = (
+            ("missing digest", "source_snapshot_sha256", None),
+            (
+                "digest drift",
+                "source_snapshot_sha256",
+                f"sha256:{'b' * 64}",
+            ),
+            (
+                "identity drift",
+                "source_snapshot_content_version_fingerprint",
+                "unreserved-source",
+            ),
+            ("size drift", "source_snapshot_size_bytes", 1),
+        )
+        for label, field, value in mutations:
+            calibration = _calibration_payload(
+                assignment=assignment,
+                source_identity=source_identity,
+                crf=28.0,
+                compatibility=_compatibility(assignment),
+            )
+            sample_item = calibration["sample_item"]
+            assert isinstance(sample_item, dict)
+            if value is None:
+                sample_item.pop(field)
+            else:
+                sample_item[field] = value
+            with self.subTest(label=label), self.assertRaises(
+                AV1ValidationDerivationError
+            ):
+                build_av1_validation_derivation_attempt(
+                    plan=self.plan,
+                    partition=self.partition,
+                    assignment_id=assignment.assignment_id,
+                    started_at="2026-07-28T01:00:00Z",
+                    completed_at="2026-07-28T01:05:00Z",
+                    status="review_pending",
+                    calibration_payload=calibration,
+                )
 
     def test_review_claim_race_leaves_one_terminal_unresolved_claim(self) -> None:
         proposal = self._candidate_proposal()
@@ -1915,6 +2010,48 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         self.assertEqual(attempt.reason_code, "interrupted_claim")
         self.assertEqual(terminal.attempt_id, attempt.attempt_id)
 
+    def test_source_integrity_probe_fails_before_assignment_claim(self) -> None:
+        assignment = self.plan.assignments[0]
+        attempts_dir = self.runtime_artifact_root / "attempts"
+        records_dir = self.runtime_artifact_root / "terminal-records"
+        with (
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.assert_av1_validation_derivation_execution_contract"
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.open_readonly_db",
+                return_value=nullcontext(object()),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_av1_validation_partition_inventory",
+                return_value=SimpleNamespace(
+                    sources=self.sources,
+                    expectations=self.expectations,
+                ),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.probe_macos_file_integrity",
+                side_effect=FileIntegrityError("probe failed"),
+            ) as integrity_probe,
+            self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "probe failed before assignment claim",
+            ),
+        ):
+            _run_av1_validation_derivation_assignment_locked(
+                config=self.runtime_config,
+                manifest=self.manifest,
+                partition=self.partition,
+                token_key=self.token_key,
+                plan=self.plan,
+                assignment_id=assignment.assignment_id,
+                attempts_directory=attempts_dir,
+                terminal_records_directory=records_dir,
+                now_iso=lambda: "2026-07-29T01:00:00Z",
+            )
+        integrity_probe.assert_called_once_with(self.runtime_artifact_root.resolve())
+        self.assertFalse(attempts_dir.exists())
+
     def test_fresh_authorization_timestamp_is_sampled_after_preflight(self) -> None:
         assignment = self.plan.assignments[0]
         attempts_dir = self.runtime_artifact_root / "attempts"
@@ -1972,6 +2109,438 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 mediaforce_runtime_lock_path(real_config),
                 mediaforce_runtime_lock_path(alias_config),
             )
+
+    def test_pinned_source_snapshot_survives_original_path_swap(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact_root = root / "artifacts"
+            artifact_root.mkdir(mode=0o700)
+            source_path = root / "source.mkv"
+            original_bytes = b"original-source" * 20_000
+            source_path.write_bytes(original_bytes)
+            source_identity = content_version_fingerprint(
+                source_path,
+                source_path.stat(),
+            )
+            with (
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.shutil.disk_usage",
+                    return_value=SimpleNamespace(free=100 * 1024 ** 3),
+                ),
+                _pinned_derivation_source(
+                    artifact_root=artifact_root,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    source_path=source_path,
+                    expected_content_version_fingerprint=source_identity,
+                    expected_source_sha256=(
+                        f"sha256:{hashlib.sha256(original_bytes).hexdigest()}"
+                    ),
+                    expected_size_bytes=len(original_bytes),
+                    process_controller=ManagedProcessController(),
+                ) as pinned_source,
+            ):
+                moved_source = root / "moved-source.mkv"
+                source_path.rename(moved_source)
+                source_path.write_bytes(b"replacement-source" * 20_000)
+                self.assertEqual(pinned_source.path.read_bytes(), original_bytes)
+                self.assertEqual(
+                    pinned_source.content_version_fingerprint,
+                    source_identity,
+                )
+                self.assertEqual(pinned_source.size_bytes, len(original_bytes))
+                self.assertTrue(pinned_source.content_sha256.startswith("sha256:"))
+                self.assertEqual(pinned_source.path.stat().st_mode & 0o777, 0o400)
+                self.assertEqual(pinned_source.path.parent.stat().st_mode & 0o777, 0o500)
+            self.assertFalse((artifact_root / "source-snapshots").exists())
+
+    def test_pinned_source_snapshot_rejects_full_digest_mismatch_before_media(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact_root = root / "artifacts"
+            artifact_root.mkdir(mode=0o700)
+            source_path = root / "source.mkv"
+            source_bytes = b"registered-source" * 20_000
+            source_path.write_bytes(source_bytes)
+            source_identity = content_version_fingerprint(
+                source_path,
+                source_path.stat(),
+            )
+            media_entered = False
+            with (
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.shutil.disk_usage",
+                    return_value=SimpleNamespace(free=100 * 1024 ** 3),
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "source changed while its snapshot was created",
+                ),
+            ):
+                with _pinned_derivation_source(
+                    artifact_root=artifact_root,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    source_path=source_path,
+                    expected_content_version_fingerprint=source_identity,
+                    expected_source_sha256=f"sha256:{'f' * 64}",
+                    expected_size_bytes=len(source_bytes),
+                    process_controller=ManagedProcessController(),
+                ):
+                    media_entered = True
+            self.assertFalse(media_entered)
+            self.assertFalse((artifact_root / "source-snapshots").exists())
+
+    def test_pinned_source_snapshot_rejects_swap_before_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact_root = root / "artifacts"
+            artifact_root.mkdir(mode=0o700)
+            source_path = root / "source.mkv"
+            registered_bytes = b"registered-source" * 20_000
+            source_path.write_bytes(registered_bytes)
+            source_identity = content_version_fingerprint(
+                source_path,
+                source_path.stat(),
+            )
+            replacement_bytes = b"unreserved-source" * 20_000
+            source_path.write_bytes(replacement_bytes)
+            with (
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.shutil.disk_usage",
+                    return_value=SimpleNamespace(free=100 * 1024 ** 3),
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "source bytes drifted from the frozen reservation",
+                ),
+            ):
+                with _pinned_derivation_source(
+                    artifact_root=artifact_root,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    source_path=source_path,
+                    expected_content_version_fingerprint=source_identity,
+                    expected_source_sha256=(
+                        f"sha256:{hashlib.sha256(registered_bytes).hexdigest()}"
+                    ),
+                    expected_size_bytes=len(replacement_bytes),
+                    process_controller=ManagedProcessController(),
+                ):
+                    pass
+            self.assertFalse((artifact_root / "source-snapshots").exists())
+
+    def test_pinned_source_snapshot_detects_private_snapshot_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact_root = root / "artifacts"
+            artifact_root.mkdir(mode=0o700)
+            source_path = root / "source.mkv"
+            source_bytes = b"registered-source" * 20_000
+            source_path.write_bytes(source_bytes)
+            source_identity = content_version_fingerprint(
+                source_path,
+                source_path.stat(),
+            )
+            with (
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.shutil.disk_usage",
+                    return_value=SimpleNamespace(free=100 * 1024 ** 3),
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "pinned source changed during media execution",
+                ),
+            ):
+                with _pinned_derivation_source(
+                    artifact_root=artifact_root,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    source_path=source_path,
+                    expected_content_version_fingerprint=source_identity,
+                    expected_source_sha256=(
+                        f"sha256:{hashlib.sha256(source_bytes).hexdigest()}"
+                    ),
+                    expected_size_bytes=len(source_bytes),
+                    process_controller=ManagedProcessController(),
+                ) as pinned_source:
+                    pinned_source.path.parent.chmod(0o700)
+                    pinned_source.path.chmod(0o600)
+                    pinned_source.path.write_bytes(b"mutated-source")
+            self.assertFalse((artifact_root / "source-snapshots").exists())
+
+    def test_pinned_source_snapshot_detects_transient_write_and_restore(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact_root = root / "artifacts"
+            artifact_root.mkdir(mode=0o700)
+            source_path = root / "source.mkv"
+            source_bytes = b"registered-source" * 20_000
+            source_path.write_bytes(source_bytes)
+            source_identity = content_version_fingerprint(
+                source_path,
+                source_path.stat(),
+            )
+            with (
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.shutil.disk_usage",
+                    return_value=SimpleNamespace(free=100 * 1024 ** 3),
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "pinned source changed during media execution",
+                ),
+            ):
+                with _pinned_derivation_source(
+                    artifact_root=artifact_root,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    source_path=source_path,
+                    expected_content_version_fingerprint=source_identity,
+                    expected_source_sha256=(
+                        f"sha256:{hashlib.sha256(source_bytes).hexdigest()}"
+                    ),
+                    expected_size_bytes=len(source_bytes),
+                    process_controller=ManagedProcessController(),
+                ) as pinned_source:
+                    pinned_source.path.chmod(0o600)
+                    pinned_source.path.write_bytes(b"transient-source")
+                    pinned_source.path.write_bytes(source_bytes)
+                    pinned_source.path.chmod(0o400)
+            self.assertFalse((artifact_root / "source-snapshots").exists())
+
+    def test_pinned_source_snapshot_detects_hardlink_and_restore(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact_root = root / "artifacts"
+            artifact_root.mkdir(mode=0o700)
+            source_path = root / "source.mkv"
+            source_bytes = b"registered-source" * 20_000
+            source_path.write_bytes(source_bytes)
+            source_identity = content_version_fingerprint(
+                source_path,
+                source_path.stat(),
+            )
+            link_path = root / "snapshot-alias"
+            with (
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.shutil.disk_usage",
+                    return_value=SimpleNamespace(free=100 * 1024 ** 3),
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "pinned source changed during media execution",
+                ),
+            ):
+                with _pinned_derivation_source(
+                    artifact_root=artifact_root,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    source_path=source_path,
+                    expected_content_version_fingerprint=source_identity,
+                    expected_source_sha256=(
+                        f"sha256:{hashlib.sha256(source_bytes).hexdigest()}"
+                    ),
+                    expected_size_bytes=len(source_bytes),
+                    process_controller=ManagedProcessController(),
+                ) as pinned_source:
+                    os.link(pinned_source.path, link_path)
+                    link_path.unlink()
+            self.assertFalse(link_path.exists())
+            self.assertFalse((artifact_root / "source-snapshots").exists())
+
+    def test_pinned_source_snapshot_detects_parent_swap_and_restore(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact_root = root / "artifacts"
+            artifact_root.mkdir(mode=0o700)
+            source_path = root / "source.mkv"
+            source_bytes = b"registered-source" * 20_000
+            source_path.write_bytes(source_bytes)
+            source_identity = content_version_fingerprint(
+                source_path,
+                source_path.stat(),
+            )
+            with (
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.shutil.disk_usage",
+                    return_value=SimpleNamespace(free=100 * 1024 ** 3),
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "pinned source changed during media execution",
+                ),
+            ):
+                with _pinned_derivation_source(
+                    artifact_root=artifact_root,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    source_path=source_path,
+                    expected_content_version_fingerprint=source_identity,
+                    expected_source_sha256=(
+                        f"sha256:{hashlib.sha256(source_bytes).hexdigest()}"
+                    ),
+                    expected_size_bytes=len(source_bytes),
+                    process_controller=ManagedProcessController(),
+                ) as pinned_source:
+                    assignment_root = pinned_source.path.parent
+                    moved_root = assignment_root.with_name(
+                        f"{assignment_root.name}-moved"
+                    )
+                    assignment_root.rename(moved_root)
+                    try:
+                        assignment_root.mkdir(mode=0o700)
+                        replacement_path = assignment_root / pinned_source.path.name
+                        replacement_path.write_bytes(b"replacement-source")
+                        replacement_path.chmod(0o400)
+                        assignment_root.chmod(0o500)
+                        self.assertEqual(
+                            pinned_source.path.read_bytes(),
+                            b"replacement-source",
+                        )
+                    finally:
+                        if assignment_root.exists():
+                            assignment_root.chmod(0o700)
+                            replacement_path = assignment_root / pinned_source.path.name
+                            if replacement_path.exists():
+                                replacement_path.chmod(0o600)
+                                replacement_path.unlink()
+                            assignment_root.rmdir()
+                        moved_root.rename(assignment_root)
+            self.assertFalse((artifact_root / "source-snapshots").exists())
+
+    def test_pinned_source_snapshot_guard_runs_when_body_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact_root = root / "artifacts"
+            artifact_root.mkdir(mode=0o700)
+            source_path = root / "source.mkv"
+            source_bytes = b"registered-source" * 20_000
+            source_path.write_bytes(source_bytes)
+            source_identity = content_version_fingerprint(
+                source_path,
+                source_path.stat(),
+            )
+            with (
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.shutil.disk_usage",
+                    return_value=SimpleNamespace(free=100 * 1024 ** 3),
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "pinned source changed during media execution",
+                ),
+            ):
+                with _pinned_derivation_source(
+                    artifact_root=artifact_root,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    source_path=source_path,
+                    expected_content_version_fingerprint=source_identity,
+                    expected_source_sha256=(
+                        f"sha256:{hashlib.sha256(source_bytes).hexdigest()}"
+                    ),
+                    expected_size_bytes=len(source_bytes),
+                    process_controller=ManagedProcessController(),
+                ) as pinned_source:
+                    pinned_source.path.chmod(0o600)
+                    pinned_source.path.write_bytes(b"transient-source")
+                    pinned_source.path.write_bytes(source_bytes)
+                    pinned_source.path.chmod(0o400)
+                    raise RuntimeError("media body failed")
+
+    def test_pinned_source_snapshot_uses_read_only_monitored_descriptor(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact_root = root / "artifacts"
+            artifact_root.mkdir(mode=0o700)
+            source_path = root / "source.mkv"
+            source_bytes = b"registered-source" * 20_000
+            source_path.write_bytes(source_bytes)
+            source_identity = content_version_fingerprint(
+                source_path,
+                source_path.stat(),
+            )
+            access_modes: list[int] = []
+            original_guard = MacOSFileIntegrityGuard
+
+            def guard_factory(**kwargs: object) -> MacOSFileIntegrityGuard:
+                descriptor = int(kwargs["descriptor"])
+                access_modes.append(
+                    fcntl.fcntl(descriptor, fcntl.F_GETFL) & os.O_ACCMODE
+                )
+                return original_guard(**kwargs)
+
+            with (
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.shutil.disk_usage",
+                    return_value=SimpleNamespace(free=100 * 1024 ** 3),
+                ),
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.MacOSFileIntegrityGuard",
+                    side_effect=guard_factory,
+                ),
+                _pinned_derivation_source(
+                    artifact_root=artifact_root,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    source_path=source_path,
+                    expected_content_version_fingerprint=source_identity,
+                    expected_source_sha256=(
+                        f"sha256:{hashlib.sha256(source_bytes).hexdigest()}"
+                    ),
+                    expected_size_bytes=len(source_bytes),
+                    process_controller=ManagedProcessController(),
+                ),
+            ):
+                pass
+            self.assertEqual(access_modes, [os.O_RDONLY])
+
+    def test_pinned_source_snapshot_rejects_mutation_during_copy(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact_root = root / "artifacts"
+            artifact_root.mkdir(mode=0o700)
+            source_path = root / "source.mkv"
+            source_bytes = b"registered-source" * 400_000
+            source_path.write_bytes(source_bytes)
+            source_stat = source_path.stat()
+            source_identity = content_version_fingerprint(source_path, source_stat)
+            mutation_injected = False
+
+            def write_and_mutate(descriptor: int, payload: bytes) -> None:
+                nonlocal mutation_injected
+                _write_all(descriptor, payload)
+                if mutation_injected:
+                    return
+                mutation_injected = True
+                with source_path.open("r+b") as source_handle:
+                    source_handle.seek(1024 * 1024)
+                    source_handle.write(b"X")
+                os.utime(
+                    source_path,
+                    ns=(source_stat.st_atime_ns, source_stat.st_mtime_ns + 1_000_000_000),
+                )
+
+            with (
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.shutil.disk_usage",
+                    return_value=SimpleNamespace(free=100 * 1024 ** 3),
+                ),
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation._write_all",
+                    side_effect=write_and_mutate,
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "source changed while its snapshot was created",
+                ),
+            ):
+                with _pinned_derivation_source(
+                    artifact_root=artifact_root,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    source_path=source_path,
+                    expected_content_version_fingerprint=source_identity,
+                    expected_source_sha256=(
+                        f"sha256:{hashlib.sha256(source_bytes).hexdigest()}"
+                    ),
+                    expected_size_bytes=len(source_bytes),
+                    process_controller=ManagedProcessController(),
+                ):
+                    pass
+            self.assertTrue(mutation_injected)
+            self.assertFalse((artifact_root / "source-snapshots").exists())
 
     def test_assignment_loader_allows_recovery_before_full_runtime_context_check(self) -> None:
         drifted_config = SimpleNamespace(
@@ -3572,6 +4141,7 @@ def _calibration_payload(
     artifact = f"artifact_{assignment.assignment_id}"
     duration_seconds = 3_600.0
     predicted_video_bytes = round((bitrate * duration_seconds) / 8)
+    source_size_bytes = predicted_video_bytes * 2
     candidate = {
         "attempt": 1,
         "role": "target_seed",
@@ -3605,6 +4175,10 @@ def _calibration_payload(
         "sample_item": {
             "library_item_id": assignment.local_item_id,
             "content_version_fingerprint": source_identity,
+            "source_size_bytes": source_size_bytes,
+            "source_snapshot_sha256": assignment.source_sha256,
+            "source_snapshot_size_bytes": source_size_bytes,
+            "source_snapshot_content_version_fingerprint": source_identity,
             "duration_seconds": duration_seconds,
             "stream_budget_ledger": {
                 "schema_version": 1,

--- a/tests/test_av1_validation_derivation.py
+++ b/tests/test_av1_validation_derivation.py
@@ -26,6 +26,8 @@ from mediaforce.tuning.av1_validation_derivation import (
     AV1ValidationDerivationReviewClaim,
     AV1ValidationDerivationTerminalRecord,
     _attempt_semantic_payload,
+    _code_review_marker,
+    _completed_code_review_message,
     _derivation_id,
     _payload_sha256,
     _terminal_semantic_payload,
@@ -35,6 +37,7 @@ from mediaforce.tuning.av1_validation_derivation import (
     build_av1_validation_derivation_attempt,
     build_av1_validation_derivation_plan,
     build_av1_validation_derivation_review_claim,
+    build_av1_validation_derivation_review_prompt,
     build_av1_validation_derivation_review_attestation,
     build_av1_validation_derivation_review_envelope,
     build_av1_validation_derivation_terminal_record,
@@ -64,6 +67,7 @@ from mediaforce.web.runtime.av1_validation_derivation import (
     _current_derivation_review_artifact_fingerprint,
     _prepare_derivation_review_root,
     _recover_interrupted_derivation_state,
+    _run_av1_validation_derivation_assignment_locked,
     _secure_derivation_review_media,
     assert_av1_validation_derivation_execution_contract,
     av1_validation_derivation_execution_environment_sha256,
@@ -73,6 +77,7 @@ from mediaforce.web.runtime.av1_validation_derivation import (
     record_av1_validation_derivation_visual_verdict,
     run_av1_validation_derivation_assignment,
 )
+from mediaforce.web.runtime_lock import mediaforce_runtime_lock_path
 from mediaforce.tuning.av1_cold_start_evaluation import (
     AV1ColdStartValidationError,
     build_av1_cold_start_validation_candidate_lock,
@@ -423,7 +428,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             code_binary.write_bytes(REVIEW_RUNNER_BYTES)
             code_binary.chmod(0o700)
             final_message = (
-                "Review complete.\n"
+                "Résumé\u2028review\u2029complete.\n"
                 "MEDIAFORCE_AV1_REVIEW_V2 "
                 f"{json.dumps(marker, sort_keys=True, separators=(',', ':'))}"
             )
@@ -438,21 +443,21 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                     "workdir": str(root),
                     "approval": "never",
                     "sandbox": "read-only",
-                }),
-                json.dumps({"prompt": prompt}),
+                }, ensure_ascii=False),
+                json.dumps({"prompt": prompt}, ensure_ascii=False),
                 json.dumps({
                     "msg": {
                         "type": "agent_message",
                         "message": final_message,
                     }
-                }),
+                }, ensure_ascii=False),
                 json.dumps({
                     "msg": {
                         "type": "task_lifecycle",
                         "phase": "quiescent",
                         "last_agent_message": final_message,
                     }
-                }),
+                }, ensure_ascii=False),
             ))
             completed = SimpleNamespace(
                 returncode=0,
@@ -507,6 +512,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 verify_av1_cold_start_preregistration._AGENT_REVIEW_SAFE_PATH,
             )
             evidence_payload = json.loads(evidence)
+            self.assertEqual(evidence, canonical_json_bytes(evidence_payload))
             self.assertEqual(evidence_payload["review_run_id"], agent_id)
             self.assertEqual(evidence_payload["returncode"], 0)
             self.assertNotIn(str(code_binary), evidence.decode("utf-8"))
@@ -546,6 +552,243 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 ),
             ):
                 verify_av1_cold_start_preregistration._review_runner_identity()
+
+    def test_review_recorder_rejects_noncanonical_transcript(self) -> None:
+        agent_id = "12345678-1234-1234-1234-123456789abd"
+        proposal = self._candidate_proposal()
+        expected_claim = build_av1_validation_derivation_review_claim(
+            plan=self.plan,
+            proposal=proposal,
+            lane="architecture",
+            review_run_id=agent_id,
+            review_runner_canonical_path_sha256=(
+                self.authorization.review_runner_canonical_path_sha256
+            ),
+            review_runner_binary_sha256=(
+                self.authorization.review_runner_binary_sha256
+            ),
+            claimed_at="2026-07-28T03:00:00Z",
+        )
+        prompt = verify_av1_cold_start_preregistration._agent_review_prompt(
+            proposal=proposal,
+            claim=expected_claim,
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            code_binary = Path(directory) / "code"
+            code_binary.write_bytes(REVIEW_RUNNER_BYTES)
+            code_binary.chmod(0o700)
+            completed = SimpleNamespace(
+                returncode=0,
+                stdout="\n".join((
+                    json.dumps({
+                        "provider": "test",
+                        "model": "test-model",
+                        "workdir": directory,
+                        "approval": "never",
+                        "sandbox": "read-only",
+                    }),
+                    json.dumps({"prompt": prompt}),
+                    "not-json",
+                )),
+                stderr="",
+            )
+            with (
+                patch.object(
+                    verify_av1_cold_start_preregistration,
+                    "_authorized_review_runner_identity",
+                    return_value=(
+                        code_binary,
+                        self.authorization.review_runner_canonical_path_sha256,
+                        self.authorization.review_runner_binary_sha256,
+                        REVIEW_RUNNER_BYTES,
+                    ),
+                ),
+                patch.object(
+                    verify_av1_cold_start_preregistration.subprocess,
+                    "run",
+                    return_value=completed,
+                ),
+                patch.object(
+                    verify_av1_cold_start_preregistration.uuid,
+                    "uuid4",
+                    return_value=agent_id,
+                ),
+                patch.object(
+                    verify_av1_cold_start_preregistration,
+                    "_now_iso",
+                    return_value="2026-07-28T03:00:00Z",
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "not canonical JSONL",
+                ),
+            ):
+                verify_av1_cold_start_preregistration._run_code_agent_review(
+                    artifact_root=self.runtime_artifact_root,
+                    plan=self.plan,
+                    proposal=proposal,
+                    lane="architecture",
+                )
+            self.assertEqual(
+                load_av1_validation_derivation_review_claims(
+                    self.runtime_artifact_root,
+                    plan=self.plan,
+                    proposal=proposal,
+                ),
+                (expected_claim,),
+            )
+
+    def test_review_transcript_requires_ordered_valid_config_and_prompt(self) -> None:
+        config = {
+            "provider": "test",
+            "model": "test-model",
+            "workdir": "/private/test",
+            "approval": "never",
+            "sandbox": "read-only",
+        }
+        prompt = {"prompt": "review prompt"}
+        final_message = "Review complete."
+        message = {
+            "msg": {
+                "type": "agent_message",
+                "message": final_message,
+            }
+        }
+        completion = {
+            "msg": {
+                "type": "task_lifecycle",
+                "phase": "quiescent",
+                "last_agent_message": final_message,
+            }
+        }
+        cases = (
+            (
+                "malformed config",
+                ({**config, "provider": None}, prompt, message, completion),
+                "configuration is invalid",
+            ),
+            (
+                "config with message fields",
+                (
+                    {
+                        **config,
+                        "msg": {
+                            "type": "agent_message",
+                            "message": final_message,
+                        },
+                    },
+                    prompt,
+                    message,
+                    completion,
+                ),
+                "configuration is invalid",
+            ),
+            (
+                "duplicate prompt",
+                (config, prompt, prompt, message, completion),
+                "prompt is duplicated or out of order",
+            ),
+            (
+                "smuggled duplicate prompt",
+                (
+                    config,
+                    prompt,
+                    {
+                        "prompt": "drifted prompt",
+                        "msg": {
+                            "type": "agent_message",
+                            "message": final_message,
+                        },
+                    },
+                    completion,
+                ),
+                "prompt is duplicated or out of order",
+            ),
+            (
+                "smuggled config field",
+                (
+                    config,
+                    prompt,
+                    {
+                        "provider": "drifted-provider",
+                        "msg": {
+                            "type": "agent_message",
+                            "message": final_message,
+                        },
+                    },
+                    completion,
+                ),
+                "configuration is duplicated or out of order",
+            ),
+            (
+                "prompt after completion",
+                (config, prompt, message, completion, prompt),
+                "events after completion",
+            ),
+            (
+                "malformed early completion",
+                (
+                    config,
+                    prompt,
+                    {
+                        "msg": {
+                            "type": "task_lifecycle",
+                            "phase": "quiescent",
+                            "last_agent_message": None,
+                        }
+                    },
+                    message,
+                    completion,
+                ),
+                "completion is invalid",
+            ),
+        )
+        for label, events, expected_error in cases:
+            with self.subTest(label=label), self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                expected_error,
+            ):
+                _completed_code_review_message("\n".join(
+                    canonical_json_bytes(event).decode("utf-8")
+                    for event in events
+                ))
+
+        duplicate_key_lines = (
+            (
+                "duplicate prompt key",
+                '{"prompt":"first","prompt":"review prompt"}',
+            ),
+            (
+                "duplicate config key",
+                (
+                    '{"provider":"first","provider":"test",'
+                    '"model":"test-model","workdir":"/private/test",'
+                    '"approval":"never","sandbox":"read-only"}'
+                ),
+            ),
+        )
+        for label, duplicate_line in duplicate_key_lines:
+            lines = [
+                canonical_json_bytes(config).decode("utf-8"),
+                canonical_json_bytes(prompt).decode("utf-8"),
+                canonical_json_bytes(message).decode("utf-8"),
+                canonical_json_bytes(completion).decode("utf-8"),
+            ]
+            lines[0 if "config" in label else 1] = duplicate_line
+            with self.subTest(label=label), self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "duplicate JSON keys",
+            ):
+                _completed_code_review_message("\n".join(lines))
+
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "duplicate JSON keys",
+        ):
+            _code_review_marker(
+                'MEDIAFORCE_AV1_REVIEW_V2 '
+                '{"decision":"approved","decision":"rejected"}'
+            )
 
     def test_review_runner_environment_removes_injection_overrides(self) -> None:
         with patch.dict(
@@ -962,6 +1205,56 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         with self.assertRaisesRegex(
             AV1ValidationDerivationError,
             "digest does not match its canonical evidence",
+        ):
+            validate_av1_validation_derivation_review_run_evidence(
+                evidence,
+                review=review,
+            )
+
+    def test_review_evidence_rejects_prompt_drift_with_matching_digest(self) -> None:
+        proposal = self._candidate_proposal()
+        claim = build_av1_validation_derivation_review_claim(
+            plan=self.plan,
+            proposal=proposal,
+            lane="architecture",
+            review_run_id="50000000-0000-0000-0000-000000000002",
+            review_runner_canonical_path_sha256=(
+                self.authorization.review_runner_canonical_path_sha256
+            ),
+            review_runner_binary_sha256=(
+                self.authorization.review_runner_binary_sha256
+            ),
+            claimed_at="2026-07-28T03:00:01Z",
+        )
+        evidence_payload = json.loads(
+            _review_run_evidence(proposal=proposal, claim=claim)
+        )
+        events = [
+            json.loads(line)
+            for line in str(evidence_payload["stdout"]).split("\n")
+        ]
+        drifted_prompt = f"proposal_id={proposal.proposal_id}"
+        events[1] = {"prompt": drifted_prompt}
+        evidence_payload["stdout"] = "\n".join(
+            canonical_json_bytes(event).decode("utf-8")
+            for event in events
+        )
+        evidence_payload["prompt_sha256"] = (
+            f"sha256:{hashlib.sha256(drifted_prompt.encode('utf-8')).hexdigest()}"
+        )
+        evidence = canonical_json_bytes(evidence_payload)
+        review = build_av1_validation_derivation_review_attestation(
+            proposal=proposal,
+            claim=claim,
+            review_evidence_sha256=(
+                f"sha256:{hashlib.sha256(evidence).hexdigest()}"
+            ),
+            decision="approved",
+            reviewed_at="2026-07-28T03:01:00Z",
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "prompt does not match its frozen inputs",
         ):
             validate_av1_validation_derivation_review_run_evidence(
                 evidence,
@@ -1571,6 +1864,136 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             self.assertEqual(attempt.status, "stopped")
             self.assertEqual(attempt.reason_code, "interrupted_claim")
             self.assertEqual(terminal.attempt_id, attempt.attempt_id)
+
+    def test_interrupted_claim_terminalizes_before_live_inventory_validation(self) -> None:
+        assignment = self.plan.assignments[0]
+        attempts_dir = self.runtime_artifact_root / "attempts"
+        records_dir = self.runtime_artifact_root / "terminal-records"
+        write_av1_validation_derivation_assignment_claim(
+            attempts_dir,
+            assignment_id=assignment.assignment_id,
+            plan_id=self.plan.plan_id,
+            authorization_id=self.plan.authorization.authorization_id,
+            claimed_at="2026-07-28T01:00:00Z",
+        )
+        drifted_config = SimpleNamespace(
+            paths=SimpleNamespace(
+                db_path=self.runtime_config.paths.db_path.with_name("drifted.sqlite3"),
+                review_dir=self.runtime_config.paths.review_dir.with_name("drifted-review"),
+                web_state_dir=self.runtime_config.paths.web_state_dir,
+            )
+        )
+        with (
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.open_readonly_db",
+                side_effect=AssertionError("live inventory must not be read"),
+            ) as open_database,
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.assert_av1_validation_derivation_execution_contract",
+                side_effect=AssertionError("execution drift must not be checked"),
+            ) as execution_contract,
+            self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "interrupted state was terminalized",
+            ),
+        ):
+            _run_av1_validation_derivation_assignment_locked(
+                config=drifted_config,
+                manifest=self.manifest,
+                partition=self.partition,
+                token_key=self.token_key,
+                plan=self.plan,
+                assignment_id=assignment.assignment_id,
+                attempts_directory=attempts_dir,
+                terminal_records_directory=records_dir,
+                now_iso=lambda: "2026-07-28T01:01:00Z",
+            )
+        open_database.assert_not_called()
+        execution_contract.assert_not_called()
+        attempt = load_av1_validation_derivation_attempts(attempts_dir)[0]
+        terminal = load_av1_validation_derivation_terminal_records(records_dir)[0]
+        self.assertEqual(attempt.reason_code, "interrupted_claim")
+        self.assertEqual(terminal.attempt_id, attempt.attempt_id)
+
+    def test_fresh_authorization_timestamp_is_sampled_after_preflight(self) -> None:
+        assignment = self.plan.assignments[0]
+        attempts_dir = self.runtime_artifact_root / "attempts"
+        records_dir = self.runtime_artifact_root / "terminal-records"
+        timestamps = iter(("2026-07-31T23:59:59Z", VALID_UNTIL))
+        with (
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.assert_av1_validation_derivation_execution_contract"
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.open_readonly_db",
+                return_value=nullcontext(object()),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_av1_validation_partition_inventory",
+                return_value=SimpleNamespace(
+                    sources=self.sources,
+                    expectations=self.expectations,
+                ),
+            ),
+            self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "outside its authorization window",
+            ),
+        ):
+            _run_av1_validation_derivation_assignment_locked(
+                config=self.runtime_config,
+                manifest=self.manifest,
+                partition=self.partition,
+                token_key=self.token_key,
+                plan=self.plan,
+                assignment_id=assignment.assignment_id,
+                attempts_directory=attempts_dir,
+                terminal_records_directory=records_dir,
+                now_iso=lambda: next(timestamps),
+            )
+        self.assertFalse(attempts_dir.exists())
+
+    def test_runtime_lock_path_canonicalizes_web_state_symlinks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state_dir = root / "real" / "state"
+            state_dir.mkdir(parents=True)
+            alias_parent = root / "alias"
+            alias_parent.mkdir()
+            alias_state = alias_parent / "state"
+            alias_state.symlink_to(state_dir, target_is_directory=True)
+            real_config = SimpleNamespace(
+                paths=SimpleNamespace(web_state_dir=state_dir)
+            )
+            alias_config = SimpleNamespace(
+                paths=SimpleNamespace(web_state_dir=alias_state)
+            )
+            self.assertEqual(
+                mediaforce_runtime_lock_path(real_config),
+                mediaforce_runtime_lock_path(alias_config),
+            )
+
+    def test_assignment_loader_allows_recovery_before_full_runtime_context_check(self) -> None:
+        drifted_config = SimpleNamespace(
+            paths=SimpleNamespace(
+                db_path=self.runtime_config.paths.db_path.with_name("drifted.sqlite3"),
+                review_dir=self.runtime_config.paths.review_dir.with_name("drifted-review"),
+                web_state_dir=self.runtime_config.paths.web_state_dir,
+            )
+        )
+        with patch.object(
+            verify_av1_cold_start_preregistration,
+            "load_config",
+            return_value=drifted_config,
+        ):
+            plan, artifact_root = (
+                verify_av1_cold_start_preregistration._load_recovery_capable_derivation_plan(
+                    plan_path=self.runtime_artifact_root / "plan.json",
+                    config_path=Path("unused.toml"),
+                )
+            )
+        self.assertEqual(plan, self.plan)
+        self.assertEqual(artifact_root, self.runtime_artifact_root.resolve())
 
     def test_nonreview_attempt_without_terminal_is_recovered(self) -> None:
         attempt = self._failed_attempt(self.plan.assignments[0].assignment_id)
@@ -3231,7 +3654,7 @@ def _calibration_payload(
 
 def _review_run_evidence(
         *,
-        proposal: object,
+        proposal: AV1ValidationDerivationCandidateProposal,
         claim: AV1ValidationDerivationReviewClaim,
         decision: Literal["approved", "rejected"] = "approved",
 ) -> bytes:
@@ -3241,13 +3664,9 @@ def _review_run_evidence(
     review_run_id = str(getattr(claim, "review_run_id"))
     review_claim_id = str(getattr(claim, "claim_id"))
     review_claim_payload_sha256 = str(getattr(claim, "payload_sha256"))
-    prompt = (
-        f"review_run_id={review_run_id}\n"
-        f"proposal_id={proposal_id}\n"
-        f"proposal_payload_sha256={proposal_payload_sha256}\n"
-        f"review_claim_id={review_claim_id}\n"
-        f"review_claim_payload_sha256={review_claim_payload_sha256}\n"
-        f"lane={lane}"
+    prompt = build_av1_validation_derivation_review_prompt(
+        proposal=proposal,
+        claim=claim,
     )
     marker = {
         "decision": decision,
@@ -3261,30 +3680,30 @@ def _review_run_evidence(
     final_message = (
         "Review complete.\n"
         "MEDIAFORCE_AV1_REVIEW_V2 "
-        f"{json.dumps(marker, sort_keys=True, separators=(',', ':'))}"
+        f"{canonical_json_bytes(marker).decode('utf-8')}"
     )
     stdout = "\n".join((
-        json.dumps({
+        canonical_json_bytes({
             "provider": "test",
             "model": "test-model",
             "workdir": "/private/test",
             "approval": "never",
             "sandbox": "read-only",
-        }, sort_keys=True),
-        json.dumps({"prompt": prompt}, sort_keys=True),
-        json.dumps({
+        }).decode("utf-8"),
+        canonical_json_bytes({"prompt": prompt}).decode("utf-8"),
+        canonical_json_bytes({
             "msg": {
                 "type": "agent_message",
                 "message": final_message,
             }
-        }, sort_keys=True),
-        json.dumps({
+        }).decode("utf-8"),
+        canonical_json_bytes({
             "msg": {
                 "type": "task_lifecycle",
                 "phase": "quiescent",
                 "last_agent_message": final_message,
             }
-        }, sort_keys=True),
+        }).decode("utf-8"),
     ))
     return canonical_json_bytes({
         "schema": "mediaforce.av1_derivation_agent_review_run",
@@ -3303,6 +3722,8 @@ def _review_run_evidence(
         "review_runner_binary_sha256": str(
             getattr(claim, "review_runner_binary_sha256")
         ),
+        "proposal": proposal.to_payload(),
+        "review_claim": claim.to_payload(),
         "prompt_sha256": f"sha256:{hashlib.sha256(prompt.encode('utf-8')).hexdigest()}",
         "stdout": stdout,
         "stderr": "",

--- a/tests/test_av1_validation_derivation.py
+++ b/tests/test_av1_validation_derivation.py
@@ -91,6 +91,7 @@ from mediaforce.tuning.av1_validation_v2 import (
 from mediaforce.tuning.content_intent_observations import (
     ContentIntentBoundaryCompatibilityV1,
     ContentIntentBoundaryObservation,
+    ContentIntentObservationConflictError,
     ContentIntentObservationBuildResult,
     _build_observation,
     _rehash_observation,
@@ -106,6 +107,7 @@ V2_MANIFEST_PATH = Path("docs/validation/av1-cold-start-preregistration-v2.json"
 SELECTED_AT = "2026-07-27T22:50:00Z"
 AUTHORIZED_AT = "2026-07-28T00:00:00Z"
 VALID_UNTIL = "2026-08-01T00:00:00Z"
+REVIEW_RUNNER_BYTES = b"test-code-binary"
 
 
 class AV1ValidationDerivationTests(unittest.TestCase):
@@ -175,7 +177,9 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 av1_validation_derivation_statistics_contract_sha256(self.manifest)
             ),
             review_runner_canonical_path_sha256=f"sha256:{'a' * 64}",
-            review_runner_binary_sha256=f"sha256:{'b' * 64}",
+            review_runner_binary_sha256=(
+                f"sha256:{hashlib.sha256(REVIEW_RUNNER_BYTES).hexdigest()}"
+            ),
             authorized_at=AUTHORIZED_AT,
             valid_until=VALID_UNTIL,
         )
@@ -414,7 +418,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             code_binary = root / "code"
-            code_binary.write_bytes(b"test-code-binary")
+            code_binary.write_bytes(REVIEW_RUNNER_BYTES)
             code_binary.chmod(0o700)
             final_message = (
                 "Review complete.\n"
@@ -461,13 +465,14 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                         code_binary,
                         self.authorization.review_runner_canonical_path_sha256,
                         self.authorization.review_runner_binary_sha256,
+                        REVIEW_RUNNER_BYTES,
                     ),
                 ),
                 patch.object(
                     verify_av1_cold_start_preregistration.subprocess,
                     "run",
                     return_value=completed,
-                ),
+                ) as run_review,
                 patch.object(
                     verify_av1_cold_start_preregistration.uuid,
                     "uuid4",
@@ -489,6 +494,9 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 )
             self.assertEqual(claim, expected_claim)
             self.assertEqual(decision, "approved")
+            launched_runner = Path(run_review.call_args.args[0][0])
+            self.assertNotEqual(launched_runner, code_binary)
+            self.assertFalse(launched_runner.exists())
             evidence_payload = json.loads(evidence)
             self.assertEqual(evidence_payload["review_run_id"], agent_id)
             self.assertEqual(evidence_payload["returncode"], 0)
@@ -516,6 +524,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                     Path("/private/substitute-code"),
                     f"sha256:{'c' * 64}",
                     self.authorization.review_runner_binary_sha256,
+                    REVIEW_RUNNER_BYTES,
                 ),
             ),
             patch.object(
@@ -541,11 +550,13 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             Path("/private/authorized-code"),
             self.authorization.review_runner_canonical_path_sha256,
             self.authorization.review_runner_binary_sha256,
+            REVIEW_RUNNER_BYTES,
         )
         after_identity = (
             Path("/private/substitute-code"),
             f"sha256:{'c' * 64}",
             self.authorization.review_runner_binary_sha256,
+            REVIEW_RUNNER_BYTES,
         )
         completed = SimpleNamespace(returncode=0, stdout="", stderr="")
         with (
@@ -589,6 +600,81 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             )),
             1,
         )
+
+    @unittest.skipUnless(hasattr(__import__("select"), "kqueue"), "requires kqueue")
+    def test_private_review_runner_detects_swap_and_restore(self) -> None:
+        expected_sha256 = (
+            f"sha256:{hashlib.sha256(REVIEW_RUNNER_BYTES).hexdigest()}"
+        )
+        runner_directory: Path | None = None
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "changed during review",
+        ):
+            with verify_av1_cold_start_preregistration._private_review_runner(
+                REVIEW_RUNNER_BYTES,
+                expected_sha256=expected_sha256,
+            ) as runner:
+                runner_directory = runner.parent
+                substitute = runner.with_name("substitute")
+                original = runner.with_name("original")
+                substitute.write_bytes(b"substitute-code-binary")
+                substitute.chmod(0o500)
+                runner.rename(original)
+                substitute.rename(runner)
+                runner.rename(substitute)
+                original.rename(runner)
+        assert runner_directory is not None
+        self.assertFalse(runner_directory.exists())
+
+    @unittest.skipUnless(hasattr(__import__("select"), "kqueue"), "requires kqueue")
+    def test_private_review_runner_detects_write_and_restore(self) -> None:
+        expected_sha256 = (
+            f"sha256:{hashlib.sha256(REVIEW_RUNNER_BYTES).hexdigest()}"
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "changed during review",
+        ):
+            with verify_av1_cold_start_preregistration._private_review_runner(
+                REVIEW_RUNNER_BYTES,
+                expected_sha256=expected_sha256,
+            ) as runner:
+                runner.chmod(0o700)
+                runner.write_bytes(b"substitute-code-binary")
+                runner.write_bytes(REVIEW_RUNNER_BYTES)
+                runner.chmod(0o500)
+
+    def test_attempt_rejects_persisted_stream_budget_drift(self) -> None:
+        assignment = self.plan.assignments[0]
+        calibration = _calibration_payload(
+            assignment=assignment,
+            source_identity=_source_identity(self.partition, assignment),
+            crf=28.0,
+            compatibility=_compatibility(assignment),
+        )
+        sample_item = calibration["sample_item"]
+        assert isinstance(sample_item, dict)
+        persisted_ledger = sample_item["stream_budget_ledger"]
+        assert isinstance(persisted_ledger, dict)
+        ledger = dict(persisted_ledger)
+        ledger["remaining_video_bitrate_bps"] = (
+            assignment.target_video_bitrate_bps + 1
+        )
+        sample_item["stream_budget_ledger"] = ledger
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "unchanged measured full search",
+        ):
+            build_av1_validation_derivation_attempt(
+                plan=self.plan,
+                partition=self.partition,
+                assignment_id=assignment.assignment_id,
+                started_at="2026-07-28T01:00:00Z",
+                completed_at="2026-07-28T01:05:00Z",
+                status="review_pending",
+                calibration_payload=calibration,
+            )
 
     def test_review_claim_race_leaves_one_terminal_unresolved_claim(self) -> None:
         proposal = self._candidate_proposal()
@@ -1577,6 +1663,93 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON,
         )
 
+    def test_derivation_verdict_does_not_write_terminal_on_observation_conflict(self) -> None:
+        assignment = self.plan.assignments[0]
+        source_identity = _source_identity(self.partition, assignment)
+        observation = _observation(
+            assignment=assignment,
+            source_identity=source_identity,
+            crf=28.0,
+            bitrate=1_000_000,
+            verdict="acceptable",
+        )
+        attempt = build_av1_validation_derivation_attempt(
+            plan=self.plan,
+            partition=self.partition,
+            assignment_id=assignment.assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            calibration_payload=_calibration_payload(
+                assignment=assignment,
+                source_identity=source_identity,
+                crf=28.0,
+                compatibility=_compatibility(assignment),
+            ),
+        )
+        write_av1_validation_derivation_attempt(
+            self.runtime_artifact_root / "attempts",
+            attempt,
+        )
+        connection = SimpleNamespace(exec_driver_sql=lambda _sql: None)
+        with (
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_config",
+                return_value=self.runtime_config,
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.open_db",
+                return_value=nullcontext(connection),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_av1_validation_partition_inventory",
+                return_value=SimpleNamespace(
+                    sources=self.sources,
+                    expectations=self.expectations,
+                ),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation._derivation_prefix",
+                return_value="private/derivation",
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.build_visual_content_intent_observation",
+                return_value=ContentIntentObservationBuildResult(observation, None),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation._current_derivation_review_artifact_fingerprint",
+                return_value=attempt.calibration_payload()["review_artifact_fingerprint"],
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.append_content_intent_boundary_observation",
+                side_effect=ContentIntentObservationConflictError("conflict"),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.ensure_av1_validation_derivation_terminal_record"
+            ) as write_terminal,
+            self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "conflicts with existing evidence",
+            ),
+        ):
+            record_av1_validation_derivation_visual_verdict(
+                config_path=Path("unused.toml"),
+                manifest=self.manifest,
+                plan=self.plan,
+                partition=self.partition,
+                token_key=self.token_key,
+                attempt=attempt,
+                terminal_records_directory=(
+                    self.runtime_artifact_root / "terminal-records"
+                ),
+                verdict="approved",
+                concern_tags=[],
+                evidence_ids=[],
+                moment_indexes=[],
+                recorded_at="2026-07-28T01:06:00Z",
+            )
+        write_terminal.assert_not_called()
+
     def test_derivation_verdict_rejects_changed_review_media(self) -> None:
         assignment = self.plan.assignments[0]
         attempt = build_av1_validation_derivation_attempt(
@@ -1807,9 +1980,9 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             "verdict-intent",
             "terminal-intent",
             "db-append",
+            "terminal-record",
             "db-exit",
             "execution-contract",
-            "terminal-record",
             "lock-exit",
         ])
 
@@ -2542,6 +2715,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                         root / "private-code-runner",
                         self.authorization.review_runner_canonical_path_sha256,
                         self.authorization.review_runner_binary_sha256,
+                        REVIEW_RUNNER_BYTES,
                     ),
                 ),
                 redirect_stdout(stdout),
@@ -2869,6 +3043,11 @@ def _calibration_payload(
             "library_item_id": assignment.local_item_id,
             "content_version_fingerprint": source_identity,
             "duration_seconds": duration_seconds,
+            "stream_budget_ledger": {
+                "remaining_video_bitrate_bps": (
+                    assignment.target_video_bitrate_bps
+                ),
+            },
         },
         "sample_result": {
             "chosen_crf": crf,

--- a/tests/test_av1_validation_derivation.py
+++ b/tests/test_av1_validation_derivation.py
@@ -1,0 +1,2092 @@
+from contextlib import redirect_stdout
+from dataclasses import replace
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+from types import SimpleNamespace
+from typing import Literal, Sequence
+import unittest
+from unittest.mock import patch
+
+from mediaforce.core.evidence import canonical_json_bytes
+from mediaforce.tuning.av1_validation_derivation import (
+    AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY,
+    AV1_VALIDATION_DERIVATION_REVIEW_LANES,
+    AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON,
+    AV1ValidationDerivationAttempt,
+    AV1ValidationDerivationError,
+    AV1ValidationDerivationPlan,
+    AV1ValidationDerivationTerminalRecord,
+    _attempt_semantic_payload,
+    _derivation_id,
+    _payload_sha256,
+    _terminal_semantic_payload,
+    assert_av1_validation_derivation_authorization_active,
+    av1_validation_derivation_plan_public_summary,
+    av1_validation_derivation_statistics_contract_sha256,
+    build_av1_validation_derivation_attempt,
+    build_av1_validation_derivation_plan,
+    build_av1_validation_derivation_review_attestation,
+    build_av1_validation_derivation_review_envelope,
+    build_av1_validation_derivation_terminal_record,
+    evaluate_av1_validation_derivation_candidate,
+    _finalize_and_write_av1_validation_derivation_candidate_lock as finalize_and_write_av1_validation_derivation_candidate_lock,
+    finalize_av1_validation_derivation_candidate_lock,
+    load_av1_validation_derivation_candidate_proposal,
+    _load_verified_av1_validation_derivation_candidate_lock as load_verified_av1_validation_derivation_candidate_lock,
+    load_av1_validation_derivation_plan,
+    load_av1_validation_derivation_attempts,
+    load_av1_validation_derivation_review_envelopes,
+    load_av1_validation_derivation_terminal_records,
+    resolve_av1_validation_derivation_verdict_intent,
+    validate_av1_validation_derivation_review_run_evidence,
+    validate_av1_validation_derivation_plan_binding,
+    write_av1_validation_derivation_candidate_proposal,
+    write_av1_validation_derivation_plan,
+    write_av1_validation_derivation_review_envelope,
+    write_av1_validation_derivation_attempt,
+    write_av1_validation_derivation_assignment_claim,
+    write_av1_validation_derivation_terminal_record,
+)
+from mediaforce.web.runtime.av1_validation_derivation import (
+    _assert_next_assignment,
+    _current_derivation_review_artifact_fingerprint,
+    _prepare_derivation_review_root,
+    _secure_derivation_review_media,
+    assert_av1_validation_derivation_execution_contract,
+    av1_validation_derivation_execution_environment_sha256,
+    av1_validation_derivation_runtime_context_sha256,
+    finalize_av1_validation_derivation_candidate_lock as finalize_runtime_av1_validation_derivation_candidate_lock,
+    load_verified_av1_validation_derivation_candidate_lock as load_verified_runtime_av1_validation_derivation_candidate_lock,
+    record_av1_validation_derivation_visual_verdict,
+    run_av1_validation_derivation_assignment,
+)
+from mediaforce.tuning.av1_cold_start_evaluation import (
+    AV1ColdStartValidationError,
+    build_av1_cold_start_validation_candidate_lock,
+)
+from mediaforce.tuning.av1_validation_partition import (
+    AV1ValidationPartitionAssignment,
+    AV1ValidationPartitionExpectations,
+    AV1ValidationPartitionSource,
+    AV1ValidationPrivatePartition,
+    av1_validation_partition_key_id,
+    build_av1_validation_private_partition,
+)
+from mediaforce.tuning.av1_validation_v2 import (
+    build_av1_validation_v2_derivation_authorization,
+    load_av1_validation_manifest_v2,
+)
+from mediaforce.tuning.content_intent_observations import (
+    ContentIntentBoundaryCompatibilityV1,
+    ContentIntentBoundaryObservation,
+    ContentIntentObservationBuildResult,
+    _build_observation,
+    _rehash_observation,
+    build_content_intent_boundary_compatibility,
+    correct_content_intent_boundary_observation,
+    replay_content_intent_personalization,
+    withdraw_content_intent_boundary_observation,
+)
+from scripts import verify_av1_cold_start_preregistration
+
+
+V2_MANIFEST_PATH = Path("docs/validation/av1-cold-start-preregistration-v2.json")
+SELECTED_AT = "2026-07-27T22:50:00Z"
+AUTHORIZED_AT = "2026-07-28T00:00:00Z"
+VALID_UNTIL = "2026-08-01T00:00:00Z"
+
+
+class AV1ValidationDerivationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        runtime_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(runtime_directory.cleanup)
+        runtime_root = Path(runtime_directory.name)
+        self.runtime_config = SimpleNamespace(
+            paths=SimpleNamespace(
+                db_path=runtime_root / "mediaforce.sqlite3",
+                review_dir=runtime_root / "review",
+                web_state_dir=runtime_root / "state",
+            )
+        )
+        toolchain_patcher = patch(
+            "mediaforce.web.runtime.av1_validation_derivation.quality_toolchain_identity",
+            return_value={
+                "schema_version": 1,
+                "status": "available",
+                "encoder": "libsvtav1",
+                "encoder_version": "SVT-AV1 Encoder Lib vtest",
+                "encoder_runtime_version": "ffmpeg version test",
+                "encoder_runtime_signature_id": "erti1_test_contract",
+                "quality_tool": "ab-av1",
+                "quality_tool_version": "ab-av1 test",
+                "metric_runtime_signature_id": "qmri1_test_contract",
+                "signature_id": "qti1_test_contract",
+            },
+        )
+        toolchain_patcher.start()
+        self.addCleanup(toolchain_patcher.stop)
+        self.manifest = load_av1_validation_manifest_v2(V2_MANIFEST_PATH)
+        self.expectations = AV1ValidationPartitionExpectations(
+            compatibility_signature="av1vcompat1_test_contract",
+            base_policy_signature="av1vbasepolicy1_test_contract",
+            quality_metric="vmaf",
+            quality_target=85.0,
+            minimum_quality_score=80.0,
+        )
+        self.sources = _partition_sources(self.expectations)
+        self.token_key = b"k" * 32
+        self.partition = build_av1_validation_private_partition(
+            manifest=self.manifest,
+            eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+            eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+            sources=self.sources,
+            expectations=self.expectations,
+            token_key=self.token_key,
+            expected_token_key_id=av1_validation_partition_key_id(self.token_key),
+            selected_at=SELECTED_AT,
+        )
+        runtime_context_sha256 = av1_validation_derivation_runtime_context_sha256(
+            self.runtime_config
+        )
+        execution_environment_sha256 = (
+            av1_validation_derivation_execution_environment_sha256(
+                quality_metric=self.expectations.quality_metric,
+            )
+        )
+        self.authorization = build_av1_validation_v2_derivation_authorization(
+            manifest=self.manifest,
+            selection_lock_sha256=self.partition.selection_lock_sha256,
+            derivation_partition_sha256=self.partition.derivation_partition_sha256,
+            runtime_context_sha256=runtime_context_sha256,
+            execution_environment_sha256=execution_environment_sha256,
+            statistics_contract_sha256=(
+                av1_validation_derivation_statistics_contract_sha256(self.manifest)
+            ),
+            authorized_at=AUTHORIZED_AT,
+            valid_until=VALID_UNTIL,
+        )
+        self.plan = build_av1_validation_derivation_plan(
+            manifest=self.manifest,
+            partition=self.partition,
+            authorization=self.authorization,
+            runtime_context_sha256=runtime_context_sha256,
+        )
+        self.runtime_artifact_root = (
+            self.runtime_config.paths.web_state_dir
+            / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
+            / self.plan.plan_id
+        )
+        write_av1_validation_derivation_plan(
+            self.runtime_artifact_root,
+            self.plan,
+        )
+
+    def test_plan_contains_only_exact_reserved_derivation_assignments(self) -> None:
+        self.assertEqual(len(self.plan.assignments), 24)
+        self.assertEqual({assignment.role for assignment in self.plan.assignments}, {"derivation"})
+        self.assertEqual(
+            sorted(
+                sum(assignment.cell_plan_id == cell_plan_id for assignment in self.plan.assignments)
+                for cell_plan_id in {assignment.cell_plan_id for assignment in self.plan.assignments}
+            ),
+            [12, 12],
+        )
+        summary = av1_validation_derivation_plan_public_summary(self.plan)
+        serialized = json.dumps(summary)
+        self.assertNotIn("local_item_id", serialized)
+        self.assertNotIn("source_token", serialized)
+        self.assertTrue(summary["derivation_execution_authorized"])
+        self.assertFalse(summary["holdout_execution_authorized"])
+        self.assertFalse(summary["guided_probe_allowed"])
+
+    def test_plan_binding_rejects_digest_valid_assignment_drift(self) -> None:
+        assignments = list(self.plan.assignments)
+        assignments[0] = replace(
+            assignments[0],
+            local_item_id=assignments[1].local_item_id,
+        )
+        semantic_payload = self.plan.semantic_payload()
+        semantic_payload["assignments"] = [
+            assignment.to_payload() for assignment in assignments
+        ]
+        plan_id = _derivation_id("plan", semantic_payload)
+        drifted_plan = AV1ValidationDerivationPlan(
+            plan_id=plan_id,
+            manifest_id=self.plan.manifest_id,
+            manifest_payload_sha256=self.plan.manifest_payload_sha256,
+            partition_id=self.plan.partition_id,
+            partition_payload_sha256=self.plan.partition_payload_sha256,
+            selection_lock_sha256=self.plan.selection_lock_sha256,
+            derivation_partition_sha256=self.plan.derivation_partition_sha256,
+            runtime_context_sha256=self.plan.runtime_context_sha256,
+            authorization=self.plan.authorization,
+            assignments=tuple(assignments),
+            payload_sha256=_payload_sha256({
+                "plan_id": plan_id,
+                **semantic_payload,
+            }),
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "does not match the private partition",
+        ):
+            validate_av1_validation_derivation_plan_binding(
+                plan=drifted_plan,
+                partition=self.partition,
+            )
+
+    def test_derivation_authorization_must_be_active_before_execution(self) -> None:
+        assert_av1_validation_derivation_authorization_active(
+            self.plan,
+            at=AUTHORIZED_AT,
+        )
+        for timestamp in ("2026-07-27T23:59:59Z", VALID_UNTIL):
+            with self.subTest(timestamp=timestamp), self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "outside its authorization window",
+            ):
+                assert_av1_validation_derivation_authorization_active(
+                    self.plan,
+                    at=timestamp,
+                )
+
+    def test_owner_only_plan_and_terminal_files_are_immutable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "private"
+            root.mkdir(mode=0o700)
+            artifact_root = (
+                root
+                / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
+                / self.plan.plan_id
+            )
+            plan_path = write_av1_validation_derivation_plan(
+                artifact_root,
+                self.plan,
+            )
+            self.assertEqual(os.stat(plan_path).st_mode & 0o777, 0o600)
+            self.assertEqual(load_av1_validation_derivation_plan(plan_path), self.plan)
+            with self.assertRaisesRegex(AV1ValidationDerivationError, "already exists"):
+                write_av1_validation_derivation_plan(artifact_root, self.plan)
+
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "plan-global canonical root",
+            ):
+                write_av1_validation_derivation_plan(
+                    root / "alternate" / self.plan.plan_id,
+                    self.plan,
+                )
+
+            record = self._failed_record(self.plan.assignments[0].assignment_id)
+            attempt = self._failed_attempt(self.plan.assignments[0].assignment_id)
+            attempts_dir = root / "attempts"
+            write_av1_validation_derivation_attempt(attempts_dir, attempt)
+            self.assertEqual(load_av1_validation_derivation_attempts(attempts_dir), (attempt,))
+            with self.assertRaisesRegex(AV1ValidationDerivationError, "already exists"):
+                write_av1_validation_derivation_attempt(attempts_dir, attempt)
+
+            records_dir = root / "records"
+            write_av1_validation_derivation_terminal_record(records_dir, record)
+            self.assertEqual(load_av1_validation_derivation_terminal_records(records_dir), (record,))
+            with self.assertRaisesRegex(AV1ValidationDerivationError, "already exists"):
+                write_av1_validation_derivation_terminal_record(records_dir, record)
+
+    def test_review_attestation_identity_comes_from_code_managed_result(self) -> None:
+        agent_id = "12345678-1234-1234-1234-123456789abc"
+        proposal = SimpleNamespace(
+            proposal_id="av1vdproposal1_test",
+            payload_sha256="sha256:" + "a" * 64,
+            proposed_at="2026-07-28T02:00:00Z",
+            to_payload=lambda: {
+                "proposal_id": "av1vdproposal1_test",
+                "payload_sha256": "sha256:" + "a" * 64,
+            },
+        )
+        marker = {
+            "decision": "approved",
+            "lane": "architecture",
+            "proposal_id": proposal.proposal_id,
+            "proposal_payload_sha256": proposal.payload_sha256,
+            "review_run_id": agent_id,
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            code_binary = root / "code"
+            code_binary.write_bytes(b"test-code-binary")
+            code_binary.chmod(0o700)
+            final_message = (
+                "Review complete.\n"
+                "MEDIAFORCE_AV1_REVIEW_V2 "
+                f"{json.dumps(marker, sort_keys=True, separators=(',', ':'))}"
+            )
+            prompt = verify_av1_cold_start_preregistration._agent_review_prompt(
+                proposal=proposal,
+                lane="architecture",
+                review_run_id=agent_id,
+            )
+            stdout = "\n".join((
+                json.dumps({
+                    "provider": "test",
+                    "model": "test-model",
+                    "workdir": str(root),
+                    "approval": "never",
+                    "sandbox": "read-only",
+                }),
+                json.dumps({"prompt": prompt}),
+                json.dumps({
+                    "msg": {
+                        "type": "agent_message",
+                        "message": final_message,
+                    }
+                }),
+                json.dumps({
+                    "msg": {
+                        "type": "task_lifecycle",
+                        "phase": "quiescent",
+                        "last_agent_message": final_message,
+                    }
+                }),
+            ))
+            completed = SimpleNamespace(
+                returncode=0,
+                stdout=stdout,
+                stderr="",
+            )
+            with (
+                patch.object(
+                    verify_av1_cold_start_preregistration.shutil,
+                    "which",
+                    return_value=str(code_binary),
+                ),
+                patch.object(
+                    verify_av1_cold_start_preregistration.subprocess,
+                    "run",
+                    return_value=completed,
+                ),
+                patch.object(
+                    verify_av1_cold_start_preregistration.uuid,
+                    "uuid4",
+                    return_value=agent_id,
+                ),
+            ):
+                reviewer_token, evidence, decision = (
+                    verify_av1_cold_start_preregistration._run_code_agent_review(
+                        proposal=proposal,
+                        lane="architecture",
+                    )
+                )
+            self.assertEqual(reviewer_token, f"agent:{agent_id}")
+            self.assertEqual(decision, "approved")
+            evidence_payload = json.loads(evidence)
+            self.assertEqual(evidence_payload["review_run_id"], agent_id)
+            self.assertEqual(evidence_payload["returncode"], 0)
+            review = build_av1_validation_derivation_review_attestation(
+                proposal=proposal,
+                lane="architecture",
+                reviewer_token=reviewer_token,
+                review_evidence_sha256=(
+                    f"sha256:{hashlib.sha256(evidence).hexdigest()}"
+                ),
+                decision=decision,
+                reviewed_at="2026-07-28T03:00:00Z",
+            )
+            validate_av1_validation_derivation_review_run_evidence(
+                evidence,
+                review=review,
+            )
+
+    def test_verdict_retry_reuses_first_immutable_timestamp(self) -> None:
+        assignment = self.plan.assignments[0]
+        attempt = build_av1_validation_derivation_attempt(
+            plan=self.plan,
+            partition=self.partition,
+            assignment_id=assignment.assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            calibration_payload=_calibration_payload(
+                assignment=assignment,
+                source_identity=_source_identity(self.partition, assignment),
+                crf=28.0,
+                compatibility=_compatibility(assignment),
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            intent_directory = Path(directory) / "verdict-intents"
+            first = resolve_av1_validation_derivation_verdict_intent(
+                intent_directory,
+                plan=self.plan,
+                attempt=attempt,
+                verdict="approved",
+                concern_tags=[],
+                evidence_ids=["evidence_test"],
+                moment_indexes=[1],
+                recorded_at="2026-07-28T01:06:00Z",
+            )
+            retry = resolve_av1_validation_derivation_verdict_intent(
+                intent_directory,
+                plan=self.plan,
+                attempt=attempt,
+                verdict="approved",
+                concern_tags=[],
+                evidence_ids=["evidence_test"],
+                moment_indexes=[1],
+                recorded_at="2026-07-28T01:07:00Z",
+            )
+            self.assertEqual(retry, first)
+            self.assertEqual(retry["recorded_at"], "2026-07-28T01:06:00Z")
+
+    def test_candidate_blocks_missing_failed_and_unacceptable_records(self) -> None:
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [item for item in self.plan.assignments if item.cell_plan_id == cell_plan_id]
+        records = [self._observed_record(item.assignment_id, crf=28.0) for item in assignments[:-1]]
+        records.append(self._failed_record(assignments[-1].assignment_id))
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
+            proposed_at="2026-07-28T03:00:00Z",
+        )
+        self.assertIsNone(evaluation.proposal)
+        self.assertIn("terminal_failed", evaluation.blockers)
+
+        unacceptable = self._observed_record(assignments[-1].assignment_id, crf=28.0, verdict="unacceptable")
+        records[-1] = unacceptable
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
+            proposed_at="2026-07-28T03:00:00Z",
+        )
+        self.assertIsNone(evaluation.proposal)
+        self.assertIn("observation_unacceptable", evaluation.blockers)
+        self.assertEqual(evaluation.derivation_conflict_count, 1)
+
+    def test_candidate_rejects_proposal_before_authorization(self) -> None:
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "outside its authorization window",
+        ):
+            evaluate_av1_validation_derivation_candidate(
+                manifest=self.manifest,
+                plan=self.plan,
+                partition=self.partition,
+                cell_plan_id=self.plan.assignments[0].cell_plan_id,
+                attempts=(),
+                records=(),
+                current_observations={},
+                proposed_at="2026-07-27T23:59:59Z",
+            )
+
+    def test_candidate_rejects_observation_that_is_no_longer_current(self) -> None:
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [item for item in self.plan.assignments if item.cell_plan_id == cell_plan_id]
+        records = [self._observed_record(item.assignment_id, crf=28.0) for item in assignments]
+        current_observations = self._current_observations(records)
+        del current_observations[assignments[0].assignment_id]
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=current_observations,
+            proposed_at="2026-07-28T03:00:00Z",
+        )
+        self.assertIsNone(evaluation.proposal)
+        self.assertIn("observation_not_current", evaluation.blockers)
+
+    def test_candidate_rejects_observation_after_proposal_cutoff(self) -> None:
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [
+            item for item in self.plan.assignments
+            if item.cell_plan_id == cell_plan_id
+        ]
+        records = [
+            self._observed_record(
+                assignment.assignment_id,
+                crf=28.0,
+                recorded_at=(
+                    "2026-07-28T03:01:00Z"
+                    if index == 0
+                    else "2026-07-28T01:06:00Z"
+                ),
+            )
+            for index, assignment in enumerate(assignments)
+        ]
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
+            proposed_at="2026-07-28T03:00:00Z",
+        )
+        self.assertIsNone(evaluation.proposal)
+        self.assertIn("observation_after_proposal", evaluation.blockers)
+
+    def test_candidate_rejects_forged_terminal_projection(self) -> None:
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [
+            item for item in self.plan.assignments if item.cell_plan_id == cell_plan_id
+        ]
+        records = [
+            self._observed_record(item.assignment_id, crf=28.0)
+            for item in assignments
+        ]
+        attempts = self._attempts(records)
+        original = records[0]
+        assert original.observation is not None
+        forged_projection = replace(original.observation, chosen_crf=35.0)
+        assignment = assignments[0]
+        semantic_payload = _terminal_semantic_payload(
+            plan=self.plan,
+            assignment=assignment,
+            attempt=attempts[0],
+            status="observed",
+            reason_code=None,
+            observation=forged_projection,
+        )
+        record_id = _derivation_id("terminal", semantic_payload)
+        records[0] = AV1ValidationDerivationTerminalRecord(
+            record_id=record_id,
+            plan_id=original.plan_id,
+            authorization_id=original.authorization_id,
+            attempt_id=original.attempt_id,
+            attempt_payload_sha256=original.attempt_payload_sha256,
+            assignment_id=original.assignment_id,
+            cell_plan_id=original.cell_plan_id,
+            ordinal=original.ordinal,
+            started_at=original.started_at,
+            completed_at=original.completed_at,
+            status="observed",
+            reason_code=None,
+            observation=forged_projection,
+            payload_sha256=_payload_sha256({
+                "record_id": record_id,
+                **semantic_payload,
+            }),
+        )
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=attempts,
+            records=records,
+            current_observations=self._current_observations([
+                self._observed_record(item.assignment_id, crf=28.0)
+                for item in assignments
+            ]),
+            proposed_at="2026-07-28T03:00:00Z",
+        )
+        self.assertIsNone(evaluation.proposal)
+        self.assertIn("terminal_projection_mismatch", evaluation.blockers)
+
+    def test_attempt_rejects_any_warm_start_trace(self) -> None:
+        assignment = self.plan.assignments[0]
+        payload = _calibration_payload(
+            assignment=assignment,
+            source_identity=_source_identity(self.partition, assignment),
+            crf=28.0,
+            compatibility=_compatibility(assignment),
+        )
+        payload["sample_result"]["target_size_trace"]["warm_start"] = {
+            "status": "accepted",
+        }
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "unchanged measured full search",
+        ):
+            build_av1_validation_derivation_attempt(
+                plan=self.plan,
+                partition=self.partition,
+                assignment_id=assignment.assignment_id,
+                started_at="2026-07-28T01:00:00Z",
+                completed_at="2026-07-28T01:05:00Z",
+                status="review_pending",
+                calibration_payload=payload,
+            )
+
+    def test_attempt_rejects_incomplete_full_search_trace(self) -> None:
+        assignment = self.plan.assignments[0]
+        payload = _calibration_payload(
+            assignment=assignment,
+            source_identity=_source_identity(self.partition, assignment),
+            crf=28.0,
+            compatibility=_compatibility(assignment),
+        )
+        selected_candidate = payload["sample_result"]["target_size_trace"][
+            "selected_candidate"
+        ]
+        del selected_candidate["sampled_clip_bytes"]
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "unchanged measured full search",
+        ):
+            build_av1_validation_derivation_attempt(
+                plan=self.plan,
+                partition=self.partition,
+                assignment_id=assignment.assignment_id,
+                started_at="2026-07-28T01:00:00Z",
+                completed_at="2026-07-28T01:05:00Z",
+                status="review_pending",
+                calibration_payload=payload,
+            )
+
+    def test_terminal_revalidates_loaded_attempt_against_assignment(self) -> None:
+        assignment = self.plan.assignments[0]
+        calibration = _calibration_payload(
+            assignment=assignment,
+            source_identity=_source_identity(self.partition, assignment),
+            crf=28.0,
+            compatibility=_compatibility(assignment),
+        )
+        calibration["sample_item"]["library_item_id"] = self.plan.assignments[1].local_item_id
+        calibration_sha256 = _payload_sha256(calibration)
+        semantic_payload = _attempt_semantic_payload(
+            plan=self.plan,
+            assignment=assignment,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            reason_code=None,
+            calibration_payload=calibration,
+            calibration_payload_sha256=calibration_sha256,
+        )
+        attempt_id = _derivation_id("attempt", semantic_payload)
+        attempt = AV1ValidationDerivationAttempt(
+            attempt_id=attempt_id,
+            plan_id=self.plan.plan_id,
+            authorization_id=self.plan.authorization.authorization_id,
+            assignment_id=assignment.assignment_id,
+            cell_plan_id=assignment.cell_plan_id,
+            ordinal=assignment.ordinal,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            reason_code=None,
+            calibration_payload_json=canonical_json_bytes(calibration).decode("utf-8"),
+            calibration_payload_sha256=calibration_sha256,
+            payload_sha256=_payload_sha256({"attempt_id": attempt_id, **semantic_payload}),
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "unchanged measured full search",
+        ):
+            build_av1_validation_derivation_terminal_record(
+                plan=self.plan,
+                partition=self.partition,
+                attempt=attempt,
+                observation_exclusion_reason="content_intent_observation_excluded",
+            )
+
+    def test_artifact_directories_are_bound_to_one_plan(self) -> None:
+        second_authorization = build_av1_validation_v2_derivation_authorization(
+            manifest=self.manifest,
+            selection_lock_sha256=self.partition.selection_lock_sha256,
+            derivation_partition_sha256=self.partition.derivation_partition_sha256,
+            runtime_context_sha256=self.authorization.runtime_context_sha256,
+            execution_environment_sha256=(
+                self.authorization.execution_environment_sha256
+            ),
+            statistics_contract_sha256=(
+                self.authorization.statistics_contract_sha256
+            ),
+            authorized_at="2026-07-28T00:01:00Z",
+            valid_until=VALID_UNTIL,
+        )
+        second_plan = build_av1_validation_derivation_plan(
+            manifest=self.manifest,
+            partition=self.partition,
+            authorization=second_authorization,
+            runtime_context_sha256=self.plan.runtime_context_sha256,
+        )
+        first_assignment = self.plan.assignments[0]
+        first_attempt = self._failed_attempt(first_assignment.assignment_id)
+        second_attempt = build_av1_validation_derivation_attempt(
+            plan=second_plan,
+            partition=self.partition,
+            assignment_id=first_assignment.assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="failed",
+            reason_code="runtime_failure",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            attempts_dir = Path(directory) / "attempts"
+            write_av1_validation_derivation_attempt(attempts_dir, first_attempt)
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "another artifact set",
+            ):
+                write_av1_validation_derivation_attempt(attempts_dir, second_attempt)
+
+    def test_unsuccessful_attempt_stops_remaining_worklist(self) -> None:
+        first_assignment, second_assignment = self.plan.assignments[:2]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            attempts_dir = root / "attempts"
+            write_av1_validation_derivation_attempt(
+                attempts_dir,
+                self._failed_attempt(first_assignment.assignment_id),
+            )
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "unsuccessful attempt",
+            ):
+                _assert_next_assignment(
+                    plan=self.plan,
+                    assignment_id=second_assignment.assignment_id,
+                    attempts_directory=attempts_dir,
+                    terminal_records_directory=root / "records",
+                )
+
+    def test_review_pending_attempt_requires_human_terminal_before_continuing(self) -> None:
+        first_assignment, second_assignment = self.plan.assignments[:2]
+        attempt = build_av1_validation_derivation_attempt(
+            plan=self.plan,
+            partition=self.partition,
+            assignment_id=first_assignment.assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            calibration_payload=_calibration_payload(
+                assignment=first_assignment,
+                source_identity=_source_identity(self.partition, first_assignment),
+                crf=28.0,
+                compatibility=_compatibility(first_assignment),
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            attempts_dir = root / "attempts"
+            write_av1_validation_derivation_attempt(attempts_dir, attempt)
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "prior human visual terminal",
+            ):
+                _assert_next_assignment(
+                    plan=self.plan,
+                    assignment_id=second_assignment.assignment_id,
+                    attempts_directory=attempts_dir,
+                    terminal_records_directory=root / "records",
+                )
+
+    def test_next_assignment_rejects_terminal_for_another_attempt(self) -> None:
+        first_assignment, second_assignment = self.plan.assignments[:2]
+        source_identity = _source_identity(self.partition, first_assignment)
+        compatibility = _compatibility(first_assignment)
+        persisted_attempt = build_av1_validation_derivation_attempt(
+            plan=self.plan,
+            partition=self.partition,
+            assignment_id=first_assignment.assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            calibration_payload=_calibration_payload(
+                assignment=first_assignment,
+                source_identity=source_identity,
+                crf=28.0,
+                compatibility=compatibility,
+            ),
+        )
+        other_attempt = build_av1_validation_derivation_attempt(
+            plan=self.plan,
+            partition=self.partition,
+            assignment_id=first_assignment.assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            calibration_payload=_calibration_payload(
+                assignment=first_assignment,
+                source_identity=source_identity,
+                crf=29.0,
+                compatibility=compatibility,
+            ),
+        )
+        mismatched_record = build_av1_validation_derivation_terminal_record(
+            plan=self.plan,
+            partition=self.partition,
+            attempt=other_attempt,
+            observation=_observation(
+                assignment=first_assignment,
+                source_identity=source_identity,
+                crf=29.0,
+                bitrate=1_000_000,
+                verdict="acceptable",
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            attempts_dir = root / "attempts"
+            records_dir = root / "records"
+            write_av1_validation_derivation_attempt(attempts_dir, persisted_attempt)
+            write_av1_validation_derivation_terminal_record(records_dir, mismatched_record)
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "does not match its attempt",
+            ):
+                _assert_next_assignment(
+                    plan=self.plan,
+                    assignment_id=second_assignment.assignment_id,
+                    attempts_directory=attempts_dir,
+                    terminal_records_directory=records_dir,
+                )
+
+    def test_next_assignment_requires_attempts_to_form_an_ordered_prefix(self) -> None:
+        first_assignment, second_assignment = self.plan.assignments[:2]
+        record = self._observed_record(second_assignment.assignment_id, crf=28.0)
+        attempt = self._attempts((record,))[0]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            attempts_dir = root / "attempts"
+            records_dir = root / "records"
+            write_av1_validation_derivation_attempt(attempts_dir, attempt)
+            write_av1_validation_derivation_terminal_record(records_dir, record)
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "ordered prefix",
+            ):
+                _assert_next_assignment(
+                    plan=self.plan,
+                    assignment_id=first_assignment.assignment_id,
+                    attempts_directory=attempts_dir,
+                    terminal_records_directory=records_dir,
+                )
+
+    def test_orphaned_claim_stops_remaining_worklist(self) -> None:
+        assignment = self.plan.assignments[0]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            attempts_dir = root / "attempts"
+            write_av1_validation_derivation_assignment_claim(
+                attempts_dir,
+                assignment_id=assignment.assignment_id,
+                plan_id=self.plan.plan_id,
+                authorization_id=self.plan.authorization.authorization_id,
+            )
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "interrupted claimed assignment",
+            ):
+                _assert_next_assignment(
+                    plan=self.plan,
+                    assignment_id=assignment.assignment_id,
+                    attempts_directory=attempts_dir,
+                    terminal_records_directory=root / "records",
+                )
+
+    def test_runtime_rejects_noncanonical_artifact_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with (
+                patch(
+                    "mediaforce.web.runtime.av1_validation_derivation.load_config",
+                    return_value=self.runtime_config,
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationDerivationError,
+                    "plan-global canonical directory",
+                ),
+            ):
+                run_av1_validation_derivation_assignment(
+                    config_path=Path("unused.toml"),
+                    manifest=self.manifest,
+                    partition=self.partition,
+                    token_key=self.token_key,
+                    plan=self.plan,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    attempts_directory=root / "alternate-attempts",
+                    terminal_records_directory=root / "alternate-records",
+                )
+
+    def test_execution_contract_rejects_statistics_drift(self) -> None:
+        with (
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.av1_validation_derivation_statistics_contract_sha256",
+                return_value="sha256:" + "f" * 64,
+            ),
+            self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "statistics contract drifted",
+            ),
+        ):
+            assert_av1_validation_derivation_execution_contract(
+                self.manifest,
+                self.plan,
+            )
+
+    def test_runtime_lock_apis_reject_noncanonical_plan_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            plan_path = Path(directory) / "plan.json"
+            plan_path.write_bytes(canonical_json_bytes(self.plan.to_payload()))
+            plan_path.chmod(0o600)
+            for operation in (
+                finalize_runtime_av1_validation_derivation_candidate_lock,
+                load_verified_runtime_av1_validation_derivation_candidate_lock,
+            ):
+                with self.subTest(operation=operation.__name__):
+                    with (
+                        patch(
+                            "mediaforce.web.runtime.av1_validation_derivation.load_config",
+                            return_value=self.runtime_config,
+                        ),
+                        self.assertRaisesRegex(
+                            AV1ValidationDerivationError,
+                            "config-derived canonical root",
+                        ),
+                    ):
+                        operation(
+                            config_path=Path("unused.toml"),
+                            manifest=self.manifest,
+                            partition=self.partition,
+                            token_key=self.token_key,
+                            plan_path=plan_path,
+                            cell_plan_id=self.plan.assignments[0].cell_plan_id,
+                        )
+
+    def test_derivation_review_media_is_owner_only_and_no_follow(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            artifact_root = Path(directory) / "artifact-root"
+            artifact_root.mkdir(mode=0o700)
+            review_root = _prepare_derivation_review_root(artifact_root)
+            clip_directory = review_root / "run" / "item-00"
+            clip_directory.mkdir(parents=True)
+            clip_path = clip_directory / "encoded-01.mp4"
+            clip_path.write_bytes(b"review-clip")
+
+            _secure_derivation_review_media(review_root)
+
+            self.assertEqual(review_root.stat().st_mode & 0o777, 0o700)
+            self.assertEqual(clip_directory.stat().st_mode & 0o777, 0o700)
+            self.assertEqual(clip_path.stat().st_mode & 0o777, 0o600)
+            calibration = {
+                "preview_clips": [{
+                    "path": clip_path.as_uri(),
+                    "timestamp_seconds": 1.0,
+                    "duration_seconds": 8.0,
+                }],
+                "source_clips": [],
+            }
+            self.assertIsNotNone(
+                _current_derivation_review_artifact_fingerprint(
+                    review_root=review_root,
+                    calibration=calibration,
+                )
+            )
+
+            linked_clip = clip_directory / "linked.mp4"
+            linked_clip.symlink_to(clip_path)
+            calibration["preview_clips"][0]["path"] = linked_clip.as_uri()
+            self.assertIsNone(
+                _current_derivation_review_artifact_fingerprint(
+                    review_root=review_root,
+                    calibration=calibration,
+                )
+            )
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "must not contain links",
+            ):
+                _secure_derivation_review_media(review_root)
+
+    def test_derivation_verdict_validates_terminal_before_database_append(self) -> None:
+        assignment = self.plan.assignments[0]
+        source = next(
+            item
+            for item in self.partition.inventory_sources
+            if item.local_item_id == assignment.local_item_id
+        )
+        observation = _observation(
+            assignment=assignment,
+            source_identity=source.source_identity,
+            crf=28.0,
+            bitrate=1_000_000,
+            verdict="acceptable",
+        )
+        attempt = build_av1_validation_derivation_attempt(
+            plan=self.plan,
+            partition=self.partition,
+            assignment_id=assignment.assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            calibration_payload=_calibration_payload(
+                assignment=assignment,
+                source_identity=source.source_identity,
+                crf=28.0,
+                compatibility=_compatibility(assignment),
+            ),
+        )
+        terminal_records_directory = (
+            self.runtime_config.paths.web_state_dir
+            / "av1-validation-derivation"
+            / self.plan.plan_id
+            / "terminal-records"
+        )
+        with (
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_config",
+                return_value=self.runtime_config,
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation._derivation_prefix",
+                return_value="private/derivation",
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.build_visual_content_intent_observation",
+                return_value=ContentIntentObservationBuildResult(observation, None),
+            ) as build_observation,
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation._current_derivation_review_artifact_fingerprint",
+                return_value=attempt.calibration_payload()["review_artifact_fingerprint"],
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.build_av1_validation_derivation_terminal_record",
+                side_effect=AV1ValidationDerivationError("terminal validation failed"),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.append_content_intent_boundary_observation"
+            ) as append_observation,
+        ):
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "terminal validation failed",
+            ):
+                record_av1_validation_derivation_visual_verdict(
+                    config_path=Path("unused.toml"),
+                    plan=self.plan,
+                    partition=self.partition,
+                    attempt=attempt,
+                    terminal_records_directory=terminal_records_directory,
+                    verdict="approved",
+                    concern_tags=[],
+                    evidence_ids=[],
+                    moment_indexes=[],
+                    recorded_at="2026-07-28T01:06:00Z",
+                )
+        append_observation.assert_not_called()
+        self.assertFalse(build_observation.call_args.kwargs["personalization_eligible"])
+        self.assertEqual(
+            build_observation.call_args.kwargs["personalization_exclusion_reason"],
+            AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON,
+        )
+
+    def test_derivation_verdict_rejects_changed_review_media(self) -> None:
+        assignment = self.plan.assignments[0]
+        attempt = build_av1_validation_derivation_attempt(
+            plan=self.plan,
+            partition=self.partition,
+            assignment_id=assignment.assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            calibration_payload=_calibration_payload(
+                assignment=assignment,
+                source_identity=_source_identity(self.partition, assignment),
+                crf=28.0,
+                compatibility=_compatibility(assignment),
+            ),
+        )
+        terminal_records_directory = (
+            self.runtime_config.paths.web_state_dir
+            / "av1-validation-derivation"
+            / self.plan.plan_id
+            / "terminal-records"
+        )
+        with (
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_config",
+                return_value=self.runtime_config,
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation._current_derivation_review_artifact_fingerprint",
+                return_value="changed-review-artifact",
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.build_visual_content_intent_observation"
+            ) as build_observation,
+            self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "review media is unavailable or changed",
+            ),
+        ):
+            record_av1_validation_derivation_visual_verdict(
+                config_path=Path("unused.toml"),
+                plan=self.plan,
+                partition=self.partition,
+                attempt=attempt,
+                terminal_records_directory=terminal_records_directory,
+                verdict="approved",
+                concern_tags=[],
+                evidence_ids=[],
+                moment_indexes=[],
+                recorded_at="2026-07-28T01:06:00Z",
+            )
+        build_observation.assert_not_called()
+
+    def test_derivation_observation_is_not_replay_eligible(self) -> None:
+        assignment = self.plan.assignments[0]
+        source = next(
+            item
+            for item in self.partition.inventory_sources
+            if item.local_item_id == assignment.local_item_id
+        )
+        observation = _observation(
+            assignment=assignment,
+            source_identity=source.source_identity,
+            crf=28.0,
+            bitrate=1_000_000,
+            verdict="acceptable",
+        )
+        state = replay_content_intent_personalization(
+            [observation.values()],
+            source_id=observation.source_id,
+            content_id=observation.content_id,
+            prefix=observation.prefix,
+            content_profile_id=observation.content_profile_id,
+            intent_semantic_id=observation.intent_semantic_id,
+            compatibility_key=observation.compatibility_key,
+        )
+        self.assertEqual(state.item_boundary.status, "empty")
+        self.assertTrue(all(cohort.observation_count == 0 for cohort in state.cohorts))
+
+        forged_values = observation.values()
+        forged_values["personalization_eligible"] = True
+        forged_values["exclusion_reason"] = None
+        provenance = json.loads(str(forged_values["provenance_json"]))
+        provenance["calibration_action"] = "av1_derivation"
+        forged_values["provenance_json"] = canonical_json_bytes(provenance).decode(
+            "utf-8"
+        )
+        forged = _rehash_observation(forged_values)
+        forged_state = replay_content_intent_personalization(
+            [forged.values()],
+            source_id=forged.source_id,
+            content_id=forged.content_id,
+            prefix=forged.prefix,
+            content_profile_id=forged.content_profile_id,
+            intent_semantic_id=forged.intent_semantic_id,
+            compatibility_key=forged.compatibility_key,
+        )
+        self.assertEqual(forged_state.item_boundary.status, "empty")
+
+        withdrawn = withdraw_content_intent_boundary_observation(
+            observation,
+            reason_code="operator_invalidated_derivation_evidence",
+            recorded_at="2026-07-28T01:07:00Z",
+        )
+        self.assertEqual(withdrawn.disposition, "withdrawn")
+        self.assertEqual(
+            withdrawn.exclusion_reason,
+            AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON,
+        )
+        self.assertEqual(
+            withdrawn.supersession_reason,
+            "operator_invalidated_derivation_evidence",
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "quarantine cannot be lifted",
+        ):
+            correct_content_intent_boundary_observation(
+                observation,
+                verdict="unacceptable",
+                personalization_eligible=True,
+                exclusion_reason=None,
+                reason_code="operator_reassessed_same_review",
+                recorded_at="2026-07-28T01:05:00Z",
+            )
+
+    def test_candidate_uses_full_crf_range_and_dispersion_confidence(self) -> None:
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [item for item in self.plan.assignments if item.cell_plan_id == cell_plan_id]
+        records = [
+            self._observed_record(
+                assignment.assignment_id,
+                crf=27.0 if index < 6 else 29.0,
+                bitrate=850_000 if index < 6 else 1_150_000,
+            )
+            for index, assignment in enumerate(assignments)
+        ]
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
+            proposed_at="2026-07-28T03:00:00Z",
+        )
+        self.assertEqual(evaluation.blockers, ())
+        assert evaluation.proposal is not None
+        self.assertEqual(evaluation.proposal.crf_lower, 27.0)
+        self.assertEqual(evaluation.proposal.crf_center, 28.0)
+        self.assertEqual(evaluation.proposal.crf_upper, 29.0)
+        self.assertEqual(evaluation.proposal.crf_mad, 1.0)
+        self.assertEqual(evaluation.proposal.bitrate_relative_mad, 0.15)
+        self.assertEqual(
+            evaluation.proposal.statistics_contract_sha256,
+            self.authorization.statistics_contract_sha256,
+        )
+        self.assertEqual(evaluation.proposal.derivation_conflict_count, 0)
+        self.assertEqual(evaluation.proposal.confidence_level, "moderate")
+        self.assertEqual(evaluation.proposal.confidence_score, 0.85)
+        self.assertEqual(evaluation.proposal.target_video_bitrate_min_bps, 850_000)
+        self.assertEqual(evaluation.proposal.target_video_bitrate_max_bps, 1_150_000)
+
+    def test_candidate_rejects_full_crf_span_even_when_center_is_tight(self) -> None:
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [item for item in self.plan.assignments if item.cell_plan_id == cell_plan_id]
+        crfs = [24.0, *([28.0] * 10), 31.0]
+        records = [
+            self._observed_record(assignment.assignment_id, crf=crf)
+            for assignment, crf in zip(assignments, crfs, strict=True)
+        ]
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
+            proposed_at="2026-07-28T03:00:00Z",
+        )
+        self.assertIsNone(evaluation.proposal)
+        self.assertIn("crf_span_too_wide", evaluation.blockers)
+
+    def test_candidate_rejects_wide_crf_dispersion_with_acceptable_span(self) -> None:
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [
+            item for item in self.plan.assignments
+            if item.cell_plan_id == cell_plan_id
+        ]
+        crfs = [26.0] * 6 + [31.0] * 6
+        records = [
+            self._observed_record(assignment.assignment_id, crf=crf)
+            for assignment, crf in zip(assignments, crfs, strict=True)
+        ]
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
+            proposed_at="2026-07-28T03:00:00Z",
+        )
+        self.assertIsNone(evaluation.proposal)
+        self.assertIn("crf_dispersion_too_wide", evaluation.blockers)
+        self.assertNotIn("crf_span_too_wide", evaluation.blockers)
+
+    def test_candidate_rejects_limited_confidence(self) -> None:
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [
+            item for item in self.plan.assignments
+            if item.cell_plan_id == cell_plan_id
+        ]
+        records = [
+            self._observed_record(
+                assignment.assignment_id,
+                crf=28.0,
+                bitrate=500_000 if index < 6 else 1_500_000,
+            )
+            for index, assignment in enumerate(assignments)
+        ]
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
+            proposed_at="2026-07-28T03:00:00Z",
+        )
+        self.assertIsNone(evaluation.proposal)
+        self.assertIn("confidence_insufficient", evaluation.blockers)
+
+    def test_five_distinct_approvals_are_required_before_lock_finalization(self) -> None:
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [item for item in self.plan.assignments if item.cell_plan_id == cell_plan_id]
+        records = [self._observed_record(item.assignment_id, crf=28.0) for item in assignments]
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
+            proposed_at="2026-07-28T03:00:00Z",
+        )
+        assert evaluation.proposal is not None
+        review_evidence: dict[str, bytes] = {}
+        reviews = []
+        for index, lane in enumerate(
+            AV1_VALIDATION_DERIVATION_REVIEW_LANES,
+            start=1,
+        ):
+            review_run_id = f"00000000-0000-0000-0000-{index:012x}"
+            evidence = _review_run_evidence(
+                proposal=evaluation.proposal,
+                lane=lane,
+                review_run_id=review_run_id,
+            )
+            review_evidence[lane] = evidence
+            reviews.append(build_av1_validation_derivation_review_attestation(
+                proposal=evaluation.proposal,
+                lane=lane,
+                reviewer_token=f"agent:{review_run_id}",
+                review_evidence_sha256=(
+                    f"sha256:{hashlib.sha256(evidence).hexdigest()}"
+                ),
+                decision="approved",
+                reviewed_at=f"2026-07-28T03:{index:02d}:00Z",
+            ))
+        locked_at = "2026-07-28T03:06:00Z"
+        current_evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
+            proposed_at=locked_at,
+        )
+        with self.assertRaisesRegex(AV1ValidationDerivationError, "all five"):
+            finalize_av1_validation_derivation_candidate_lock(
+                proposal=evaluation.proposal,
+                reviews=reviews[:-1],
+                current_evaluation=current_evaluation,
+                locked_at=locked_at,
+            )
+        duplicate_evidence_reviews = [
+            build_av1_validation_derivation_review_attestation(
+                proposal=evaluation.proposal,
+                lane=lane,
+                reviewer_token=(
+                    f"agent:10000000-0000-0000-0000-{index:012x}"
+                ),
+                review_evidence_sha256=f"sha256:{1:064x}",
+                decision="approved",
+                reviewed_at=f"2026-07-28T03:{index:02d}:30Z",
+            )
+            for index, lane in enumerate(
+                AV1_VALIDATION_DERIVATION_REVIEW_LANES,
+                start=1,
+            )
+        ]
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "independent agent runs",
+        ):
+            finalize_av1_validation_derivation_candidate_lock(
+                proposal=evaluation.proposal,
+                reviews=duplicate_evidence_reviews,
+                current_evaluation=current_evaluation,
+                locked_at=locked_at,
+            )
+        lock = finalize_av1_validation_derivation_candidate_lock(
+            proposal=evaluation.proposal,
+            reviews=reviews,
+            current_evaluation=current_evaluation,
+            locked_at=locked_at,
+        )
+        self.assertEqual(lock.review_state, "approved_for_holdout")
+        self.assertEqual(lock.derivation_snapshot_sha256, evaluation.derivation_snapshot_sha256)
+        self.assertEqual(lock.locked_at, locked_at)
+        self.assertEqual(lock.reviewed_at, locked_at)
+
+        with tempfile.TemporaryDirectory() as directory:
+            artifact_root = (
+                Path(directory)
+                / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
+                / self.plan.plan_id
+            )
+            write_av1_validation_derivation_plan(artifact_root, self.plan)
+            proposal_path = write_av1_validation_derivation_candidate_proposal(
+                artifact_root,
+                plan=self.plan,
+                proposal=evaluation.proposal,
+            )
+            self.assertEqual(
+                proposal_path,
+                (artifact_root / "proposals" / f"{cell_plan_id}.json").resolve(),
+            )
+            self.assertEqual(
+                load_av1_validation_derivation_candidate_proposal(
+                    artifact_root,
+                    plan=self.plan,
+                    cell_plan_id=cell_plan_id,
+                ),
+                evaluation.proposal,
+            )
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "not authorized",
+            ):
+                load_av1_validation_derivation_candidate_proposal(
+                    artifact_root,
+                    plan=self.plan,
+                    cell_plan_id="../outside",
+                )
+            review_envelopes = []
+            for review in reviews:
+                envelope = build_av1_validation_derivation_review_envelope(
+                    review=review,
+                    evidence=review_evidence[review.lane],
+                )
+                write_av1_validation_derivation_review_envelope(
+                    artifact_root,
+                    plan=self.plan,
+                    proposal=evaluation.proposal,
+                    envelope=envelope,
+                )
+                review_envelopes.append(envelope)
+            stale_temporary = (
+                artifact_root
+                / "reviews"
+                / evaluation.proposal.proposal_id
+                / ".architecture.json.interrupted.tmp"
+            )
+            stale_temporary.write_bytes(b"interrupted")
+            stale_temporary.chmod(0o600)
+            loaded_envelopes = load_av1_validation_derivation_review_envelopes(
+                artifact_root,
+                plan=self.plan,
+                proposal=evaluation.proposal,
+            )
+            self.assertEqual(
+                {
+                    envelope.review.attestation_id
+                    for envelope in loaded_envelopes
+                },
+                {review.attestation_id for review in reviews},
+            )
+            persisted_envelope = finalize_and_write_av1_validation_derivation_candidate_lock(
+                artifact_root,
+                plan=self.plan,
+                proposal=evaluation.proposal,
+                review_envelopes=loaded_envelopes,
+                current_evaluation=current_evaluation,
+                locked_at=locked_at,
+            )
+            self.assertEqual(persisted_envelope.candidate_lock, lock)
+            self.assertEqual(
+                load_verified_av1_validation_derivation_candidate_lock(
+                    artifact_root,
+                    plan=self.plan,
+                    proposal=evaluation.proposal,
+                    review_envelopes=loaded_envelopes,
+                    current_evaluation=current_evaluation,
+                    cell_plan_id=cell_plan_id,
+                ),
+                persisted_envelope,
+            )
+            lock_path = (
+                artifact_root / "candidate-locks" / f"{cell_plan_id}.json"
+            ).resolve()
+            self.assertEqual(
+                lock_path,
+                (artifact_root / "candidate-locks" / f"{cell_plan_id}.json").resolve(),
+            )
+
+        changed_observations = self._current_observations(records)
+        del changed_observations[assignments[0].assignment_id]
+        stale_evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=changed_observations,
+            proposed_at=locked_at,
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "no longer current",
+        ):
+            finalize_av1_validation_derivation_candidate_lock(
+                proposal=evaluation.proposal,
+                reviews=reviews,
+                current_evaluation=stale_evaluation,
+                locked_at=locked_at,
+            )
+
+    def test_candidate_lock_allows_shared_source_groups(self) -> None:
+        source_tokens = tuple(f"source_token_{index:02d}" for index in range(12))
+        series_tokens = tuple(f"series_token_{index:02d}" for index in range(12))
+        shared_tokens = tuple(f"shared_token_{index:02d}" for index in range(6))
+        candidate_lock_kwargs = {
+            "manifest_id": self.manifest.manifest_id,
+            "cell_plan_id": self.plan.assignments[0].cell_plan_id,
+            "exact_traits": ("darkness",),
+            "crf_lower": 27.0,
+            "crf_center": 28.0,
+            "crf_upper": 29.0,
+            "compatibility_signature": "compatibility_test_contract",
+            "policy_signature": "policy_test_contract",
+            "target_video_bitrate_min_bps": 850_000,
+            "target_video_bitrate_max_bps": 1_150_000,
+            "minimum_quality_score": 80.0,
+            "confidence_level": "moderate",
+            "confidence_score": 0.85,
+            "derivation_evidence_count": 12,
+            "derivation_source_count": 12,
+            "derivation_source_tokens": source_tokens,
+            "derivation_title_tokens": tuple(
+                f"title_{index:02d}_independent" for index in range(12)
+            ),
+            "derivation_series_tokens": series_tokens,
+            "derivation_source_group_tokens": shared_tokens,
+            "derivation_source_group_observation_tokens": tuple(
+                token for token in shared_tokens for _ in range(2)
+            ),
+            "derivation_oldest_recorded_at": "2026-07-28T01:00:00Z",
+            "derivation_newest_recorded_at": "2026-07-28T02:00:00Z",
+            "derivation_conflict_count": 0,
+            "derivation_snapshot_sha256": "sha256:" + "1" * 64,
+            "selection_lock_sha256": self.plan.selection_lock_sha256,
+            "locked_at": "2026-07-28T03:00:00Z",
+            "reviewed_at": "2026-07-28T04:00:00Z",
+        }
+        candidate_lock = build_av1_cold_start_validation_candidate_lock(
+            **candidate_lock_kwargs,
+        )
+        self.assertEqual(candidate_lock.derivation_source_count, 12)
+        self.assertEqual(len(candidate_lock.derivation_source_group_tokens), 6)
+        self.assertEqual(
+            len(candidate_lock.derivation_source_group_observation_tokens),
+            12,
+        )
+
+        with self.assertRaisesRegex(
+            AV1ColdStartValidationError,
+            "at least six source groups",
+        ):
+            build_av1_cold_start_validation_candidate_lock(
+                **{
+                    **candidate_lock_kwargs,
+                    "derivation_source_group_tokens": shared_tokens[:5],
+                    "derivation_source_group_observation_tokens": tuple(
+                        shared_tokens[index % 5] for index in range(12)
+                    ),
+                }
+            )
+
+        concentrated_tokens = tuple(f"concentrated_{index:02d}" for index in range(8))
+        with self.assertRaisesRegex(
+            AV1ColdStartValidationError,
+            "concentration is too high",
+        ):
+            build_av1_cold_start_validation_candidate_lock(
+                **{
+                    **candidate_lock_kwargs,
+                    "derivation_source_group_tokens": concentrated_tokens,
+                    "derivation_source_group_observation_tokens": (
+                        (concentrated_tokens[0],) * 5
+                        + concentrated_tokens[1:]
+                    ),
+                }
+            )
+
+    def test_create_plan_cli_output_is_public_safe(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "private"
+            root.mkdir(mode=0o700)
+            runtime_config = SimpleNamespace(
+                paths=SimpleNamespace(
+                    db_path=root / "db.sqlite3",
+                    review_dir=root / "review",
+                    web_state_dir=root / "state",
+                )
+            )
+            stdout = io.StringIO()
+            with (
+                patch.object(
+                    verify_av1_cold_start_preregistration,
+                    "_load_current_derivation_inputs",
+                    return_value=(self.manifest, self.partition, self.token_key),
+                ),
+                patch.object(
+                    verify_av1_cold_start_preregistration,
+                    "load_config",
+                    return_value=runtime_config,
+                ),
+                patch.object(
+                    verify_av1_cold_start_preregistration,
+                    "_now_iso",
+                    return_value=AUTHORIZED_AT,
+                ),
+                redirect_stdout(stdout),
+            ):
+                exit_code = verify_av1_cold_start_preregistration.main([
+                    "create-derivation-plan",
+                    str(V2_MANIFEST_PATH),
+                    str(root / "eligibility.json"),
+                    str(root / "partition.json"),
+                    "--key",
+                    str(root / "partition.key"),
+                    "--valid-until",
+                    VALID_UNTIL,
+                    "--json",
+                ])
+            self.assertEqual(exit_code, 0)
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(payload["derivation_assignment_count"], 24)
+            plan_path = (
+                runtime_config.paths.web_state_dir
+                / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
+                / payload["plan_id"]
+                / "plan.json"
+            )
+            self.assertTrue(plan_path.is_file())
+            serialized = json.dumps(payload)
+            self.assertNotIn("local_item_id", serialized)
+            self.assertNotIn("source_token", serialized)
+            self.assertNotIn(str(root), serialized)
+
+    def _failed_attempt(self, assignment_id: str) -> AV1ValidationDerivationAttempt:
+        return build_av1_validation_derivation_attempt(
+            plan=self.plan,
+            partition=self.partition,
+            assignment_id=assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="failed",
+            reason_code="runtime_failure",
+        )
+
+    def _failed_record(self, assignment_id: str) -> AV1ValidationDerivationTerminalRecord:
+        return build_av1_validation_derivation_terminal_record(
+            plan=self.plan,
+            partition=self.partition,
+            attempt=self._failed_attempt(assignment_id),
+        )
+
+    def _observed_record(
+            self,
+            assignment_id: str,
+            *,
+            crf: float,
+            bitrate: int = 1_000_000,
+            verdict: Literal["acceptable", "unacceptable"] = "acceptable",
+            recorded_at: str = "2026-07-28T01:06:00Z",
+    ) -> AV1ValidationDerivationTerminalRecord:
+        assignment = next(item for item in self.plan.assignments if item.assignment_id == assignment_id)
+        source = next(item for item in self.partition.inventory_sources if item.local_item_id == assignment.local_item_id)
+        observation = _observation(
+            assignment=assignment,
+            source_identity=source.source_identity,
+            crf=crf,
+            bitrate=bitrate,
+            verdict=verdict,
+            recorded_at=recorded_at,
+        )
+        attempt = build_av1_validation_derivation_attempt(
+            plan=self.plan,
+            partition=self.partition,
+            assignment_id=assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            calibration_payload=_calibration_payload(
+                assignment=assignment,
+                source_identity=source.source_identity,
+                crf=crf,
+                compatibility=_compatibility(assignment),
+                bitrate=bitrate,
+            ),
+        )
+        return build_av1_validation_derivation_terminal_record(
+            plan=self.plan,
+            partition=self.partition,
+            attempt=attempt,
+            observation=observation,
+        )
+
+    def _attempts(
+            self,
+            records: Sequence[AV1ValidationDerivationTerminalRecord],
+    ) -> list[AV1ValidationDerivationAttempt]:
+        attempts: list[AV1ValidationDerivationAttempt] = []
+        for record in records:
+            if record.status == "observed":
+                assert record.observation is not None
+                assignment = next(
+                    item for item in self.plan.assignments
+                    if item.assignment_id == record.assignment_id
+                )
+                attempts.append(
+                    build_av1_validation_derivation_attempt(
+                        plan=self.plan,
+                        partition=self.partition,
+                        assignment_id=record.assignment_id,
+                        started_at=record.started_at,
+                        completed_at=record.completed_at,
+                        status="review_pending",
+                        calibration_payload=_calibration_payload(
+                            assignment=assignment,
+                            source_identity=_source_identity(self.partition, assignment),
+                            crf=record.observation.chosen_crf,
+                            compatibility=_compatibility(assignment),
+                            bitrate=record.observation.boundary_bitrate_bps,
+                        ),
+                    )
+                )
+            else:
+                attempts.append(
+                    build_av1_validation_derivation_attempt(
+                        plan=self.plan,
+                        partition=self.partition,
+                        assignment_id=record.assignment_id,
+                        started_at=record.started_at,
+                        completed_at=record.completed_at,
+                        status=record.status,
+                        reason_code=record.reason_code,
+                    )
+                )
+        return attempts
+
+    def _current_observations(
+            self,
+            records: Sequence[AV1ValidationDerivationTerminalRecord],
+    ) -> dict[str, ContentIntentBoundaryObservation]:
+        observations: dict[str, ContentIntentBoundaryObservation] = {}
+        for record in records:
+            if record.observation is None:
+                continue
+            assignment = next(
+                item
+                for item in self.plan.assignments
+                if item.assignment_id == record.assignment_id
+            )
+            observations[record.assignment_id] = _observation(
+                assignment=assignment,
+                source_identity=_source_identity(self.partition, assignment),
+                crf=record.observation.chosen_crf,
+                bitrate=record.observation.boundary_bitrate_bps,
+                verdict=record.observation.verdict,
+                recorded_at=record.observation.recorded_at,
+            )
+        return observations
+
+
+def _observation(
+        *,
+        assignment: AV1ValidationPartitionAssignment,
+        source_identity: str,
+        crf: float,
+        bitrate: int,
+        verdict: Literal["acceptable", "unacceptable"],
+        recorded_at: str = "2026-07-28T01:06:00Z",
+) -> ContentIntentBoundaryObservation:
+    compatibility = _compatibility(assignment)
+    acceptable = verdict == "acceptable"
+    return _build_observation(
+        series_id=f"series_{assignment.assignment_id}",
+        boundary_group_id=f"group_{assignment.assignment_id}",
+        revision=0,
+        supersedes_observation_id=None,
+        supersession_reason=None,
+        authority="runtime_native",
+        disposition="active",
+        personalization_eligible=False,
+        exclusion_reason=AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON,
+        library_item_id=assignment.local_item_id,
+        prefix="private/derivation",
+        source_rel_path="private/derivation/item.mkv",
+        source_id=f"source_{assignment.assignment_id}",
+        source_fingerprint="fingerprint_test",
+        content_fingerprint=source_identity,
+        content_id=f"content_{assignment.assignment_id}",
+        content_profile_id=f"profile_{assignment.assignment_id}",
+        content_traits=assignment.traits,
+        intent_semantic_id=f"intent_{assignment.assignment_id}",
+        intent_snapshot_id=f"snapshot_{assignment.assignment_id}",
+        intent_level=assignment.intent_level,
+        compatibility=compatibility,
+        policy_hash="policy_hash_test_contract",
+        source_event_kind="post_test_review",
+        source_event_id=f"event_{assignment.assignment_id}",
+        job_id=f"job_{assignment.assignment_id}",
+        artifact_fingerprint=f"artifact_{assignment.assignment_id}",
+        source_evidence_ids=("evidence_test",),
+        observation_kind="visual_approval" if acceptable else "visual_rejection",
+        verdict="acceptable" if acceptable else "unacceptable",
+        boundary_kind="upper_bound" if acceptable else "lower_bound",
+        authoritative_anchor_bytes=500_000_000,
+        boundary_size_bytes=450_000_000,
+        actual_output_bytes=None,
+        sampled_clip_bytes=5_000_000,
+        duration_seconds=3_600.0,
+        boundary_bitrate_bps=bitrate,
+        direction="smaller",
+        quality_metric=assignment.quality_metric,
+        quality_target=assignment.quality_target,
+        minimum_quality_score=assignment.minimum_quality_score,
+        measured_quality_score=assignment.minimum_quality_score + 1.0,
+        quality_floor_met=True,
+        assessment={
+            "schema_version": 1,
+            "measurement_basis": "sample_projection",
+            "chosen_crf": crf,
+        },
+        provenance={
+            "schema_version": 1,
+            "source": "operator_visual_review",
+            "recorded_at": recorded_at,
+        },
+        recorded_at=recorded_at,
+    )
+
+
+def _compatibility(
+        assignment: AV1ValidationPartitionAssignment,
+) -> ContentIntentBoundaryCompatibilityV1:
+    return build_content_intent_boundary_compatibility(
+        encoder="libsvtav1",
+        encoder_version="4.2.0",
+        encoder_runtime_version="8.1.2",
+        encoder_runtime_signature_id="encoder_runtime_test",
+        quality_tool="ab-av1",
+        quality_tool_version="0.11.3",
+        metric_runtime_signature_id="metric_runtime_test",
+        preset=6,
+        pixel_format="yuv420p10le",
+        encoder_parameters=("preset=6",),
+        output_width=1920,
+        output_height=1080,
+        frame_rate="24000/1001",
+        cadence_transform="none",
+        video_filter=None,
+        output_container="mkv",
+        stream_plan_id="stream_plan_test",
+        measurement_basis="sample_projection",
+        quality_metric=assignment.quality_metric,
+        quality_target=assignment.quality_target,
+        minimum_quality_score=assignment.minimum_quality_score,
+    )
+
+
+def _calibration_payload(
+        *,
+        assignment: AV1ValidationPartitionAssignment,
+        source_identity: str,
+        crf: float,
+        compatibility: ContentIntentBoundaryCompatibilityV1,
+        bitrate: int = 1_000_000,
+) -> dict[str, object]:
+    artifact = f"artifact_{assignment.assignment_id}"
+    duration_seconds = 3_600.0
+    predicted_video_bytes = round((bitrate * duration_seconds) / 8)
+    candidate = {
+        "attempt": 1,
+        "role": "target_seed",
+        "crf": crf,
+        "metric": assignment.quality_metric.upper(),
+        "metric_target": assignment.quality_target,
+        "metric_score": assignment.minimum_quality_score + 1.0,
+        "min_metric_score": assignment.minimum_quality_score,
+        "quality_floor_met": True,
+        "sampled_clip_bytes": 5_000_000,
+        "predicted_video_bytes": predicted_video_bytes,
+        "predicted_whole_episode_bytes": predicted_video_bytes,
+        "predicted_encode_percent": 50.0,
+        "predicted_encode_seconds": 1_800.0,
+        "target_distance_bytes": 0,
+        "within_sample_band": True,
+        "violates_source_cap": False,
+    }
+    return {
+        "mode": "sample",
+        "action": "av1_derivation",
+        "host": {
+            "mode": "local",
+            "media_access": "direct",
+        },
+        "job_id": f"job_{assignment.assignment_id}",
+        "review_media_ready": True,
+        "boundary_review_media_ready": True,
+        "review_artifact_fingerprint": artifact,
+        "current_review_artifact_fingerprint": artifact,
+        "sample_item": {
+            "library_item_id": assignment.local_item_id,
+            "content_version_fingerprint": source_identity,
+            "duration_seconds": duration_seconds,
+        },
+        "sample_result": {
+            "chosen_crf": crf,
+            "quality_metric": assignment.quality_metric,
+            "quality_target": assignment.quality_target,
+            "quality_score": assignment.minimum_quality_score + 1.0,
+            "predicted_video_size_bytes": predicted_video_bytes,
+            "predicted_total_size_bytes": predicted_video_bytes,
+            "content_intent_compatibility": compatibility.to_payload(),
+            "av1_cold_start_prior": {
+                "status": "unavailable",
+                "reason": "cold_start_planner_unavailable",
+                "execution": None,
+            },
+            "target_size_trace": {
+                "schema_version": 1,
+                "status": "selected",
+                "selection_reason": "inside_target_band",
+                "quality_floor": {
+                    "metric": assignment.quality_metric.upper(),
+                    "target": assignment.quality_target,
+                    "minimum": assignment.minimum_quality_score,
+                },
+                "curve": {
+                    "shape": "single_point",
+                    "candidate_count": 1,
+                    "max_candidates": 6,
+                },
+                "retry_policy": {
+                    "max_final_output_retries": 1,
+                },
+                "candidates": [candidate],
+                "selected_candidate": candidate,
+            },
+        },
+    }
+
+
+def _review_run_evidence(
+        *,
+        proposal: object,
+        lane: str,
+        review_run_id: str,
+) -> bytes:
+    proposal_id = str(getattr(proposal, "proposal_id"))
+    proposal_payload_sha256 = str(getattr(proposal, "payload_sha256"))
+    prompt = (
+        f"review_run_id={review_run_id}\n"
+        f"proposal_id={proposal_id}\n"
+        f"proposal_payload_sha256={proposal_payload_sha256}\n"
+        f"lane={lane}"
+    )
+    marker = {
+        "decision": "approved",
+        "lane": lane,
+        "proposal_id": proposal_id,
+        "proposal_payload_sha256": proposal_payload_sha256,
+        "review_run_id": review_run_id,
+    }
+    final_message = (
+        "Review complete.\n"
+        "MEDIAFORCE_AV1_REVIEW_V2 "
+        f"{json.dumps(marker, sort_keys=True, separators=(',', ':'))}"
+    )
+    stdout = "\n".join((
+        json.dumps({
+            "provider": "test",
+            "model": "test-model",
+            "workdir": "/private/test",
+            "approval": "never",
+            "sandbox": "read-only",
+        }, sort_keys=True),
+        json.dumps({"prompt": prompt}, sort_keys=True),
+        json.dumps({
+            "msg": {
+                "type": "agent_message",
+                "message": final_message,
+            }
+        }, sort_keys=True),
+        json.dumps({
+            "msg": {
+                "type": "task_lifecycle",
+                "phase": "quiescent",
+                "last_agent_message": final_message,
+            }
+        }, sort_keys=True),
+    ))
+    return canonical_json_bytes({
+        "schema": "mediaforce.av1_derivation_agent_review_run",
+        "schema_version": 1,
+        "review_run_id": review_run_id,
+        "reviewer_token": f"agent:{review_run_id}",
+        "proposal_id": proposal_id,
+        "proposal_payload_sha256": proposal_payload_sha256,
+        "lane": lane,
+        "decision": "approved",
+        "code_binary_sha256": "sha256:" + "c" * 64,
+        "prompt_sha256": f"sha256:{hashlib.sha256(prompt.encode('utf-8')).hexdigest()}",
+        "stdout": stdout,
+        "stderr": "",
+        "returncode": 0,
+    })
+
+
+def _source_identity(
+        partition: AV1ValidationPrivatePartition,
+        assignment: AV1ValidationPartitionAssignment,
+) -> str:
+    return next(
+        source.source_identity
+        for source in partition.inventory_sources
+        if source.local_item_id == assignment.local_item_id
+    )
+
+
+def _partition_sources(
+        expectations: AV1ValidationPartitionExpectations,
+) -> tuple[AV1ValidationPartitionSource, ...]:
+    sources = []
+    local_item_id = 1
+    for label, traits, count in (
+        ("darkness", ("darkness",), 32),
+        ("motion", ("motion",), 32),
+        ("grain", ("grain_noise",), 6),
+        ("mixed", ("mixed",), 6),
+        ("texture", ("texture_detail",), 6),
+        ("typical", ("typical",), 12),
+    ):
+        for ordinal in range(1, count + 1):
+            identity = f"{label}-{ordinal:03d}"
+            sources.append(
+                AV1ValidationPartitionSource(
+                    local_item_id=local_item_id,
+                    source_identity=f"source-{identity}",
+                    title_identity=f"title-{identity}",
+                    series_identity=f"series-{identity}",
+                    source_group_identity=f"group-{identity}",
+                    traits=traits,
+                    compatibility_signature=expectations.compatibility_signature,
+                    base_policy_signature=expectations.base_policy_signature,
+                    target_video_bitrate_bps=500_000 + local_item_id,
+                    quality_metric=expectations.quality_metric,
+                    quality_target=expectations.quality_target,
+                    minimum_quality_score=expectations.minimum_quality_score,
+                    evidence_summary_sha256=f"sha256:{local_item_id:064x}",
+                )
+            )
+            local_item_id += 1
+    return tuple(sources)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_av1_validation_derivation.py
+++ b/tests/test_av1_validation_derivation.py
@@ -1,4 +1,6 @@
-from contextlib import redirect_stdout
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager, nullcontext, redirect_stdout
 from dataclasses import replace
 import hashlib
 import io
@@ -6,6 +8,7 @@ import json
 import os
 from pathlib import Path
 import tempfile
+import threading
 from types import SimpleNamespace
 from typing import Literal, Sequence
 import unittest
@@ -17,8 +20,10 @@ from mediaforce.tuning.av1_validation_derivation import (
     AV1_VALIDATION_DERIVATION_REVIEW_LANES,
     AV1_VALIDATION_DERIVATION_PERSONALIZATION_EXCLUSION_REASON,
     AV1ValidationDerivationAttempt,
+    AV1ValidationDerivationCandidateProposal,
     AV1ValidationDerivationError,
     AV1ValidationDerivationPlan,
+    AV1ValidationDerivationReviewClaim,
     AV1ValidationDerivationTerminalRecord,
     _attempt_semantic_payload,
     _derivation_id,
@@ -29,6 +34,7 @@ from mediaforce.tuning.av1_validation_derivation import (
     av1_validation_derivation_statistics_contract_sha256,
     build_av1_validation_derivation_attempt,
     build_av1_validation_derivation_plan,
+    build_av1_validation_derivation_review_claim,
     build_av1_validation_derivation_review_attestation,
     build_av1_validation_derivation_review_envelope,
     build_av1_validation_derivation_terminal_record,
@@ -39,6 +45,7 @@ from mediaforce.tuning.av1_validation_derivation import (
     _load_verified_av1_validation_derivation_candidate_lock as load_verified_av1_validation_derivation_candidate_lock,
     load_av1_validation_derivation_plan,
     load_av1_validation_derivation_attempts,
+    load_av1_validation_derivation_review_claims,
     load_av1_validation_derivation_review_envelopes,
     load_av1_validation_derivation_terminal_records,
     resolve_av1_validation_derivation_verdict_intent,
@@ -46,6 +53,7 @@ from mediaforce.tuning.av1_validation_derivation import (
     validate_av1_validation_derivation_plan_binding,
     write_av1_validation_derivation_candidate_proposal,
     write_av1_validation_derivation_plan,
+    write_av1_validation_derivation_review_claim,
     write_av1_validation_derivation_review_envelope,
     write_av1_validation_derivation_attempt,
     write_av1_validation_derivation_assignment_claim,
@@ -166,6 +174,8 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             statistics_contract_sha256=(
                 av1_validation_derivation_statistics_contract_sha256(self.manifest)
             ),
+            review_runner_canonical_path_sha256=f"sha256:{'a' * 64}",
+            review_runner_binary_sha256=f"sha256:{'b' * 64}",
             authorized_at=AUTHORIZED_AT,
             valid_until=VALID_UNTIL,
         )
@@ -178,7 +188,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         self.runtime_artifact_root = (
             self.runtime_config.paths.web_state_dir
             / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
-            / self.plan.plan_id
+            / self.plan.partition_id
         )
         write_av1_validation_derivation_plan(
             self.runtime_artifact_root,
@@ -261,7 +271,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             artifact_root = (
                 root
                 / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
-                / self.plan.plan_id
+                / self.plan.partition_id
             )
             plan_path = write_av1_validation_derivation_plan(
                 artifact_root,
@@ -274,10 +284,10 @@ class AV1ValidationDerivationTests(unittest.TestCase):
 
             with self.assertRaisesRegex(
                 AV1ValidationDerivationError,
-                "plan-global canonical root",
+                "partition-global canonical root",
             ):
                 write_av1_validation_derivation_plan(
-                    root / "alternate" / self.plan.plan_id,
+                    root / "alternate" / self.plan.partition_id,
                     self.plan,
                 )
 
@@ -295,22 +305,110 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             with self.assertRaisesRegex(AV1ValidationDerivationError, "already exists"):
                 write_av1_validation_derivation_terminal_record(records_dir, record)
 
+    def test_assignment_and_review_claim_directories_are_fsynced_through_parents(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            attempts_directory = root / "nested" / "claims" / "attempts"
+            with patch(
+                "mediaforce.tuning.av1_validation_derivation._fsync_directory"
+            ) as fsync_directory:
+                write_av1_validation_derivation_assignment_claim(
+                    attempts_directory,
+                    assignment_id=self.plan.assignments[0].assignment_id,
+                    plan_id=self.plan.plan_id,
+                    authorization_id=self.plan.authorization.authorization_id,
+                )
+            fsynced_paths = {
+                call.args[0] for call in fsync_directory.call_args_list
+            }
+            self.assertTrue({
+                root,
+                root / "nested",
+                root / "nested" / "claims",
+                attempts_directory,
+            }.issubset(fsynced_paths))
+
+        proposal = self._candidate_proposal()
+        claim = build_av1_validation_derivation_review_claim(
+            plan=self.plan,
+            proposal=proposal,
+            lane="architecture",
+            review_run_id="70000000-0000-0000-0000-000000000001",
+            review_runner_canonical_path_sha256=(
+                self.authorization.review_runner_canonical_path_sha256
+            ),
+            review_runner_binary_sha256=(
+                self.authorization.review_runner_binary_sha256
+            ),
+            claimed_at="2026-07-28T03:00:01Z",
+        )
+        with patch(
+            "mediaforce.tuning.av1_validation_derivation._fsync_directory"
+        ) as fsync_directory:
+            write_av1_validation_derivation_review_claim(
+                self.runtime_artifact_root,
+                plan=self.plan,
+                proposal=proposal,
+                claim=claim,
+            )
+        fsynced_paths = {
+            call.args[0] for call in fsync_directory.call_args_list
+        }
+        resolved_artifact_root = self.runtime_artifact_root.resolve()
+        self.assertTrue({
+            resolved_artifact_root,
+            resolved_artifact_root / "review-claims",
+            (
+                resolved_artifact_root
+                / "review-claims"
+                / proposal.proposal_id
+            ),
+        }.issubset(fsynced_paths))
+
     def test_review_attestation_identity_comes_from_code_managed_result(self) -> None:
         agent_id = "12345678-1234-1234-1234-123456789abc"
-        proposal = SimpleNamespace(
-            proposal_id="av1vdproposal1_test",
-            payload_sha256="sha256:" + "a" * 64,
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [
+            assignment
+            for assignment in self.plan.assignments
+            if assignment.cell_plan_id == cell_plan_id
+        ]
+        records = [
+            self._observed_record(assignment.assignment_id, crf=28.0)
+            for assignment in assignments
+        ]
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
             proposed_at="2026-07-28T02:00:00Z",
-            to_payload=lambda: {
-                "proposal_id": "av1vdproposal1_test",
-                "payload_sha256": "sha256:" + "a" * 64,
-            },
+        )
+        assert evaluation.proposal is not None
+        proposal = evaluation.proposal
+        expected_claim = build_av1_validation_derivation_review_claim(
+            plan=self.plan,
+            proposal=proposal,
+            lane="architecture",
+            review_run_id=agent_id,
+            review_runner_canonical_path_sha256=(
+                self.authorization.review_runner_canonical_path_sha256
+            ),
+            review_runner_binary_sha256=(
+                self.authorization.review_runner_binary_sha256
+            ),
+            claimed_at="2026-07-28T03:00:00Z",
         )
         marker = {
             "decision": "approved",
             "lane": "architecture",
             "proposal_id": proposal.proposal_id,
             "proposal_payload_sha256": proposal.payload_sha256,
+            "review_claim_id": expected_claim.claim_id,
+            "review_claim_payload_sha256": expected_claim.payload_sha256,
             "review_run_id": agent_id,
         }
         with tempfile.TemporaryDirectory() as directory:
@@ -325,8 +423,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             )
             prompt = verify_av1_cold_start_preregistration._agent_review_prompt(
                 proposal=proposal,
-                lane="architecture",
-                review_run_id=agent_id,
+                claim=expected_claim,
             )
             stdout = "\n".join((
                 json.dumps({
@@ -358,9 +455,13 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             )
             with (
                 patch.object(
-                    verify_av1_cold_start_preregistration.shutil,
-                    "which",
-                    return_value=str(code_binary),
+                    verify_av1_cold_start_preregistration,
+                    "_authorized_review_runner_identity",
+                    return_value=(
+                        code_binary,
+                        self.authorization.review_runner_canonical_path_sha256,
+                        self.authorization.review_runner_binary_sha256,
+                    ),
                 ),
                 patch.object(
                     verify_av1_cold_start_preregistration.subprocess,
@@ -372,28 +473,314 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                     "uuid4",
                     return_value=agent_id,
                 ),
+                patch.object(
+                    verify_av1_cold_start_preregistration,
+                    "_now_iso",
+                    return_value="2026-07-28T03:00:00Z",
+                ),
             ):
-                reviewer_token, evidence, decision = (
+                claim, evidence, decision = (
                     verify_av1_cold_start_preregistration._run_code_agent_review(
+                        artifact_root=self.runtime_artifact_root,
+                        plan=self.plan,
                         proposal=proposal,
                         lane="architecture",
                     )
                 )
-            self.assertEqual(reviewer_token, f"agent:{agent_id}")
+            self.assertEqual(claim, expected_claim)
             self.assertEqual(decision, "approved")
             evidence_payload = json.loads(evidence)
             self.assertEqual(evidence_payload["review_run_id"], agent_id)
             self.assertEqual(evidence_payload["returncode"], 0)
+            self.assertNotIn(str(code_binary), evidence.decode("utf-8"))
             review = build_av1_validation_derivation_review_attestation(
                 proposal=proposal,
-                lane="architecture",
-                reviewer_token=reviewer_token,
+                claim=claim,
                 review_evidence_sha256=(
                     f"sha256:{hashlib.sha256(evidence).hexdigest()}"
                 ),
                 decision=decision,
                 reviewed_at="2026-07-28T03:00:00Z",
             )
+            validate_av1_validation_derivation_review_run_evidence(
+                evidence,
+                review=review,
+            )
+
+    def test_review_runner_rejects_path_substitution_before_launch(self) -> None:
+        with (
+            patch.object(
+                verify_av1_cold_start_preregistration,
+                "_review_runner_identity",
+                return_value=(
+                    Path("/private/substitute-code"),
+                    f"sha256:{'c' * 64}",
+                    self.authorization.review_runner_binary_sha256,
+                ),
+            ),
+            patch.object(
+                verify_av1_cold_start_preregistration.subprocess,
+                "run",
+            ) as run_review,
+            self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "drifted from the authorization",
+            ),
+        ):
+            verify_av1_cold_start_preregistration._run_code_agent_review(
+                artifact_root=self.runtime_artifact_root,
+                plan=self.plan,
+                proposal=self._candidate_proposal(),
+                lane="architecture",
+            )
+        run_review.assert_not_called()
+
+    def test_review_runner_is_reverified_after_launch(self) -> None:
+        proposal = self._candidate_proposal()
+        before_identity = (
+            Path("/private/authorized-code"),
+            self.authorization.review_runner_canonical_path_sha256,
+            self.authorization.review_runner_binary_sha256,
+        )
+        after_identity = (
+            Path("/private/substitute-code"),
+            f"sha256:{'c' * 64}",
+            self.authorization.review_runner_binary_sha256,
+        )
+        completed = SimpleNamespace(returncode=0, stdout="", stderr="")
+        with (
+            patch.object(
+                verify_av1_cold_start_preregistration,
+                "_review_runner_identity",
+                side_effect=(before_identity, after_identity),
+            ),
+            patch.object(
+                verify_av1_cold_start_preregistration.subprocess,
+                "run",
+                return_value=completed,
+            ) as run_review,
+            patch.object(
+                verify_av1_cold_start_preregistration.uuid,
+                "uuid4",
+                return_value="60000000-0000-0000-0000-000000000001",
+            ),
+            patch.object(
+                verify_av1_cold_start_preregistration,
+                "_now_iso",
+                return_value="2026-07-28T03:00:01Z",
+            ),
+            self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "drifted from the authorization",
+            ),
+        ):
+            verify_av1_cold_start_preregistration._run_code_agent_review(
+                artifact_root=self.runtime_artifact_root,
+                plan=self.plan,
+                proposal=proposal,
+                lane="architecture",
+            )
+        run_review.assert_called_once()
+        self.assertEqual(
+            len(load_av1_validation_derivation_review_claims(
+                self.runtime_artifact_root,
+                plan=self.plan,
+                proposal=proposal,
+            )),
+            1,
+        )
+
+    def test_review_claim_race_leaves_one_terminal_unresolved_claim(self) -> None:
+        proposal = self._candidate_proposal()
+        claims = [
+            build_av1_validation_derivation_review_claim(
+                plan=self.plan,
+                proposal=proposal,
+                lane="architecture",
+                review_run_id=f"20000000-0000-0000-0000-{index:012x}",
+                review_runner_canonical_path_sha256=(
+                    self.authorization.review_runner_canonical_path_sha256
+                ),
+                review_runner_binary_sha256=(
+                    self.authorization.review_runner_binary_sha256
+                ),
+                claimed_at=f"2026-07-28T03:00:0{index}Z",
+            )
+            for index in (1, 2)
+        ]
+        barrier = threading.Barrier(2)
+
+        def write_claim(claim: AV1ValidationDerivationReviewClaim) -> bool:
+            barrier.wait()
+            try:
+                write_av1_validation_derivation_review_claim(
+                    self.runtime_artifact_root,
+                    plan=self.plan,
+                    proposal=proposal,
+                    claim=claim,
+                )
+            except AV1ValidationDerivationError:
+                return False
+            return True
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            outcomes = tuple(executor.map(write_claim, claims))
+        self.assertEqual(sorted(outcomes), [False, True])
+        persisted_claims = load_av1_validation_derivation_review_claims(
+            self.runtime_artifact_root,
+            plan=self.plan,
+            proposal=proposal,
+        )
+        self.assertEqual(len(persisted_claims), 1)
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "all five immutable review claims",
+        ):
+            finalize_av1_validation_derivation_candidate_lock(
+                proposal=proposal,
+                review_claims=persisted_claims,
+                reviews=(),
+                current_evaluation=SimpleNamespace(
+                    blockers=(),
+                    proposal=proposal,
+                    cell_plan_id=proposal.cell_plan_id,
+                    derivation_snapshot_sha256=(
+                        proposal.derivation_snapshot_sha256
+                    ),
+                ),
+                locked_at=proposal.proposed_at,
+            )
+
+    def test_rejected_review_is_persisted_and_cannot_be_replaced(self) -> None:
+        proposal = self._candidate_proposal()
+        claims = []
+        reviews = []
+        for index, lane in enumerate(
+            AV1_VALIDATION_DERIVATION_REVIEW_LANES,
+            start=1,
+        ):
+            claim = build_av1_validation_derivation_review_claim(
+                plan=self.plan,
+                proposal=proposal,
+                lane=lane,
+                review_run_id=f"30000000-0000-0000-0000-{index:012x}",
+                review_runner_canonical_path_sha256=(
+                    self.authorization.review_runner_canonical_path_sha256
+                ),
+                review_runner_binary_sha256=(
+                    self.authorization.review_runner_binary_sha256
+                ),
+                claimed_at=f"2026-07-28T03:00:{index:02d}Z",
+            )
+            decision: Literal["approved", "rejected"] = (
+                "rejected" if lane == "privacy_security" else "approved"
+            )
+            evidence = _review_run_evidence(
+                proposal=proposal,
+                claim=claim,
+                decision=decision,
+            )
+            review = build_av1_validation_derivation_review_attestation(
+                proposal=proposal,
+                claim=claim,
+                review_evidence_sha256=(
+                    f"sha256:{hashlib.sha256(evidence).hexdigest()}"
+                ),
+                decision=decision,
+                reviewed_at=f"2026-07-28T03:{index:02d}:00Z",
+            )
+            envelope = build_av1_validation_derivation_review_envelope(
+                review=review,
+                evidence=evidence,
+            )
+            write_av1_validation_derivation_review_claim(
+                self.runtime_artifact_root,
+                plan=self.plan,
+                proposal=proposal,
+                claim=claim,
+            )
+            write_av1_validation_derivation_review_envelope(
+                self.runtime_artifact_root,
+                plan=self.plan,
+                proposal=proposal,
+                claim=claim,
+                envelope=envelope,
+            )
+            claims.append(claim)
+            reviews.append(review)
+
+        replacement = build_av1_validation_derivation_review_claim(
+            plan=self.plan,
+            proposal=proposal,
+            lane="privacy_security",
+            review_run_id="40000000-0000-0000-0000-000000000001",
+            review_runner_canonical_path_sha256=(
+                self.authorization.review_runner_canonical_path_sha256
+            ),
+            review_runner_binary_sha256=(
+                self.authorization.review_runner_binary_sha256
+            ),
+            claimed_at="2026-07-28T03:10:00Z",
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "already exists",
+        ):
+            write_av1_validation_derivation_review_claim(
+                self.runtime_artifact_root,
+                plan=self.plan,
+                proposal=proposal,
+                claim=replacement,
+            )
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "did not approve",
+        ):
+            current_proposal = self._candidate_proposal(
+                proposed_at="2026-07-28T03:10:00Z"
+            )
+            finalize_av1_validation_derivation_candidate_lock(
+                proposal=proposal,
+                review_claims=claims,
+                reviews=reviews,
+                current_evaluation=SimpleNamespace(
+                    blockers=(),
+                    proposal=current_proposal,
+                    cell_plan_id=current_proposal.cell_plan_id,
+                    derivation_snapshot_sha256=(
+                        current_proposal.derivation_snapshot_sha256
+                    ),
+                ),
+                locked_at="2026-07-28T03:10:00Z",
+            )
+
+    def test_review_evidence_digest_must_match_canonical_evidence(self) -> None:
+        proposal = self._candidate_proposal()
+        claim = build_av1_validation_derivation_review_claim(
+            plan=self.plan,
+            proposal=proposal,
+            lane="architecture",
+            review_run_id="50000000-0000-0000-0000-000000000001",
+            review_runner_canonical_path_sha256=(
+                self.authorization.review_runner_canonical_path_sha256
+            ),
+            review_runner_binary_sha256=(
+                self.authorization.review_runner_binary_sha256
+            ),
+            claimed_at="2026-07-28T03:00:01Z",
+        )
+        evidence = _review_run_evidence(proposal=proposal, claim=claim)
+        review = build_av1_validation_derivation_review_attestation(
+            proposal=proposal,
+            claim=claim,
+            review_evidence_sha256=f"sha256:{'f' * 64}",
+            decision="approved",
+            reviewed_at="2026-07-28T03:01:00Z",
+        )
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "digest does not match its canonical evidence",
+        ):
             validate_av1_validation_derivation_review_run_evidence(
                 evidence,
                 review=review,
@@ -708,6 +1095,12 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             statistics_contract_sha256=(
                 self.authorization.statistics_contract_sha256
             ),
+            review_runner_canonical_path_sha256=(
+                self.authorization.review_runner_canonical_path_sha256
+            ),
+            review_runner_binary_sha256=(
+                self.authorization.review_runner_binary_sha256
+            ),
             authorized_at="2026-07-28T00:01:00Z",
             valid_until=VALID_UNTIL,
         )
@@ -717,6 +1110,14 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             authorization=second_authorization,
             runtime_context_sha256=self.plan.runtime_context_sha256,
         )
+        with self.assertRaisesRegex(
+            AV1ValidationDerivationError,
+            "another artifact set",
+        ):
+            write_av1_validation_derivation_plan(
+                self.runtime_artifact_root,
+                second_plan,
+            )
         first_assignment = self.plan.assignments[0]
         first_attempt = self._failed_attempt(first_assignment.assignment_id)
         second_attempt = build_av1_validation_derivation_attempt(
@@ -737,25 +1138,95 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             ):
                 write_av1_validation_derivation_attempt(attempts_dir, second_attempt)
 
-    def test_unsuccessful_attempt_stops_remaining_worklist(self) -> None:
+    def test_unsuccessful_attempt_stops_only_the_affected_cell(self) -> None:
         first_assignment, second_assignment = self.plan.assignments[:2]
+        other_cell_assignment = next(
+            assignment
+            for assignment in self.plan.assignments
+            if assignment.cell_plan_id != first_assignment.cell_plan_id
+        )
+        later_other_cell_assignment = next(
+            assignment
+            for assignment in self.plan.assignments
+            if (
+                assignment.cell_plan_id == other_cell_assignment.cell_plan_id
+                and assignment.ordinal > other_cell_assignment.ordinal
+            )
+        )
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             attempts_dir = root / "attempts"
+            records_dir = root / "records"
             write_av1_validation_derivation_attempt(
                 attempts_dir,
                 self._failed_attempt(first_assignment.assignment_id),
             )
+            write_av1_validation_derivation_terminal_record(
+                records_dir,
+                self._failed_record(first_assignment.assignment_id),
+            )
             with self.assertRaisesRegex(
                 AV1ValidationDerivationError,
-                "unsuccessful attempt",
+                "affected stopped cell",
             ):
                 _assert_next_assignment(
                     plan=self.plan,
                     assignment_id=second_assignment.assignment_id,
                     attempts_directory=attempts_dir,
-                    terminal_records_directory=root / "records",
+                    terminal_records_directory=records_dir,
                 )
+            _assert_next_assignment(
+                plan=self.plan,
+                assignment_id=other_cell_assignment.assignment_id,
+                attempts_directory=attempts_dir,
+                terminal_records_directory=records_dir,
+            )
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "not next in the immutable worklist",
+            ):
+                _assert_next_assignment(
+                    plan=self.plan,
+                    assignment_id=later_other_cell_assignment.assignment_id,
+                    attempts_directory=attempts_dir,
+                    terminal_records_directory=records_dir,
+                )
+
+    def test_unfavorable_verdict_stops_only_the_affected_cell(self) -> None:
+        first_assignment, second_assignment = self.plan.assignments[:2]
+        other_cell_assignment = next(
+            assignment
+            for assignment in self.plan.assignments
+            if assignment.cell_plan_id != first_assignment.cell_plan_id
+        )
+        record = self._observed_record(
+            first_assignment.assignment_id,
+            crf=28.0,
+            verdict="unacceptable",
+        )
+        attempt = self._attempts((record,))[0]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            attempts_dir = root / "attempts"
+            records_dir = root / "records"
+            write_av1_validation_derivation_attempt(attempts_dir, attempt)
+            write_av1_validation_derivation_terminal_record(records_dir, record)
+            with self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "affected stopped cell",
+            ):
+                _assert_next_assignment(
+                    plan=self.plan,
+                    assignment_id=second_assignment.assignment_id,
+                    attempts_directory=attempts_dir,
+                    terminal_records_directory=records_dir,
+                )
+            _assert_next_assignment(
+                plan=self.plan,
+                assignment_id=other_cell_assignment.assignment_id,
+                attempts_directory=attempts_dir,
+                terminal_records_directory=records_dir,
+            )
 
     def test_review_pending_attempt_requires_human_terminal_before_continuing(self) -> None:
         first_assignment, second_assignment = self.plan.assignments[:2]
@@ -849,7 +1320,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                     terminal_records_directory=records_dir,
                 )
 
-    def test_next_assignment_requires_attempts_to_form_an_ordered_prefix(self) -> None:
+    def test_next_assignment_requires_immutable_canonical_order(self) -> None:
         first_assignment, second_assignment = self.plan.assignments[:2]
         record = self._observed_record(second_assignment.assignment_id, crf=28.0)
         attempt = self._attempts((record,))[0]
@@ -861,7 +1332,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             write_av1_validation_derivation_terminal_record(records_dir, record)
             with self.assertRaisesRegex(
                 AV1ValidationDerivationError,
-                "ordered prefix",
+                "immutable canonical order",
             ):
                 _assert_next_assignment(
                     plan=self.plan,
@@ -902,7 +1373,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 ),
                 self.assertRaisesRegex(
                     AV1ValidationDerivationError,
-                    "plan-global canonical directory",
+                    "partition-global canonical directory",
                 ),
             ):
                 run_av1_validation_derivation_assignment(
@@ -1037,13 +1508,29 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         terminal_records_directory = (
             self.runtime_config.paths.web_state_dir
             / "av1-validation-derivation"
-            / self.plan.plan_id
+            / self.plan.partition_id
             / "terminal-records"
         )
+        write_av1_validation_derivation_attempt(
+            self.runtime_artifact_root / "attempts",
+            attempt,
+        )
+        connection = SimpleNamespace(exec_driver_sql=lambda _sql: None)
         with (
             patch(
                 "mediaforce.web.runtime.av1_validation_derivation.load_config",
                 return_value=self.runtime_config,
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.open_db",
+                return_value=nullcontext(connection),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_av1_validation_partition_inventory",
+                return_value=SimpleNamespace(
+                    sources=self.sources,
+                    expectations=self.expectations,
+                ),
             ),
             patch(
                 "mediaforce.web.runtime.av1_validation_derivation._derivation_prefix",
@@ -1071,8 +1558,10 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             ):
                 record_av1_validation_derivation_visual_verdict(
                     config_path=Path("unused.toml"),
+                    manifest=self.manifest,
                     plan=self.plan,
                     partition=self.partition,
+                    token_key=self.token_key,
                     attempt=attempt,
                     terminal_records_directory=terminal_records_directory,
                     verdict="approved",
@@ -1107,13 +1596,29 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         terminal_records_directory = (
             self.runtime_config.paths.web_state_dir
             / "av1-validation-derivation"
-            / self.plan.plan_id
+            / self.plan.partition_id
             / "terminal-records"
         )
+        write_av1_validation_derivation_attempt(
+            self.runtime_artifact_root / "attempts",
+            attempt,
+        )
+        connection = SimpleNamespace(exec_driver_sql=lambda _sql: None)
         with (
             patch(
                 "mediaforce.web.runtime.av1_validation_derivation.load_config",
                 return_value=self.runtime_config,
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.open_db",
+                return_value=nullcontext(connection),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_av1_validation_partition_inventory",
+                return_value=SimpleNamespace(
+                    sources=self.sources,
+                    expectations=self.expectations,
+                ),
             ),
             patch(
                 "mediaforce.web.runtime.av1_validation_derivation._current_derivation_review_artifact_fingerprint",
@@ -1129,8 +1634,10 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         ):
             record_av1_validation_derivation_visual_verdict(
                 config_path=Path("unused.toml"),
+                manifest=self.manifest,
                 plan=self.plan,
                 partition=self.partition,
+                token_key=self.token_key,
                 attempt=attempt,
                 terminal_records_directory=terminal_records_directory,
                 verdict="approved",
@@ -1140,6 +1647,254 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 recorded_at="2026-07-28T01:06:00Z",
             )
         build_observation.assert_not_called()
+
+    def test_derivation_verdict_holds_runtime_lock_through_terminal_commit(self) -> None:
+        assignment = self.plan.assignments[0]
+        source_identity = _source_identity(self.partition, assignment)
+        attempt = build_av1_validation_derivation_attempt(
+            plan=self.plan,
+            partition=self.partition,
+            assignment_id=assignment.assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            calibration_payload=_calibration_payload(
+                assignment=assignment,
+                source_identity=source_identity,
+                crf=28.0,
+                compatibility=_compatibility(assignment),
+            ),
+        )
+        write_av1_validation_derivation_attempt(
+            self.runtime_artifact_root / "attempts",
+            attempt,
+        )
+        observation = _observation(
+            assignment=assignment,
+            source_identity=source_identity,
+            crf=28.0,
+            bitrate=1_000_000,
+            verdict="acceptable",
+        )
+        events: list[str] = []
+        lock_held = False
+
+        @contextmanager
+        def runtime_lock(
+                _config: object,
+                *,
+                owner_payload: object,
+        ) -> Iterator[None]:
+            nonlocal lock_held
+            self.assertIsNotNone(owner_payload)
+            lock_held = True
+            events.append("lock-enter")
+            try:
+                yield
+            finally:
+                events.append("lock-exit")
+                lock_held = False
+
+        @contextmanager
+        def database(_path: Path) -> Iterator[SimpleNamespace]:
+            self.assertTrue(lock_held)
+            events.append("db-enter")
+            try:
+                yield SimpleNamespace(exec_driver_sql=lambda _sql: None)
+            finally:
+                events.append("db-exit")
+
+        def record_event(label: str) -> None:
+            self.assertTrue(lock_held)
+            events.append(label)
+
+        with (
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_config",
+                return_value=self.runtime_config,
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.exclusive_mediaforce_runtime_lock",
+                side_effect=runtime_lock,
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.open_db",
+                side_effect=database,
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_av1_validation_partition_inventory",
+                return_value=SimpleNamespace(
+                    sources=self.sources,
+                    expectations=self.expectations,
+                ),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.validate_av1_validation_partition_current_inputs",
+                side_effect=lambda *_args, **_kwargs: record_event(
+                    "partition-current"
+                ),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.assert_av1_validation_derivation_execution_contract",
+                side_effect=lambda *_args, **_kwargs: record_event(
+                    "execution-contract"
+                ),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation._current_derivation_review_artifact_fingerprint",
+                side_effect=lambda **_kwargs: (
+                    record_event("media-recheck")
+                    or attempt.calibration_payload()["review_artifact_fingerprint"]
+                ),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.resolve_av1_validation_derivation_verdict_intent",
+                side_effect=lambda *_args, **_kwargs: (
+                    record_event("verdict-intent")
+                    or {
+                        "verdict": "approved",
+                        "concern_tags": [],
+                        "evidence_ids": [],
+                        "moment_indexes": [],
+                        "recorded_at": "2026-07-28T01:06:00Z",
+                    }
+                ),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation._derivation_prefix",
+                return_value="private/derivation",
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.build_visual_content_intent_observation",
+                return_value=ContentIntentObservationBuildResult(observation, None),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.ensure_av1_validation_derivation_terminal_intent",
+                side_effect=lambda *_args, **_kwargs: record_event("terminal-intent"),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.append_content_intent_boundary_observation",
+                side_effect=lambda *_args, **_kwargs: record_event("db-append"),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.ensure_av1_validation_derivation_terminal_record",
+                side_effect=lambda *_args, **_kwargs: record_event("terminal-record"),
+            ),
+        ):
+            terminal = record_av1_validation_derivation_visual_verdict(
+                config_path=Path("unused.toml"),
+                manifest=self.manifest,
+                plan=self.plan,
+                partition=self.partition,
+                token_key=self.token_key,
+                attempt=attempt,
+                terminal_records_directory=(
+                    self.runtime_artifact_root / "terminal-records"
+                ),
+                verdict="approved",
+                concern_tags=[],
+                evidence_ids=[],
+                moment_indexes=[],
+                recorded_at="2026-07-28T01:06:00Z",
+            )
+        self.assertEqual(terminal.status, "observed")
+        self.assertEqual(events, [
+            "lock-enter",
+            "db-enter",
+            "partition-current",
+            "execution-contract",
+            "media-recheck",
+            "verdict-intent",
+            "terminal-intent",
+            "db-append",
+            "db-exit",
+            "execution-contract",
+            "terminal-record",
+            "lock-exit",
+        ])
+
+    def test_derivation_verdict_fails_closed_on_current_input_drift(self) -> None:
+        assignment = self.plan.assignments[0]
+        attempt = build_av1_validation_derivation_attempt(
+            plan=self.plan,
+            partition=self.partition,
+            assignment_id=assignment.assignment_id,
+            started_at="2026-07-28T01:00:00Z",
+            completed_at="2026-07-28T01:05:00Z",
+            status="review_pending",
+            calibration_payload=_calibration_payload(
+                assignment=assignment,
+                source_identity=_source_identity(self.partition, assignment),
+                crf=28.0,
+                compatibility=_compatibility(assignment),
+            ),
+        )
+        write_av1_validation_derivation_attempt(
+            self.runtime_artifact_root / "attempts",
+            attempt,
+        )
+        connection = SimpleNamespace(exec_driver_sql=lambda _sql: None)
+        with (
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_config",
+                return_value=self.runtime_config,
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.exclusive_mediaforce_runtime_lock",
+                return_value=nullcontext(),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.open_db",
+                return_value=nullcontext(connection),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.load_av1_validation_partition_inventory",
+                return_value=SimpleNamespace(
+                    sources=self.sources,
+                    expectations=self.expectations,
+                ),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.validate_av1_validation_partition_current_inputs",
+                side_effect=AV1ValidationDerivationError("current inputs drifted"),
+            ),
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation._current_derivation_review_artifact_fingerprint"
+            ) as review_fingerprint,
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.resolve_av1_validation_derivation_verdict_intent"
+            ) as verdict_intent,
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.append_content_intent_boundary_observation"
+            ) as append_observation,
+            patch(
+                "mediaforce.web.runtime.av1_validation_derivation.ensure_av1_validation_derivation_terminal_record"
+            ) as write_terminal,
+            self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                "current inputs drifted",
+            ),
+        ):
+            record_av1_validation_derivation_visual_verdict(
+                config_path=Path("unused.toml"),
+                manifest=self.manifest,
+                plan=self.plan,
+                partition=self.partition,
+                token_key=self.token_key,
+                attempt=attempt,
+                terminal_records_directory=(
+                    self.runtime_artifact_root / "terminal-records"
+                ),
+                verdict="approved",
+                concern_tags=[],
+                evidence_ids=[],
+                moment_indexes=[],
+                recorded_at="2026-07-28T01:06:00Z",
+            )
+        review_fingerprint.assert_not_called()
+        verdict_intent.assert_not_called()
+        append_observation.assert_not_called()
+        write_terminal.assert_not_called()
 
     def test_derivation_observation_is_not_replay_eligible(self) -> None:
         assignment = self.plan.assignments[0]
@@ -1215,7 +1970,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 recorded_at="2026-07-28T01:05:00Z",
             )
 
-    def test_candidate_uses_full_crf_range_and_dispersion_confidence(self) -> None:
+    def test_candidate_uses_assignment_bitrate_range_and_observed_dispersion(self) -> None:
         cell_plan_id = self.plan.assignments[0].cell_plan_id
         assignments = [item for item in self.plan.assignments if item.cell_plan_id == cell_plan_id]
         records = [
@@ -1250,8 +2005,14 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         self.assertEqual(evaluation.proposal.derivation_conflict_count, 0)
         self.assertEqual(evaluation.proposal.confidence_level, "moderate")
         self.assertEqual(evaluation.proposal.confidence_score, 0.85)
-        self.assertEqual(evaluation.proposal.target_video_bitrate_min_bps, 850_000)
-        self.assertEqual(evaluation.proposal.target_video_bitrate_max_bps, 1_150_000)
+        self.assertEqual(
+            evaluation.proposal.target_video_bitrate_min_bps,
+            min(assignment.target_video_bitrate_bps for assignment in assignments),
+        )
+        self.assertEqual(
+            evaluation.proposal.target_video_bitrate_max_bps,
+            max(assignment.target_video_bitrate_bps for assignment in assignments),
+        )
 
     def test_candidate_rejects_full_crf_span_even_when_center_is_tight(self) -> None:
         cell_plan_id = self.plan.assignments[0].cell_plan_id
@@ -1273,6 +2034,48 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         )
         self.assertIsNone(evaluation.proposal)
         self.assertIn("crf_span_too_wide", evaluation.blockers)
+
+    def test_proposal_type_reasserts_preregistered_invariants(self) -> None:
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [
+            assignment
+            for assignment in self.plan.assignments
+            if assignment.cell_plan_id == cell_plan_id
+        ]
+        records = [
+            self._observed_record(assignment.assignment_id, crf=28.0)
+            for assignment in assignments
+        ]
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
+            proposed_at="2026-07-28T03:00:00Z",
+        )
+        assert evaluation.proposal is not None
+        proposal = evaluation.proposal
+
+        for field_updates, message in (
+            ({"crf_lower": 24.0, "crf_upper": 31.0}, "CRF span is too wide"),
+            ({"minimum_derivation_source_count": 5}, "source-count contract"),
+            (
+                {"derivation_series_tokens": proposal.derivation_series_tokens[:-1]},
+                "unique source, title, and series reservations",
+            ),
+            (
+                {"derivation_oldest_recorded_at": "2026-01-01T00:00:00Z"},
+                "evidence is stale",
+            ),
+        ):
+            with self.subTest(field_updates=field_updates), self.assertRaisesRegex(
+                AV1ValidationDerivationError,
+                message,
+            ):
+                replace(proposal, **field_updates)
 
     def test_candidate_rejects_wide_crf_dispersion_with_acceptable_span(self) -> None:
         cell_plan_id = self.plan.assignments[0].cell_plan_id
@@ -1342,22 +2145,34 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         )
         assert evaluation.proposal is not None
         review_evidence: dict[str, bytes] = {}
+        review_claims = []
         reviews = []
         for index, lane in enumerate(
             AV1_VALIDATION_DERIVATION_REVIEW_LANES,
             start=1,
         ):
-            review_run_id = f"00000000-0000-0000-0000-{index:012x}"
-            evidence = _review_run_evidence(
+            claim = build_av1_validation_derivation_review_claim(
+                plan=self.plan,
                 proposal=evaluation.proposal,
                 lane=lane,
-                review_run_id=review_run_id,
+                review_run_id=f"00000000-0000-0000-0000-{index:012x}",
+                review_runner_canonical_path_sha256=(
+                    self.authorization.review_runner_canonical_path_sha256
+                ),
+                review_runner_binary_sha256=(
+                    self.authorization.review_runner_binary_sha256
+                ),
+                claimed_at=f"2026-07-28T03:00:{index:02d}Z",
+            )
+            review_claims.append(claim)
+            evidence = _review_run_evidence(
+                proposal=evaluation.proposal,
+                claim=claim,
             )
             review_evidence[lane] = evidence
             reviews.append(build_av1_validation_derivation_review_attestation(
                 proposal=evaluation.proposal,
-                lane=lane,
-                reviewer_token=f"agent:{review_run_id}",
+                claim=claim,
                 review_evidence_sha256=(
                     f"sha256:{hashlib.sha256(evidence).hexdigest()}"
                 ),
@@ -1378,25 +2193,39 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         with self.assertRaisesRegex(AV1ValidationDerivationError, "all five"):
             finalize_av1_validation_derivation_candidate_lock(
                 proposal=evaluation.proposal,
+                review_claims=review_claims,
                 reviews=reviews[:-1],
                 current_evaluation=current_evaluation,
                 locked_at=locked_at,
             )
-        duplicate_evidence_reviews = [
-            build_av1_validation_derivation_review_attestation(
+        duplicate_evidence_claims = [
+            build_av1_validation_derivation_review_claim(
+                plan=self.plan,
                 proposal=evaluation.proposal,
                 lane=lane,
-                reviewer_token=(
-                    f"agent:10000000-0000-0000-0000-{index:012x}"
+                review_run_id=f"10000000-0000-0000-0000-{index:012x}",
+                review_runner_canonical_path_sha256=(
+                    self.authorization.review_runner_canonical_path_sha256
                 ),
-                review_evidence_sha256=f"sha256:{1:064x}",
-                decision="approved",
-                reviewed_at=f"2026-07-28T03:{index:02d}:30Z",
+                review_runner_binary_sha256=(
+                    self.authorization.review_runner_binary_sha256
+                ),
+                claimed_at=f"2026-07-28T03:00:{index:02d}Z",
             )
             for index, lane in enumerate(
                 AV1_VALIDATION_DERIVATION_REVIEW_LANES,
                 start=1,
             )
+        ]
+        duplicate_evidence_reviews = [
+            build_av1_validation_derivation_review_attestation(
+                proposal=evaluation.proposal,
+                claim=claim,
+                review_evidence_sha256=f"sha256:{1:064x}",
+                decision="approved",
+                reviewed_at=f"2026-07-28T03:{index:02d}:30Z",
+            )
+            for index, claim in enumerate(duplicate_evidence_claims, start=1)
         ]
         with self.assertRaisesRegex(
             AV1ValidationDerivationError,
@@ -1404,12 +2233,14 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         ):
             finalize_av1_validation_derivation_candidate_lock(
                 proposal=evaluation.proposal,
+                review_claims=duplicate_evidence_claims,
                 reviews=duplicate_evidence_reviews,
                 current_evaluation=current_evaluation,
                 locked_at=locked_at,
             )
         lock = finalize_av1_validation_derivation_candidate_lock(
             proposal=evaluation.proposal,
+            review_claims=review_claims,
             reviews=reviews,
             current_evaluation=current_evaluation,
             locked_at=locked_at,
@@ -1423,7 +2254,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             artifact_root = (
                 Path(directory)
                 / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
-                / self.plan.plan_id
+                / self.plan.partition_id
             )
             write_av1_validation_derivation_plan(artifact_root, self.plan)
             proposal_path = write_av1_validation_derivation_candidate_proposal(
@@ -1453,7 +2284,13 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                     cell_plan_id="../outside",
                 )
             review_envelopes = []
-            for review in reviews:
+            for claim, review in zip(review_claims, reviews, strict=True):
+                write_av1_validation_derivation_review_claim(
+                    artifact_root,
+                    plan=self.plan,
+                    proposal=evaluation.proposal,
+                    claim=claim,
+                )
                 envelope = build_av1_validation_derivation_review_envelope(
                     review=review,
                     evidence=review_evidence[review.lane],
@@ -1462,6 +2299,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                     artifact_root,
                     plan=self.plan,
                     proposal=evaluation.proposal,
+                    claim=claim,
                     envelope=envelope,
                 )
                 review_envelopes.append(envelope)
@@ -1473,10 +2311,16 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             )
             stale_temporary.write_bytes(b"interrupted")
             stale_temporary.chmod(0o600)
+            loaded_claims = load_av1_validation_derivation_review_claims(
+                artifact_root,
+                plan=self.plan,
+                proposal=evaluation.proposal,
+            )
             loaded_envelopes = load_av1_validation_derivation_review_envelopes(
                 artifact_root,
                 plan=self.plan,
                 proposal=evaluation.proposal,
+                claims=loaded_claims,
             )
             self.assertEqual(
                 {
@@ -1489,6 +2333,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 artifact_root,
                 plan=self.plan,
                 proposal=evaluation.proposal,
+                review_claims=loaded_claims,
                 review_envelopes=loaded_envelopes,
                 current_evaluation=current_evaluation,
                 locked_at=locked_at,
@@ -1499,6 +2344,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                     artifact_root,
                     plan=self.plan,
                     proposal=evaluation.proposal,
+                    review_claims=loaded_claims,
                     review_envelopes=loaded_envelopes,
                     current_evaluation=current_evaluation,
                     cell_plan_id=cell_plan_id,
@@ -1531,6 +2377,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
         ):
             finalize_av1_validation_derivation_candidate_lock(
                 proposal=evaluation.proposal,
+                review_claims=review_claims,
                 reviews=reviews,
                 current_evaluation=stale_evaluation,
                 locked_at=locked_at,
@@ -1613,6 +2460,53 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                 }
             )
 
+        with self.assertRaisesRegex(
+            AV1ColdStartValidationError,
+            "CRF span is too wide",
+        ):
+            build_av1_cold_start_validation_candidate_lock(
+                **{
+                    **candidate_lock_kwargs,
+                    "crf_lower": 24.0,
+                    "crf_upper": 31.0,
+                }
+            )
+
+        with self.assertRaisesRegex(
+            AV1ColdStartValidationError,
+            "series tokens are incomplete",
+        ):
+            build_av1_cold_start_validation_candidate_lock(
+                **{
+                    **candidate_lock_kwargs,
+                    "derivation_series_tokens": series_tokens[:-1],
+                }
+            )
+
+        with self.assertRaisesRegex(
+            AV1ColdStartValidationError,
+            "below the preregistered minimum",
+        ):
+            build_av1_cold_start_validation_candidate_lock(
+                **{
+                    **candidate_lock_kwargs,
+                    "derivation_source_count": 5,
+                    "derivation_source_tokens": source_tokens[:5],
+                }
+            )
+
+        with self.assertRaisesRegex(
+            AV1ColdStartValidationError,
+            "evidence is stale",
+        ):
+            build_av1_cold_start_validation_candidate_lock(
+                **{
+                    **candidate_lock_kwargs,
+                    "locked_at": "2027-02-01T03:00:00Z",
+                    "reviewed_at": "2027-02-01T03:00:00Z",
+                }
+            )
+
     def test_create_plan_cli_output_is_public_safe(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory) / "private"
@@ -1641,6 +2535,15 @@ class AV1ValidationDerivationTests(unittest.TestCase):
                     "_now_iso",
                     return_value=AUTHORIZED_AT,
                 ),
+                patch.object(
+                    verify_av1_cold_start_preregistration,
+                    "_review_runner_identity",
+                    return_value=(
+                        root / "private-code-runner",
+                        self.authorization.review_runner_canonical_path_sha256,
+                        self.authorization.review_runner_binary_sha256,
+                    ),
+                ),
                 redirect_stdout(stdout),
             ):
                 exit_code = verify_av1_cold_start_preregistration.main([
@@ -1660,7 +2563,7 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             plan_path = (
                 runtime_config.paths.web_state_dir
                 / AV1_VALIDATION_DERIVATION_ARTIFACT_DIRECTORY
-                / payload["plan_id"]
+                / self.partition.partition_id
                 / "plan.json"
             )
             self.assertTrue(plan_path.is_file())
@@ -1668,6 +2571,35 @@ class AV1ValidationDerivationTests(unittest.TestCase):
             self.assertNotIn("local_item_id", serialized)
             self.assertNotIn("source_token", serialized)
             self.assertNotIn(str(root), serialized)
+
+    def _candidate_proposal(
+            self,
+            *,
+            proposed_at: str = "2026-07-28T03:00:00Z",
+    ) -> AV1ValidationDerivationCandidateProposal:
+        cell_plan_id = self.plan.assignments[0].cell_plan_id
+        assignments = [
+            assignment
+            for assignment in self.plan.assignments
+            if assignment.cell_plan_id == cell_plan_id
+        ]
+        records = [
+            self._observed_record(assignment.assignment_id, crf=28.0)
+            for assignment in assignments
+        ]
+        evaluation = evaluate_av1_validation_derivation_candidate(
+            manifest=self.manifest,
+            plan=self.plan,
+            partition=self.partition,
+            cell_plan_id=cell_plan_id,
+            attempts=self._attempts(records),
+            records=records,
+            current_observations=self._current_observations(records),
+            proposed_at=proposed_at,
+        )
+        if evaluation.proposal is None:
+            raise AssertionError(evaluation.blockers)
+        return evaluation.proposal
 
     def _failed_attempt(self, assignment_id: str) -> AV1ValidationDerivationAttempt:
         return build_av1_validation_derivation_attempt(
@@ -1978,22 +2910,30 @@ def _calibration_payload(
 def _review_run_evidence(
         *,
         proposal: object,
-        lane: str,
-        review_run_id: str,
+        claim: AV1ValidationDerivationReviewClaim,
+        decision: Literal["approved", "rejected"] = "approved",
 ) -> bytes:
     proposal_id = str(getattr(proposal, "proposal_id"))
     proposal_payload_sha256 = str(getattr(proposal, "payload_sha256"))
+    lane = str(getattr(claim, "lane"))
+    review_run_id = str(getattr(claim, "review_run_id"))
+    review_claim_id = str(getattr(claim, "claim_id"))
+    review_claim_payload_sha256 = str(getattr(claim, "payload_sha256"))
     prompt = (
         f"review_run_id={review_run_id}\n"
         f"proposal_id={proposal_id}\n"
         f"proposal_payload_sha256={proposal_payload_sha256}\n"
+        f"review_claim_id={review_claim_id}\n"
+        f"review_claim_payload_sha256={review_claim_payload_sha256}\n"
         f"lane={lane}"
     )
     marker = {
-        "decision": "approved",
+        "decision": decision,
         "lane": lane,
         "proposal_id": proposal_id,
         "proposal_payload_sha256": proposal_payload_sha256,
+        "review_claim_id": review_claim_id,
+        "review_claim_payload_sha256": review_claim_payload_sha256,
         "review_run_id": review_run_id,
     }
     final_message = (
@@ -2031,9 +2971,16 @@ def _review_run_evidence(
         "reviewer_token": f"agent:{review_run_id}",
         "proposal_id": proposal_id,
         "proposal_payload_sha256": proposal_payload_sha256,
+        "review_claim_id": review_claim_id,
+        "review_claim_payload_sha256": review_claim_payload_sha256,
         "lane": lane,
-        "decision": "approved",
-        "code_binary_sha256": "sha256:" + "c" * 64,
+        "decision": decision,
+        "review_runner_canonical_path_sha256": str(
+            getattr(claim, "review_runner_canonical_path_sha256")
+        ),
+        "review_runner_binary_sha256": str(
+            getattr(claim, "review_runner_binary_sha256")
+        ),
         "prompt_sha256": f"sha256:{hashlib.sha256(prompt.encode('utf-8')).hexdigest()}",
         "stdout": stdout,
         "stderr": "",

--- a/tests/test_av1_validation_harness.py
+++ b/tests/test_av1_validation_harness.py
@@ -346,8 +346,14 @@ class AV1ValidationHarnessTests(unittest.TestCase):
             derivation_evidence_count=12,
             derivation_source_count=6,
             derivation_source_tokens=tuple(f"source_{index}" for index in range(6)),
+            derivation_title_tokens=tuple(
+                f"title_token_{index}" for index in range(12)
+            ),
             derivation_series_tokens=tuple(f"series_{index}" for index in range(12)),
             derivation_source_group_tokens=tuple(f"group_{index:03d}" for index in range(6)),
+            derivation_source_group_observation_tokens=tuple(
+                f"group_{index:03d}" for index in range(6) for _ in range(2)
+            ),
             derivation_oldest_recorded_at="2026-07-01T00:00:00Z",
             derivation_newest_recorded_at="2026-07-10T00:00:00Z",
             derivation_conflict_count=0,

--- a/tests/test_av1_validation_partition.py
+++ b/tests/test_av1_validation_partition.py
@@ -2,14 +2,17 @@ import copy
 from contextlib import redirect_stdout
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
+import hashlib
 import io
 import json
 import os
 from pathlib import Path
 import tempfile
+from types import SimpleNamespace
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from mediaforce.core.utils import content_version_fingerprint
 from mediaforce.tuning.av1_validation_partition import (
     AV1ValidationPartitionError,
     AV1ValidationPartitionExpectations,
@@ -30,12 +33,24 @@ from mediaforce.tuning.av1_validation_partition import (
     validate_av1_validation_private_partition,
     write_av1_validation_private_partition,
 )
+from mediaforce.tuning.av1_validation_partition_inventory import (
+    av1_validation_partition_source_sha256_resolver,
+)
 from mediaforce.tuning.av1_validation_v2 import load_av1_validation_manifest_v2
 from scripts import verify_av1_cold_start_preregistration
 
 
 V2_MANIFEST_PATH = Path("docs/validation/av1-cold-start-preregistration-v2.json")
 SELECTED_AT = "2026-07-27T22:50:00Z"
+
+
+def _source_sha256(source: AV1ValidationPartitionSource) -> str:
+    return f"sha256:{hashlib.sha256(source.source_identity.encode()).hexdigest()}"
+
+
+def _summary_sha256(summary: object) -> str:
+    payload = json.dumps(summary, separators=(",", ":"), sort_keys=True)
+    return f"sha256:{hashlib.sha256(payload.encode()).hexdigest()}"
 
 
 class AV1ValidationPartitionTests(unittest.TestCase):
@@ -81,6 +96,44 @@ class AV1ValidationPartitionTests(unittest.TestCase):
         self.assertFalse(summary["holdout_execution_authorized"])
         self.assertNotIn("local_item_id", json.dumps(summary))
         self.assertNotIn("source_token", json.dumps(summary))
+        self.assertNotIn(partition.assignments[0].source_sha256, json.dumps(summary))
+
+    def test_source_digest_changes_every_locked_partition_identity(self) -> None:
+        expected = self._build()
+        changed_item_id = expected.assignments[0].local_item_id
+
+        def changed_source_sha256(source: AV1ValidationPartitionSource) -> str:
+            if source.local_item_id == changed_item_id:
+                return f"sha256:{'f' * 64}"
+            return _source_sha256(source)
+
+        actual = build_av1_validation_private_partition(
+            manifest=self.manifest,
+            eligibility_attestation_id=self.manifest.eligibility_attestation_id,
+            eligibility_payload_sha256=self.manifest.eligibility_payload_sha256,
+            sources=self.sources,
+            expectations=self.expectations,
+            token_key=self.token_key,
+            expected_token_key_id=self.token_key_id,
+            selected_at=SELECTED_AT,
+            source_sha256_resolver=changed_source_sha256,
+        )
+        self.assertNotEqual(actual.selection_lock_sha256, expected.selection_lock_sha256)
+        self.assertNotEqual(
+            actual.derivation_partition_sha256,
+            expected.derivation_partition_sha256,
+        )
+        self.assertNotEqual(actual.partition_id, expected.partition_id)
+        self.assertNotEqual(actual.payload_sha256, expected.payload_sha256)
+
+    def test_partition_without_frozen_source_digest_fails_closed(self) -> None:
+        payload = copy.deepcopy(self._build().to_payload())
+        del payload["assignments"][0]["source_sha256"]
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError,
+            "assignment keys are invalid",
+        ):
+            av1_validation_private_partition_from_payload(payload)
 
     def test_partition_expectations_require_positive_quality_floor(self) -> None:
         with self.assertRaisesRegex(
@@ -100,6 +153,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
             token_key=self.token_key,
             expected_token_key_id=self.token_key_id,
             selected_at=SELECTED_AT,
+            source_sha256_resolver=_source_sha256,
         )
         self.assertEqual(actual, expected)
         validate_av1_validation_private_partition(
@@ -131,6 +185,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
             token_key=self.token_key,
             expected_token_key_id=self.token_key_id,
             selected_at=self.manifest.registered_at,
+            source_sha256_resolver=_source_sha256,
         )
         self.assertEqual(partition.selected_at, self.manifest.registered_at)
 
@@ -166,6 +221,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
                         token_key=self.token_key,
                         expected_token_key_id=self.token_key_id,
                         selected_at=selected_at,
+                        source_sha256_resolver=_source_sha256,
                     )
 
     def test_derivation_selection_cannot_remap_frozen_holdouts(self) -> None:
@@ -217,6 +273,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
                 token_key=self.token_key,
                 expected_token_key_id="av1vkey1_not_the_committed_key",
                 selected_at=SELECTED_AT,
+                source_sha256_resolver=_source_sha256,
             )
 
     def test_current_input_validation_rejects_a_narrowed_inventory(self) -> None:
@@ -236,6 +293,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
             token_key=self.token_key,
             expected_token_key_id=self.token_key_id,
             selected_at=SELECTED_AT,
+            source_sha256_resolver=_source_sha256,
         )
         validate_av1_validation_private_partition(
             narrowed_partition,
@@ -273,6 +331,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
                 token_key=self.token_key,
                 expected_token_key_id=self.token_key_id,
                 selected_at=SELECTED_AT,
+                source_sha256_resolver=_source_sha256,
             )
 
     def test_partition_fails_closed_when_global_series_disjointness_is_impossible(
@@ -296,6 +355,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
                 token_key=self.token_key,
                 expected_token_key_id=self.token_key_id,
                 selected_at=SELECTED_AT,
+                source_sha256_resolver=_source_sha256,
             )
 
     def test_partition_rejects_candidate_source_group_concentration(self) -> None:
@@ -325,6 +385,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
                 token_key=self.token_key,
                 expected_token_key_id=self.token_key_id,
                 selected_at=SELECTED_AT,
+                source_sha256_resolver=_source_sha256,
             )
 
     def test_partition_rejects_fewer_than_six_candidate_source_groups(self) -> None:
@@ -350,6 +411,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
                 token_key=self.token_key,
                 expected_token_key_id=self.token_key_id,
                 selected_at=SELECTED_AT,
+                source_sha256_resolver=_source_sha256,
             )
 
     def test_partition_rejects_duplicate_content_versions(self) -> None:
@@ -370,6 +432,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
                 token_key=self.token_key,
                 expected_token_key_id=self.token_key_id,
                 selected_at=SELECTED_AT,
+                source_sha256_resolver=_source_sha256,
             )
 
     def test_partition_filters_policy_incompatible_sources(self) -> None:
@@ -391,6 +454,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
                 token_key=self.token_key,
                 expected_token_key_id=self.token_key_id,
                 selected_at=SELECTED_AT,
+                source_sha256_resolver=_source_sha256,
             )
 
     def test_private_key_and_partition_are_owner_only_and_canonical(self) -> None:
@@ -410,6 +474,7 @@ class AV1ValidationPartitionTests(unittest.TestCase):
                 token_key=key,
                 expected_token_key_id=av1_validation_partition_key_id(key),
                 selected_at=SELECTED_AT,
+                source_sha256_resolver=_source_sha256,
             )
             write_av1_validation_private_partition(partition_path, partition)
             self.assertEqual(os.stat(key_path).st_mode & 0o777, 0o600)
@@ -462,7 +527,100 @@ class AV1ValidationPartitionTests(unittest.TestCase):
             token_key=self.token_key,
             expected_token_key_id=self.token_key_id,
             selected_at=SELECTED_AT,
+            source_sha256_resolver=_source_sha256,
         )
+
+
+class AV1ValidationPartitionSourceDigestTests(unittest.TestCase):
+    def test_selected_source_digest_replays_exact_fingerprint_evidence(self) -> None:
+        summary = {
+            "schema_version": 1,
+            "analysis": {"sampled_frames": 24},
+            "decision": {"status": "measured", "traits": ["typical"]},
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            source_path = Path(directory) / "source.mkv"
+            source_bytes = b"registered-source" * 80_000
+            source_path.write_bytes(source_bytes)
+            source_identity = content_version_fingerprint(
+                source_path,
+                source_path.stat(),
+            )
+            source = _digest_test_source(
+                source_identity=source_identity,
+                evidence_summary_sha256=_summary_sha256(summary),
+            )
+            connection = _digest_test_connection(
+                source=source,
+                source_path=source_path,
+                source_size_bytes=len(source_bytes),
+            )
+            with patch(
+                "mediaforce.tuning.av1_validation_partition_inventory.probe_evidence",
+                return_value=summary,
+            ) as probe:
+                resolver = av1_validation_partition_source_sha256_resolver(
+                    connection,
+                    config=SimpleNamespace(),
+                    verify_evidence=True,
+                )
+                source_sha256 = resolver(source)
+            self.assertEqual(
+                source_sha256,
+                f"sha256:{hashlib.sha256(source_bytes).hexdigest()}",
+            )
+            self.assertEqual(probe.call_args.args[0], source_path.resolve())
+
+    def test_selected_source_digest_rejects_unsampled_evidence_drift(self) -> None:
+        stored_summary = {
+            "schema_version": 1,
+            "analysis": {"sampled_frames": 24},
+            "decision": {"status": "measured", "traits": ["typical"]},
+        }
+        fresh_summary = {
+            "schema_version": 1,
+            "analysis": {"sampled_frames": 24},
+            "decision": {"status": "measured", "traits": ["motion"]},
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            source_path = Path(directory) / "source.mkv"
+            source_bytes = bytearray(b"A" * (1024 * 1024))
+            source_path.write_bytes(source_bytes)
+            source_identity = content_version_fingerprint(
+                source_path,
+                source_path.stat(),
+            )
+            source_bytes[128 * 1024] = ord("B")
+            source_path.write_bytes(source_bytes)
+            self.assertEqual(
+                content_version_fingerprint(source_path, source_path.stat()),
+                source_identity,
+            )
+            source = _digest_test_source(
+                source_identity=source_identity,
+                evidence_summary_sha256=_summary_sha256(stored_summary),
+            )
+            connection = _digest_test_connection(
+                source=source,
+                source_path=source_path,
+                source_size_bytes=len(source_bytes),
+            )
+            with (
+                patch(
+                    "mediaforce.tuning.av1_validation_partition_inventory.probe_evidence",
+                    return_value=fresh_summary,
+                ),
+                self.assertRaisesRegex(
+                    AV1ValidationPartitionError,
+                    "evidence does not replay from its frozen bytes",
+                ),
+            ):
+                resolver = av1_validation_partition_source_sha256_resolver(
+                    connection,
+                    config=SimpleNamespace(),
+                    verify_evidence=True,
+                )
+                resolver(source)
 
 
 class AV1ValidationPartitionCliTests(unittest.TestCase):
@@ -542,6 +700,48 @@ def _partition_sources(
             )
             local_item_id += 1
     return tuple(sources)
+
+
+def _digest_test_source(
+    *,
+    source_identity: str,
+    evidence_summary_sha256: str,
+) -> AV1ValidationPartitionSource:
+    return AV1ValidationPartitionSource(
+        local_item_id=1,
+        source_identity=source_identity,
+        title_identity="title-digest-test",
+        series_identity="series-digest-test",
+        source_group_identity="group-digest-test",
+        traits=("typical",),
+        compatibility_signature="av1vcompat1_digest_test",
+        base_policy_signature="av1vbasepolicy1_digest_test",
+        target_video_bitrate_bps=1_000_000,
+        quality_metric="vmaf",
+        quality_target=85.0,
+        minimum_quality_score=80.0,
+        evidence_summary_sha256=evidence_summary_sha256,
+    )
+
+
+def _digest_test_connection(
+    *,
+    source: AV1ValidationPartitionSource,
+    source_path: Path,
+    source_size_bytes: int,
+) -> Mock:
+    result = Mock()
+    result.mappings.return_value.one_or_none.return_value = {
+        "id": source.local_item_id,
+        "source_path": str(source_path),
+        "rel_path": source_path.name,
+        "media_root": "",
+        "content_version_fingerprint": source.source_identity,
+        "size_bytes": source_size_bytes,
+    }
+    connection = Mock()
+    connection.execute.return_value = result
+    return connection
 
 
 if __name__ == "__main__":

--- a/tests/test_av1_validation_partition.py
+++ b/tests/test_av1_validation_partition.py
@@ -82,6 +82,13 @@ class AV1ValidationPartitionTests(unittest.TestCase):
         self.assertNotIn("local_item_id", json.dumps(summary))
         self.assertNotIn("source_token", json.dumps(summary))
 
+    def test_partition_expectations_require_positive_quality_floor(self) -> None:
+        with self.assertRaisesRegex(
+            AV1ValidationPartitionError,
+            "quality expectations",
+        ):
+            replace(self.expectations, minimum_quality_score=0.0)
+
     def test_partition_is_deterministic_for_shuffled_inventory(self) -> None:
         expected = self._build()
         actual = build_av1_validation_private_partition(
@@ -410,6 +417,15 @@ class AV1ValidationPartitionTests(unittest.TestCase):
             self.assertEqual(
                 load_av1_validation_private_partition(partition_path), partition
             )
+
+            key_link = private_dir / "partition-key-link"
+            partition_link = private_dir / "partition-link.json"
+            key_link.symlink_to(key_path)
+            partition_link.symlink_to(partition_path)
+            with self.assertRaisesRegex(AV1ValidationPartitionError, "regular file"):
+                load_av1_validation_partition_key(key_link)
+            with self.assertRaisesRegex(AV1ValidationPartitionError, "regular file"):
+                load_av1_validation_private_partition(partition_link)
 
     def test_private_artifact_path_rejects_repository_contents(self) -> None:
         with self.assertRaisesRegex(

--- a/tests/test_av1_validation_v2.py
+++ b/tests/test_av1_validation_v2.py
@@ -23,7 +23,6 @@ from mediaforce.tuning.av1_validation_harness import (
 from mediaforce.tuning.av1_validation_v2 import (
     AV1_VALIDATION_V1_MANIFEST_ID,
     AV1_VALIDATION_V1_MANIFEST_PAYLOAD_SHA256,
-    AV1ValidationManifestV2,
     AV1ValidationV2EligibilityCell,
     AV1ValidationV2Error,
     assert_preregistered_av1_validation_manifest_v2,
@@ -124,6 +123,8 @@ class AV1ValidationV2Tests(unittest.TestCase):
             runtime_context_sha256=f"sha256:{'c' * 64}",
             execution_environment_sha256=f"sha256:{'d' * 64}",
             statistics_contract_sha256=f"sha256:{'e' * 64}",
+            review_runner_canonical_path_sha256=f"sha256:{'f' * 64}",
+            review_runner_binary_sha256=f"sha256:{'0' * 64}",
             authorized_at="2026-08-01T00:00:00Z",
             valid_until="2026-08-02T00:00:00Z",
         )
@@ -137,6 +138,14 @@ class AV1ValidationV2Tests(unittest.TestCase):
         self.assertFalse(payload["guided_probe_allowed"])
         self.assertFalse(payload["holdout_case_execution_allowed"])
         self.assertFalse(payload["public_bundle_activation_allowed"])
+        self.assertEqual(
+            payload["review_runner_canonical_path_sha256"],
+            f"sha256:{'f' * 64}",
+        )
+        self.assertEqual(
+            payload["review_runner_binary_sha256"],
+            f"sha256:{'0' * 64}",
+        )
 
         payload["guided_probe_allowed"] = True
         with self.assertRaises(AV1ValidationV2Error):

--- a/tests/test_av1_validation_v2.py
+++ b/tests/test_av1_validation_v2.py
@@ -121,6 +121,9 @@ class AV1ValidationV2Tests(unittest.TestCase):
             manifest=self.manifest,
             selection_lock_sha256=f"sha256:{'a' * 64}",
             derivation_partition_sha256=f"sha256:{'b' * 64}",
+            runtime_context_sha256=f"sha256:{'c' * 64}",
+            execution_environment_sha256=f"sha256:{'d' * 64}",
+            statistics_contract_sha256=f"sha256:{'e' * 64}",
             authorized_at="2026-08-01T00:00:00Z",
             valid_until="2026-08-02T00:00:00Z",
         )
@@ -175,8 +178,14 @@ class AV1ValidationV2Tests(unittest.TestCase):
             derivation_evidence_count=12,
             derivation_source_count=6,
             derivation_source_tokens=tuple(f"source_{index}" for index in range(6)),
+            derivation_title_tokens=tuple(
+                f"title_token_{index}" for index in range(12)
+            ),
             derivation_series_tokens=tuple(f"series_{index}" for index in range(12)),
             derivation_source_group_tokens=tuple(f"group_{index:03d}" for index in range(6)),
+            derivation_source_group_observation_tokens=tuple(
+                f"group_{index:03d}" for index in range(6) for _ in range(2)
+            ),
             derivation_oldest_recorded_at="2026-07-01T00:00:00Z",
             derivation_newest_recorded_at="2026-07-10T00:00:00Z",
             derivation_conflict_count=0,

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import sqlite3
 import subprocess
+import sys
 import tempfile
 import threading
 import tomllib
@@ -69,6 +70,7 @@ from mediaforce.tuning.size_goals import SizeGoalIntent
 from mediaforce.review import BrowserReviewClip, CompareClip, EncodedPreviewClip
 from mediaforce.reviewing.helpers import ReviewMoment
 from mediaforce.web import app as web_app
+from mediaforce.web import runtime_lock as runtime_lock_module
 from mediaforce.web import settings_runtime
 from mediaforce.web.runtime import completed_runtime, dashboard_payloads, encode_runtime, \
     folder_actions as folder_actions_runtime, \
@@ -6392,6 +6394,70 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
                     pass
 
         self.assertIn("pid 123 on 127.0.0.1:8777", str(raised.exception))
+
+    def test_runtime_lock_survives_lock_file_unlink_and_recreation(self) -> None:
+        lock_path = runtime_lock_module.mediaforce_runtime_lock_path(self.config)
+        child = """
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from mediaforce.web.runtime_lock import (
+    MediaforceRuntimeBusyError,
+    exclusive_mediaforce_runtime_lock,
+)
+
+config = SimpleNamespace(
+    paths=SimpleNamespace(web_state_dir=Path(sys.argv[1])),
+)
+try:
+    with exclusive_mediaforce_runtime_lock(
+        config,
+        owner_payload={"purpose": "child-lock-probe"},
+    ):
+        pass
+except MediaforceRuntimeBusyError:
+    raise SystemExit(23)
+raise SystemExit(0)
+"""
+        with runtime_lock_module.exclusive_mediaforce_runtime_lock(
+            self.config,
+            owner_payload={"purpose": "parent-lock-probe"},
+        ):
+            lock_path.unlink()
+            lock_path.write_text(
+                json.dumps({"pid": 999, "purpose": "replacement"}),
+                encoding="utf-8",
+            )
+            lock_path.chmod(0o600)
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    child,
+                    str(self.config.paths.web_state_dir),
+                ],
+                cwd=Path.cwd(),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(completed.returncode, 23, completed.stderr)
+
+        with runtime_lock_module.exclusive_mediaforce_runtime_lock(
+            self.config,
+            owner_payload={"purpose": "post-recreation-probe"},
+        ):
+            self.assertIn("post-recreation-probe", lock_path.read_text())
+
+    def test_dev_stop_never_deletes_the_shared_runtime_lock(self) -> None:
+        script = Path("scripts/mediaforce-dev.sh").read_text(encoding="utf-8")
+        lock_deletions = [
+            line
+            for line in script.splitlines()
+            if "rm -f" in line and "BACKEND_LOCK_FILE" in line
+        ]
+        self.assertEqual(lock_deletions, [])
 
     @staticmethod
     def test_create_reloadable_app_uses_default_config_when_env_path_is_blank() -> None:

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -8224,6 +8224,40 @@ raise SystemExit(0)
         self.assertEqual(payload["host"], host)
         self.assertEqual(payload["compare_clips"][0]["path"], "/review-media/remote-run/item-00/compare-01-12m-00s.mkv")
 
+        pinned_source_path = self._create_source_file("pinned-source.mkv")
+        for mocked_operation in (
+            search_quality_mock,
+            sample_encode_mock,
+            recommend_timestamps_mock,
+            encode_preview_mock,
+            source_review_mock,
+            compare_preview_mock,
+        ):
+            mocked_operation.reset_mock()
+        web_app._run_sampled_calibration(
+            config=self.config,
+            prefix="tv/show",
+            action="baseline",
+            host_data=host,
+            notes="Use the pinned source snapshot.",
+            policy=policy,
+            seed_metadata=None,
+            sample_item=sample_item,
+            calibration_run_id="pinned-run",
+            process_controller=web_app.ManagedProcessController(),
+            source_path_override=pinned_source_path,
+        )
+        self.assertEqual(search_quality_mock.call_args.args[0], pinned_source_path)
+        self.assertEqual(sample_encode_mock.call_args.args[0], pinned_source_path)
+        self.assertEqual(
+            encode_preview_mock.call_args.kwargs["source_path"],
+            pinned_source_path,
+        )
+        self.assertEqual(
+            source_review_mock.call_args.kwargs["source_path"],
+            pinned_source_path,
+        )
+
     @patch("mediaforce.web.app.generate_compare_clips_from_review_pairs")
     @patch("mediaforce.web.app.render_source_review_clips")
     @patch("mediaforce.web.app.encode_preview_clips")

--- a/tests/test_encode_queue_recovery.py
+++ b/tests/test_encode_queue_recovery.py
@@ -6383,7 +6383,10 @@ class EncodeQueueRecoveryTests(unittest.TestCase):
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         lock_path.write_text(json.dumps({"pid": 123, "host": "127.0.0.1", "port": 8777}))
 
-        with patch("mediaforce.web.app.fcntl.flock", side_effect=BlockingIOError):
+        with patch(
+            "mediaforce.web.runtime_lock.fcntl.flock",
+            side_effect=BlockingIOError,
+        ):
             with self.assertRaises(SystemExit) as raised:
                 with web_app._exclusive_web_server_lock(self.config, settings):
                     pass


### PR DESCRIPTION
# Bounded AV1 v2 Derivation Workflow

## Summary

- Add the bounded AV1 v2 derivation-only workflow for the preregistered 24
  reserved attempts.
- Bind every selected source to immutable evidence, sampled content identity,
  and full SHA-256 before authorization.
- Copy exact source bytes into owner-only private snapshots and route crop,
  search, encode, and review work exclusively through monitored read-only
  snapshots.
- Fail closed on source drift, path-chain mutation, compatibility drift,
  interruption, review mismatch, or evidence conflict without replacement,
  relabeling, retry, holdout access, or publication authority.

## Safety Boundary

- No real media has run.
- Mediaforce remains disabled and unloaded.
- No private paths, titles, source identifiers, fingerprints, mappings,
  databases, or review media are committed or included here.
- This PR does not authorize holdout execution or activate a public prior
  bundle. #288 and #278 remain blocked, and #256/#262 receive no evidence
  credit.

## Validation

- `bash scripts/pre-commit-check.sh`
- Focused partition/derivation suite: 95 passed, 26 subtests passed
- Broad AV1 suite: 176 passed, 75 subtests passed
- Sampled calibration integration: 4 passed
- `uv build`
- `uv run python scripts/verify_package_contents.py dist/*.whl dist/*.tar.gz`
- Scoped PyCharm inspection of all changed Python files: zero findings
- Five independent exact-commit reviews of
  `a7b520bf715df10fcee5bfa2f1012fb584ab76cb`: architecture,
  statistical/model-contract, privacy/security, experimental-design, and
  adversarial all approved

Refs #287, #277, and #273.

Does not close #287: candidate-lock derivation and human visual review remain
separate, post-merge work.
